### PR TITLE
Increase cypress retries in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ workflows:
           parallelism: 2
           group: 'care ops chrome'
           start: 'npm start'
+          config: retries=2
       - cypress/run:
           pre-steps:
             - jq/install
@@ -180,3 +181,4 @@ workflows:
           parallelism: 2
           group: 'care ops firefox'
           start: 'npm start'
+          config: retries=2


### PR DESCRIPTION
- [x] Add the Clubhouse Story ID: [ch24456]

I'm still trying to sort out how this plays with the retries config in cypress.json. I think it should override that setting.