### PR TITLE
Hardset cypress orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1
+  cypress: cypress-io/cypress@1.13
   codecov: codecov/codecov@1.0.4
   aws-s3: circleci/aws-s3@1.0.11
 


### PR DESCRIPTION
Because we're currently stuck on Cypress 3.4.1 we're seeing: https://github.com/cypress-io/circleci-orb/issues/223
