### PR TITLE
Add E2E env variable for E2E testing a production build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
   },
   "globals": {
     _PRODUCTION_: true,
-    _DEVELOP_: true
+    _DEVELOP_: true,
+    _E2E_: true
   },
   "rules": {
     "array-bracket-spacing": ["error", "never"],

--- a/config/webpack.env.js
+++ b/config/webpack.env.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
   isCI: !!process.env.CI,
+  isE2E: !!process.env.E2E,
   isProduction: process.env.NODE_ENV === 'production',
   jsRoot: path.resolve(process.cwd(), './src/js'),
   sassRoot: path.resolve(process.cwd(), './src/sass'),

--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const { isProduction, jsRoot } = require('./webpack.env.js');
+const { isProduction, isE2E, jsRoot } = require('./webpack.env.js');
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
@@ -12,6 +12,7 @@ const pkg = require('../package.json');
 const definePlugin = new webpack.DefinePlugin({
   _PRODUCTION_: isProduction,
   _DEVELOP_: !isProduction,
+  _E2E_: isE2E,
 });
 
 const extractPlugin = new MiniCssExtractPlugin({

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -58,7 +58,7 @@ function getConfig() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (_DEVELOP_ && sessionStorage.getItem('cypress')) {
+  if ((_DEVELOP_ || _E2E_) && sessionStorage.getItem('cypress')) {
     $.ajaxSetup({
       contentType: 'application/vnd.api+json',
       beforeSend(xhr) {


### PR DESCRIPTION
Had a thought to add a E2E build variable that allows us to have a specific build for E2E that could _also_ be a production build.  This does two things.  It makes the E2E testing (both in cypress and localhost) a production build and _much_ closer if not pretty much entirely identical to a production build of FE.  And it now allows us to use the `_DEVELOP_` flag all we want to hide things in development such that they'll show up locally for you and I, but they will not show up for QA, E2E, or production.