### PR TITLE
Expose formio evaluator errors as error

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -52,6 +52,18 @@ Formio.use({
   },
 });
 
+// NOTE: Evaluator should throw errors
+// https://github.com/formio/formio.js/issues/4613
+const evaluator = Formio.Evaluator.evaluator;
+Formio.Evaluator.evaluator = function(func, ...params) {
+  try {
+    return evaluator(func, ...params);
+  } catch (e) {
+    /* eslint-disable-next-line no-console */
+    console.error(e);
+  }
+};
+
 function getDirectory(directoryName, query) {
   return router.request('fetch:directory', { directoryName, query });
 }

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -9,5 +9,26 @@
     "options": {
       "read_only": true
     }
+  },
+  {
+    "id": "33333",
+    "name": "Script and Reducers",
+    "options": {
+      "context": [
+        "return { foo() { return 'foo'; } }"
+      ],
+      "reducers": [
+        "formSubmission.storyTime = foo()\nreturn formSubmission"
+      ]
+    }
+  },
+  {
+    "id": "44444",
+    "name": "Reducer Error",
+    "options": {
+      "reducers": [
+        "syntaxError('foo;"
+      ]
+    }
   }
 ]

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -951,6 +951,52 @@ context('Patient Form', function() {
       .find('textarea[name="data[storyTime]"]');
   });
 
+  specify('form scripts and reducers', function() {
+    cy
+      .server()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormFields()
+      .visit('/patient/1/form/33333')
+      .wait('@routePatient')
+      .wait('@routeFormFields')
+      .wait('@routeFormDefinition');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[storyTime]"]')
+      .should('contain', 'foo');
+  });
+
+  specify('form reducer error', function() {
+    cy
+      .server()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormFields()
+      .visit('/patient/1/form/44444');
+
+    cy
+      .get('iframe')
+      .its('0.contentWindow')
+      .should('not.be.empty')
+      .then(win => {
+        cy
+          .stub(win.console, 'error')
+          .as('consoleError');
+
+        cy
+          .get('@consoleError')
+          .should('be.calledOnce');
+      });
+  });
+
   specify('form error', function() {
     cy
       .server()


### PR DESCRIPTION
[sc-27773]

Currently errors that occur in our custom javascript added to forms either in the definition or context scripts/reducers are caught and delivered as warnings instead of errors by form.io

This prevents us from seeing errors on production and makes it such that real errors are not obvious.

I’ve asked form.io to formally allow for caught errors to throw as errors here:
https://github.com/formio/formio.js/issues/4613

Shortcut Story ID: [sc-###]
