### PR TITLE
Add Ipad touch support for tooltips

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -107,7 +107,7 @@ const Application = App.extend({
       Radio.trigger('user-activity', 'document:mouseleave', evt);
     });
 
-    $('body').on('mousedown.app touchstart.app', function(evt) {
+    $('body').on('pointerdown.app', function(evt) {
       Radio.trigger('user-activity', 'body:down', evt);
     });
   },

--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -45,9 +45,11 @@ export default Component.extend({
   setListeners() {
     if (!this.ui) return;
 
-    this.ui.on('mouseenter.tooltip', bind(this.showTooltip, this));
+    this.ui.on('pointerenter.tooltip', bind(this.showTooltip, this));
 
     this.ui.on('mouseleave.tooltip', bind(this.hideTooltip, this));
+
+    this.ui.on('pointerdown.tooltip', bind(this.showTooltip, this));
   },
   showTooltip() {
     clearTimeout(this.delayTimeout);

--- a/test/integration/components/tooltip.js
+++ b/test/integration/components/tooltip.js
@@ -61,7 +61,21 @@ context('Tooltip', function() {
         .get('@hook')
         .contains(model.id)
         .as('button')
-        .trigger('mouseover');
+        .trigger('pointerover');
+
+      cy
+        .get('.tooltip')
+        .contains(model.id);
+
+      cy
+        .get('@button')
+        .trigger('mouseout');
+
+      cy
+        .get('@hook')
+        .contains(model.id)
+        .as('button')
+        .trigger('pointerdown');
 
       cy
         .get('.tooltip')
@@ -89,7 +103,21 @@ context('Tooltip', function() {
         .get('@hook')
         .contains(model.id)
         .as('button')
-        .trigger('mouseover');
+        .trigger('pointerover');
+
+      cy
+        .get('.tooltip')
+        .contains(model.id);
+
+      cy
+        .get('@button')
+        .trigger('mouseout');
+
+      cy
+        .get('@hook')
+        .contains(model.id)
+        .as('button')
+        .trigger('pointerdown');
 
       cy
         .get('.tooltip')

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -293,7 +293,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.js-print-button')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -306,7 +306,7 @@ context('Patient Action Form', function() {
     cy
       .get('.js-expand-button')
       .as('expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -324,7 +324,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('@expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -341,7 +341,7 @@ context('Patient Action Form', function() {
     cy
       .get('.js-history-button')
       .as('historyBtn')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -378,7 +378,7 @@ context('Patient Action Form', function() {
     cy
       .get('@historyBtn')
       .should('have.class', 'is-selected')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -470,7 +470,7 @@ context('Patient Action Form', function() {
       .get('.js-sidebar-button')
       .as('sidebarButton')
       .should('have.class', 'is-selected')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -817,7 +817,7 @@ context('Patient Action Form', function() {
     cy
       .get('.js-expand-button')
       .as('expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -879,7 +879,7 @@ context('Patient Form', function() {
     cy
       .get('.js-expand-button')
       .as('expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -897,7 +897,7 @@ context('Patient Form', function() {
 
     cy
       .get('@expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1151,7 +1151,7 @@ context('Patient Form', function() {
     cy
       .get('.js-expand-button')
       .as('expandButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -807,7 +807,7 @@ context('action sidebar', function() {
       .eq(2)
       .find('.js-edit')
       .as('editIcon')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -833,7 +833,7 @@ context('action sidebar', function() {
       .eq(1)
       .as('activityComment')
       .find('.js-edit')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -279,7 +279,7 @@ context('schedule page', function() {
       .find('tr')
       .last()
       .find('[data-details-region] div')
-      .trigger('mouseover', { force: true });
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -847,7 +847,7 @@ context('worklist page', function() {
       .find('.table-list__item')
       .last()
       .find('[data-details-region]')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -863,7 +863,7 @@ context('worklist page', function() {
       .find('.table-list__item')
       .first()
       .find('[data-details-region]')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1290,7 +1290,7 @@ context('worklist page', function() {
       .should('contain', 'Added:')
       .should('contain', formatDate(filterDate, 'MM/DD/YYYY'))
       .find('.js-prev')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1314,7 +1314,7 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', formatDate(testDateSubtract(2), 'MM/DD/YYYY'))
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1361,13 +1361,12 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', 'Last Week')
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
       .should('contain', formatDate(dayjs(filterDate).startOf('week'), 'MM/DD/YYYY'))
       .should('contain', formatDate(dayjs(filterDate).endOf('week'), 'MM/DD/YYYY'));
-
 
     cy
       .get('[data-date-filter-region]')
@@ -1429,7 +1428,7 @@ context('worklist page', function() {
       .should('contain', 'Updated:')
       .should('contain', 'This Month')
       .find('.js-prev')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1468,7 +1467,7 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', 'This Month')
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1520,7 +1519,7 @@ context('worklist page', function() {
       .should('contain', 'Due:')
       .should('contain', 'Today')
       .find('.js-prev')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1560,7 +1559,7 @@ context('worklist page', function() {
       .should('contain', 'Added:')
       .should('contain', 'Today')
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1610,7 +1609,7 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', 'Yesterday')
       .find('.js-prev')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1644,7 +1643,7 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', 'Yesterday')
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1693,7 +1692,7 @@ context('worklist page', function() {
     cy
       .get('[data-date-filter-region]')
       .find('.js-prev')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -1716,7 +1715,7 @@ context('worklist page', function() {
       .get('[data-date-filter-region]')
       .should('contain', formatDate(testDateSubtract(1, 'month'), 'MMM YYYY'))
       .find('.js-next')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -455,7 +455,7 @@ context('program action sidebar', function() {
       .find('[data-state-region]')
       .contains('To Do')
       .as('stateButton')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -310,7 +310,7 @@ context('flow sidebar', function() {
 
     cy
       .get('[data-state-region]')
-      .trigger('mouseover');
+      .trigger('pointerover');
 
     cy
       .get('.tooltip')
@@ -420,5 +420,3 @@ context('flow sidebar', function() {
       .should('contain', 'program/1');
   });
 });
-
-


### PR DESCRIPTION
Shortcut Story ID: [sc-27936]

Adds better support for tooltips on touch devices. The change was specifically made to accommodate Ipad devices.

Currently, the `mouseenter` event is being used to open tooltips. Which works smoothly on non-touch devices, but not as well on touch screens. This pull request uses `pointerenter` to open tooltips on conventional desktop devices. And also adds a `pointerdown` event listener to open tooltips on touch screens. These changes add touch support without breaking anything on the non-touch device experience.

These code changes caused many tests to break where tooltips were opened. To fix that, instances of `trigger('mouseover')` were replaced with `trigger('pointerover)` in the tests.

Also, some additional testing was added to the tooltip component to ensure the tooltips open on touch screens using the `pointerdown` event trigger.