### PR TITLE
Wrapping visit changed default timeout

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -25,6 +25,5 @@
   "projectId": "ep9zr6",
   "viewportWidth": 1280,
   "viewportHeight": 768,
-  "chromeWebSecurity": false,
-  "defaultCommandTimeout": 10000
+  "chromeWebSecurity": false
 }

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -71,8 +71,9 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => {
     waits = 0;
   }
 
+  // pageLoadTimeout for visit is 60000ms
   return cy
-    .wrap(originalFn(url, options))
+    .wrap(originalFn(url, options), { timeout: 60000 })
     .wait(waits);
 });
 


### PR DESCRIPTION
From https://github.com/cypress-io/cypress/pull/7284

> NOTE: This is a breaking change.
> Previously, any promises passed as parameters to any cy command would be awaited before the function was called, and the function would be called with the result of the promise.
> With these changes, the promises will be passed directly to the function without evaluation fist.

~~I'm not convinced that this change makes any real difference.  However I haven't seen it fail locally. It might just be that we need to add a very long timeout to this one instance as it's dependent on the localhost server working in time.~~

The default timeout for `visit` is 60000ms but `wrap`ing the `visit` made it 4000ms

I'm going to run circleci a few times if it doesn't fail right away.