### PR TITLE
Fix check-in data discrepancies & check-in event display bugs

### DIFF
--- a/src/js/apps/patients/patient/data-events/data-events_app.js
+++ b/src/js/apps/patients/patient/data-events/data-events_app.js
@@ -16,7 +16,12 @@ export default App.extend({
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
       Radio.request('entities', 'fetch:flows:collection:byPatient', { patientId: patient.id, filter }),
-      Radio.request('entities', 'fetch:patientEvents:collection', patient.id),
+      Radio.request('entities', 'fetch:patientEvents:collection', {
+        patientId: patient.id,
+        filter: {
+          type: 'PatientCheckInCompleted',
+        },
+      }),
     ];
   },
   onStart({ patient }, [actions], [flows], [events]) {

--- a/src/js/base/moment.js
+++ b/src/js/base/moment.js
@@ -45,7 +45,7 @@ Handlebars.registerHelper({
   formatMoment(date, format, { hash = {} }) {
     if (!date) return new Handlebars.SafeString(hash.defaultHtml || '');
 
-    date = moment(date, hash.inputFormat);
+    date = hash.utc ? moment.utc(date, hash.inputFormat).local() : moment(date, hash.inputFormat);
 
     date = formatDate(date, format);
 

--- a/src/js/entities-service/entities/check-ins.js
+++ b/src/js/entities-service/entities/check-ins.js
@@ -11,6 +11,9 @@ const _Model = BaseModel.extend({
   getContent() {
     return new Backbone.Collection(this.get('content'));
   },
+  parseModel(data) {
+    return data.checkin;
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/patient-events.js
+++ b/src/js/entities-service/patient-events.js
@@ -7,9 +7,12 @@ const Entity = BaseEntity.extend({
     'patientEvents:model': 'getModel',
     'fetch:patientEvents:collection': 'fetchPatientEvents',
   },
-  fetchPatientEvents({ patientId }) {
-    const url = `/api/patient/${ patientId }/relationships/events`;
-    return this.fetchCollection({ url });
+  fetchPatientEvents({ patientId, filter }) {
+    const url = `/api/patient/${ patientId }/relationships/events?`;
+    return this.fetchCollection({
+      url,
+      data: { filter },
+    });
   },
 });
 

--- a/src/js/views/check-ins/check-in/check-in.scss
+++ b/src/js/views/check-ins/check-in/check-in.scss
@@ -67,6 +67,10 @@
   &:last-of-type {
     border-bottom: none;
   }
+
+  li {
+    margin-left: 24px;
+  }
 }
 
 .check-in__patient-answer {

--- a/src/js/views/check-ins/check-in/check-in_views.js
+++ b/src/js/views/check-ins/check-in/check-in_views.js
@@ -12,7 +12,7 @@ const ContextTrailView = View.extend({
   <a class="js-back check-in__context-link">
     {{fas "chevron-left"}}{{ @intl.checkIns.checkInViews.contextTrailView.backBtn }}
   </a>
-  {{fas "chevron-right"}}{{ patient.first_name }} {{ patient.last_name }} - {{formatHTMLMessage (intlGet "checkIns.checkInViews.contextTrailView.checkInCompleted") date=(formatMoment finished_at "LONG" inputFormat="YYYY-MM-DD") }}
+  {{fas "chevron-right"}}{{ patient.first_name }} {{ patient.last_name }} - {{formatHTMLMessage (intlGet "checkIns.checkInViews.contextTrailView.checkInCompleted") date=(formatMoment finishedTs "LONG") utc=true }}
   `,
   templateContext() {
     const patient = this.patient;

--- a/src/js/views/patients/patient/data-events/data-events_views.js
+++ b/src/js/views/patients/patient/data-events/data-events_views.js
@@ -206,8 +206,8 @@ const ListView = CollectionView.extend({
   },
   emptyView: EmptyView,
   viewComparator({ model: modelA }, { model: modelB }) {
-    const modelAAttr = modelA.get('updated_at') || modelA.get('finished_at');
-    const modelBAttr = modelB.get('updated_at') || modelB.get('finished_at');
+    const modelAAttr = modelA.get('updated_at') || modelA.get('date');
+    const modelBAttr = modelB.get('updated_at') || modelB.get('date');
     return - modelAAttr.localeCompare(modelBAttr);
   },
   viewFilter({ model }) {

--- a/test/fixtures/config/patient-events.js
+++ b/test/fixtures/config/patient-events.js
@@ -15,8 +15,7 @@ module.exports = {
 
     const baseAttributes = {
       event_type: null,
-      started_at: faker.date.past(),
-      finished_at: faker.date.past(),
+      date: faker.date.past(),
     };
 
     const event_types = {

--- a/test/fixtures/test/check-in-response.json
+++ b/test/fixtures/test/check-in-response.json
@@ -1,14 +1,5 @@
 {
-  "id": 6717,
-  "issue_id": 14,
-  "evaluated": true,
-  "started": "2015-11-19 15:50:14.000000",
-  "finished": "2015-11-19 15:50:41.000000",
-  "checkin_duration": 31,
-  "organization_patient_id": 1669,
-  "requesting_user_id": null,
-  "responder": "patient",
-  "_type": "checkin",
+  "finishedTs": "2020-06-17 16:05:22",
   "content": [
     {
       "response_id": 6717,
@@ -118,6 +109,61 @@
       ],
       "duration": 1,
       "viewed_ts": "2015-11-19 15:50:35",
+      "answered_by_role": "patient",
+      "_answer": null,
+      "_is_question": false
+    },
+    {
+      "response_id": 157,
+      "content_id": 9524,
+      "message_id": null,
+      "type": "copy",
+      "content": {
+        "id": 9524,
+        "type": "copy",
+        "label": "Let’s Get Organized",
+        "body": "<span>It can be difficult to keep track of all your medications. Here are some tips to stay organized:\n<br><\/span><ul><li>Make a list. Write down the names of your medications. Then add&nbsp;information about how to take them, the dose to take, and why you need them. Let us know if you need help making a list like this.<\/li><li>Use a pill sorter. Have you ever seen one of those boxes with separate compartments for each day of the week? That’s a pill sorter. Sort your medications at the beginning of each week to make it easier.<\/li><li><span>Ask a loved one to help you. Sometimes it helps to have another set of eyes on your medication schedule.<br><\/span><\/li><\/ul>We can talk about this in more detail at your next visit. In the meantime, do your best to take all your medications as directed!",
+        "why": null,
+        "attributes": {
+          "mask": "",
+          "required": "0"
+        },
+        "options": [],
+        "aspects": [],
+        "rules": [
+          {
+            "id": 11941,
+            "subject_content_id": 9524,
+            "content_id": 9523,
+            "content_option_id": 11109,
+            "algorithm": null,
+            "quantifier": "=",
+            "value": null,
+            "attributes": null,
+            "created": "2016-05-27 02:40:42.825196",
+            "updated": null
+          }
+        ],
+        "from_module": {
+          "id": 1,
+          "name": "Heart Failure Post",
+          "type": "core"
+        },
+        "_required": false,
+        "_mask": ""
+      },
+      "name": null,
+      "score": 0,
+      "answers": [
+        {
+          "content_aspect_id": null,
+          "content_aspect_label": null,
+          "content_option_id": null,
+          "answer": null
+        }
+      ],
+      "duration": 4,
+      "viewed_ts": "2020-06-17 16:04:57",
       "answered_by_role": "patient",
       "_answer": null,
       "_is_question": false
@@ -237,13 +283,5 @@
       "_answer": null,
       "_is_question": false
     }
-  ],
-  "_clinician_name": null,
-  "_permissions": [
-    "create",
-    "get",
-    "update_finished",
-    "status"
-  ],
-  "_related": []
+  ]
 }

--- a/test/fixtures/test/patient-events.json
+++ b/test/fixtures/test/patient-events.json
@@ -2,8 +2,7 @@
   {
     "id": "11111",
     "attributes": {
-      "started_at": "2019-09-09T23:02:56.723Z",
-      "finished_at": "2019-09-09T23:10:56.723Z",
+      "date": "2019-09-09T23:10:56.723Z",
       "type": "EngagementCheckInCompleted"
     },
     "relationships": {

--- a/test/integration/check-ins/check-in.js
+++ b/test/integration/check-ins/check-in.js
@@ -4,7 +4,7 @@ import formatDate from 'helpers/format-date';
 
 context('patient check-in', function() {
   specify('display patient check-in', function() {
-    const completedDate = moment().subtract(7, 'days');
+    const completedDate = '2020-06-17 16:05:22';
 
     cy
       .server()
@@ -15,7 +15,7 @@ context('patient check-in', function() {
         return fx;
       })
       .routePatientCheckIn(fx => {
-        fx.data.attributes.finished_at = completedDate.format();
+        fx.data.checkin.finishedTs = completedDate;
 
         return fx;
       })
@@ -27,7 +27,7 @@ context('patient check-in', function() {
       .get('.check-in__frame')
       .find('.check-in__context-trail')
       .should('contain', 'Test Patient')
-      .should('contain', formatDate(completedDate, 'LONG'));
+      .should('contain', formatDate(moment.utc(completedDate).local(), 'LONG'));
 
     cy
       .get('.check-in__frame')

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -82,10 +82,10 @@ context('patient data and events page', function() {
         fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '7';
-        fx.data[0].attributes.finished_at = moment.utc().subtract(4, 'days').format();
+        fx.data[0].attributes.date = moment.utc().subtract(4, 'days').format();
         fx.data[0].relationships.patient.data.id = '1';
         fx.data[1].id = '8';
-        fx.data[1].attributes.finished_at = moment.utc().subtract(5, 'days').format();
+        fx.data[1].attributes.date = moment.utc().subtract(5, 'days').format();
         fx.data[1].relationships.patient.data.id = '1';
 
         return fx;

--- a/test/support/api/check-ins.js
+++ b/test/support/api/check-ins.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import { getResource } from 'helpers/json-api';
 
 Cypress.Commands.add('routePatientCheckIn', (mutator = _.identity) => {
   cy
@@ -9,8 +8,9 @@ Cypress.Commands.add('routePatientCheckIn', (mutator = _.identity) => {
     url: /api\/patients\/.\/checkins\?filter\[checkin\]/,
     response() {
       return mutator({
-        data: getResource(this.fxCheckInResponse, 'check-ins'),
-        included: [],
+        data: {
+          checkin: this.fxCheckInResponse,
+        },
       });
     },
   })


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch22743]

- Aligns FE data structure expectations with what is actually returned from the BE. This includes overriding `parseModel` on the check-in entity because BE has to format the response as `data.checkin` instead of `data.attributes`.
- Applies a filter to the patient events request to only retrieve `PatientCheckInCompleted` type.
