### PR TITLE
Change “Attachment” references to “Form”

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -96,11 +96,11 @@ careOptsFrontend:
       components:
         accessComponent:
           headingText: Update Access Type
-        attachmentComponent:
-          defaultText: Add Attachment...
-          headingText: Select Attachment
+        formComponent:
+          defaultText: Add Form...
+          headingText: Select Form
           noResultsText: No Available Forms
-          placeholderText: Attachment...
+          placeholderText: Form...
         dueDayComponent:
           defaultText: "Select # Days..."
           headingText: Select Day
@@ -122,7 +122,7 @@ careOptsFrontend:
         actionNameTemplate:
           placeholder: New Program Action
         actionSidebarTemplate:
-          attachmentLabel: Attachment
+          formLabel: Form
           dueDayLabel: Due In
           headingText: Program Action
           noResultsText: No Available Forms
@@ -313,7 +313,7 @@ careOptsFrontend:
         previewView:
           backBtn: Go Back
           title: Form Preview
-        printAttachment: Print Attachment
+        printForm: Print Form
         responseHistory: See Form Response History
         showActionSidebar: Show Action Sidebar
       formHistoryViews:
@@ -435,7 +435,7 @@ careOptsFrontend:
           placeholder: New Action
         actionSidebarTemplate:
           activityHeadingText: Activity Log
-          attachmentLabel: Attachment
+          formLabel: Form
           dueDayLabel: Due Date
           durationLabel: Duration
           headingText: Action
@@ -463,9 +463,9 @@ careOptsFrontend:
           dueTimeUpdated: '<strong>{ name }</strong> ({ role }) changed the Due Time to { time }'
           durationCleared: '<strong>{ name }</strong> ({ role }) cleared Duration'
           durationUpdated: '<strong>{ name }</strong> ({ role }) changed Duration to { duration }'
-          formUpdated: '<strong>{ name }</strong> ({ role }) added the attachment { form }'
-          formRemoved: '<strong>{ name }</strong> ({ role }) removed the attachment { form }'
-          formResponded: '<strong>{ name }</strong> ({ role }) worked on the attachment { form }'
+          formUpdated: '<strong>{ name }</strong> ({ role }) added the form { form }'
+          formRemoved: '<strong>{ name }</strong> ({ role }) removed the form { form }'
+          formResponded: '<strong>{ name }</strong> ({ role }) worked on the form { form }'
           nameUpdated: '<strong>{ name }</strong> ({ role }) changed the name of this Action from { from_name } to { to_name }'
           roleAssigned: '<strong>{ name }</strong> ({ role }) changed the Owner to { to_role }'
           stateUpdated: '<strong>{ name }</strong> ({ role }) changed State to { to_state }'
@@ -607,7 +607,7 @@ careOptsFrontend:
         placeholderText: Role...
       tableHeaderTemplate:
         actionHeader: Action
-        actionAttrHeader: State, Owner, Due Date, Attachment
+        actionAttrHeader: State, Owner, Due Date, Form
         createdHeader: Created
         flowAttrHeader: State, Owner
         flowHeader: Flow

--- a/src/js/views/admin/program/flow/action-item.hbs
+++ b/src/js/views/admin/program/flow/action-item.hbs
@@ -11,8 +11,8 @@
     <span class="table-list__meta" data-owner-region></span>{{~ remove_whitespace ~}}
     <span class="table-list__meta" data-due-region></span>{{~ remove_whitespace ~}}
     <span class="table-list__meta">
-      {{#if hasAttachment}}
-        <button class="js-attachment button-secondary--compact is-icon-only">{{far "poll-h"}}</button>
+      {{#if hasForm}}
+        <button class="js-form button-secondary--compact is-icon-only">{{far "poll-h"}}</button>
       {{/if }}
     </span>{{~ remove_whitespace ~}}
     <span class="program-flow__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>

--- a/src/js/views/admin/program/flow/flow_views.js
+++ b/src/js/views/admin/program/flow/flow_views.js
@@ -121,7 +121,7 @@ const ActionItemView = View.extend({
   template: ActionItemTemplate,
   templateContext() {
     return {
-      hasAttachment: this.model.getForm(),
+      hasForm: this.model.getForm(),
     };
   },
   tagName: 'tr',
@@ -131,11 +131,11 @@ const ActionItemView = View.extend({
     due: '[data-due-region]',
   },
   ui: {
-    'attachment': '.js-attachment',
+    'form': '.js-form',
   },
   triggers: {
     'click': 'click',
-    'click @ui.attachment': 'click:attachment',
+    'click @ui.form': 'click:form',
   },
   onClick() {
     if (this.model.isNew()) {
@@ -144,7 +144,7 @@ const ActionItemView = View.extend({
     }
     Radio.trigger('event-router', 'programFlow:action', this.model.get('_program_flow'), this.model.id);
   },
-  onClickAttachment() {
+  onClickForm() {
     const form = this.model.getForm();
     Radio.trigger('event-router', 'form:preview', form.id);
   },

--- a/src/js/views/admin/program/workflows/action-item.hbs
+++ b/src/js/views/admin/program/workflows/action-item.hbs
@@ -10,8 +10,8 @@
   <span class="table-list__meta" data-owner-region></span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-due-region></span>{{~ remove_whitespace ~}}
   <span class="table-list__meta">
-    {{#if hasAttachment}}
-      <button class="js-attachment button-secondary--compact is-icon-only">{{far "poll-h"}}</button>
+    {{#if hasForm}}
+      <button class="js-form button-secondary--compact is-icon-only">{{far "poll-h"}}</button>
     {{/if }}
   </span>{{~ remove_whitespace ~}}
   <span class="workflows__item-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>

--- a/src/js/views/admin/program/workflows/workflows_views.js
+++ b/src/js/views/admin/program/workflows/workflows_views.js
@@ -61,15 +61,15 @@ const ActionItemView = View.extend({
   template: ActionItemTemplate,
   templateContext() {
     return {
-      hasAttachment: this.model.getForm(),
+      hasForm: this.model.getForm(),
     };
   },
   ui: {
-    'attachment': '.js-attachment',
+    'form': '.js-form',
   },
   triggers: {
     'click': 'click',
-    'click @ui.attachment': 'click:attachment',
+    'click @ui.form': 'click:form',
   },
   onClick() {
     if (this.model.isNew()) {
@@ -79,7 +79,7 @@ const ActionItemView = View.extend({
 
     Radio.trigger('event-router', 'program:action', this.model.get('_program'), this.model.id);
   },
-  onClickAttachment() {
+  onClickForm() {
     const form = this.model.getForm();
     Radio.trigger('event-router', 'form:preview', form.id);
   },

--- a/src/js/views/admin/shared/actions_views.js
+++ b/src/js/views/admin/shared/actions_views.js
@@ -1,6 +1,6 @@
 import Radio from 'backbone.radio';
 
-import AttachmentComponent from './components/attachment_component';
+import FormComponent from './components/form_component';
 import RoleComponent from './components/role_component';
 import DueDayComponent from './components/dueday_component';
 import PublishedComponent from './components/published_component';
@@ -27,7 +27,7 @@ const OwnerComponent = RoleComponent.extend({
 });
 
 export {
-  AttachmentComponent,
+  FormComponent,
   OwnerComponent,
   DueDayComponent,
   PublishedComponent,

--- a/src/js/views/admin/shared/components/form-component.scss
+++ b/src/js/views/admin/shared/components/form-component.scss
@@ -1,4 +1,4 @@
-.attachment-component__form-button {
+.form-component__form-button {
   color: color(blue);
   padding: 8px 12px;
 

--- a/src/js/views/admin/shared/components/form_component.js
+++ b/src/js/views/admin/shared/components/form_component.js
@@ -1,0 +1,76 @@
+import Radio from 'backbone.radio';
+import hbs from 'handlebars-inline-precompile';
+
+import 'sass/modules/buttons.scss';
+
+import intl from 'js/i18n';
+
+import Droplist from 'js/components/droplist';
+
+import './form-component.scss';
+
+const i18n = intl.admin.shared.components.formComponent;
+
+const FormItemTemplate = hbs`{{far "poll-h"}} {{matchText text query}}`;
+const FormTemplate = hbs`
+  <button class="js-button button-secondary button__group flex-grow">
+    {{far "poll-h"}}{{ name }}
+  </button><button class="js-click-form button button__group form-component__form-button">{{far "expand-alt"}}</button>
+`;
+const NoFormTemplate = hbs`
+  <button class="js-button button-secondary w-100">
+    {{far "poll-h"}}{{ @intl.admin.shared.components.formComponent.defaultText }}
+  </button>
+`;
+
+let formsCollection;
+
+function getForms() {
+  if (formsCollection) return formsCollection;
+  const currentOrg = Radio.request('bootstrap', 'currentOrg');
+  formsCollection = currentOrg.getForms();
+  return formsCollection;
+}
+
+export default Droplist.extend({
+  viewOptions() {
+    const selected = this.getState('selected');
+    return {
+      className: 'flex',
+      template: selected ? FormTemplate : NoFormTemplate,
+      tagName: 'div',
+      triggers: {
+        'click .js-button': 'click',
+        'focus .js-button': 'focus',
+        'click .js-click-form': 'click:form',
+      },
+    };
+  },
+  viewEvents: {
+    'click': 'onClick',
+    'click:form': 'onViewClickForm',
+  },
+  onViewClickForm() {
+    this.triggerMethod('click:form', this.getState('selected'));
+  },
+  picklistOptions: {
+    canClear: true,
+    headingText: i18n.headingText,
+    placeholderText: i18n.placeholderText,
+    noResultsText: i18n.noResultsText,
+    isSelectlist: true,
+    itemTemplate: FormItemTemplate,
+    attr: 'name',
+  },
+  initialize({ form }) {
+    this.collection = getForms();
+
+    this.setState({ selected: form });
+  },
+  popWidth() {
+    return this.getView().$el.outerWidth();
+  },
+  onChangeSelected(selected) {
+    this.triggerMethod('change:form', selected);
+  },
+});

--- a/src/js/views/admin/shared/components/form_component.js
+++ b/src/js/views/admin/shared/components/form_component.js
@@ -13,12 +13,12 @@ const i18n = intl.admin.shared.components.formComponent;
 
 const FormItemTemplate = hbs`{{far "poll-h"}} {{matchText text query}}`;
 const FormTemplate = hbs`
-  <button class="js-button button-secondary button__group flex-grow">
+  <button class="js-button button-secondary button__group flex-grow" {{#if isDisabled}}disabled{{/if}}>
     {{far "poll-h"}}{{ name }}
-  </button><button class="js-click-form button button__group form-component__form-button">{{far "expand-alt"}}</button>
+  </button><button class="js-click-form button button__group form-component__form-button" {{#if isDisabled}}disabled{{/if}}>{{far "expand-alt"}}</button>
 `;
 const NoFormTemplate = hbs`
-  <button class="js-button button-secondary w-100">
+  <button class="js-button button-secondary w-100" {{#if isDisabled}}disabled{{/if}}>
     {{far "poll-h"}}{{ @intl.admin.shared.components.formComponent.defaultText }}
   </button>
 `;
@@ -38,6 +38,11 @@ export default Droplist.extend({
     return {
       className: 'flex',
       template: selected ? FormTemplate : NoFormTemplate,
+      templateContext() {
+        return {
+          isDisabled: this.getOption('state').isDisabled,
+        };
+      },
       tagName: 'div',
       triggers: {
         'click .js-button': 'click',

--- a/src/js/views/admin/sidebar/action/action-sidebar.hbs
+++ b/src/js/views/admin/sidebar/action/action-sidebar.hbs
@@ -17,7 +17,7 @@
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.admin.sidebar.action.actionSidebarTemplate.stateLabel }}</h4><div class="flex-grow" data-state-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.admin.sidebar.action.actionSidebarTemplate.ownerLabel }}</h4><div class="flex-grow" data-owner-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.admin.sidebar.action.actionSidebarTemplate.dueDayLabel }}</h4><div class="flex-grow" data-due-region></div></div>
-    <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.admin.sidebar.action.actionSidebarTemplate.attachmentLabel }}</h4><div class="flex-grow" data-attachment-region></div></div>
+    <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.admin.sidebar.action.actionSidebarTemplate.formLabel }}</h4><div class="flex-grow" data-form-region></div></div>
   </div>
 </div>
 <div data-timestamps-region></div>

--- a/src/js/views/admin/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/admin/sidebar/action/action-sidebar_views.js
@@ -17,7 +17,7 @@ import InputWatcherBehavior from 'js/behaviors/input-watcher';
 import Optionlist from 'js/components/optionlist';
 import Tooltip from 'js/components/tooltip';
 
-import { PublishedComponent, OwnerComponent, DueDayComponent, AttachmentComponent } from 'js/views/admin/shared/actions_views';
+import { PublishedComponent, OwnerComponent, DueDayComponent, FormComponent } from 'js/views/admin/shared/actions_views';
 
 import ActionSidebarTemplate from './action-sidebar.hbs';
 import ActionNameTemplate from './action-name.hbs';
@@ -139,7 +139,7 @@ const LayoutView = View.extend({
     state: '[data-state-region]',
     owner: '[data-owner-region]',
     due: '[data-due-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
     save: '[data-save-region]',
     timestamps: '[data-timestamps-region]',
   },
@@ -200,14 +200,14 @@ const LayoutView = View.extend({
     this.showTimestamps();
   },
   showAction() {
-    this.showForm();
+    this.showEditForm();
     this.showPublished();
     this.showState();
     this.showOwner();
     this.showDueDay();
-    this.showAttachment();
+    this.showForm();
   },
-  showForm() {
+  showEditForm() {
     this.stopListening(this.model);
     this.model = this.action.clone();
     this.listenTo(this.model, 'change:name change:details', this.showSave);
@@ -257,11 +257,11 @@ const LayoutView = View.extend({
 
     this.showChildView('due', dueDayComponent);
   },
-  showAttachment() {
+  showForm() {
     const isDisabled = this.action.isNew();
-    const attachmentComponent = new AttachmentComponent({ form: this.action.getForm(), state: { isDisabled } });
+    const formComponent = new FormComponent({ form: this.action.getForm(), state: { isDisabled } });
 
-    this.listenTo(attachmentComponent, {
+    this.listenTo(formComponent, {
       'change:form'(form) {
         this.action.saveForm(form);
       },
@@ -270,7 +270,7 @@ const LayoutView = View.extend({
       },
     });
 
-    this.showChildView('attachment', attachmentComponent);
+    this.showChildView('form', formComponent);
   },
   showTimestamps() {
     if (this.action.isNew()) return;
@@ -293,7 +293,7 @@ const LayoutView = View.extend({
       return;
     }
 
-    this.showForm();
+    this.showEditForm();
   },
 });
 

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -78,7 +78,7 @@ const ContextTrailView = View.extend({
   },
   renderPrintTooltip() {
     new Tooltip({
-      message: intl.forms.form.formViews.printAttachment,
+      message: intl.forms.form.formViews.printForm,
       uiView: this,
       ui: this.ui.printButton,
     });

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -12,6 +12,6 @@
     <span data-due-day-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
-  <span class="table-list__meta" data-attachment-region></span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -12,7 +12,7 @@ import 'sass/modules/table-list.scss';
 
 import PreloadRegion from 'js/regions/preload_region';
 
-import { StateComponent, OwnerComponent, DueComponent, TimeComponent, AttachmentButton } from 'js/views/patients/shared/actions_views';
+import { StateComponent, OwnerComponent, DueComponent, TimeComponent, FormButton } from 'js/views/patients/shared/actions_views';
 
 import ActionItemTemplate from './action-item.hbs';
 import FlowItemTemplate from './flow-item.hbs';
@@ -82,7 +82,7 @@ const ActionItemView = View.extend({
     owner: '[data-owner-region]',
     dueDay: '[data-due-day-region]',
     dueTime: '[data-due-time-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
   },
   template: ActionItemTemplate,
   triggers: {
@@ -96,7 +96,7 @@ const ActionItemView = View.extend({
     this.showOwner();
     this.showDueDay();
     this.showDueTime();
-    this.showAttachment();
+    this.showForm();
   },
   showState() {
     const isDisabled = this.model.isNew();
@@ -143,10 +143,10 @@ const ActionItemView = View.extend({
 
     this.showChildView('dueTime', dueTimeComponent);
   },
-  showAttachment() {
+  showForm() {
     if (!this.model.getForm()) return;
 
-    this.showChildView('attachment', new AttachmentButton({ model: this.model }));
+    this.showChildView('form', new FormButton({ model: this.model }));
   },
 });
 

--- a/src/js/views/patients/patient/data-events/action-item.hbs
+++ b/src/js/views/patients/patient/data-events/action-item.hbs
@@ -9,6 +9,6 @@
     <span data-due-day-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
-  <span class="table-list__meta" data-attachment-region></span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>{{~ remove_whitespace ~}}
 </td>

--- a/src/js/views/patients/patient/data-events/data-events_views.js
+++ b/src/js/views/patients/patient/data-events/data-events_views.js
@@ -9,7 +9,7 @@ import 'sass/modules/table-list.scss';
 
 import PreloadRegion from 'js/regions/preload_region';
 
-import { StateComponent, OwnerComponent, DueComponent, TimeComponent, AttachmentButton } from 'js/views/patients/shared/actions_views';
+import { StateComponent, OwnerComponent, DueComponent, TimeComponent, FormButton } from 'js/views/patients/shared/actions_views';
 
 import ActionItemTemplate from './action-item.hbs';
 import FlowItemTemplate from './flow-item.hbs';
@@ -74,7 +74,7 @@ const ActionItemView = View.extend({
     owner: '[data-owner-region]',
     dueDay: '[data-due-day-region]',
     dueTime: '[data-due-time-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
   },
   template: ActionItemTemplate,
   triggers: {
@@ -88,7 +88,7 @@ const ActionItemView = View.extend({
     this.showOwner();
     this.showDueDay();
     this.showDueTime();
-    this.showAttachment();
+    this.showForm();
   },
   showState() {
     const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
@@ -119,10 +119,10 @@ const ActionItemView = View.extend({
 
     this.showChildView('dueTime', dueTimeComponent);
   },
-  showAttachment() {
+  showForm() {
     if (!this.model.getForm()) return;
 
-    this.showChildView('attachment', new AttachmentButton({ model: this.model }));
+    this.showChildView('form', new FormButton({ model: this.model }));
   },
 });
 

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -12,6 +12,6 @@
     <span data-due-day-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
-  <span class="table-list__meta" data-attachment-region></span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -7,7 +7,7 @@ import 'sass/modules/table-list.scss';
 
 import PreloadRegion from 'js/regions/preload_region';
 
-import { StateComponent, OwnerComponent, DueComponent, TimeComponent, AttachmentButton } from 'js/views/patients/shared/actions_views';
+import { StateComponent, OwnerComponent, DueComponent, TimeComponent, FormButton } from 'js/views/patients/shared/actions_views';
 import { FlowStateComponent, OwnerComponent as FlowOwnerComponent } from 'js/views/patients/shared/flows_views';
 
 import HeaderTemplate from './header.hbs';
@@ -133,7 +133,7 @@ const ActionItemView = View.extend({
   template: ActionItemTemplate,
   templateContext() {
     return {
-      hasAttachment: this.model.getForm(),
+      hasForm: this.model.getForm(),
     };
   },
   tagName: 'tr',
@@ -142,7 +142,7 @@ const ActionItemView = View.extend({
     owner: '[data-owner-region]',
     dueDay: '[data-due-day-region]',
     dueTime: '[data-due-time-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
   },
   triggers: {
     'click': 'click',
@@ -158,7 +158,7 @@ const ActionItemView = View.extend({
     this.showOwner();
     this.showDueDay();
     this.showDueTime();
-    this.showAttachment();
+    this.showForm();
   },
   showState() {
     const isDisabled = this.flow.isDone();
@@ -205,10 +205,10 @@ const ActionItemView = View.extend({
 
     this.showChildView('dueTime', dueTimeComponent);
   },
-  showAttachment() {
+  showForm() {
     if (!this.model.getForm()) return;
 
-    this.showChildView('attachment', new AttachmentButton({ model: this.model }));
+    this.showChildView('form', new FormButton({ model: this.model }));
   },
 });
 

--- a/src/js/views/patients/shared/actions_views.js
+++ b/src/js/views/patients/shared/actions_views.js
@@ -10,7 +10,7 @@ import DueComponent from './components/due_component';
 import TimeComponent from './components/time_component';
 import DurationComponent from './components/duration_component';
 
-const AttachmentButton = View.extend({
+const FormButton = View.extend({
   className: 'button-secondary--compact is-icon-only',
   tagName: 'button',
   template: hbs`{{far "poll-h"}}`,
@@ -28,5 +28,5 @@ export {
   DueComponent,
   TimeComponent,
   DurationComponent,
-  AttachmentButton,
+  FormButton,
 };

--- a/src/js/views/patients/sidebar/action/action-sidebar.hbs
+++ b/src/js/views/patients/sidebar/action/action-sidebar.hbs
@@ -23,9 +23,9 @@
     </div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarTemplate.durationLabel }}</h4><div class="flex-grow" data-duration-region></div></div>
     {{#if hasForm}}
-    <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarTemplate.attachmentLabel }}</h4><div class="flex-grow" data-attachment-region></div></div>
+    <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarTemplate.formLabel }}</h4><div class="flex-grow" data-form-region></div></div>
     {{else}}
-    <div data-attachment-region></div>
+    <div data-form-region></div>
     {{/if}}
   </div>
   {{#unless isNew}}

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -98,7 +98,7 @@ const DetailsView = View.extend({
   },
 });
 
-const AttachmentView = View.extend({
+const FormView = View.extend({
   attributes() {
     return {
       disabled: !!this.getOption('isShowingForm'),
@@ -127,7 +127,7 @@ const LayoutView = View.extend({
     dueDay: '[data-due-day-region]',
     dueTime: '[data-due-time-region]',
     duration: '[data-duration-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
     save: '[data-save-region]',
     activity: {
       el: '[data-activity-region]',
@@ -212,15 +212,15 @@ const LayoutView = View.extend({
     this.clonedAction = this.action.clone();
   },
   showAction() {
-    this.showForm();
+    this.showEditForm();
     this.showState();
     this.showOwner();
     this.showDueDay();
     this.showDueTime();
     this.showDuration();
-    this.showAttachment();
+    this.showForm();
   },
-  showForm() {
+  showEditForm() {
     this.cloneAction();
     this.listenTo(this.clonedAction, 'change:name change:details', this.showSave);
 
@@ -292,20 +292,20 @@ const LayoutView = View.extend({
 
     this.showChildView('duration', durationComponent);
   },
-  showAttachment() {
+  showForm() {
     const form = this.action.getForm();
     if (!form || this.action.isNew()) return;
 
-    const attachmentView = new AttachmentView({
+    const formView = new FormView({
       model: form,
       isShowingForm: this.getOption('isShowingForm'),
     });
 
-    this.listenTo(attachmentView, 'click', () => {
+    this.listenTo(formView, 'click', () => {
       this.triggerMethod('click:form', form);
     });
 
-    this.showChildView('attachment', attachmentView);
+    this.showChildView('form', formView);
   },
   showSave() {
     if (!this.clonedAction.isValid()) return this.showDisabledSave();
@@ -324,7 +324,7 @@ const LayoutView = View.extend({
       return;
     }
 
-    this.showForm();
+    this.showEditForm();
   },
 });
 

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -14,7 +14,7 @@
     <span data-due-date-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
-  <span class="table-list__meta" data-attachment-region></span>{{~ remove_whitespace ~}}
+  <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
 </td>
 <td class="table-list__cell worklist-list__action-ts w-7_5">{{formatDateTime created_at "TIME_OR_DAY"}}</td>
 <td class="table-list__cell worklist-list__action-ts w-7_5">{{formatDateTime updated_at "TIME_OR_DAY"}}</td>

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -4,7 +4,7 @@ import { View } from 'marionette';
 
 import 'sass/modules/table-list.scss';
 
-import { StateComponent, OwnerComponent, DueComponent, TimeComponent, AttachmentButton } from 'js/views/patients/shared/actions_views';
+import { StateComponent, OwnerComponent, DueComponent, TimeComponent, FormButton } from 'js/views/patients/shared/actions_views';
 
 import ActionItemTemplate from './action-item.hbs';
 
@@ -39,7 +39,7 @@ const ActionItemView = View.extend({
     owner: '[data-owner-region]',
     dueDate: '[data-due-date-region]',
     dueTime: '[data-due-time-region]',
-    attachment: '[data-attachment-region]',
+    form: '[data-form-region]',
   },
   templateContext() {
     return {
@@ -86,7 +86,7 @@ const ActionItemView = View.extend({
     this.showOwner();
     this.showDueDate();
     this.showDueTime();
-    this.showAttachment();
+    this.showForm();
   },
   showState() {
     const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
@@ -132,10 +132,10 @@ const ActionItemView = View.extend({
 
     this.showChildView('dueTime', dueTimeComponent);
   },
-  showAttachment() {
+  showForm() {
     if (!this.model.getForm()) return;
 
-    this.showChildView('attachment', new AttachmentButton({ model: this.model }));
+    this.showChildView('form', new FormButton({ model: this.model }));
   },
 });
 

--- a/test/integration/admin/programs/program/program-flow.js
+++ b/test/integration/admin/programs/program/program-flow.js
@@ -643,7 +643,7 @@ context('program flow page', function() {
 
     cy
       .get('@actionSidebar')
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .should('contain', 'Test Form')
       .click();
 
@@ -705,14 +705,14 @@ context('program flow page', function() {
     cy
       .get('.table-list__item')
       .first()
-      .find('.js-attachment')
+      .find('.js-form')
       .should('not.exist');
 
     cy
       .get('.table-list__item')
       .first()
       .next()
-      .find('.js-attachment')
+      .find('.js-form')
       .click();
 
     cy

--- a/test/integration/admin/programs/program/workflows.js
+++ b/test/integration/admin/programs/program/workflows.js
@@ -174,7 +174,7 @@ context('program workflows page', function() {
     cy
       .get('.table-list__item')
       .first()
-      .find('.js-attachment')
+      .find('.js-form')
       .click();
 
     cy
@@ -188,7 +188,7 @@ context('program workflows page', function() {
       .get('.table-list__item')
       .first()
       .next()
-      .find('.js-attachment')
+      .find('.js-form')
       .should('not.exist');
   });
 

--- a/test/integration/admin/sidebar/action-sidebar.js
+++ b/test/integration/admin/sidebar/action-sidebar.js
@@ -57,15 +57,12 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-<<<<<<< Updated upstream
-=======
       .find('[data-form-region]')
       .contains('Add Form')
       .should('be.disabled');
 
     cy
       .get('.sidebar')
->>>>>>> Stashed changes
       .find('[data-name-region] .js-input')
       .type('Test Name')
       .tab()

--- a/test/integration/admin/sidebar/action-sidebar.js
+++ b/test/integration/admin/sidebar/action-sidebar.js
@@ -57,6 +57,15 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
+<<<<<<< Updated upstream
+=======
+      .find('[data-form-region]')
+      .contains('Add Form')
+      .should('be.disabled');
+
+    cy
+      .get('.sidebar')
+>>>>>>> Stashed changes
       .find('[data-name-region] .js-input')
       .type('Test Name')
       .tab()
@@ -481,8 +490,8 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-attachment-region]')
-      .contains('Add Attachment...')
+      .find('[data-form-region]')
+      .contains('Add Form...')
       .click();
 
     cy
@@ -523,7 +532,7 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .should('contain', 'Test Form')
       .find('.fa-expand-alt')
       .click();
@@ -556,8 +565,8 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-attachment-region]')
-      .contains('Add Attachment...')
+      .find('[data-form-region]')
+      .contains('Add Form...')
       .click();
 
     cy

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -83,7 +83,7 @@ context('Patient Form', function() {
 
     cy
       .get('.tooltip')
-      .should('contain', 'Print Attachment');
+      .should('contain', 'Print Form');
 
     cy
       .get('.js-print-button')
@@ -285,7 +285,7 @@ context('Patient Form', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .find('button')
       .should('be.disabled');
 
@@ -405,7 +405,7 @@ context('Patient Form', function() {
       .get('.table-list')
       .find('.table-list__item')
       .first()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .click()
       .wait('@routeAction')
       .wait('@routePatientByAction');

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -333,10 +333,10 @@ context('patient dashboard page', function() {
       .first()
       .next()
       .next()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .should('be.empty');
 
-    // dirty hack to make sure the attachment button isn't offscreen
+    // dirty hack to make sure the form button isn't offscreen
     cy
       .get('.table-list__item')
       .first()
@@ -351,7 +351,7 @@ context('patient dashboard page', function() {
     cy
       .get('.table-list__item')
       .first()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .find('button')
       .click();
 

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -293,13 +293,13 @@ context('patient data and events page', function() {
       .first()
       .next()
       .next()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .should('be.empty');
 
     cy
       .get('.table-list__item')
       .first()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .click();
 
     cy

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -202,7 +202,7 @@ context('patient flow page', function() {
         expect($action.find('.fa-exclamation-circle')).to.exist;
         expect($action.find('[data-owner-region')).to.contain('NUR');
         expect($action.find('[data-due-day-region] .is-overdue')).to.exist;
-        expect($action.find('[data-attachment-region]')).not.to.be.empty;
+        expect($action.find('[data-form-region]')).not.to.be.empty;
       });
 
     cy

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -78,7 +78,7 @@ context('action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .should('not.contain', 'Attachment');
+      .should('not.contain', 'Form');
 
     cy
       .get('.sidebar')
@@ -638,7 +638,8 @@ context('action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .should('not.contain', 'Attachment');
+      .find('[data-form-region]')
+      .should('be.empty');
 
     cy
       .get('.sidebar__footer')
@@ -664,9 +665,9 @@ context('action sidebar', function() {
       .should('contain', 'Clinician McTester (Nurse) changed the name of this Action from New Action to New Action Name Updated')
       .should('contain', 'Clinician McTester (Nurse) changed the Owner to Physician')
       .should('contain', 'Clinician McTester (Nurse) changed State to Done')
-      .should('contain', 'Clinician McTester (Nurse) added the attachment Test Form')
-      .should('contain', 'Clinician McTester (Nurse) removed the attachment Test Form')
-      .should('contain', 'Clinician McTester (Nurse) worked on the attachment Test Form')
+      .should('contain', 'Clinician McTester (Nurse) added the form Test Form')
+      .should('contain', 'Clinician McTester (Nurse) removed the form Test Form')
+      .should('contain', 'Clinician McTester (Nurse) worked on the form Test Form')
       .should('contain', 'Clinician McTester (Nurse) changed the Due Time to ')
       .should('contain', 'Clinician McTester (Nurse) cleared the Due Time');
   });
@@ -1001,7 +1002,7 @@ context('action sidebar', function() {
       .routePatientByAction();
 
     cy
-      .get('[data-attachment-region] button')
+      .get('[data-form-region] button')
       .should('contain', 'Test Form')
       .click();
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -533,7 +533,7 @@ context('worklist page', function() {
       .eq(2)
       .should('contain', 'Action')
       .next()
-      .should('contain', 'State, Owner, Due Date, Attachment')
+      .should('contain', 'State, Owner, Due Date, Form')
       .next()
       .should('contain', 'Created')
       .next()
@@ -762,12 +762,12 @@ context('worklist page', function() {
       .get('.app-frame__content')
       .find('.table-list__item')
       .last()
-      .find('[data-attachment-region]')
+      .find('[data-form-region]')
       .should('be.empty');
 
     cy
       .get('@secondRow')
-      .find('[data-attachment-region] button')
+      .find('[data-form-region] button')
       .click();
 
     cy


### PR DESCRIPTION
[x] [ch23757]
This does not go as far as to change classnames, component names and `data-attachment-region` names. It's mainly i18n changes. 

@paulfalgout, do you think we should also change region names to `data-form-region` in this PR?

Sofia also found an existing button with the attachment component disabled state. That's been fixed in this PR as well.