### PR TITLE
Bulk action flow data

### DIFF
--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -34,4 +34,16 @@ export default Backbone.Collection.extend(_.extend({
 
     return _.map(response.data, this.parseModel, this);
   },
+  destroy(options) {
+    return this.sync('delete', this, {
+      url: _.result(this, 'url'),
+      data: JSON.stringify({
+        data: _.pluck(this.models, 'id', 'type'),
+      }),
+    }).always(() => {
+      this.models.each(action => {
+        action.trigger('destroy', action, action.collection, options);
+      });
+    });
+  },
 }, JsonApiMixin));

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -86,15 +86,18 @@ const _Model = BaseModel.extend({
       },
     });
   },
-  saveAll(attrs) {
-    attrs = _.extend({}, this.attributes, attrs);
-
-    const relationships = {
+  getSaveRelationships(attrs) {
+    return {
       'form': this.toRelation(attrs._form, 'forms'),
       'owner': this.toRelation(attrs._owner),
       'state': this.toRelation(attrs._state, 'states'),
       'program-action': this.toRelation(attrs._program_action, 'program-actions'),
     };
+  },
+  saveAll(attrs) {
+    attrs = _.extend({}, this.attributes, attrs);
+
+    const relationships = this.getSaveRelationships(attrs);
 
     return this.save(attrs, { relationships }, { wait: true });
   },
@@ -106,6 +109,24 @@ const Collection = BaseCollection.extend({
   url: '/api/actions',
   model: Model,
   parseRelationship: _parseRelationship,
+  save(attrs = {}) {
+    if (attrs.due_date === null) {
+      attrs.due_time = null;
+    }
+
+    const data = this.map(action => {
+      const actionData = action.toJSONApi(attrs);
+
+      actionData.relationships = action.getSaveRelationships(attrs);
+
+      return actionData;
+    });
+
+    return this.sync('patch', this, {
+      url: _.result(this, 'url'),
+      data: JSON.stringify({ data }),
+    });
+  },
 });
 
 export {

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import _ from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
@@ -54,8 +53,7 @@ const _Model = BaseModel.extend({
 
     this.set({ _role: role.id });
 
-    $.ajax({
-      type: 'PUT',
+    this.sync('update', this, {
       url,
       data: JSON.stringify(this.toRelation(role)),
     });

--- a/src/js/entities-service/entities/groups.js
+++ b/src/js/entities-service/entities/groups.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import _ from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
@@ -29,8 +28,7 @@ const _Model = BaseModel.extend({
 
     this.set({ _clinicians: _.union(this.get('_clinicians'), [{ id: clinician.id }]) });
 
-    $.ajax({
-      type: 'POST',
+    return this.sync('create', this, {
       url,
       data: JSON.stringify({
         data: [{
@@ -49,8 +47,7 @@ const _Model = BaseModel.extend({
       _clinicians: _.reject(this.get('_clinicians'), { id: clinician.id }),
     });
 
-    $.ajax({
-      type: 'DELETE',
+    return this.sync('delete', this, {
       url,
       data: JSON.stringify({
         data: [{


### PR DESCRIPTION
So after some back and forth on things, it seems like the data can be this simple... but we'll be doing a bit more work setting up the data for `save`.  Likely we'll want to setup a model for the sidebar that the component update which then gets passed to the `collection.save` on the `save` button.  The `save` will update the models automatically when the server responds unless there's an error.  If there's an error we'll want the sidebar to pass that error up to the worklist and display an alert that says "Uh oh, one or more actions could not be updated." and then the worklist will need to restart to re-request the actions/flows as some of the request may have been successful.  If this all makes sense we can talk through next steps if needed.