### PR TITLE
Clean up node_modules sourcemaps warnings

### DIFF
--- a/config/webpack.rules.js
+++ b/config/webpack.rules.js
@@ -46,7 +46,7 @@ const postcssLoader = {
         ['autoprefixer', { cascade: false }],
         ['cssnano', { preset: 'default' }],
       ],
-    }
+    },
   },
 };
 
@@ -83,6 +83,25 @@ const resolveLoader = {
   },
 };
 
+const sourceMapLoader = {
+  test: /\.js$/,
+  enforce: 'pre',
+  use: [
+    {
+      loader: 'source-map-loader',
+      options: {
+        filterSourceMappingUrl(url, resourcePath) {
+          if (resourcePath.includes('node_modules')) {
+            return 'remove';
+          }
+
+          return true;
+        },
+      },
+    },
+  ],
+};
+
 module.exports = {
   babelLoader,
   hbsLoader,
@@ -91,4 +110,5 @@ module.exports = {
   sassExtractLoader,
   ymlLoader,
   resolveLoader,
+  sourceMapLoader,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2349,6 +2349,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "dev": true
+    },
     "abortcontroller-polyfill": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
@@ -12311,6 +12317,71 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-loader": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-1.1.1.tgz",
+      "integrity": "sha512-m2HjSWP2R1yR9P31e4+ciGHFOPvW6GmqHgZkneOkrME2VvWysXTGi4o0yS28iKWWP3vAUmAoa+3x5ZRI2BIX6A==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.2",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0",
+        "source-map": "^0.6.1",
+        "whatwg-mimetype": "^2.3.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+          "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -14917,6 +14988,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
+      "dev": true
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "sass": "^1.27.0",
     "sass-loader": "^10.0.3",
     "shelljs": "^0.8.4",
+    "source-map-loader": "^1.0.0",
     "stylelint": "^13.7.2",
     "stylelint-bare-webpack-plugin": "^2.0.2",
     "stylelint-config-recommended": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const {
   sassExtractLoader,
   ymlLoader,
   resolveLoader,
+  sourceMapLoader,
 } = require('./config/webpack.rules.js');
 
 // Setup StyleLint here to get around Cypress issue
@@ -62,6 +63,7 @@ module.exports = {
     rules: [
       babelLoader,
       hbsLoader,
+      sourceMapLoader,
       eslintLoader,
       sassExtractLoader,
       ymlLoader,


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch23612]

This addition gets our dev sourcemaps warning down to one:
```
DevTools failed to load SourceMap: Could not load content for webpack://care-ops-frontend/node_modules/backbone.store/dist/backbone.store.mjs.map: HTTP error: status code 404, net::ERR_UNKNOWN_URL_SCHEME
```

I'm still poking around to see why this sourcemap doesn't get picked up by the filter. It looks like this file never passes through the loader.