### PR TITLE
Disable flow publishing when no actions are present

### DIFF
--- a/src/js/apps/admin/program/flow/flow_app.js
+++ b/src/js/apps/admin/program/flow/flow_app.js
@@ -39,6 +39,10 @@ export default SubRouterApp.extend({
     this.program = program;
     this.flow = flow;
     this.flowActions = flowActions;
+    this.programActions = Radio.request('entities', 'programActions:collection');
+
+    this.setActions();
+    this.listenTo(this.flowActions, 'update', this.setActions);
 
     this.showChildView('contextTrail', new ContextTrailView({
       model: this.flow,
@@ -56,10 +60,14 @@ export default SubRouterApp.extend({
     });
   },
 
+  setActions() {
+    this.programActions.reset(this.flowActions.invoke('getAction'));
+  },
+
   showHeader() {
     const headerView = new HeaderView({
       model: this.flow,
-      flowActions: this.flowActions,
+      programActions: this.programActions,
     });
 
     this.listenTo(headerView, {

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -9,7 +9,7 @@ const TYPE = 'program-actions';
 
 const _Model = BaseModel.extend({
   urlRoot() {
-    if (this.isNew()) return `/api/programs/${ this.get('_program') }/relationships/actions`;
+    if (this.isNew() && this.get('_program')) return `/api/programs/${ this.get('_program') }/relationships/actions`;
 
     return '/api/program-actions';
   },

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -51,6 +51,7 @@ careOptsFrontend:
           newProgramFlowAction: New Flow Action
       flowViews:
         emptyView: No Actions
+        flowStatusInfoText: A flow requires published actions before the flow can be published.
       programViews:
         contextBackBtn: Back to List
       sidebar:

--- a/src/js/views/admin/actions/actions_views.js
+++ b/src/js/views/admin/actions/actions_views.js
@@ -37,10 +37,18 @@ const PublishedComponent = Droplist.extend({
         icon: 'play-circle',
         className: 'program-action--published',
         name: i18n.publishedComponent.publishedText,
+        isDisabled: this.getOption('disablePublished'),
       },
     ]);
 
     this.setState({ selected: this.collection.find({ status: model.get('status') }) });
+  },
+  onPicklistSelect({ model }) {
+    if (model.get('isDisabled')) {
+      return;
+    }
+    this.setState('selected', model);
+    this.popRegion.empty();
   },
   onChangeSelected(selected) {
     this.triggerMethod('change:status', selected.get('status'));
@@ -58,12 +66,15 @@ const PublishedComponent = Droplist.extend({
       template: this.getTemplate(),
     };
   },
-  picklistOptions: {
-    headingText: i18n.publishedComponent.headingText,
-    getItemFormat({ attributes }) {
-      const template = hbs`<span class="{{ className }}">{{far icon}}{{ name }}</span>`;
-      return new Handlebars.SafeString(template(attributes));
-    },
+  picklistOptions() {
+    return {
+      headingText: i18n.publishedComponent.headingText,
+      getItemFormat({ attributes }) {
+        const template = hbs`<span class="{{ className }}{{#if isDisabled}} is-disabled{{/if}}">{{far icon}}{{ name }}</span>`;
+        return new Handlebars.SafeString(template(attributes));
+      },
+      infoText: this.getOption('infoText'),
+    };
   },
 });
 

--- a/src/js/views/admin/program/flow/flow_views.js
+++ b/src/js/views/admin/program/flow/flow_views.js
@@ -2,6 +2,8 @@ import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
 
+import intl from 'js/i18n';
+
 import PreloadRegion from 'js/regions/preload_region';
 
 import { DueDayComponent, OwnerComponent, PublishedComponent } from 'js/views/admin/actions/actions_views';
@@ -69,12 +71,23 @@ const HeaderView = View.extend({
   ui: {
     flow: '.js-flow',
   },
+  initialize() {
+    this.programActions = this.getOption('programActions');
+
+    this.listenTo(this.programActions, 'change:status', this.showPublished);
+  },
   onRender() {
     this.showPublished();
     this.showOwner();
   },
   showPublished() {
-    const publishedComponent = new PublishedComponent({ model: this.model, isCompact: true });
+    const disablePublished = !this.programActions.some({ status: 'published' });
+    const publishedComponent = new PublishedComponent({
+      model: this.model,
+      isCompact: true,
+      infoText: (disablePublished) ? intl.admin.program.flowViews.flowStatusInfoText : null,
+      disablePublished,
+    });
 
     this.listenTo(publishedComponent, 'change:status', status => {
       this.model.save({ status });

--- a/src/js/views/admin/program/workflows/flow-item.hbs
+++ b/src/js/views/admin/program/workflows/flow-item.hbs
@@ -3,7 +3,13 @@
   {{~#unless name}}<em>{{ @intl.admin.program.workflows.flowItemTemplate.newProgramFlow }}</em>{{/unless~}}
 </td>
 <td class="table-list__cell w-60">
-  <span class="table-list__meta" data-published-region></span>
+  <span class="table-list__meta workflows__flow-status">
+    {{#if isPublished}}
+      {{far "play-circle"}}
+    {{ else }}
+      {{far "edit"}}
+    {{/if}}
+  </span>
   <span class="table-list__meta" data-owner-region></span>
   <span class="table-list__meta" data-due-region></span>
   <span class="workflows__item-ts">{{formatMoment updated_at "TIME_OR_DAY"}}</span>

--- a/src/js/views/admin/program/workflows/workflows.scss
+++ b/src/js/views/admin/program/workflows/workflows.scss
@@ -65,6 +65,12 @@
   }
 }
 
+.workflows__flow-status {
+  display: inline-block;
+  text-align: center;
+  width: 34px;
+}
+
 .workflows__action-icon .icon {
   color: color(blue);
 }

--- a/src/js/views/admin/program/workflows/workflows_views.js
+++ b/src/js/views/admin/program/workflows/workflows_views.js
@@ -100,8 +100,12 @@ const ActionItemView = ItemView.extend({
 
 const FlowItemView = ItemView.extend({
   template: FlowItemTemplate,
+  templateContext() {
+    return {
+      isPublished: this.model.get('status') === 'published',
+    };
+  },
   onRender() {
-    this.showPublished();
     this.showOwner();
   },
   onClick() {

--- a/test/integration/admin/programs/program/workflows.js
+++ b/test/integration/admin/programs/program/workflows.js
@@ -201,28 +201,6 @@ context('program workflows page', function() {
         response: {},
       })
       .as('routePatchFlow');
-    
-    cy
-      .get('@flowItem')
-      .find('[data-published-region]')
-      .click();
-    
-    cy
-      .get('.picklist')
-      .find('.picklist__item')
-      .contains('Published')
-      .click();
-
-    cy
-      .wait('@routePatchFlow')
-      .its('request.body')
-      .should(({ data }) => {
-        expect(data.attributes.status).to.equal('published');
-      });
-    
-    cy
-      .get('@flowItem')
-      .find('.program-action--published');
 
     cy
       .get('@flowItem')
@@ -234,7 +212,7 @@ context('program workflows page', function() {
       .find('.picklist__item')
       .contains('Nurse')
       .click();
-    
+
     cy
       .wait('@routePatchFlow')
       .its('request.body')
@@ -351,10 +329,7 @@ context('program workflows page', function() {
 
     cy
       .get('@newFlow')
-      .find('[data-published-region]')
-      .find('button')
-      .should('be.disabled')
-      .find('svg')
+      .find('.workflows__flow-status svg')
       .should('have.class', 'fa-edit');
 
     cy


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch21600]

This prevents a flow from being published if there are no published actions on it.

Only thing left is to sort out styles on the droplist. Supporting a disabled item in the picklist is complicated and requires more discussion.