### PR TITLE
Vertically center loading spinner

### DIFF
--- a/src/js/regions/preload.scss
+++ b/src/js/regions/preload.scss
@@ -1,7 +1,9 @@
 .spinner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
   position: relative;
-  top: 50%;
-  transform: translate(0, -50%);
 }
 
 .spinner-circle {

--- a/src/js/views/admin/list/reports-all_views.js
+++ b/src/js/views/admin/list/reports-all_views.js
@@ -26,6 +26,7 @@ const ListView = CollectionView.extend({
 });
 
 const LayoutView = View.extend({
+  className: 'flex-region',
   template: hbs`
   <div class="list-page__header">
     <div class="list-page__title">{{ @intl.admin.list.reportsAllViews.layoutView.title }}</div>


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch22910]

Using flex to vertically center the loading spinner. Verified with a visual check of the prelogin view, list views, and sidebar views.