### PR TITLE
Remove include param from action request

### DIFF
--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -11,7 +11,7 @@ const Entity = BaseEntity.extend({
     'fetch:actions:collection:byPatient': 'fetchActionsByPatient',
   },
   fetchActions({ filter }) {
-    const data = { include: 'patient', filter };
+    const data = { filter };
 
     return this.fetchCollection({ data });
   },


### PR DESCRIPTION
Backend will enforce include.  Patient models are still included, but by default.

This is such a nothing change, if tests pass I'll merge it