### PR TITLE
Chore/parallel requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,12 +1520,6 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
-    "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
-      "dev": true
-    },
     "@types/tapable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
@@ -3899,14 +3893,13 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.6.0.tgz",
-      "integrity": "sha512-ODhbOrH1XZx0DUoYmJSvOSbEQjycNOpFYe7jOnHkT1+sdsn2+uqwAjZ1x982q3H4R/5iZjpSd50gd/iw2bofzg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.4.1.tgz",
+      "integrity": "sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
         "@cypress/xvfb": "1.2.4",
-        "@types/sizzle": "2.3.2",
         "arch": "2.1.1",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
@@ -3933,7 +3926,6 @@
         "request-progress": "3.0.0",
         "supports-color": "5.5.0",
         "tmp": "0.1.0",
-        "untildify": "3.0.3",
         "url": "0.11.0",
         "yauzl": "2.10.0"
       },
@@ -13327,12 +13319,6 @@
           "dev": true
         }
       }
-    },
-    "untildify": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
-      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
-      "dev": true
     },
     "upath": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "cross-env": "^6.0.3",
     "css-loader": "^3.2.0",
     "cssnano": "^4.1.10",
-    "cypress": "3.6.0",
+    "cypress": "3.4.1",
     "eslint": "6.5.1",
     "eslint-loader": "^3.0.2",
     "eslint-plugin-mocha": "^6.2.1",

--- a/src/js/apps/admin/program/workflows/workflows_app.js
+++ b/src/js/apps/admin/program/workflows/workflows_app.js
@@ -14,7 +14,7 @@ export default App.extend({
     this.getRegion('content').startPreloader();
   },
   beforeStart({ program }) {
-    return Radio.request('entities', 'fetch:programActions:collection', { program });
+    return Radio.request('entities', 'fetch:programActions:collection:byProgram', { programId: program.id });
   },
   onStart({ program }, actions) {
     this.actions = actions;

--- a/src/js/apps/patients/patient/dashboard/add-action_app.js
+++ b/src/js/apps/patients/patient/dashboard/add-action_app.js
@@ -9,7 +9,7 @@ export default App.extend({
   beforeStart() {
     return [
       Radio.request('entities', 'fetch:programs:collection'),
-      Radio.request('entities', 'fetch:programActions:all', { filter: 'published' }),
+      Radio.request('entities', 'fetch:programActions:collection'),
     ];
   },
   onStart(options, [programs]) {

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -19,7 +19,7 @@ export default App.extend({
 
   beforeStart({ patient }) {
     const filter = { status: 'queued,started' };
-    return Radio.request('entities', 'fetch:patientActions:collection', { patient, filter });
+    return Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter });
   },
 
   onStart({ patient }, actions) {

--- a/src/js/apps/patients/patient/data-events/data-events_app.js
+++ b/src/js/apps/patients/patient/data-events/data-events_app.js
@@ -11,7 +11,7 @@ export default App.extend({
   },
   beforeStart({ patient }) {
     const filter = { status: 'done' };
-    return Radio.request('entities', 'fetch:patientActions:collection', { patient, filter });
+    return Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter });
   },
   onStart({ patient }, actions) {
     this.showChildView('content', new ListView({ collection: actions }));

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -38,10 +38,13 @@ export default SubRouterApp.extend({
   },
 
   beforeStart({ patientId }) {
-    return Radio.request('entities', 'fetch:patients:model', patientId);
+    return [
+      Radio.request('entities', 'fetch:patients:model', patientId),
+      Radio.request('entities', 'fetch:patientFields:collection', patientId),
+    ];
   },
 
-  onStart({ currentRoute }, patient) {
+  onStart({ currentRoute }, [patient]) {
     this.patient = patient;
 
     this.setView(new LayoutView({ model: patient }));

--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -6,8 +6,8 @@ import { getActiveXhr, registerXhr } from './control';
 import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Collection.extend(_.extend({
-  fetch(options) {
-    const baseUrl = _.result(this, 'url');
+  fetch(options = {}) {
+    const baseUrl = options.url || _.result(this, 'url');
     let xhr = getActiveXhr(baseUrl, options);
 
     /* istanbul ignore if */

--- a/src/js/base/control.js
+++ b/src/js/base/control.js
@@ -15,8 +15,7 @@ function getActiveXhr(baseUrl, options = {}) {
 
   /* istanbul ignore if: async safety */
   if (xhr && xhr.readyState !== 4 && !options.async) {
-    // Aborts if forced or if there's a success callback and not explicitly false
-    if (options.abort || (options.success && options.abort !== false)) {
+    if (options.abort !== false) {
       xhr.abort();
       return false;
     }

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -9,7 +9,7 @@ export default Backbone.Model.extend(_.extend({
     // Model fetches default to aborting.
     options = _.extend({ abort: true }, options);
 
-    const baseUrl = _.result(this, 'url');
+    const baseUrl = options.url || _.result(this, 'url');
     let xhr = getActiveXhr(baseUrl, options);
 
     /* istanbul ignore if */

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -8,16 +8,16 @@ const Entity = BaseEntity.extend({
     'actions:collection': 'getCollection',
     'fetch:actions:model': 'fetchCachedModel',
     'fetch:actions:collection': 'fetchActions',
-    'fetch:patientActions:collection': 'fetchPatientActions',
+    'fetch:actions:collection:byPatient': 'fetchActionsByPatient',
   },
   fetchActions({ filter }) {
     const data = { include: 'patient', filter };
 
     return this.fetchCollection({ data });
   },
-  fetchPatientActions({ patient, filter }) {
+  fetchActionsByPatient({ patientId, filter }) {
     const data = { filter };
-    const url = `${ patient.url() }/relationships/actions`;
+    const url = `/api/patients/${ patientId }/relationships/actions`;
 
     return this.fetchCollection({ url, data });
   },

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -59,7 +59,7 @@ const _Model = BaseModel.extend({
 
 const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
-  url: '/api/actions',
+  url: '/api/program-actions',
   model: Model,
 });
 

--- a/src/js/entities-service/groups.js
+++ b/src/js/entities-service/groups.js
@@ -6,12 +6,7 @@ const Entity = BaseEntity.extend({
   radioRequests: {
     'groups:model': 'getModel',
     'groups:collection': 'getCollection',
-    'fetch:groups:collection': 'fetchGroups',
-  },
-  fetchGroups() {
-    const data = { include: 'clinicians' };
-
-    return this.fetchCollection({ data });
+    'fetch:groups:collection': 'fetchCollection',
   },
 });
 

--- a/src/js/entities-service/patient-fields.js
+++ b/src/js/entities-service/patient-fields.js
@@ -6,6 +6,12 @@ const Entity = BaseEntity.extend({
   radioRequests: {
     'patientFields:model': 'getModel',
     'patientFields:collection': 'getCollection',
+    'fetch:patientFields:collection': 'fetchPatientFields',
+  },
+  fetchPatientFields(patientId) {
+    const url = `/api/patients/${ patientId }/fields`;
+
+    return this.fetchCollection({ url });
   },
 });
 

--- a/src/js/entities-service/patients.js
+++ b/src/js/entities-service/patients.js
@@ -6,13 +6,8 @@ const Entity = BaseEntity.extend({
   radioRequests: {
     'patients:model': 'getModel',
     'patients:collection': 'getCollection',
-    'fetch:patients:model': 'fetchPatient',
+    'fetch:patients:model': 'fetchModel',
     'fetch:patients:collection': 'fetchPatients',
-  },
-  fetchPatient(id) {
-    const data = { include: 'patient-fields' };
-
-    return this.fetchModel(id, { data });
   },
   fetchPatients({ groupId }) {
     const filter = { group: groupId };

--- a/src/js/entities-service/program-actions.js
+++ b/src/js/entities-service/program-actions.js
@@ -7,18 +7,17 @@ const Entity = BaseEntity.extend({
     'programActions:model': 'getModel',
     'programActions:collection': 'getCollection',
     'fetch:programActions:model': 'fetchCachedModel',
+    'fetch:programActions:collection:byProgram': 'fetchProgramActionsByProgram',
     'fetch:programActions:collection': 'fetchProgramActions',
-    'fetch:programActions:all': 'fetchAllProgramActions',
   },
-  fetchProgramActions({ program }) {
-    const url = `${ program.url() }/relationships/actions`;
+  fetchProgramActionsByProgram({ programId }) {
+    const url = `/api/programs/${ programId }/relationships/actions`;
 
     return this.fetchCollection({ url });
   },
-  fetchAllProgramActions({ filter }) {
+  fetchProgramActions({ filter = { status: 'published' } } = {}) {
     const data = { filter };
-    const url = '/api/program-actions';
-    return this.fetchCollection({ url, data });
+    return this.fetchCollection({ data });
   },
 });
 

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -11,6 +11,7 @@ export default App.extend({
     'fetch': 'fetchBootstrap',
   },
   initialize({ name }) {
+    this.bootstrapPromise = $.Deferred();
     this.currentOrg = Radio.request('entities', 'organizations:model', { name });
   },
   getCurrentUser() {
@@ -19,17 +20,23 @@ export default App.extend({
   getCurrentOrg() {
     return this.currentOrg;
   },
+  beforeStart() {
+    return [
+      Radio.request('entities', 'fetch:clinicians:current'),
+      Radio.request('entities', 'fetch:roles:collection'),
+      Radio.request('entities', 'fetch:states:collection'),
+      Radio.request('entities', 'fetch:groups:collection'),
+      Radio.request('entities', 'fetch:clinicians:collection'),
+    ];
+  },
+  onStart(options, [currentUser], [roles], [states]) {
+    this.currentUser = currentUser;
+    this.currentOrg.set({ states, roles });
+    this.bootstrapPromise.resolve();
+  },
   fetchBootstrap() {
-    const d = $.Deferred();
-    const fetchCurrentUser = Radio.request('entities', 'fetch:clinicians:current');
-    const fetchGroups = Radio.request('entities', 'fetch:groups:collection');
-    const fetchRoles = Radio.request('entities', 'fetch:roles:collection');
-    const fetchStates = Radio.request('entities', 'fetch:states:collection');
-    $.when(fetchCurrentUser, fetchRoles, fetchStates, fetchGroups).done(([currentUser], [roles], [states]) => {
-      this.currentUser = currentUser;
-      this.currentOrg.set({ states, roles });
-      d.resolve(currentUser);
-    });
-    return d.promise();
+    this.start();
+
+    return this.bootstrapPromise;
   },
 });

--- a/test/integration/patients/list/patients-all.js
+++ b/test/integration/patients/list/patients-all.js
@@ -21,7 +21,7 @@ context('patient all list', function() {
   specify('group filtering', function() {
     cy
       .server()
-      .routeGroups(_.indentity, testGroups)
+      .routeGroupsBootstrap(_.indentity, testGroups)
       .routePatient()
       .routePatientActions()
       .routePatients(fx => {
@@ -80,7 +80,7 @@ context('patient all list', function() {
   specify('name sorting', function() {
     cy
       .server()
-      .routeGroups(_.indentity, testGroups)
+      .routeGroupsBootstrap(_.indentity, testGroups)
       .routePatient()
       .routePatientActions()
       .routePatients(fx => {

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -22,6 +22,7 @@ context('patient data and events page', function() {
             updated_at: moment.utc().format(),
           },
           relationships: {
+            patient: { data: { id: '11111' } },
             clinician: { data: { id: '11111' } },
             role: { data: { id: null } },
             state: { data: { id: '55555' } },

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -204,10 +204,12 @@ context('action sidebar', function() {
 
     cy
       .server()
-      .routeGroups(fx => {
+      .routeGroupsBootstrap(fx => {
         fx.data[2].relationships.clinicians.data[1] = { id: '22222', type: 'clinicians' };
 
-        fx.included[0] = {
+        return fx;
+      }, null, fx => {
+        fx.data.push({
           id: '22222',
           type: 'clinicians',
           attributes: {
@@ -215,8 +217,7 @@ context('action sidebar', function() {
             last_name: 'Clinician',
             name: 'Another Clinician',
           },
-        };
-
+        });
         return fx;
       })
       .routeAction(fx => {

--- a/test/integration/patients/view.js
+++ b/test/integration/patients/view.js
@@ -223,7 +223,7 @@ context('view page', function() {
   specify('group filtering', function() {
     cy
       .server()
-      .routeGroups(_.indentity, testGroups)
+      .routeGroupsBootstrap(_.indentity, testGroups)
       .routeGroupActions()
       .visit('/view/owned-by-me')
       .wait('@routeGroupActions')
@@ -253,7 +253,7 @@ context('view page', function() {
 
     cy
       .server()
-      .routeGroups(_.indentity, testGroups)
+      .routeGroupsBootstrap(_.indentity, testGroups)
       .routeGroupActions()
       .visit('/view/new-actions')
       .wait('@routeGroupActions')

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -54,6 +54,8 @@ Cypress.Commands.add('routeAction', (mutator = _.identity) => {
     },
   })
     .as('routeAction');
+
+  cy.routeProgramByAction();
 });
 
 Cypress.Commands.add('routePatientActions', (mutator = _.identity, patientId) => {

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -16,3 +16,21 @@ Cypress.Commands.add('routeCurrentClinician', (mutator = _.identity) => {
   })
     .as('routeCurrentClinician');
 });
+
+Cypress.Commands.add('routeClinicians', (mutator = _.identity, clinicians) => {
+  cy
+    .fixture('collections/clinicians').as('fxClinicians');
+
+  cy.route({
+    url: '/api/clinicians',
+    response() {
+      clinicians = clinicians || _.sample(this.fxClinicians, 9);
+
+      return mutator({
+        data: getResource(clinicians, 'clinicians'),
+        included: [],
+      });
+    },
+  })
+    .as('routeClinicians');
+});

--- a/test/support/api/groups.js
+++ b/test/support/api/groups.js
@@ -1,62 +1,87 @@
 import _ from 'underscore';
 import { getResource, getRelationship } from 'helpers/json-api';
 
-function getGroups(groups, clinicians) {
+function makeResources(groups, clinicians, fxPatients) {
+  clinicians = getResource(clinicians, 'clinicians');
   groups = getResource(groups, 'groups');
 
   _.each(clinicians, clinician => {
     clinician.relationships.groups = { data: [] };
   });
 
-  mutateGroup.call(this, groups[0], clinicians);
+  mutateGroup(groups[0], clinicians, fxPatients);
 
   if (groups[1]) {
-    mutateGroup.call(this, groups[1], _.first(clinicians, 5));
+    mutateGroup(groups[1], _.first(clinicians, 5), fxPatients);
   }
 
   if (groups[2]) {
-    mutateGroup.call(this, groups[2], _.last(clinicians, 5));
+    mutateGroup(groups[2], _.last(clinicians, 5), fxPatients);
   }
 
-  return groups;
+  return { groupsData: groups, cliniciansData: clinicians };
 }
 
-function mutateGroup(group, clinicians) {
+function mutateGroup(group, clinicians, fxPatients) {
   const groupRelation = getRelationship(group, 'groups');
-  group.relationships = getGroupRelations.call(this, clinicians);
+  group.relationships = getGroupRelations(clinicians, fxPatients);
   _.each(clinicians, clinician => {
     clinician.relationships.groups.data.push(groupRelation);
   });
 }
 
-function getGroupRelations(clinicians) {
+function getGroupRelations(clinicians, fxPatients) {
   return {
-    patients: { data: getRelationship(_.sample(this.fxPatients, 2), 'patients') },
+    patients: { data: getRelationship(_.sample(fxPatients, 2), 'patients') },
     clinicians: { data: getRelationship(clinicians, 'clinicians') },
   };
 }
 
-Cypress.Commands.add('routeGroups', (mutator = _.identity, groups) => {
+Cypress.Commands.add('routeGroups', (mutator = _.identity) => {
+  cy
+    .fixture('collections/groups').as('fxGroups');
+
+  cy.route({
+    url: '/api/groups',
+    response() {
+      return mutator({
+        data: getResource(_.sample(this.fxGroups, 4), 'groups'),
+        included: [],
+      });
+    },
+  })
+    .as('routeGroups');
+});
+
+Cypress.Commands.add('routeGroupsBootstrap', (groupsMutator = _.identity, groups, cliniciansMutator = _.identity) => {
   cy
     .fixture('test/clinicians').as('fxTestClinicians')
     .fixture('collections/clinicians').as('fxClinicians')
     .fixture('collections/groups').as('fxGroups')
     .fixture('collections/patients').as('fxPatients');
 
-  cy.route({
-    url: '/api/groups?*',
-    response() {
+  cy
+    .wrap(null)
+    .then(function() {
       // Get an odd number of clinicians for group assignment.
       // The active clinician is the "halfway" one, so number 4 here
-      const clinicians = getResource(_.sample(this.fxClinicians, 9), 'clinicians');
-      clinicians[4] = getResource(this.fxTestClinicians[0], 'clinicians');
+      const fxPatients = this.fxPatients;
+      const clinicians = _.sample(this.fxClinicians, 9);
+      clinicians[4] = this.fxTestClinicians[0];
       groups = groups || _.sample(this.fxGroups, 4);
 
-      return mutator({
-        data: getGroups.call(this, groups, clinicians),
-        included: clinicians,
+      const { groupsData, cliniciansData } = makeResources(groups, clinicians, fxPatients);
+
+      cy.routeGroups(fx => {
+        fx.data = groupsData;
+
+        return groupsMutator(fx);
       });
-    },
-  })
-    .as('routeGroups');
+
+      cy.routeClinicians(fx => {
+        fx.data = cliniciansData;
+
+        return cliniciansMutator(fx);
+      });
+    });
 });

--- a/test/support/api/patient-fields.js
+++ b/test/support/api/patient-fields.js
@@ -1,0 +1,20 @@
+import _ from 'underscore';
+import { getResource } from 'helpers/json-api';
+
+Cypress.Commands.add('routePatientFields', (mutator = _.identity) => {
+  cy
+    .fixture('collections/patient-fields').as('fxPatientFields');
+
+  cy.route({
+    url: '/api/patients/**/fields',
+    response() {
+      const data = getResource(_.sample(this.fxPatientFields, 5), 'patient-fields');
+
+      return mutator({
+        data,
+        included: [],
+      });
+    },
+  })
+    .as('routePatientFields');
+});

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 import { getResource, getIncluded, getRelationship } from 'helpers/json-api';
 
+// NOTE: Uses includes for testing relationships
 Cypress.Commands.add('routePatient', (mutator = _.identity) => {
   cy
     .fixture('collections/patients').as('fxPatients')
@@ -30,6 +31,8 @@ Cypress.Commands.add('routePatient', (mutator = _.identity) => {
     },
   })
     .as('routePatient');
+
+  cy.routePatientFields();
 });
 
 Cypress.Commands.add('routePatients', (mutator = _.identity) => {

--- a/test/support/defaults.js
+++ b/test/support/defaults.js
@@ -25,5 +25,5 @@ beforeEach(function() {
     .routePatients() // Setup default patients/all route
     .routeStates()
     .routeRoles()
-    .routeGroups();
+    .routeGroupsBootstrap();
 });

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -21,6 +21,7 @@ import './api/actions';
 import './api/clinicians';
 import './api/events';
 import './api/groups';
+import './api/patient-fields';
 import './api/patients';
 import './api/program-actions';
 import './api/programs';


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch21286]

In addition to changing group clinicians in the bootstrap and patient fields to parallel requests, I looked at entity requests as a whole and tried to standardize naming and functionality.  In some places we were passing the entity to get the id and some places we were passing the id, and in those cases we didn't have the entity, so the id everywhere is probably best.

Also I found a minor bug in the model/collection fetch change we just merged.  It was aborting calls based on the root url of the entity.. so when we fetched clinicians in the bootstrap it was aborting the `clinicians/me` request due to the root url of the clinician model being the same.  So now the xhr control uses the `url` when we override it and it was modified along with recent changes which no longer use a `success` callback.

Finally the patient-actions request wasn't setting up the filter quite right, so this'll be a bug in that epic until this gets in, but I also modified the style such that changing that on its own would be conflicting.  