### PR TITLE
Add app structure and routing

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -1,9 +1,8 @@
-import _ from 'underscore';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import RouterApp from 'js/base/routerapp';
+import PatientsMainApp from 'js/apps/patients/patients-main_app';
 
 import { AppNavView } from 'js/views/globals/app-nav/app-nav_views';
 
@@ -12,18 +11,19 @@ export default App.extend({
   radioRequests: {
     'select': 'select',
   },
+  childApps: {
+    patients: {
+      AppClass: PatientsMainApp,
+      startWithParent: true,
+    },
+  },
   beforeStart() {
     return Radio.request('auth', 'bootstrap');
   },
   onStart() {
-    const TempApp = RouterApp.extend({
-      initialize() {
-        this.router.route('', 'default', _.noop);
-      },
-    });
-
-    new TempApp();
-
+    this.showAppNav();
+  },
+  showAppNav() {
     this.showChildView('nav', new AppNavView({
       model: Radio.request('auth', 'currentUser'),
       currentOrg: Radio.request('auth', 'currentOrg'),

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -12,6 +12,9 @@ export default App.extend({
   radioRequests: {
     'select': 'select',
   },
+  beforeStart() {
+    return Radio.request('auth', 'bootstrap');
+  },
   onStart() {
     const TempApp = RouterApp.extend({
       initialize() {

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
@@ -20,6 +21,9 @@ export default App.extend({
 
     new TempApp();
 
-    this.showChildView('nav', new AppNavView());
+    this.showChildView('nav', new AppNavView({
+      model: Radio.request('auth', 'currentUser'),
+      currentOrg: Radio.request('auth', 'currentOrg'),
+    }));
   },
 });

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -2,6 +2,8 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
+import SidebarService from 'js/services/sidebar';
+
 import PatientsMainApp from 'js/apps/patients/patients-main_app';
 
 import { AppNavView } from 'js/views/globals/app-nav/app-nav_views';
@@ -15,12 +17,15 @@ export default App.extend({
     patients: {
       AppClass: PatientsMainApp,
       startWithParent: true,
+      regionName: 'content',
     },
   },
   beforeStart() {
     return Radio.request('auth', 'bootstrap');
   },
   onStart() {
+    new SidebarService({ region: this.getRegion('sidebar') });
+
     this.showAppNav();
   },
   showAppNav() {

--- a/src/js/apps/patients/list/patients-all_app.js
+++ b/src/js/apps/patients/list/patients-all_app.js
@@ -1,3 +1,18 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+
 import App from 'js/base/app';
 
-export default App.extend({});
+import { ListView } from 'js/views/patients/list/patients-all_views';
+
+export default App.extend({
+  beforeStart() {
+    return Radio.request('entities', 'patients', 'fetch:patients:collection');
+  },
+  onStart(options, collection) {
+    // FIXME: Temporary
+    collection = new Backbone.Collection([{ name: 'foo patient' }]);
+
+    this.showView(new ListView({ collection }));
+  },
+});

--- a/src/js/apps/patients/list/patients-all_app.js
+++ b/src/js/apps/patients/list/patients-all_app.js
@@ -1,0 +1,3 @@
+import App from 'js/base/app';
+
+export default App.extend({});

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -1,0 +1,7 @@
+import App from 'js/base/app';
+
+export default App.extend({
+  onStart() {
+    this.showView('content');
+  },
+});

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -1,3 +1,58 @@
-import App from 'js/base/app';
+import _ from 'underscore';
+import Radio from 'backbone.radio';
 
-export default App.extend({});
+import SubRouterApp from 'js/base/subrouterapp';
+
+import DashboardApp from 'js/apps/patients/patient/dashboard/dashboard_app';
+
+import { LayoutView, SidebarView } from 'js/views/patients/patient/patient_views';
+
+export default SubRouterApp.extend({
+  eventRoutes() {
+    return {
+      'patient:dashboard': _.partial(this.startCurrent, 'dashboard'),
+    };
+  },
+
+  childApps: {
+    dashboard: {
+      AppClass: DashboardApp,
+      regionName: 'content',
+    },
+  },
+
+  onBeforeStart() {
+    this.getRegion().startPreloader();
+  },
+
+  beforeStart({ patientId }) {
+    // FIXME: Temporary
+    // return Radio.request('entities', 'fetch:patient:model', patientId);
+  },
+
+  onStart({ currentRoute }, patient) {
+    this.patient = patient;
+
+    this.setView(new LayoutView());
+
+    this.showSidebar();
+
+    // Show/Empty patient sidebar based on app sidebar
+    this.listenTo(Radio.channel('sidebar'), {
+      'show': this.emptySidebar,
+      'close': this.showSidebar,
+    });
+
+    this.startRoute(currentRoute);
+
+    this.showView();
+  },
+
+  showSidebar() {
+    this.showChildView('sidebar', new SidebarView({ model: this.patient }));
+  },
+
+  emptySidebar() {
+    this.getRegion('sidebar').empty();
+  },
+});

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -1,0 +1,3 @@
+import App from 'js/base/app';
+
+export default App.extend({});

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -1,0 +1,65 @@
+import _ from 'underscore';
+
+import RouterApp from 'js/base/routerapp';
+
+import PatientApp from 'js/apps/patients/patient/patient_app';
+import PatientsAllApp from 'js/apps/patients/list/patients-all_app';
+import ViewApp from 'js/apps/patients/view/view_app';
+
+export default RouterApp.extend({
+  routerAppName: 'PatientsApp',
+
+  childApps: {
+    patient: PatientApp,
+    patientsAll: PatientsAllApp,
+    view: ViewApp,
+  },
+
+  initialize() {
+    this.router.route('', 'default', _.bind(this.defaultRoute, this));
+  },
+
+  defaultRoute() {
+    const defaultRoute = 'patients:all';
+
+    this.routeAction(defaultRoute, () => {
+      this.replaceRoute(defaultRoute);
+      this.showPatientsAll();
+    });
+  },
+
+  eventRoutes: {
+    'patients:all': {
+      action: 'showPatientsAll',
+      route: 'patients/all',
+      isList: true,
+    },
+    'view': {
+      action: 'showPatientsView',
+      route: 'view/:id',
+      isList: true,
+    },
+    'patient:dashboard': {
+      action: 'showPatient',
+      route: 'patient/dashboard/:id',
+      hasLatestList: true,
+    },
+    'patient:action': {
+      action: 'showPatient',
+      route: 'patient/:id/action/:id',
+      hasLatestList: true,
+    },
+  },
+
+  showPatient(patientId) {
+    this.startCurrent('patient', { patientId });
+  },
+
+  showPatientsAll() {
+    this.startCurrent('patientsAll');
+  },
+
+  showPatientsView(viewId) {
+    this.startCurrent('view', { viewId });
+  },
+});

--- a/src/js/apps/patients/view/view_app.js
+++ b/src/js/apps/patients/view/view_app.js
@@ -1,0 +1,3 @@
+import App from 'js/base/app';
+
+export default App.extend({});

--- a/src/js/apps/patients/view/view_app.js
+++ b/src/js/apps/patients/view/view_app.js
@@ -1,3 +1,18 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+
 import App from 'js/base/app';
 
-export default App.extend({});
+import { ListView } from 'js/views/patients/view/view_views';
+
+export default App.extend({
+  beforeStart({ viewId }) {
+    return Radio.request('entities', 'actions', 'fetch:actions:collection');
+  },
+  onStart(options, collection) {
+    // FIXME: Temporary
+    collection = new Backbone.Collection([{ name: 'foo action' }]);
+
+    this.showView(new ListView({ collection }));
+  },
+});

--- a/src/js/base/entity-service.js
+++ b/src/js/base/entity-service.js
@@ -40,7 +40,7 @@ export default MnObject.extend({
   fetchCollection(options) {
     const d = $.Deferred();
 
-    const ajaxAuth = Radio.request('auth', 'get:ajaxAuth');
+    const ajaxAuth = Radio.request('auth', 'ajaxAuth');
 
     const collection = new this.Entity.Collection();
 
@@ -58,7 +58,7 @@ export default MnObject.extend({
   fetchModel(modelId, options) {
     const d = $.Deferred();
 
-    const ajaxAuth = Radio.request('auth', 'get:ajaxAuth');
+    const ajaxAuth = Radio.request('auth', 'ajaxAuth');
 
     const model = new this.Entity.Model({ id: modelId });
 

--- a/src/js/base/routerapp.js
+++ b/src/js/base/routerapp.js
@@ -70,7 +70,7 @@ export default App.extend({
 
     this.triggerMethod('before:appRoute', event, ...args);
 
-    Radio.request('sidebar', 'watch');
+    Radio.request('sidebar', 'close');
 
     Radio.request('nav', 'select', this.routerAppName, event, args);
 
@@ -89,13 +89,11 @@ export default App.extend({
 
     Backbone.history.trigger('current', event, ...args);
 
-    Radio.request('sidebar', 'closeWatch');
-
     this.triggerMethod('appRoute', event, ...args);
   },
 
   setLatestList(event, eventArgs) {
-    if (this._routes[event].isPatientList) {
+    if (this._routes[event].isList) {
       Radio.request('history', 'set:latestList', event, eventArgs);
       return;
     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -94,6 +94,10 @@ const Application = App.extend({
     appFrame: AppFrameApp,
   },
 
+  beforeStart() {
+    return Radio.request('auth', 'bootstrap');
+  },
+
   //
   // Start all Global Apps and Main Apps
   // Finish with starting the backbone history to kick off the first router

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -20,6 +20,7 @@ import ActivityService from 'js/services/activity';
 import AlertService from 'js/services/alert';
 import AuthService from 'js/services/auth';
 import HistoryService from 'js/services/history';
+import LastestListService from 'js/services/latest-list';
 import ModalService from 'js/services/modal';
 
 import AppFrameApp from 'js/apps/globals/app-frame_app';
@@ -57,6 +58,7 @@ const Application = App.extend({
     new ActivityService();
     new AlertService({ region: this.getRegion('alert') });
     new AuthService();
+    new LastestListService();
     new ModalService({
       modalRegion: this.getRegion('modal'),
       modalSmallRegion: this.getRegion('modalSmall'),

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -90,20 +90,11 @@ const Application = App.extend({
     });
   },
 
-  childApps: {
-    appFrame: AppFrameApp,
-  },
-
-  beforeStart() {
-    return Radio.request('auth', 'bootstrap');
-  },
-
-  //
-  // Start all Global Apps and Main Apps
-  // Finish with starting the backbone history to kick off the first router
   onStart() {
+    // Ensure Error is the first app initialized
     new ErrorApp({ region: this.getRegion('error') });
 
+    this.addChildApp('appFrame', AppFrameApp);
     this.startChildApp('appFrame', { view: this.getView().appView });
 
     Backbone.history.start({ pushState: true });

--- a/src/js/services/auth.js
+++ b/src/js/services/auth.js
@@ -1,3 +1,7 @@
+import Backbone from 'backbone';
+
+import App from 'js/base/app';
+
 let bearer;
 
 /* istanbul ignore if */
@@ -7,12 +11,13 @@ if (_DEVELOP_ || _PRODUCTION_) {
   bearer = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjbGluaWNpYW4iOiJlNDkyZjA3Yy1mZjRmLTRkOTEtOTNhYS1hN2VkMGEwZWQzYTEifQ.5tan08SQx3vmSPkj4HzX0sjBC__SlNfEWr3TNWomQHc';
 }
 
-import App from 'js/base/app';
-
 export default App.extend({
   channelName: 'auth',
   radioRequests: {
-    'get:ajaxAuth': 'getAjaxAuth',
+    'ajaxAuth': 'getAjaxAuth',
+    'currentUser': 'getCurrentUser',
+    'currentOrg': 'getCurrentOrg',
+    'bootstrap': 'initBootstrap',
   },
   getAjaxAuth() {
     return {
@@ -20,5 +25,22 @@ export default App.extend({
         request.setRequestHeader('Authorization', `Bearer ${ bearer }`);
       },
     };
+  },
+  getCurrentUser() {
+    return this.currentUser;
+  },
+  getCurrentOrg() {
+    return this.currentOrg;
+  },
+  initBootstrap() {
+    // TODO: Radio request(s) for preloaded model cache at login
+    // Should set currentUser, currentOrg and any other explicit non-relation cache here
+    // Should return a single Promise
+
+    // FIXME: should be a clinician model
+    this.currentUser = new Backbone.Model();
+
+    // FIXME: should be an organization model
+    this.currentOrg = new Backbone.Model();
   },
 });

--- a/src/js/services/latest-list.js
+++ b/src/js/services/latest-list.js
@@ -1,0 +1,27 @@
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'history',
+
+  radioRequests: {
+    'set:latestList': 'setLatestList',
+    'has:latestList': 'hasLatestList',
+    'go:latestList': 'goLatestList',
+  },
+
+  setLatestList(event, eventArgs = []) {
+    this._latestList = event;
+    this._latestListArgs = eventArgs;
+  },
+
+  hasLatestList() {
+    return !!this._latestList;
+  },
+
+  goLatestList() {
+    if (!this.hasLatestList()) return;
+    Radio.trigger('event-router', this._latestList, ...this._latestListArgs);
+  },
+});

--- a/src/js/services/sidebar.js
+++ b/src/js/services/sidebar.js
@@ -1,0 +1,67 @@
+import _ from 'underscore';
+
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'sidebar',
+
+  radioRequests: {
+    'show': 'showSidebar',
+    'open': 'openSidebar',
+    'close': 'closeSidebar',
+  },
+
+  childApps: {},
+
+  startSidebarApp(appName, appOptions) {
+    if (this.isStarting) return;
+
+    this.isStarting = true;
+
+    this.stopSidebarApp();
+
+    const sidebarOpts = _.extend({
+      region: this.getRegion(),
+    }, appOptions);
+
+    this.currentApp = this.startChildApp(appName, sidebarOpts);
+
+    this.isStarting = false;
+
+    this.getChannel().trigger('show', this.currentApp);
+
+    return this.currentApp;
+  },
+
+  showSidebar(view) {
+    this.stopSidebarApp();
+
+    this.showView(view);
+
+    this.getChannel().trigger('show', view);
+  },
+
+  openSidebar() {
+    this.stopSidebarApp();
+
+    this.getRegion().show(' ');
+
+    this.getChannel().trigger('show');
+  },
+
+  closeSidebar() {
+    this.stopSidebarApp();
+
+    this.getRegion().empty();
+
+    this.getChannel().trigger('close', this.currentApp);
+  },
+
+  stopSidebarApp() {
+    if (!this.currentApp) return;
+
+    this.currentApp.stop();
+
+    delete this.currentApp;
+  },
+});

--- a/src/js/views/globals/app-nav/app-nav_views.js
+++ b/src/js/views/globals/app-nav/app-nav_views.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import Backbone from 'backbone';
 import { View } from 'marionette';
 
@@ -16,27 +15,32 @@ const AppNavView = View.extend({
   },
   ui: {
     header: '.js-header',
+    links: '.js-link',
   },
   triggers: {
     'click @ui.header': 'click:header',
+    'click @ui.links': 'click:link',
+  },
+  initialize({ currentOrg }) {
+    this.currentOrg = currentOrg;
   },
   template: hbs`
     <div class="app-nav__header js-header">
       <div>
-        <h2 class="app-nav__header-title">Example Memorial</h2>
+        <h2 class="app-nav__header-title">{{ orgName }}</h2>
         <span class="app-nav__header-arrow">{{far "angle-down"}}</span>
       </div>
-      <div>User Name</div>
+      <div>{{ first_name }}{{ last_name }}</div>
     </div>
     <div class="app-nav__content overflow-y">
       <h3 class="app-nav__title">Views</h3>
       <div data-views-region>
-        <a class="app-nav__link">Example View</a>
+        <a class="app-nav__link js-link" href="/view/assigned-to-me">Actions Assigned To Me</a>
+        <a class="app-nav__link js-link" href="/view/delegated-by-me">Actions I've Delegated</a>
       </div>
       <h3 class="app-nav__title">Patients</h3>
       <div data-patients-region>
-        <a class="app-nav__link">All Patients</a>
-        <a class="app-nav__link">Patient's I'm Following</a>
+        <a class="app-nav__link  js-link" href="/patients/all">All Patients</a>
       </div>
     </div>
   `,
@@ -46,10 +50,12 @@ const AppNavView = View.extend({
       popWidth: '248px',
       ui: this.ui.header,
       uiView: this,
-      headingText: 'Example Memorial',
+      headingText: this.currentOrg.get('name'),
       lists: [{
-        collection: new Backbone.Collection([{ text: 'Sign Out', onSelect: _.noop }]),
-        itemTemplate: hbs`<a>{{fas "sign-out-alt"}} {{ text }}</a>`,
+        collection: new Backbone.Collection([{ onSelect() {
+          window.location = '/logout';
+        } }]),
+        itemTemplate: hbs`<a>{{fas "sign-out-alt"}} Sign Out</a>`,
       }],
     });
 
@@ -61,14 +67,16 @@ const AppNavView = View.extend({
 
     optionlist.show();
   },
-});
-
-const AppNavHeader = View.extend({
-  className: 'app-nav__header-button',
-  template: hbs`Example Memorial`,
+  onClickLink(view, { target }) {
+    Backbone.history.navigate(this.$(target).attr('href'));
+  },
+  templateContext() {
+    return {
+      orgName: this.currentOrg.get('name'),
+    };
+  },
 });
 
 export {
   AppNavView,
-  AppNavHeader,
 };

--- a/src/js/views/globals/app-nav/app-nav_views.js
+++ b/src/js/views/globals/app-nav/app-nav_views.js
@@ -68,7 +68,7 @@ const AppNavView = View.extend({
     optionlist.show();
   },
   onClickLink(view, { target }) {
-    Backbone.history.navigate(this.$(target).attr('href'));
+    Backbone.history.navigate(this.$(target).attr('href'), true);
   },
   templateContext() {
     return {

--- a/src/js/views/globals/root_views.js
+++ b/src/js/views/globals/root_views.js
@@ -6,6 +6,7 @@ import hbs from 'handlebars-inline-precompile';
 
 import 'sass/modules/fill-window.scss';
 
+import PreloadRegion from 'js/regions/preload_region';
 import TopRegionBehavior from 'js/behaviors/top-region';
 
 import './app-frame.scss';
@@ -23,7 +24,10 @@ const AppView = View.extend({
   `,
   regions: {
     nav: '[data-nav-region]',
-    main: '[data-main-region]',
+    content: {
+      el: '[data-content-region]',
+      regionClass: PreloadRegion,
+    },
     sidebar: '[data-sidebar-region]',
   },
 });

--- a/src/js/views/patients/list/patients-all_views.js
+++ b/src/js/views/patients/list/patients-all_views.js
@@ -1,0 +1,15 @@
+import { View, CollectionView } from 'marionette';
+
+import hbs from 'handlebars-inline-precompile';
+
+const ItemView = View.extend({
+  template: hbs`{{ name }}`,
+});
+
+const ListView = CollectionView.extend({
+  childView: ItemView,
+});
+
+export {
+  ListView,
+};

--- a/src/js/views/patients/patient/patient_views.js
+++ b/src/js/views/patients/patient/patient_views.js
@@ -1,0 +1,33 @@
+import { View } from 'marionette';
+
+import hbs from 'handlebars-inline-precompile';
+
+import PreloadRegion from 'js/regions/preload_region';
+
+const LayoutView = View.extend({
+  className: 'flex-region overflow-y',
+  template: hbs`
+    <div class="patient__content">
+        <div data-context-trail-region></div>
+        <div data-content-region></div>
+    </div>
+    <div class="patient__sidebar" data-sidebar-region></div>
+  `,
+  regions: {
+    contextTrail: '[data-context-trail-region]',
+    sidebar: '[data-sidebar-region]',
+    content: {
+      el: '[data-content-region]',
+      regionClass: PreloadRegion,
+    },
+  },
+});
+
+const SidebarView = View.extend({
+  template: hbs`Sidebar`,
+});
+
+export {
+  LayoutView,
+  SidebarView,
+};

--- a/src/js/views/patients/view/view_views.js
+++ b/src/js/views/patients/view/view_views.js
@@ -1,0 +1,15 @@
+import { View, CollectionView } from 'marionette';
+
+import hbs from 'handlebars-inline-precompile';
+
+const ItemView = View.extend({
+  template: hbs`{{ name }}`,
+});
+
+const ListView = CollectionView.extend({
+  childView: ItemView,
+});
+
+export {
+  ListView,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
   mode: isProduction ? 'production' : 'development',
   entry: path.resolve(process.cwd(), `${ jsRoot }/index.js`),
   output: {
+    publicPath: '/',
     path: outputPath,
     filename: '[name].[hash].js',
   },


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch20557]

So what began as copying over the v3 patient sidebar morphed into setting up a basic barebones app structure.  The MVP target changed during this such that a majority of the v3 patient sidebar from mainapp isn't really being used, and it now functions a bit differently as far as how the sidebar will load and scroll.  _but_ as I was adding the sidebar to handle the new scrolling that led to setting up initial routing and the patient page structure.  I expanded that to include the MVP list of features so that we should have barebone pages for each section.

This also adds a more correct but still temporary app navigation.