### PR TITLE
Fix component tests

### DIFF
--- a/src/js/base/setup.js
+++ b/src/js/base/setup.js
@@ -21,9 +21,15 @@ const { Region, View, CollectionView, setDomApi } = Marionette;
 
 setDomApi(DomApi);
 
+// https://github.com/jquery/jquery/blob/3.4.1/src/deferred/exceptionHook.js
+const rerrorNames = /^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/;
+
 /* istanbul ignore next: Exposes errors in async */
-$.Deferred.exceptionHook = error => {
-  throw error;
+$.Deferred.exceptionHook = (error, stack) => {
+  if (!error || !rerrorNames.test(error.name)) return;
+
+  // eslint-disable-next-line no-console
+  console.error(error.message, error.stack, stack);
 };
 
 /* istanbul ignore if */

--- a/src/sass/provider-variables.scss
+++ b/src/sass/provider-variables.scss
@@ -23,7 +23,7 @@
 $colors: (
   blue: (
     base: #0582DA,
-    light: #F2F9FD,
+    light: #2490D8,
     dark: #0270BF,
   ),
   green: (

--- a/test/integration/components/datepicker.js
+++ b/test/integration/components/datepicker.js
@@ -52,12 +52,7 @@ context('Datepicker', function() {
 
   beforeEach(function() {
     cy
-      .visit('/');
-
-    cy
-      .window()
-      .should('have.property', 'Components')
-      .then(Components => {
+      .visitComponent(Components => {
         Datepicker = Components.Datepicker;
       });
   });

--- a/test/integration/components/droplist.js
+++ b/test/integration/components/droplist.js
@@ -13,7 +13,9 @@ context('Droplist', function() {
 
   beforeEach(function() {
     cy
-      .visit('/');
+      .visitComponent(Components => {
+        Droplist = Components.Droplist;
+      });
 
     // Set View prototype to window's BB for instanceOf checks
     cy
@@ -21,13 +23,6 @@ context('Droplist', function() {
       .should('have.property', 'Backbone')
       .then(winBackbone => {
         Backbone.View = winBackbone.View;
-      });
-
-    cy
-      .window()
-      .should('have.property', 'Components')
-      .then(Components => {
-        Droplist = Components.Droplist;
       });
   });
 

--- a/test/integration/components/optionlist.js
+++ b/test/integration/components/optionlist.js
@@ -32,12 +32,7 @@ context('Optionlist', function() {
 
   beforeEach(function() {
     cy
-      .visit('/');
-
-    cy
-      .window()
-      .should('have.property', 'Components')
-      .then(Components => {
+      .visitComponent(Components => {
         Optionlist = Components.Optionlist;
       });
   });

--- a/test/integration/components/picklist.js
+++ b/test/integration/components/picklist.js
@@ -34,7 +34,7 @@ context('Picklist', function() {
     const onSelect2 = cy.stub();
 
     cy
-      .visit('/');
+      .visitComponent();
 
     // Proxy module Radio to App Radio
     cy

--- a/test/integration/components/selectlist.js
+++ b/test/integration/components/selectlist.js
@@ -13,7 +13,10 @@ context('Selectlist', function() {
 
   beforeEach(function() {
     cy
-      .visit('/');
+      .visitComponent(Components => {
+        Selectlist = Components.Selectlist;
+        Selectlist.prototype.disableInput = false;
+      });
 
     // Set View prototype to window's BB for instanceOf checks
     cy
@@ -21,14 +24,6 @@ context('Selectlist', function() {
       .should('have.property', 'Backbone')
       .then(winBackbone => {
         Backbone.View = winBackbone.View;
-      });
-
-    cy
-      .window()
-      .should('have.property', 'Components')
-      .then(Components => {
-        Selectlist = Components.Selectlist;
-        Selectlist.prototype.disableInput = false;
       });
   });
 

--- a/test/integration/components/tooltip.js
+++ b/test/integration/components/tooltip.js
@@ -43,12 +43,7 @@ context('Tooltip', function() {
 
   beforeEach(function() {
     cy
-      .visit('/');
-
-    cy
-      .window()
-      .should('have.property', 'Components')
-      .then(Components => {
+      .visitComponent(Components => {
         Tooltip = Components.Tooltip;
       });
   });

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -15,6 +15,23 @@ Cypress.Commands.add('unit', cb => cy.window().then(win => {
   cb && cb.call(win, win);
 }));
 
+Cypress.Commands.add('visitComponent', cb => {
+  cy
+    .route({
+      url: '/api/clinicians/me?*',
+      delay: 999999,
+      response: { data: {}, included: [] },
+    })
+    .visit();
+
+  cy
+    .window()
+    .should('have.property', 'Components')
+    .then(Components => {
+      cb && cb(Components);
+    });
+});
+
 Cypress.Commands.add('getRadio', cb => {
   cy
     .window()
@@ -26,10 +43,12 @@ Cypress.Commands.add('getRadio', cb => {
 
 Cypress.Commands.add('getHook', cb => {
   Cypress.$('body').prepend(`
-    <div style="position:absolute;height:100%;width:100%;background:#EEE;">
+    <div style="position:absolute;height:100%;width:100%;background:#EEE;z-index:0">
       <div id="cy-hook"></div>
     </div>
   `);
+
+  Cypress.$('.app-frame').hide();
 
   cy
     .get('#cy-hook')


### PR DESCRIPTION
This is specifically fixing the flaky tooltips.  It was related to the app starting mid-test interrupting the tooltip display.  This makes it much harder for the component tests to be affected by the app.  

Additionally I snuck in a modification to the jquery exception hook for throwing the errors we want and not elevating things that aren't really errors.  I think it may also give us more accurate information as right now the stack can be largely the exception handling itself rather than what caused the issue.
