### PR TITLE
Reshow component after model is updated

### DIFF
--- a/src/js/views/patients/actions/actions_views.js
+++ b/src/js/views/patients/actions/actions_views.js
@@ -195,6 +195,9 @@ const DueComponent = Component.extend({
   },
   initialize({ model }) {
     this.model = model;
+    this.listenTo(model, 'change:due_date', () => {
+      this.show();
+    });
   },
   onClick() {
     this.getView().$el.blur();
@@ -210,9 +213,6 @@ const DueComponent = Component.extend({
     });
 
     datepicker.show();
-  },
-  onChangeDue() {
-    this.show();
   },
 });
 

--- a/test/integration/patients/view.js
+++ b/test/integration/patients/view.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import moment from 'moment';
 import 'js/utils/formatting';
+import formatDate from 'helpers/format-date';
 
 const testGroups = [
   {
@@ -187,6 +188,11 @@ context('view page', function() {
       .get('.datepicker')
       .contains('Today')
       .click();
+
+    cy
+      .get('@firstRow')
+      .find('[data-due-region]')
+      .should('contain', formatDate(moment(), 'SHORT'));
 
     cy
       .wait('@routePatchAction')


### PR DESCRIPTION
We were reshowing on the change event, but the handler on the component would happen prior to whatever else was listening updated the model.

- [x] Add the Clubhouse Story ID: [ch20996]
- [x] Add QA tasks
