### PR TITLE
Revert "fix: upgrade @fortawesome/fontawesome-svg-core from 1.2.36 to 1.3.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@datadog/browser-logs": "^4.3.0",
         "@datadog/browser-rum": "^4.3.0",
         "@fortawesome/fontawesome-pro": "^5.15.4",
-        "@fortawesome/fontawesome-svg-core": "^1.3.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/pro-light-svg-icons": "^5.15.4",
         "@fortawesome/pro-regular-svg-icons": "^5.15.4",
         "@fortawesome/pro-solid-svg-icons": "^5.15.4",
@@ -1930,22 +1930,12 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz",
-      "integrity": "sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==",
-      "hasInstallScript": true,
+      "version": "1.2.36",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/1.2.36/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
-      "integrity": "sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==",
-      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -15864,18 +15854,11 @@
       "integrity": "sha512-ApOqpDdKgA79xfLZH3B5PucZxj+TZyQUSrZ4bKkbJCR+zjmveQ4/gp/uXc5bNNhsdtJUy16BYJ/lAVydca2Y5Q=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz",
-      "integrity": "sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==",
+      "version": "1.2.36",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/1.2.36/fontawesome-svg-core-1.2.36.tgz",
+      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
-      },
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
-          "integrity": "sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w=="
-        }
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
       }
     },
     "@fortawesome/pro-light-svg-icons": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "@datadog/browser-logs": "^4.3.0",
     "@datadog/browser-rum": "^4.3.0",
     "@fortawesome/fontawesome-pro": "^5.15.4",
-    "@fortawesome/fontawesome-svg-core": "^1.3.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/pro-light-svg-icons": "^5.15.4",
     "@fortawesome/pro-regular-svg-icons": "^5.15.4",
     "@fortawesome/pro-solid-svg-icons": "^5.15.4",


### PR DESCRIPTION
This reverts commit 379ace2ddd41bd5f6210a2bc2dc49da00eba9de4.

Shortcut Story ID: [sc-27994]
