### PR TITLE
Add test helpers for moment

### DIFF
--- a/test/integration/admin/lists/clinicians-all.js
+++ b/test/integration/admin/lists/clinicians-all.js
@@ -1,9 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
-import formatDate from 'helpers/format-date';
 
-const now = moment.utc();
-const local = moment();
+import formatDate from 'helpers/format-date';
+import { testTs } from 'helpers/test-moment';
 
 context('clinicians list', function() {
   specify('display clinicians list', function() {
@@ -40,7 +38,7 @@ context('clinicians list', function() {
         fx.data[0].id = '1';
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.access = 'employee';
-        fx.data[0].attributes.last_active_at = now.format();
+        fx.data[0].attributes.last_active_at = testTs();
         fx.data[0].relationships.role.data.id = '11111';
 
         fx.data[1].attributes.name = 'Baron Baronson';
@@ -80,7 +78,7 @@ context('clinicians list', function() {
       .find('.clinician-state--active')
       .parents('.table-list__cell')
       .next()
-      .should('contain', formatDate(local, 'TIME_OR_DAY'))
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'))
       .prev()
       .contains('Employee')
       .click();

--- a/test/integration/admin/lists/programs-all.js
+++ b/test/integration/admin/lists/programs-all.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
-import moment from 'moment';
+
+import { testTs, testTsSubtract } from 'helpers/test-moment';
 
 context('program all list', function() {
   specify('display programs list', function() {
@@ -13,20 +14,20 @@ context('program all list', function() {
           attributes: {
             name: 'First in List',
             published: true,
-            updated_at: moment().utc().format(),
+            updated_at: testTs(),
           },
         };
 
         fx.data[1].attributes = {
           name: 'Last in List',
           published: true,
-          updated_at: moment().utc().subtract(2, 'days').format(),
+          updated_at: testTsSubtract(2),
         };
 
         fx.data[2].attributes = {
           name: 'Second in List, Not Published',
           published: false,
-          updated_at: moment().utc().subtract(1, 'day').format(),
+          updated_at: testTsSubtract(1),
         };
 
         return fx;

--- a/test/integration/admin/programs/program/program-flow.js
+++ b/test/integration/admin/programs/program/program-flow.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
-import moment from 'moment';
 
-const now = moment.utc();
+import { testTs } from 'helpers/test-moment';
 
 context('program flow page', function() {
   specify('context trail', function() {
@@ -11,7 +10,7 @@ context('program flow page', function() {
         fx.data.id = '1';
 
         fx.data.attributes.name = 'Test Flow';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
 
         return fx;
       })
@@ -128,7 +127,7 @@ context('program flow page', function() {
         fx.data.attributes.name = 'Test Flow';
         fx.data.attributes.details = 'Test Flow Details';
         fx.data.attributes.status = 'draft';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
 
         fx.data.relationships['program-actions'].data = _.sample(fx.data.relationships['program-actions'].data, 5);
 
@@ -413,7 +412,7 @@ context('program flow page', function() {
 
         fx.data[0].attributes.sequence = 0;
         fx.data[0].attributes.name = 'First In List';
-        fx.data[0].attributes.updated_at = moment.utc().format();
+        fx.data[0].attributes.updated_at = testTs();
         fx.data[0].attributes.status = 'draft';
         fx.data[0].relationships.owner.data = null;
         fx.data[0].relationships.form.data = { id: '11111' };
@@ -499,8 +498,8 @@ context('program flow page', function() {
             id: '98765',
             attributes: {
               name: 'Test Name',
-              created_at: now.format(),
-              updated_at: now.format(),
+              created_at: testTs(),
+              updated_at: testTs(),
             },
             relationships: {
               'program-flow': { data: { id: '1' } },

--- a/test/integration/admin/programs/program/program.js
+++ b/test/integration/admin/programs/program/program.js
@@ -1,6 +1,4 @@
-import moment from 'moment';
-
-const now = moment.utc();
+import { testTs } from 'helpers/test-moment';
 
 context('program page', function() {
   specify('context trail', function() {
@@ -10,7 +8,7 @@ context('program page', function() {
         fx.data[0].id = '1';
 
         fx.data[0].attributes.name = 'Test Program';
-        fx.data[0].attributes.updated_at = moment().utc().format();
+        fx.data[0].attributes.updated_at = testTs();
 
         return fx;
       })
@@ -52,8 +50,8 @@ context('program page', function() {
         fx.data.attributes.name = 'Test Program';
         fx.data.attributes.details = null;
         fx.data.attributes.published = true;
-        fx.data.attributes.created_at = now.format();
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.created_at = testTs();
+        fx.data.attributes.updated_at = testTs();
 
         return fx;
       })

--- a/test/integration/admin/programs/program/workflows.js
+++ b/test/integration/admin/programs/program/workflows.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
-import moment from 'moment';
+
+import { testTs, testTsSubtract } from 'helpers/test-moment';
 
 context('program workflows page', function() {
   specify('actions in list', function() {
@@ -10,8 +11,8 @@ context('program workflows page', function() {
         details: null,
         status: 'published',
         days_until_due: null,
-        created_at: moment.utc().format(),
-        updated_at: moment.utc().format(),
+        created_at: testTs(),
+        updated_at: testTs(),
       },
       relationships: {
         program: { data: { id: '1' } },
@@ -37,10 +38,10 @@ context('program workflows page', function() {
         fx.data[0] = testAction;
 
         fx.data[1].attributes.name = 'Third In List';
-        fx.data[1].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
 
         fx.data[2].attributes.name = 'Second In List';
-        fx.data[2].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(1);
 
 
         return fx;
@@ -54,7 +55,7 @@ context('program workflows page', function() {
 
         fx.data[0].attributes.name = 'Fourth In List';
         fx.data[0].relationships.owner.data = null;
-        fx.data[0].attributes.updated_at = moment.utc().subtract(3, 'days').format();
+        fx.data[0].attributes.updated_at = testTsSubtract(3);
 
         return fx;
       }, '1')
@@ -394,7 +395,7 @@ context('program workflows page', function() {
           return {
             id: '1',
             attributes: {
-              updated_at: moment.utc().format(),
+              updated_at: testTs(),
               name: 'Test Flow',
             },
           };

--- a/test/integration/admin/sidebar/action-sidebar.js
+++ b/test/integration/admin/sidebar/action-sidebar.js
@@ -1,10 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
 
 import formatDate from 'helpers/format-date';
-
-const now = moment.utc();
-const local = moment();
+import { testTs } from 'helpers/test-moment';
 
 context('program action sidebar', function() {
   specify('display new action sidebar', function() {
@@ -123,8 +120,8 @@ context('program action sidebar', function() {
           data: {
             id: '1',
             attributes: {
-              created_at: now.format(),
-              updated_at: now.format(),
+              created_at: testTs(),
+              updated_at: testTs(),
             },
           },
         },
@@ -135,8 +132,8 @@ context('program action sidebar', function() {
       .routeProgramAction(fx => {
         fx.data.id = '1';
         fx.data.attributes.name = 'Test Name';
-        fx.data.attributes.created_at = local.format();
-        fx.data.attributes.updated_at = local.format();
+        fx.data.attributes.created_at = testTs();
+        fx.data.attributes.updated_at = testTs();
         return fx;
       });
 
@@ -167,13 +164,13 @@ context('program action sidebar', function() {
       .get('.sidebar__footer')
       .contains('Created')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar')
@@ -258,8 +255,8 @@ context('program action sidebar', function() {
         details: 'Details',
         status: 'published',
         days_until_due: 5,
-        created_at: now.format(),
-        updated_at: now.format(),
+        created_at: testTs(),
+        updated_at: testTs(),
       },
       relationships: {
         owner: {
@@ -485,13 +482,13 @@ context('program action sidebar', function() {
       .get('.sidebar__footer')
       .contains('Created')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
   });
 
   specify('display action sidebar with no org forms', function() {

--- a/test/integration/admin/sidebar/clinician-sidebar.js
+++ b/test/integration/admin/sidebar/clinician-sidebar.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
 
 import { getError } from 'helpers/json-api';
+import { testTs } from 'helpers/test-moment';
 
 const stateColors = Cypress.env('stateColors');
 
@@ -24,7 +24,7 @@ context('clinician sidebar', function() {
         name: 'Test Clinician',
         email: 'test.clinician@roundingwell.com',
         access: 'employee',
-        last_active_at: moment.utc().format(),
+        last_active_at: testTs(),
       },
       relationships: {
         role: { data: { id: '11111' } },

--- a/test/integration/admin/sidebar/flow-sidebar.js
+++ b/test/integration/admin/sidebar/flow-sidebar.js
@@ -1,10 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
 
 import formatDate from 'helpers/format-date';
-
-const now = moment.utc();
-const local = moment();
+import { testTs } from 'helpers/test-moment';
 
 context('flow sidebar', function() {
   specify('display new flow sidebar', function() {
@@ -119,8 +116,8 @@ context('flow sidebar', function() {
           data: {
             id: '1',
             attributes: {
-              created_at: now.format(),
-              updated_at: now.format(),
+              created_at: testTs(),
+              updated_at: testTs(),
             },
           },
         },
@@ -162,8 +159,8 @@ context('flow sidebar', function() {
         fx.data.attributes.name = 'Test Flow';
         fx.data.attributes.details = '';
         fx.data.attributes.status = 'draft';
-        fx.data.attributes.created_at = now.format();
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.created_at = testTs();
+        fx.data.attributes.updated_at = testTs();
         fx.data.relationships.program.data.id = '1';
 
         _.each(fx.data.relationships['program-actions'].data, (programFlowAction, index) => {
@@ -326,13 +323,13 @@ context('flow sidebar', function() {
       .get('.sidebar__footer')
       .contains('Created')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('@flowSidebar')

--- a/test/integration/admin/sidebar/program-sidebar.js
+++ b/test/integration/admin/sidebar/program-sidebar.js
@@ -1,13 +1,11 @@
 import _ from 'underscore';
-import moment from 'moment';
 
 import formatDate from 'helpers/format-date';
 
 import { getError } from 'helpers/json-api';
+import { testTs } from 'helpers/test-moment';
 
 const stateColors = Cypress.env('stateColors');
-const now = moment.utc();
-const local = moment();
 
 context('program sidebar', function() {
   specify('display new program sidebar', function() {
@@ -126,8 +124,8 @@ context('program sidebar', function() {
             attributes: {
               name: 'Test Program Name',
               published: false,
-              updated_at: now.format(),
-              created_at: now.format(),
+              updated_at: testTs(),
+              created_at: testTs(),
             },
           },
         },
@@ -157,7 +155,7 @@ context('program sidebar', function() {
       .get('.table-list__item')
       .first()
       .should('contain', 'Test Program Name')
-      .should('contain', formatDate(local, 'TIME_OR_DAY'));
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
 
     cy
       .get('.js-add')
@@ -172,8 +170,8 @@ context('program sidebar', function() {
         name: 'Name',
         details: '',
         published: false,
-        created_at: now.format(),
-        updated_at: now.format(),
+        created_at: testTs(),
+        updated_at: testTs(),
       },
     };
 
@@ -298,12 +296,12 @@ context('program sidebar', function() {
       .get('.sidebar__footer')
       .contains('Created')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
   });
 });

--- a/test/integration/components/datepicker.js
+++ b/test/integration/components/datepicker.js
@@ -4,6 +4,7 @@ import { View } from 'marionette';
 import moment from 'moment';
 
 import hbs from 'handlebars-inline-precompile';
+import { testTs, testTsAdd } from 'helpers/test-moment';
 
 import formatDate from 'helpers/format-date';
 
@@ -74,9 +75,9 @@ context('Datepicker', function() {
 
     cy
       .get('.datepicker')
-      .should('contain', formatDate(moment(), 'MMM YYYY'))
+      .should('contain', formatDate(testTs(), 'MMM YYYY'))
       .find('.is-today')
-      .should('contain', formatDate(moment(), 'D'));
+      .should('contain', formatDate(testTs(), 'D'));
 
     cy
       .get('.datepicker')
@@ -89,13 +90,13 @@ context('Datepicker', function() {
 
     cy
       .get('@hook')
-      .contains(formatDate(moment(), 'LONG'))
+      .contains(formatDate(testTs(), 'LONG'))
       .click();
 
     cy
       .get('.datepicker')
       .find('.is-selected')
-      .should('contain', moment().format('D'));
+      .should('contain', formatDate(testTs(), 'D'));
 
     cy
       .get('.datepicker')
@@ -104,7 +105,7 @@ context('Datepicker', function() {
 
     cy
       .get('@hook')
-      .contains(formatDate(moment().add(1, 'days'), 'LONG'))
+      .contains(formatDate(testTsAdd(1), 'LONG'))
       .click();
 
     cy
@@ -129,18 +130,18 @@ context('Datepicker', function() {
 
     cy
       .get('.datepicker')
-      .contains(formatDate(moment().add(1, 'months'), 'MMM'))
+      .contains(formatDate(testTsAdd(1, 'months'), 'MMM'))
       .click();
 
     cy
       .get('.datepicker')
-      .should('contain', formatDate(moment().add(1, 'months'), 'MMM YYYY'))
-      .contains(formatDate(moment(), 'MMM'))
+      .should('contain', formatDate(testTsAdd(1, 'months'), 'MMM YYYY'))
+      .contains(formatDate(testTs(), 'MMM'))
       .click();
 
     cy
       .get('.datepicker')
-      .should('contain', formatDate(moment(), 'MMM YYYY'));
+      .should('contain', formatDate(testTs(), 'MMM YYYY'));
 
     cy
       .then(() => {

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
 
 import formatDate from 'helpers/format-date';
+import { testTs, testTsSubtract } from 'helpers/test-moment';
 
 context('Patient Form', function() {
   specify('deleted action', function() {
@@ -236,8 +236,8 @@ context('Patient Form', function() {
         fx.data.relationships.patient.data = { id: '2' };
         fx.data.relationships.form.data = { id: '11111' };
         fx.data.relationships['form-responses'].data = [
-          { id: '2', meta: { created_at: moment.utc().subtract(1, 'days').format() } },
-          { id: '1', meta: { created_at: moment.utc().format() } },
+          { id: '2', meta: { created_at: testTsSubtract(1) } },
+          { id: '1', meta: { created_at: testTs() } },
         ];
         return fx;
       })
@@ -276,7 +276,7 @@ context('Patient Form', function() {
     cy
       .get('.form__iframe')
       .should('contain', 'Last saved')
-      .and('contain', formatDate(moment(), 'AT_TIME'))
+      .and('contain', formatDate(testTs(), 'AT_TIME'))
       .find('.js-update')
       .click();
 

--- a/test/integration/forms/formapp.js
+++ b/test/integration/forms/formapp.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { testDate } from 'helpers/test-moment';
 
 context('Formapp', function() {
   specify('load basic form', function() {
@@ -237,6 +237,6 @@ context('Formapp', function() {
     cy
       .get('@formIOComponent')
       .find('.formio-component-datetime input[type=text]')
-      .should('have.value', `${ moment().format('YYYY-MM-DD') } 12:00 PM`);
+      .should('have.value', `${ testDate() } 12:00 PM`);
   });
 });

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
-import moment from 'moment';
+
+import { testTs, testDate, testDateAdd, testTsSubtract } from 'helpers/test-moment';
 
 function createActionPostRoute(id) {
   cy
@@ -12,7 +13,7 @@ function createActionPostRoute(id) {
           data: {
             id,
             attributes: {
-              updated_at: moment.utc().format(),
+              updated_at: testTs(),
               due_time: null,
             },
           },
@@ -32,7 +33,7 @@ context('patient dashboard page', function() {
         duration: 0,
         due_date: null,
         due_time: null,
-        updated_at: moment.utc().format(),
+        updated_at: testTs(),
       },
       relationships: {
         patient: { data: { id: '1' } },
@@ -72,11 +73,11 @@ context('patient dashboard page', function() {
 
         fx.data[2].attributes.name = 'Third In List';
         fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(2);
 
         fx.data[1].attributes.name = 'Not In List';
         fx.data[1].relationships.state = { data: { id: '55555' } };
-        fx.data[1].attributes.updated_at = moment.utc().subtract(5, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(5);
 
         return fx;
       }, '1')
@@ -85,7 +86,7 @@ context('patient dashboard page', function() {
 
         fx.data[0].attributes.name = 'Second In List';
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
 
         fx.data[2].attributes.name = 'Last In List';
         fx.data[2].id = '2';
@@ -96,11 +97,11 @@ context('patient dashboard page', function() {
             type: 'roles',
           },
         };
-        fx.data[2].attributes.updated_at = moment.utc().subtract(5, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(5);
 
         fx.data[1].attributes.name = 'Not In List';
         fx.data[1].relationships.state = { data: { id: '55555' } };
-        fx.data[1].attributes.updated_at = moment.utc().subtract(5, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(5);
 
         return fx;
       }, '1')
@@ -219,7 +220,7 @@ context('patient dashboard page', function() {
       .its('request.body')
       .should(({ data }) => {
         // Datepicker doesn't use timestamp so due_date is local.
-        expect(data.attributes.due_date).to.equal(moment().format('YYYY-MM-DD'));
+        expect(data.attributes.due_date).to.equal(testDate());
       });
 
     cy
@@ -624,7 +625,7 @@ context('patient dashboard page', function() {
         expect(data.attributes.name).to.equal('One of One');
         expect(data.attributes.details).to.equal('details');
         expect(data.attributes.duration).to.equal(0);
-        expect(data.attributes.due_date).to.equal(moment().add(1, 'days').format('YYYY-MM-DD'));
+        expect(data.attributes.due_date).to.equal(testDateAdd(1));
         expect(data.attributes.due_time).to.be.undefined;
         expect(data.relationships.state.data.id).to.equal('22222');
         expect(data.relationships.owner.data.id).to.equal('11111');
@@ -682,7 +683,7 @@ context('patient dashboard page', function() {
         expect(data.attributes.name).to.equal('One of Two');
         expect(data.attributes.details).to.equal('');
         expect(data.attributes.duration).to.equal(0);
-        expect(data.attributes.due_date).to.equal(moment().format('YYYY-MM-DD'));
+        expect(data.attributes.due_date).to.equal(testDate());
         expect(data.attributes.due_time).to.be.undefined;
         expect(data.relationships.state.data.id).to.equal('22222');
         expect(data.relationships.owner.data.id).to.be.equal('11111');
@@ -762,7 +763,7 @@ context('patient dashboard page', function() {
           return {
             data: {
               id: '1',
-              attributes: { updated_at: moment.utc().format() },
+              attributes: { updated_at: testTs() },
             },
           };
         },

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
+
 import formatDate from 'helpers/format-date';
+import { testTs, testTsSubtract } from 'helpers/test-moment';
 
 context('patient data and events page', function() {
   specify('action, flow and events list', function() {
@@ -33,7 +34,7 @@ context('patient data and events page', function() {
             duration: 0,
             due_date: null,
             due_time: null,
-            updated_at: moment.utc().format(),
+            updated_at: testTs(),
           },
           relationships: {
             patient: { data: { id: '11111' } },
@@ -50,11 +51,11 @@ context('patient data and events page', function() {
 
         fx.data[2].attributes.name = 'Third In List';
         fx.data[2].relationships.state = { data: { id: '55555' } };
-        fx.data[2].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(2);
 
         fx.data[1].attributes.name = 'Not In List';
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].attributes.updated_at = moment.utc().subtract(6, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(6);
 
         return fx;
       }, '1')
@@ -63,16 +64,16 @@ context('patient data and events page', function() {
 
         fx.data[0].attributes.name = 'Second In List';
         fx.data[0].relationships.state = { data: { id: '55555' } };
-        fx.data[0].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
 
         fx.data[2].attributes.name = 'Last In List';
         fx.data[2].id = '2';
         fx.data[2].relationships.state = { data: { id: '55555' } };
-        fx.data[2].attributes.updated_at = moment.utc().subtract(6, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(6);
 
         fx.data[1].attributes.name = 'Not In List';
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].attributes.updated_at = moment.utc().subtract(6, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(6);
 
         return fx;
       }, '1')
@@ -83,10 +84,10 @@ context('patient data and events page', function() {
         fx.data = _.sample(fx.data, 2);
 
         fx.data[0].attributes.checkin_id = '7';
-        fx.data[0].attributes.date = moment.utc().subtract(4, 'days').format();
+        fx.data[0].attributes.date = testTsSubtract(4);
         fx.data[0].relationships.patient.data.id = '1';
         fx.data[1].attributes.checkin_id = '8';
-        fx.data[1].attributes.date = moment.utc().subtract(5, 'days').format();
+        fx.data[1].attributes.date = testTsSubtract(5);
         fx.data[1].relationships.patient.data.id = '1';
 
         return fx;
@@ -132,7 +133,7 @@ context('patient data and events page', function() {
       .should('contain', 'Third In List')
       .next()
       .should('contain', 'Check-in completed')
-      .and('contain', formatDate(moment().subtract(4, 'days'), 'TIME_OR_DAY'))
+      .and('contain', formatDate(testTsSubtract(4), 'TIME_OR_DAY'))
       .next()
       .next()
       .should('contain', 'Last In List');

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
-import moment from 'moment';
 
-const now = moment.utc();
+import { testTs, testDateAdd, testDateSubtract, testTsSubtract } from 'helpers/test-moment';
 
 context('patient flow page', function() {
   specify('context trail', function() {
@@ -30,7 +29,7 @@ context('patient flow page', function() {
         fx.data.id = '1';
 
         fx.data.attributes.name = 'Test Flow';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
         fx.data.relationships.patient = { data: { id: '1' } };
 
         fx.included.push({
@@ -115,7 +114,7 @@ context('patient flow page', function() {
         fx.data.id = '1';
 
         fx.data.attributes.name = 'Test Flow';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
         fx.data.relationships.state.data.id = '33333';
 
         const flowActions = _.sample(fx.data.relationships.actions.data, 3);
@@ -133,8 +132,8 @@ context('patient flow page', function() {
 
         fx.data[0].id = '1';
         fx.data[0].attributes.name = 'First In List';
-        fx.data[0].attributes.due_date = moment.utc().subtract(1, 'day').format();
-        fx.data[0].attributes.created_at = moment.utc().subtract(1, 'day').format();
+        fx.data[0].attributes.due_date = testDateSubtract(1);
+        fx.data[0].attributes.created_at = testTsSubtract(1);
         fx.data[0].attributes.sequence = 1;
         fx.data[0].relationships.patient.data.id = '1';
         fx.data[0].relationships.state.data.id = '22222';
@@ -146,8 +145,8 @@ context('patient flow page', function() {
 
         fx.data[1].id = '2';
         fx.data[1].attributes.name = 'Third In List';
-        fx.data[1].attributes.due_date = moment.utc().add(1, 'day').format();
-        fx.data[1].attributes.created_at = moment.utc().subtract(3, 'day').format();
+        fx.data[1].attributes.due_date = testDateAdd(1);
+        fx.data[1].attributes.created_at = testTsSubtract(3);
         fx.data[1].attributes.sequence = 3;
         fx.data[1].relationships.patient.data.id = '1';
         fx.data[1].relationships.state.data.id = '55555';
@@ -159,8 +158,8 @@ context('patient flow page', function() {
 
         fx.data[2].id = '3';
         fx.data[2].attributes.name = 'Second In List';
-        fx.data[2].attributes.due_date = moment.utc().add(2, 'day').format();
-        fx.data[2].attributes.created_at = moment.utc().subtract(2, 'day').format();
+        fx.data[2].attributes.due_date = testDateAdd(2);
+        fx.data[2].attributes.created_at = testTsSubtract(2);
         fx.data[2].attributes.sequence = 2;
         fx.data[2].relationships.patient.data.id = '1';
         fx.data[2].relationships.state.data.id = '33333';
@@ -385,7 +384,7 @@ context('patient flow page', function() {
         fx.data.id = '1';
 
         fx.data.attributes.name = 'Test Flow';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
 
         return fx;
       })

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -1,12 +1,14 @@
 import _ from 'underscore';
 import 'js/utils/formatting';
 import moment from 'moment';
+
 import formatDate from 'helpers/format-date';
+import { testDate, testDateSubtract } from 'helpers/test-moment';
 import { getIncluded, getResource } from 'helpers/json-api';
 
 context('patient sidebar', function() {
   specify('display patient data', function() {
-    const dob = moment().subtract(10, 'years');
+    const dob = testDateSubtract(10, 'years');
 
     cy
       .server()
@@ -16,7 +18,7 @@ context('patient sidebar', function() {
         fx.data.attributes = {
           first_name: 'First',
           last_name: 'Last',
-          birth_date: dob.format('YYYY-MM-DD'),
+          birth_date: dob,
           sex: 'f',
           status: 'active',
         };
@@ -68,7 +70,7 @@ context('patient sidebar', function() {
       .as('patientSidebar')
       .should('contain', 'First Last')
       .should('contain', formatDate(dob, 'LONG'))
-      .should('contain', `Age ${ moment().diff(dob, 'years') }`);
+      .should('contain', `Age ${ moment(testDate()).diff(dob, 'years') }`);
 
     cy
       .get('@patientSidebar')

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1,11 +1,9 @@
-import moment from 'moment';
 import _ from 'underscore';
 
 import formatDate from 'helpers/format-date';
+import { testTs, testTsSubtract, testDate, testDateSubtract } from 'helpers/test-moment';
 
 const stateColors = Cypress.env('stateColors');
-const now = moment.utc();
-const local = moment();
 
 context('action sidebar', function() {
   specify('display new action sidebar', function() {
@@ -146,7 +144,7 @@ context('action sidebar', function() {
             id: '1',
             attributes: {
               name: 'Test Name',
-              updated_at: now.format(),
+              updated_at: testTs(),
             },
           },
         },
@@ -157,7 +155,7 @@ context('action sidebar', function() {
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.attributes.name = 'Test Name';
-        fx.data.attributes.updated_at = local.format();
+        fx.data.attributes.updated_at = testTs();
         return fx;
       });
 
@@ -191,7 +189,7 @@ context('action sidebar', function() {
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar')
@@ -275,9 +273,9 @@ context('action sidebar', function() {
         name: 'Name',
         details: 'Details',
         duration: 5,
-        due_date: moment(local).subtract(2, 'days').format('YYYY-MM-DD'),
+        due_date: testDateSubtract(2),
         due_time: null,
-        updated_at: now.format(),
+        updated_at: testTs(),
       },
       relationships: {
         owner: { data: null },
@@ -345,7 +343,7 @@ context('action sidebar', function() {
       .routeActionActivity(fx => {
         fx.data = [...this.fxEvents, {}];
         fx.data[0].relationships.editor.data = null;
-        fx.data[0].attributes.date = now.format();
+        fx.data[0].attributes.date = testTs();
 
 
         return fx;
@@ -520,7 +518,7 @@ context('action sidebar', function() {
     cy
       .get('.sidebar')
       .find('[data-due-day-region]')
-      .contains(formatDate(moment(local).subtract(2, 'days'), 'LONG'))
+      .contains(formatDate(testDateSubtract(2), 'LONG'))
       .children()
       .should('have.css', 'color', stateColors.error)
       .click();
@@ -534,7 +532,7 @@ context('action sidebar', function() {
       .wait('@routePatchAction')
       .its('request.body')
       .should(({ data }) => {
-        expect(data.attributes.due_date).to.equal(local.format('YYYY-MM-DD'));
+        expect(data.attributes.due_date).to.equal(testDate());
       });
 
     cy
@@ -574,7 +572,7 @@ context('action sidebar', function() {
     cy
       .get('.sidebar')
       .find('[data-due-day-region]')
-      .contains(formatDate(local, 'LONG'))
+      .contains(formatDate(testDate(), 'LONG'))
       .children()
       .should('not.have.css', 'color', stateColors.error)
       .click();
@@ -648,13 +646,13 @@ context('action sidebar', function() {
       .get('.sidebar__footer')
       .contains('Created')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('.sidebar__footer')
       .contains('Last Updated')
       .next()
-      .should('contain', formatDate(local, 'AT_TIME'));
+      .should('contain', formatDate(testTs(), 'AT_TIME'));
 
     cy
       .get('[data-activity-region]')
@@ -687,8 +685,8 @@ context('action sidebar', function() {
         fx.data[0] = this.fxEvents[0];
         fx.data[1] = this.fxEvents[1];
 
-        fx.data[0].attributes.date = moment(now).subtract(8, 'days').format();
-        fx.data[1].attributes.date = now.format();
+        fx.data[0].attributes.date = testTsSubtract(8);
+        fx.data[1].attributes.date = testTs();
 
         return fx;
       })
@@ -697,16 +695,16 @@ context('action sidebar', function() {
 
         fx.data[0].relationships.clinician.data = { id: '11111' };
         fx.data[0].attributes.edited_at = null;
-        fx.data[0].attributes.created_at = moment(now).subtract(2, 'days').format();
+        fx.data[0].attributes.created_at = testTsSubtract(2);
         fx.data[0].attributes.message = 'Least Recent Message from Clinician McTester';
 
         fx.data[1].relationships.clinician.data = { id: '11111' };
-        fx.data[1].attributes.edited_at = now.format();
-        fx.data[1].attributes.created_at = moment(now).subtract(1, 'days').format();
+        fx.data[1].attributes.edited_at = testTs();
+        fx.data[1].attributes.created_at = testTsSubtract(1);
         fx.data[1].attributes.message = 'Most Recent Message from Clinician McTester';
 
         fx.data[2].relationships.clinician.data = { id: '22222' };
-        fx.data[2].attributes.created_at = moment(now).subtract(4, 'days').format();
+        fx.data[2].attributes.created_at = testTsSubtract(4);
         fx.data[2].attributes.message = 'Message from Someone Else';
         fx.data[2].attributes.edited_at = null;
 
@@ -957,13 +955,13 @@ context('action sidebar', function() {
         fx.data[0] = this.fxEvents[0];
         fx.data[1] = this.fxEvents[1];
         fx.data[0].relationships.editor.data = null;
-        fx.data[0].attributes.date = now.format();
+        fx.data[0].attributes.date = testTs();
 
         fx.data.push({
           id: '12345',
           type: 'events',
           attributes: {
-            date: now.format(),
+            date: testTs(),
             type: 'ActionCopiedFromProgramAction',
           },
           relationships: {

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -1,7 +1,6 @@
-import moment from 'moment';
 import _ from 'underscore';
 
-const now = moment.utc();
+import { testTs, testTsSubtract, testDateSubtract } from 'helpers/test-moment';
 
 context('flow sidebar', function() {
   specify('display flow sidebar', function() {
@@ -12,7 +11,7 @@ context('flow sidebar', function() {
         fx.data.id = '1';
 
         fx.data.attributes.name = 'Test Flow';
-        fx.data.attributes.updated_at = now.format();
+        fx.data.attributes.updated_at = testTs();
         fx.data.relationships.patient.data.id = '1';
         fx.data.relationships.state = {
           data: {
@@ -41,7 +40,7 @@ context('flow sidebar', function() {
           attributes: {
             first_name: 'First',
             last_name: 'Last',
-            birth_date: moment().subtract(10, 'years').format('YYYY-MM-DD'),
+            birth_date: testDateSubtract(10, 'years'),
             sex: 'f',
             status: 'active',
           },
@@ -60,7 +59,7 @@ context('flow sidebar', function() {
         _.each(fx.data, (action, index) => {
           action.id = `${ index + 1 }`;
           action.relationships.state.data.id = '33333';
-          action.attributes.created_at = moment.utc().subtract(index + 1, 'day').format();
+          action.attributes.created_at = testTsSubtract(index + 1);
         });
 
         return fx;

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -154,6 +154,145 @@ context('Worklist bulk editing', function() {
       .should('contain', 'Tip: To assign a clinician, filter the worklist to a specific group.');
   });
 
+  specify('displaying common groups - actions', function() {
+    cy
+      .server()
+      .routeGroupsBootstrap(_.identity, testGroups)
+      .routeFlows()
+      .routeActions(fx => {
+        fx.data = _.sample(fx.data, 3);
+
+        fx.data[0].relationships.patient = { data: { id: '1' } };
+        fx.data[1].relationships.patient = { data: { id: '2' } };
+        fx.data[2].relationships.patient = { data: { id: '3' } };
+
+        fx.included = fx.included.concat([
+          {
+            id: '1',
+            type: 'patients',
+            attributes: {
+              first_name: 'Patient',
+              last_name: 'One',
+            },
+            relationships: {
+              groups: {
+                data: [testGroups[0]],
+              },
+            },
+          },
+          {
+            id: '2',
+            type: 'patients',
+            attributes: {
+              first_name: 'Patient',
+              last_name: 'Two',
+            },
+            relationships: {
+              groups: {
+                data: [testGroups[0], testGroups[1]],
+              },
+            },
+          },
+          {
+            id: '3',
+            type: 'patients',
+            attributes: {
+              first_name: 'Patient',
+              last_name: 'Three',
+            },
+            relationships: {
+              groups: {
+                data: [testGroups[2]],
+              },
+            },
+          },
+        ]);
+
+        return fx;
+      }, '1')
+      .visit('/worklist/owned-by')
+      .wait('@routeFlows');
+
+    cy
+      .get('.worklist-list__toggle')
+      .find('.worklist-list__toggle-actions')
+      .contains('Actions')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .contains('Patient One')
+      .prev()
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .contains('Patient Two')
+      .prev()
+      .click();
+
+    cy
+      .get('.worklist-list__filter-region')
+      .find('.js-bulk-edit')
+      .click();
+
+    cy
+      .get('.modal--sidebar')
+      .as('sidebar')
+      .find('[data-owner-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .should('have.length', 2)
+      .find('.picklist__heading')
+      .first()
+      .should('contain', 'Group One');
+
+    cy
+      .get('.picklist')
+      .find('.picklist__info')
+      .should('not.exist');
+
+    cy
+      .get('@sidebar')
+      .find('.js-close')
+      .first()
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .contains('Patient Three')
+      .prev()
+      .click();
+
+    cy
+      .get('.worklist-list__filter-region')
+      .find('.js-bulk-edit')
+      .click();
+
+    cy
+      .get('@sidebar')
+      .find('[data-owner-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .should('have.length', 1)
+      .find('.picklist__heading')
+      .should('contain', 'Roles');
+
+    cy
+      .get('.picklist')
+      .find('.picklist__info')
+      .should('contain', 'Tip: To assign a clinician, filter the worklist to a specific group.');
+  });
+
   specify('date and time components', function() {
     cy
       .server()

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -2,8 +2,9 @@ import _ from 'underscore';
 import moment from 'moment';
 
 import formatDate from 'helpers/format-date';
+import { testTs, testDateAdd, testTsSubtract } from 'helpers/test-moment';
 
-const tomorrow = moment.utc().add(1, 'days').format('YYYY-MM-DD');
+const tomorrow = testDateAdd(1);
 
 const testGroups = [
   {
@@ -21,7 +22,7 @@ const testGroups = [
 ];
 
 context('Worklist bulk editing', function() {
-  specify('displaying common groups', function() {
+  specify('displaying common groups - flows', function() {
     cy
       .server()
       .routeGroupsBootstrap(_.identity, testGroups)
@@ -172,8 +173,8 @@ context('Worklist bulk editing', function() {
 
         fx.data[0].id = '1';
         fx.data[0].attributes.name = 'First In List';
-        fx.data[0].attributes.due_date = moment().add(5, 'days').format('YYYY-MM-DD');
-        fx.data[0].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[0].attributes.due_date = testDateAdd(5);
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].attributes.due_time = null;
 
         fx.data[1].id = '3';
@@ -184,14 +185,14 @@ context('Worklist bulk editing', function() {
 
         fx.data[2].id = '2';
         fx.data[2].attributes.name = 'Second In List';
-        fx.data[2].attributes.due_date = moment().add(3, 'days').format('YYYY-MM-DD');
-        fx.data[2].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[2].attributes.due_date = testDateAdd(3);
+        fx.data[2].attributes.updated_at = testTsSubtract(2);
         fx.data[2].attributes.due_time = '07:00:00';
 
         fx.data[3].id = '4';
         fx.data[3].attributes.name = 'Third In List';
-        fx.data[3].attributes.due_date = moment().add(3, 'days').format('YYYY-MM-DD');
-        fx.data[3].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[3].attributes.due_date = testDateAdd(3);
+        fx.data[3].attributes.updated_at = testTsSubtract(2);
         fx.data[3].attributes.due_time = '07:00:00';
 
 
@@ -233,7 +234,7 @@ context('Worklist bulk editing', function() {
       .get('.modal--sidebar')
       .as('sidebar')
       .find('[data-due-date-region]')
-      .should('contain', formatDate(moment().add(3, 'days'), 'LONG'));
+      .should('contain', formatDate(testDateAdd(3), 'LONG'));
 
     cy
       .get('@sidebar')
@@ -357,7 +358,7 @@ context('Worklist bulk editing', function() {
           attributes: {
             name: 'First In List',
             details: null,
-            updated_at: moment.utc().format(),
+            updated_at: testTs(),
           },
           relationships: {
             owner: {
@@ -389,7 +390,7 @@ context('Worklist bulk editing', function() {
         };
         fx.data[1].meta.progress = { complete: 2, total: 2 };
         fx.data[1].attributes.name = 'Last In List';
-        fx.data[1].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
 
         fx.data[2] = {
           id: '2',
@@ -397,7 +398,7 @@ context('Worklist bulk editing', function() {
           attributes: {
             name: 'Second In List',
             details: null,
-            updated_at: moment.utc().subtract(1, 'days').format(),
+            updated_at: testTsSubtract(1),
           },
           relationships: {
             owner: {
@@ -724,7 +725,7 @@ context('Worklist bulk editing', function() {
             duration: 0,
             due_date: null,
             due_time: null,
-            updated_at: moment.utc().format(),
+            updated_at: testTs(),
           },
           relationships: {
             owner: {
@@ -743,8 +744,8 @@ context('Worklist bulk editing', function() {
         fx.data[1].id = '3';
         fx.data[1].relationships.state = { data: { id: '55555' } };
         fx.data[1].attributes.name = 'Last In List';
-        fx.data[1].attributes.due_date = moment.utc().add(5, 'days').format('YYYY-MM-DD');
-        fx.data[1].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[1].attributes.due_date = testDateAdd(5);
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.patient = { data: { id: '2' } };
 
         fx.data[2] = {
@@ -754,9 +755,9 @@ context('Worklist bulk editing', function() {
             name: 'Second In List',
             details: null,
             duration: 0,
-            due_date: moment.utc().add(3, 'days').format('YYYY-MM-DD'),
+            due_date: testDateAdd(3),
             due_time: null,
-            updated_at: moment.utc().subtract(1, 'days').format(),
+            updated_at: testTsSubtract(1),
           },
           relationships: {
             owner: {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
-import moment from 'moment';
 import 'js/utils/formatting';
 import formatDate from 'helpers/format-date';
+import { testTs, testTsSubtract, testDate, testDateAdd } from 'helpers/test-moment';
 
 const testGroups = [
   {
@@ -45,7 +45,7 @@ context('worklist page', function() {
           attributes: {
             name: 'First In List',
             details: null,
-            updated_at: moment.utc().format(),
+            updated_at: testTs(),
           },
           relationships: {
             owner: {
@@ -75,7 +75,7 @@ context('worklist page', function() {
           },
         };
         fx.data[1].attributes.name = 'Last In List';
-        fx.data[1].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
 
         fx.data[2] = {
           id: '2',
@@ -83,7 +83,7 @@ context('worklist page', function() {
           attributes: {
             name: 'Second In List',
             details: null,
-            updated_at: moment.utc().subtract(1, 'days').format(),
+            updated_at: testTsSubtract(1),
           },
           relationships: {
             owner: {
@@ -395,7 +395,7 @@ context('worklist page', function() {
             duration: 0,
             due_date: null,
             due_time: null,
-            updated_at: moment.utc().format(),
+            updated_at: testTs(),
           },
           relationships: {
             owner: {
@@ -413,8 +413,8 @@ context('worklist page', function() {
 
         fx.data[1].relationships.state = { data: { id: '55555' } };
         fx.data[1].attributes.name = 'Last In List';
-        fx.data[1].attributes.due_date = moment.utc().add(5, 'days').format('YYYY-MM-DD');
-        fx.data[1].attributes.updated_at = moment.utc().subtract(2, 'days').format();
+        fx.data[1].attributes.due_date = testDateAdd(5);
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
 
         fx.data[2] = {
           id: '2',
@@ -423,9 +423,9 @@ context('worklist page', function() {
             name: 'Second In List',
             details: null,
             duration: 0,
-            due_date: moment.utc().add(3, 'days').format('YYYY-MM-DD'),
+            due_date: testDateAdd(3),
             due_time: null,
-            updated_at: moment.utc().subtract(1, 'days').format(),
+            updated_at: testTsSubtract(1),
           },
           relationships: {
             owner: {
@@ -675,13 +675,13 @@ context('worklist page', function() {
     cy
       .get('@firstRow')
       .find('[data-due-date-region]')
-      .should('contain', formatDate(moment(), 'SHORT'));
+      .should('contain', formatDate(testDate(), 'SHORT'));
 
     cy
       .wait('@routePatchAction')
       .its('request.body')
       .should(({ data }) => {
-        expect(data.attributes.due_date).to.equal(moment().format('YYYY-MM-DD'));
+        expect(data.attributes.due_date).to.equal(testDate());
       });
 
     cy
@@ -1005,11 +1005,11 @@ context('worklist page', function() {
 
         fx.data[0].relationships.state = { data: { id: '33333' } };
         fx.data[0].attributes.name = 'Updated Most Recent';
-        fx.data[0].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
 
         fx.data[1].relationships.state = { data: { id: '33333' } };
         fx.data[1].attributes.name = 'Updated Least Recent';
-        fx.data[1].attributes.updated_at = moment.utc().subtract(10, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(10);
 
         return fx;
       })
@@ -1081,39 +1081,39 @@ context('worklist page', function() {
 
         fx.data[0].relationships.state = { data: { id: '33333' } };
         fx.data[0].attributes.name = 'Updated Most Recent';
-        fx.data[0].attributes.due_date = moment.utc().add(3, 'days').format('YYYY-MM-DD');
+        fx.data[0].attributes.due_date = testDateAdd(3);
         fx.data[0].attributes.due_time = null;
-        fx.data[0].attributes.updated_at = moment.utc().subtract(1, 'days').format();
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
 
         fx.data[1].relationships.state = { data: { id: '33333' } };
         fx.data[1].attributes.name = 'Updated Least Recent';
-        fx.data[1].attributes.due_date = moment.utc().add(3, 'days').format('YYYY-MM-DD');
+        fx.data[1].attributes.due_date = testDateAdd(3);
         fx.data[1].attributes.due_time = null;
-        fx.data[1].attributes.updated_at = moment.utc().subtract(10, 'days').format();
+        fx.data[1].attributes.updated_at = testTsSubtract(10);
 
         fx.data[2].relationships.state = { data: { id: '33333' } };
         fx.data[2].attributes.name = 'Due Date Least Recent';
-        fx.data[2].attributes.due_date = moment.utc().add(1, 'days').format('YYYY-MM-DD');
+        fx.data[2].attributes.due_date = testDateAdd(1);
         fx.data[2].attributes.due_time = null;
-        fx.data[2].attributes.updated_at = moment.utc().subtract(3, 'days').format();
+        fx.data[2].attributes.updated_at = testTsSubtract(3);
 
         fx.data[3].relationships.state = { data: { id: '33333' } };
         fx.data[3].attributes.name = 'Due Date Most Recent';
-        fx.data[3].attributes.due_date = moment.utc().add(10, 'days').format('YYYY-MM-DD');
+        fx.data[3].attributes.due_date = testDateAdd(10);
         fx.data[3].attributes.due_time = null;
-        fx.data[3].attributes.updated_at = moment.utc().subtract(3, 'days').format();
+        fx.data[3].attributes.updated_at = testTsSubtract(3);
 
         fx.data[4].relationships.state = { data: { id: '33333' } };
         fx.data[4].attributes.name = 'Due Time Most Recent';
-        fx.data[4].attributes.due_date = moment.utc().add(2, 'days').format('YYYY-MM-DD');
+        fx.data[4].attributes.due_date = testDateAdd(2);
         fx.data[4].attributes.due_time = '11:00:00';
-        fx.data[4].attributes.updated_at = moment.utc().subtract(3, 'days').format();
+        fx.data[4].attributes.updated_at = testTsSubtract(3);
 
         fx.data[5].relationships.state = { data: { id: '33333' } };
         fx.data[5].attributes.name = 'Due Time Least Recent';
-        fx.data[5].attributes.due_date = moment.utc().add(2, 'days').format('YYYY-MM-DD');
+        fx.data[5].attributes.due_date = testDateAdd(2);
         fx.data[5].attributes.due_time = '12:15:00';
-        fx.data[5].attributes.updated_at = moment.utc().subtract(3, 'days').format();
+        fx.data[5].attributes.updated_at = testTsSubtract(3);
 
         return fx;
       }, '1')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import 'js/utils/formatting';
+
 import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract, testDate, testDateAdd } from 'helpers/test-moment';
 

--- a/test/support/helpers/test-moment.js
+++ b/test/support/helpers/test-moment.js
@@ -1,0 +1,37 @@
+import moment from 'moment';
+
+const ts = moment.utc();
+const date = moment();
+
+function testTs() {
+  return moment(ts).format();
+}
+
+function testTsAdd(time, key = 'days') {
+  return moment(ts).add(time, key).format();
+}
+
+function testTsSubtract(time, key = 'days') {
+  return moment(ts).subtract(time, key).format();
+}
+
+function testDate() {
+  return moment(date).format('YYYY-MM-DD');
+}
+
+function testDateAdd(time, key = 'days') {
+  return moment(date).add(time, key).format('YYYY-MM-DD');
+}
+
+function testDateSubtract(time, key = 'days') {
+  return moment(date).subtract(time, key).format('YYYY-MM-DD');
+}
+
+export {
+  testTs,
+  testTsAdd,
+  testTsSubtract,
+  testDate,
+  testDateAdd,
+  testDateSubtract,
+};


### PR DESCRIPTION
Simplifies date testing by how we use it.  Centralizes “now” to a single location.  Helps enforce utc when necessary.

@LisaManresa too abstract?  I think these would work for 99% of our needs in integration tests and fixtures.  Plus it reduces a lot of `.format()` type things.  If you're :shipit: want to implement some or all of it?

