### PR TITLE
Surface error stack when unsupported icon is referenced in hbs

### DIFF
--- a/src/js/base/fontawesome.js
+++ b/src/js/base/fontawesome.js
@@ -12,7 +12,9 @@ function faHelper(prefix, iconName, { hash = {} }) {
 
   /* istanbul ignore next: dev safety */
   if (!faIcon || !faIcon.html) {
-    throw new Error(`${ prefix }:${ iconName } fontawesome icon not loaded`);
+    // eslint-disable-next-line no-console
+    console.error(new Error(`${ prefix }:${ iconName } fontawesome icon not loaded`));
+    return;
   }
   return new Handlebars.SafeString(faIcon.html);
 }


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch21820]

This will surface an error stack in the console when an icon isn't supported in handlebars. It'll provide the icon name and the hbs filename. It'll also just return out of the help function so that the rest of the template will still render, just without the icon. This seems to be a more desirable result than a whole chain of templates failing to render because of a missing icon.