### PR TITLE
ie11 display fixes

### DIFF
--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -1,9 +1,15 @@
 .patient-search__modal {
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,.5);
   height: 420px;
 }
 
 .patient-search__modal-body {
   height: 100%;
+}
+
+.patient-search__picklist-container {
+  height: 100%;
+  overflow: hidden;
 }
 
 .patient-search__picklist {


### PR DESCRIPTION
Very small fix to correct how the patient search modal displays in Edge (pre-chromium). Generic picklists are rendering fine.