### PR TITLE
Expand forms by default and store user preference in localStorage

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -79,11 +79,14 @@ export default App.extend({
     });
   },
   stateEvents: {
-    'change': 'onChangeState',
-    'change:isExpanded': 'showSidebar',
+    'change:isExpanded': 'onChangeIsExpanded',
   },
-  onChangeState(state) {
-    store.set(`form-state_${ this.currentUser.id }`, { isExpanded: this.getState('isExpanded') });
+  onChangeIsExpanded() {
+    const isExpanded = this.getState('isExpanded');
+
+    store.set(`form-state_${ this.currentUser.id }`, { isExpanded: isExpanded });
+
+    this.showSidebar();
   },
   showFormStatus(response) {
     if (this.isReadOnly) return;

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -1,7 +1,7 @@
+import { extend } from 'underscore';
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
-import { extend } from 'underscore';
 
 import App from 'js/base/app';
 
@@ -20,13 +20,14 @@ export default App.extend({
     },
   },
   initFormState() {
-    const currentUser = Radio.request('bootstrap', 'currentUser');
-    const storedState = store.get(`form-state_${ currentUser.id }`);
+    const storedState = store.get(`form-state_${ this.currentUser.id }`);
 
     this.setState(extend({ isExpanded: true }, storedState));
   },
   onBeforeStart() {
     this.getRegion().startPreloader();
+
+    this.currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.initFormState();
   },
@@ -43,7 +44,6 @@ export default App.extend({
     this.patient = patient;
     this.form = form;
     this.isReadOnly = this.form.isReadOnly();
-    this.currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.startFormService();
 

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -84,7 +84,7 @@ export default App.extend({
   onChangeIsExpanded() {
     const isExpanded = this.getState('isExpanded');
 
-    store.set(`form-state_${ this.currentUser.id }`, { isExpanded: isExpanded });
+    store.set(`form-state_${ this.currentUser.id }`, { isExpanded });
 
     this.showSidebar();
   },

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -83,8 +83,6 @@ export default App.extend({
     'change:isExpanded': 'showSidebar',
   },
   onChangeState(state) {
-    if (!state.hasChanged('isExpanded')) return;
-
     store.set(`form-state_${ this.currentUser.id }`, { isExpanded: this.getState('isExpanded') });
   },
   showFormStatus(response) {

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -1,5 +1,7 @@
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
+import store from 'store';
+import { extend } from 'underscore';
 
 import App from 'js/base/app';
 
@@ -28,14 +30,16 @@ export default App.extend({
       getOptions: ['patient'],
     },
   },
+  initFormState() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const storedState = store.get(`form-state_${ currentUser.id }`);
+
+    this.setState(extend({ isActionSidebar: true, isExpanded: true, shouldShowHistory: false }, storedState));
+  },
   onBeforeStart() {
     this.getRegion().startPreloader();
 
-    this.setState({
-      isActionSidebar: true,
-      isExpanded: false,
-      shouldShowHistory: false,
-    });
+    this.initFormState();
   },
   beforeStart({ patientActionId }) {
     return [
@@ -56,6 +60,7 @@ export default App.extend({
     this.responses = action.getFormResponses();
     this.form = this.action.getForm();
     this.isReadOnly = this.form.isReadOnly();
+    this.currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);
@@ -110,6 +115,8 @@ export default App.extend({
     if (!state.hasChanged('isExpanded') && !state.hasChanged('isActionSidebar')) return;
 
     this.showSidebar();
+
+    store.set(`form-state_${ this.currentUser.id }`, { isExpanded: this.getState('isExpanded') });
   },
   onChangeResponseId() {
     this.showForm();

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -1,7 +1,7 @@
+import { extend } from 'underscore';
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
-import { extend } from 'underscore';
 
 import App from 'js/base/app';
 
@@ -31,13 +31,14 @@ export default App.extend({
     },
   },
   initFormState() {
-    const currentUser = Radio.request('bootstrap', 'currentUser');
-    const storedState = store.get(`form-state_${ currentUser.id }`);
+    const storedState = store.get(`form-state_${ this.currentUser.id }`);
 
     this.setState(extend({ isActionSidebar: true, isExpanded: true, shouldShowHistory: false }, storedState));
   },
   onBeforeStart() {
     this.getRegion().startPreloader();
+
+    this.currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.initFormState();
   },
@@ -60,7 +61,6 @@ export default App.extend({
     this.responses = action.getFormResponses();
     this.form = this.action.getForm();
     this.isReadOnly = this.form.isReadOnly();
-    this.currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -803,7 +803,7 @@ context('Patient Action Form', function() {
       .as('sidebarButton')
       .should('have.class', 'is-selected')
       .trigger('mouseover');
-    
+
     cy
       .get('.js-expand-button')
       .as('expandButton')
@@ -812,7 +812,7 @@ context('Patient Action Form', function() {
     cy
       .get('.tooltip')
       .should('contain', 'Increase Width');
-    
+
     cy
       .get('@expandButton')
       .find('.icon')
@@ -824,7 +824,7 @@ context('Patient Action Form', function() {
       .click()
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-        
+
         expect(storage.isExpanded).to.be.true;
       });
 
@@ -834,7 +834,7 @@ context('Patient Action Form', function() {
       .click()
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-        
+
         expect(storage.isExpanded).to.be.false;
       });
   });
@@ -1137,7 +1137,7 @@ context('Patient Form', function() {
     cy
       .get('.form__sidebar')
       .should('exist');
-    
+
     cy
       .get('.js-expand-button')
       .as('expandButton')
@@ -1146,7 +1146,7 @@ context('Patient Form', function() {
     cy
       .get('.tooltip')
       .should('contain', 'Increase Width');
-    
+
     cy
       .get('@expandButton')
       .find('.icon')
@@ -1158,7 +1158,7 @@ context('Patient Form', function() {
       .click()
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-        
+
         expect(storage.isExpanded).to.be.true;
       });
 
@@ -1168,7 +1168,7 @@ context('Patient Form', function() {
       .click()
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-        
+
         expect(storage.isExpanded).to.be.false;
       });
   });

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -477,6 +477,16 @@ context('Patient Action Form', function() {
       .should('contain', 'Hide Action Sidebar');
 
     cy
+      .get('@expandButton')
+      .trigger('mouseout')
+      .click();
+
+    cy
+      .get('@sidebarButton')
+      .trigger('mouseout')
+      .click();
+
+    cy
       .get('.sidebar')
       .find('[data-form-region]')
       .find('button')

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -310,7 +310,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.tooltip')
-      .should('contain', 'Increase Width');
+      .should('contain', 'Decrease Width');
 
     cy
       .get('@expandButton')
@@ -320,7 +320,7 @@ context('Patient Action Form', function() {
     cy
       .get('@expandButton')
       .find('.icon')
-      .should('have.class', 'fa-compress-alt');
+      .should('have.class', 'fa-expand-alt');
 
     cy
       .get('@expandButton')
@@ -334,10 +334,9 @@ context('Patient Action Form', function() {
       .get('@expandButton')
       .trigger('mouseout');
 
-
     cy
       .get('.sidebar')
-      .should('not.exist');
+      .should('exist');
 
     cy
       .get('.js-history-button')
@@ -358,7 +357,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.sidebar')
-      .should('exist');
+      .should('not.exist');
 
     cy
       .get('@expandButton')
@@ -470,17 +469,12 @@ context('Patient Action Form', function() {
     cy
       .get('.js-sidebar-button')
       .as('sidebarButton')
-      .should('not.have.class', 'is-selected')
+      .should('have.class', 'is-selected')
       .trigger('mouseover');
 
     cy
       .get('.tooltip')
-      .should('contain', 'Show Action Sidebar');
-
-    cy
-      .get('@sidebarButton')
-      .trigger('mouseout')
-      .click();
+      .should('contain', 'Hide Action Sidebar');
 
     cy
       .get('.sidebar')
@@ -778,6 +772,72 @@ context('Patient Action Form', function() {
       .get('iframe')
       .should('have.attr', 'src', '/formapp/');
   });
+
+  specify('store expanded state in localStorage', function() {
+    localStorage.setItem('form-state_11111', JSON.stringify({ isExpanded: false }));
+
+    cy
+      .server()
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.form.data = { id: '22222' };
+        fx.data.relationships['form-responses'].data = [];
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeActionActivity()
+      .routePatientByAction()
+      .routeFormActionFields()
+      .visit('/patient-action/1/form/22222')
+      .wait('@routeAction')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition');
+
+    cy
+      .get('.sidebar')
+      .should('exist');
+
+    cy
+      .get('.js-sidebar-button')
+      .as('sidebarButton')
+      .should('have.class', 'is-selected')
+      .trigger('mouseover');
+    
+    cy
+      .get('.js-expand-button')
+      .as('expandButton')
+      .trigger('mouseover');
+
+    cy
+      .get('.tooltip')
+      .should('contain', 'Increase Width');
+    
+    cy
+      .get('@expandButton')
+      .find('.icon')
+      .should('have.class', 'fa-expand-alt');
+
+    cy
+      .get('@expandButton')
+      .trigger('mouseout')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+        
+        expect(storage.isExpanded).to.be.true;
+      });
+
+    cy
+      .get('@expandButton')
+      .trigger('mouseout')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+        
+        expect(storage.isExpanded).to.be.false;
+      });
+  });
 });
 
 context('Patient Form', function() {
@@ -813,7 +873,7 @@ context('Patient Form', function() {
 
     cy
       .get('.tooltip')
-      .should('contain', 'Increase Width');
+      .should('contain', 'Decrease Width');
 
     cy
       .get('@expandButton')
@@ -823,7 +883,7 @@ context('Patient Form', function() {
     cy
       .get('@expandButton')
       .find('.icon')
-      .should('have.class', 'fa-compress-alt');
+      .should('have.class', 'fa-expand-alt');
 
     cy
       .get('@expandButton')
@@ -836,7 +896,6 @@ context('Patient Form', function() {
     cy
       .get('@expandButton')
       .trigger('mouseout');
-
 
     cy
       .get('.sidebar')
@@ -1057,6 +1116,61 @@ context('Patient Form', function() {
       .get('@iframe')
       .find('.alert')
       .contains('Insufficient permissions');
+  });
+
+  specify('store expanded state in localStorage', function() {
+    localStorage.setItem('form-state_11111', JSON.stringify({ isExpanded: false }));
+
+    cy
+      .server()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormFields()
+      .visit('/patient/1/form/22222')
+      .wait('@routePatient')
+      .wait('@routeFormFields')
+      .wait('@routeFormDefinition');
+
+    cy
+      .get('.form__sidebar')
+      .should('exist');
+    
+    cy
+      .get('.js-expand-button')
+      .as('expandButton')
+      .trigger('mouseover');
+
+    cy
+      .get('.tooltip')
+      .should('contain', 'Increase Width');
+    
+    cy
+      .get('@expandButton')
+      .find('.icon')
+      .should('have.class', 'fa-expand-alt');
+
+    cy
+      .get('@expandButton')
+      .trigger('mouseout')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+        
+        expect(storage.isExpanded).to.be.true;
+      });
+
+    cy
+      .get('@expandButton')
+      .trigger('mouseout')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+        
+        expect(storage.isExpanded).to.be.false;
+      });
   });
 });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-27808]

When a form is viewed, change the default to be expanded width mode. When a user selects an option to have the form expanded or not, remember that preference across pages and app reloads.

The user's preference is persisted by storing an `isExpanded: boolean` key-value in localStorage.

This feature caused some tests to break, so those were updated to pass. And a few new tests were added to ensure the localStorage feature works properly.