### PR TITLE
Handle formio errors

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -23,8 +23,9 @@ function renderForm({ definition, submission }) {
       form.submission = clone(submission);
 
       form.on('submit', response => {
-        router.once('form:error', errors => {
-          form.emit('error', errors);
+        router.once('form:errors', errors => {
+          form.showErrors(errors);
+          form.emit('error');
         });
         router.request('submit:form', { response });
       });

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { extend } from 'underscore';
+import { extend, pluck } from 'underscore';
 
 import Radio from 'backbone.radio';
 
@@ -72,8 +72,8 @@ export default App.extend({
     formResponse.saveAll()
       .then(() => {
         this.trigger('success', formResponse);
-      }).fail(errors => {
-        /* istanbul ignore next: Don't need to test error handler */
+      }).fail(({ responseJSON }) => {
+        const errors = pluck(responseJSON.errors, 'detail');
         channel.request('send', 'form:errors', errors);
       });
   },


### PR DESCRIPTION
form.io only expects an array of string and doesn’t tie errors to specific fields.

So this in theory actually handles any error, if we ever throw errors for the form itself.

- [x] Add the Clubhouse Story ID: [ch24696]
