### PR TITLE
Use checkin_id to route to patient checkin from data and events

### DIFF
--- a/src/js/views/patients/patient/data-events/data-events_views.js
+++ b/src/js/views/patients/patient/data-events/data-events_views.js
@@ -166,7 +166,7 @@ const FlowItemView = View.extend({
   },
 });
 
-const PatientEventItemView = View.extend({
+const PatientCheckInItemView = View.extend({
   className: 'table-list__item',
   tagName: 'tr',
   behaviors: [RowBehavior],
@@ -183,7 +183,7 @@ const PatientEventItemView = View.extend({
     'click': 'click',
   },
   onClick() {
-    Radio.trigger('event-router', 'checkin', this.model.get('_patient'), this.model.id);
+    Radio.trigger('event-router', 'checkin', this.model.get('_patient'), this.model.get('checkin_id'));
   },
 });
 
@@ -194,8 +194,8 @@ const ListView = CollectionView.extend({
   className: 'table-list patient__list',
   tagName: 'table',
   childView(item) {
-    if (item.type === 'patient-events') {
-      return PatientEventItemView;
+    if (item.get('event_type') === 'PatientCheckInCompleted') {
+      return PatientCheckInItemView;
     }
 
     if (item.type === 'flows') {

--- a/test/fixtures/config/patient-events.js
+++ b/test/fixtures/config/patient-events.js
@@ -19,10 +19,13 @@ module.exports = {
     };
 
     const event_types = {
-      EngagementCheckInCompleted() {
+      PatientCheckInCompleted() {
         return {
           relationships: _.clone(baseRelationships),
-          attributes: _.clone(baseAttributes),
+          attributes: _.extend({}, baseAttributes, {
+            checkin_id: faker.random.uuid(),
+            type: 'PatientCheckInCompleted',
+          }),
         };
       },
     };

--- a/test/fixtures/test/patient-events.json
+++ b/test/fixtures/test/patient-events.json
@@ -3,7 +3,9 @@
     "id": "11111",
     "attributes": {
       "date": "2019-09-09T23:10:56.723Z",
-      "type": "EngagementCheckInCompleted"
+      "type": "PatientCheckInCompleted",
+      "event_type": "PatientCheckInCompleted",
+      "checkin_id": "11111"
     },
     "relationships": {
       "check-in": {

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -81,10 +81,10 @@ context('patient data and events page', function() {
       .routePatientEvents(fx => {
         fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].id = '7';
+        fx.data[0].attributes.checkin_id = '7';
         fx.data[0].attributes.date = moment.utc().subtract(4, 'days').format();
         fx.data[0].relationships.patient.data.id = '1';
-        fx.data[1].id = '8';
+        fx.data[1].attributes.checkin_id = '8';
         fx.data[1].attributes.date = moment.utc().subtract(5, 'days').format();
         fx.data[1].relationships.patient.data.id = '1';
 


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch22918]

Fixed the patient check-in item in data and events so that it uses the `checkin_id` instead of `id` for routing. Also modified the view to explicitly check for `event_type: PatientCheckInCompleted` since other events won't have a `checkin_id`.