### PR TITLE
Up config version

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,7 +4,7 @@ import Radio from 'backbone.radio';
 
 import 'sass/app-root.scss';
 
-const configVersion = '3';
+const configVersion = '4';
 
 function startForm() {
   import(/* webpackChunkName: "formapp" */'./formapp')


### PR DESCRIPTION
When we implement with the datadog config we’ll remove this entirely.  It’s no longer needed.

@BenCoffeed this'll force it to re-download regardless of cache.