### PR TITLE
Concurrently test and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
                 file: coverage/lcov.info
       - build:
           requires:
-            - cypress/run
+            - cypress/install
       - deploy:
           requires:
             - build


### PR DESCRIPTION
This is a simple change to have a concurrent build + test to shave off about 1:35 from CI time. Below is the new workflow:
![workflow](https://p65.f3.n0.cdn.getcloudapp.com/items/GGuLbjL0/Image+2019-09-10+at+11.47.34+AM.png?v=9ba30373eee318c65d6df909c072c74c)
