### PR TITLE
Merge recent form response with new form fields

### DIFF
--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -103,7 +103,11 @@ const LayoutView = View.extend({
         </div>
         <div class="form__iframe--has-bar"><iframe src="/formapp/{{ id }}/response/{{ response.id }}"></iframe></div>
         {{else}}
-        <iframe src="/formapp/{{ id }}/new/{{ patient.id }}/{{ action.id }}"></iframe>
+          {{#if response}}
+          <iframe src="/formapp/{{ id }}/new/{{ patient.id }}/{{ action.id }}/{{ response.id }}"></iframe>
+          {{ else }}
+          <iframe src="/formapp/{{ id }}/new/{{ patient.id }}/{{ action.id }}"></iframe>
+          {{/if}}
         {{/if}}
       </div>
     </div>

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -275,7 +275,7 @@ context('Patient Form', function() {
 
     cy
       .get('iframe')
-      .should('have.attr', 'src', '/formapp/11111/new/2/1');
+      .should('have.attr', 'src', '/formapp/11111/new/2/1/1');
 
     cy
       .get('.form__iframe')

--- a/test/integration/forms/formapp.js
+++ b/test/integration/forms/formapp.js
@@ -20,7 +20,74 @@ context('Formapp', function() {
         reloadStub = cy.stub();
         Radio.reply('forms', 'navigateResponse', reloadStub);
       });
-    
+
+    cy
+      .get('body')
+      .should('contain', 'Family Medical History');
+
+    cy
+      .get('textarea[name="data[familyHistory]"]')
+      .type('Here is some typing');
+
+    cy
+      .get('textarea[name="data[storyTime]"]')
+      .should('have.value', 'Once upon a time...');
+
+    cy
+      .route({
+        status: 201,
+        method: 'POST',
+        url: '/api/form-responses',
+        response: { data: { id: '12345' } },
+      })
+      .as('routePostResponse');
+
+    cy
+      .get('button')
+      .click();
+
+    cy
+      .wait('@routePostResponse')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.relationships.action.data.id).to.equal('1');
+        expect(data.relationships.form.data.id).to.equal('1');
+        expect(data.attributes.response.data.storyTime).to.equal('Once upon a time...');
+        expect(data.attributes.response.data.patient.first_name).to.equal('John');
+        expect(data.attributes.response.data.patient.last_name).to.equal('Doe');
+        expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
+        expect(reloadStub).to.have.been.calledOnce.and.calledWith('1', '12345');
+      });
+  });
+
+  specify('load form with response', function() {
+    cy
+      .server()
+      .routeAction(fx => {
+        fx.data.relationships['form-responses'].data = [{ type: 'form-responses', id: '1' }];
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormFields()
+      .routeFormResponse(fx => {
+        fx.data.storyTime = 'Once upon a time...';
+
+        return fx;
+      })
+      .visit('/formapp/1/new/1/1/1')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields')
+      .wait('@routeFormResponse');
+
+    let reloadStub;
+
+    cy
+      .getRadio(Radio => {
+        reloadStub = cy.stub();
+        Radio.reply('forms', 'navigateResponse', reloadStub);
+      });
+
     cy
       .get('body')
       .should('contain', 'Family Medical History');


### PR DESCRIPTION
Since form_views already had the action entity, we were able to get the most recent response from that. That removed any need to pass the response id down from the attachment click event. Hopefully this is the right approach.