### PR TITLE
Make flow state read-only on lists

### DIFF
--- a/src/js/static.js
+++ b/src/js/static.js
@@ -1,0 +1,9 @@
+const PatientStatusIcons = {
+  queued: 'exclamation-circle',
+  started: 'dot-circle',
+  done: 'check-circle',
+};
+
+export {
+  PatientStatusIcons,
+};

--- a/src/js/views/admin/program/workflows/flow-item.hbs
+++ b/src/js/views/admin/program/workflows/flow-item.hbs
@@ -7,10 +7,9 @@
     {{#if isPublished}}
       <span class="program-action--published">{{far "play-circle"}}</span>
     {{ else }}
-    <span class="program-action--draft">{{far "edit"}}</span>
+      <span class="program-action--draft">{{far "edit"}}</span>
     {{/if}}
-  </span>
-  <span class="table-list__meta" data-owner-region></span>
-  <span class="table-list__meta" data-due-region></span>
+  </span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta" data-owner-region></span>{{~ remove_whitespace ~}}
   <span class="workflows__item-ts">{{formatMoment updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/actions/actions_views.js
+++ b/src/js/views/patients/actions/actions_views.js
@@ -20,11 +20,7 @@ import './actions.scss';
 
 const i18n = intl.patients.actions.actionsViews;
 
-const StatusIcons = {
-  queued: 'exclamation-circle',
-  started: 'dot-circle',
-  done: 'check-circle',
-};
+import { PatientStatusIcons } from 'js/static';
 
 const StateTemplate = hbs`<span class="action--{{ statusClass }}">{{fas statusIcon}}{{#unless isCompact}}{{ name }}{{/unless}}</span>`;
 
@@ -55,7 +51,7 @@ const StateComponent = Droplist.extend({
         return {
           isDisabled: this.getOption('isDisabled'),
           statusClass: _.dasherize(status),
-          statusIcon: StatusIcons[status],
+          statusIcon: PatientStatusIcons[status],
           isCompact,
         };
       },
@@ -68,7 +64,7 @@ const StateComponent = Droplist.extend({
 
       return new Handlebars.SafeString(StateTemplate({
         statusClass: _.dasherize(status),
-        statusIcon: StatusIcons[status],
+        statusIcon: PatientStatusIcons[status],
         name: model.get('name'),
       }));
     },

--- a/src/js/views/patients/patient/dashboard/flow-item.hbs
+++ b/src/js/views/patients/patient/dashboard/flow-item.hbs
@@ -2,8 +2,9 @@
   <span class="patient__flow-icon">{{fas "folder"}}</span>{{ name }}
 </td>
 <td class="table-list__cell w-60">
-  <span class="table-list__meta" data-state-region></span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta patient__flow-status">
+    <span class="action--{{ statusClass }}">{{fas statusIcon}}</span>
+  </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-owner-region></span>{{~ remove_whitespace ~}}
-  <span class="table-list__meta" data-attachment-region></span>{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatMoment updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -135,3 +135,10 @@
 .patient__flow-icon .icon {
   color: $black-60;
 }
+
+.patient__flow-status {
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  width: 34px;
+}

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -19,10 +19,10 @@ import 'sass/domain/action-state.scss';
 import './flow-sidebar.scss';
 
 const TimestampsView = View.extend({
-  className: 'program-flow-sidebar__timestamps',
+  className: 'patient-flow-sidebar__timestamps',
   template: hbs`
-    <div><h4 class="program-flow-sidebar__label">{{ @intl.patients.sidebar.flow.flowSidebarViews.timestampsView.createdAt }}</h4>{{formatMoment created_at "AT_TIME"}}</div>
-    <div><h4 class="program-flow-sidebar__label">{{ @intl.patients.sidebar.flow.flowSidebarViews.timestampsView.updatedAt }}</h4>{{formatMoment updated_at "AT_TIME"}}</div>
+    <div><h4 class="patient-flow-sidebar__label">{{ @intl.patients.sidebar.flow.flowSidebarViews.timestampsView.createdAt }}</h4>{{formatMoment created_at "AT_TIME"}}</div>
+    <div><h4 class="patient-flow-sidebar__label">{{ @intl.patients.sidebar.flow.flowSidebarViews.timestampsView.updatedAt }}</h4>{{formatMoment updated_at "AT_TIME"}}</div>
   `,
 });
 
@@ -31,7 +31,7 @@ const LayoutView = View.extend({
     'save': 'save',
     'cancel': 'cancel',
   },
-  className: 'program-flow-sidebar flex-region',
+  className: 'patient-flow-sidebar flex-region',
   template: FlowSidebarTemplate,
   regions: {
     state: '[data-state-region]',
@@ -60,7 +60,7 @@ const LayoutView = View.extend({
       ui: this.ui.menu,
       uiView: this,
       headingText: intl.patients.sidebar.flow.layoutView.menuOptions.headingText,
-      itemTemplate: hbs`<span class="program-flow-sidebar__delete-icon">{{far "trash-alt"}}</span>{{ @intl.patients.sidebar.flow.layoutView.menuOptions.delete }}`,
+      itemTemplate: hbs`<span class="patient-flow-sidebar__delete-icon">{{far "trash-alt"}}</span>{{ @intl.patients.sidebar.flow.layoutView.menuOptions.delete }}`,
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,

--- a/test/integration/admin/programs/sidebar/flow-sidebar.js
+++ b/test/integration/admin/programs/sidebar/flow-sidebar.js
@@ -160,11 +160,15 @@ context('flow sidebar', function() {
         fx.data.attributes.updated_at = now.format();
         fx.data.relationships.program.data.id = '1';
 
+        _.each(fx.data.relationships['program-flow-actions'].data, (programFlowAction, index) => {
+          programFlowAction.id = index + 1;
+        });
+
         return fx;
       })
       .routeProgramFlowActions(fx => {
-        _.each(fx.included, action => {
-          action.attributes.status = 'published';
+        _.each(fx.data, (programFlowAction, index) => {
+          programFlowAction.id = index + 1;
         });
 
         return fx;

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -87,7 +87,9 @@ context('patient dashboard page', function() {
       })
       .routeActionActivity()
       .visit('/patient/dashboard/1')
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
 
     // Filters out done id 55555
     cy
@@ -195,21 +197,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('@flowItem')
-      .find('[data-state-region]')
-      .find('.action--started')
-      .click();
-
-    cy
-      .get('.picklist')
-      .contains('To Do')
-      .click();
-
-    cy
-      .wait('@routePatchFlow')
-      .its('request.body')
-      .should(({ data }) => {
-        expect(data.relationships.state.data.id).to.equal('22222');
-      });
+      .find('.action--started');
 
     cy
       .get('@flowItem')
@@ -272,13 +260,14 @@ context('patient dashboard page', function() {
       .get('.table-list__item')
       .first()
       .next()
+      .next()
       .find('[data-attachment-region]')
       .should('be.empty');
 
     cy
       .get('.table-list__item')
       .first()
-      .find('[data-attachment-region] ')
+      .find('[data-attachment-region]')
       .click();
 
     cy


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch21819]

This also includes a couple of copy-paste fixes on patient flows and it moves the view sharing to behaviors.  Taking out the state was just one more thing that wasn't common between the views and we were ending up with things in those views that weren't needed, but were only there to maintain inheritance.

This also makes a static file for the state icon translation that we now need outside of the component.