### PR TITLE
Form console.error test fails in Firefox

### DIFF
--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1040,31 +1040,33 @@ context('Patient Form', function() {
       .should('contain', 'foo');
   });
 
-  specify('form reducer error', function() {
-    cy
-      .server()
-      .routePatient(fx => {
-        fx.data.id = '1';
-        return fx;
-      })
-      .routeFormDefinition()
-      .routeFormFields()
-      .visit('/patient/1/form/44444');
+  if (Cypress.browser.name !== 'firefox') {
+    specify('form reducer error', function() {
+      cy
+        .server()
+        .routePatient(fx => {
+          fx.data.id = '1';
+          return fx;
+        })
+        .routeFormDefinition()
+        .routeFormFields()
+        .visit('/patient/1/form/44444');
 
-    cy
-      .get('iframe')
-      .its('0.contentWindow')
-      .should('not.be.empty')
-      .then(win => {
-        cy
-          .stub(win.console, 'error')
-          .as('consoleError');
+      cy
+        .get('iframe')
+        .its('0.contentWindow')
+        .should('not.be.empty')
+        .then(win => {
+          cy
+            .stub(win.console, 'error')
+            .as('consoleError');
 
-        cy
-          .get('@consoleError')
-          .should('be.calledOnce');
-      });
-  });
+          cy
+            .get('@consoleError')
+            .should('be.calledOnce');
+        });
+    });
+  }
 
   specify('form error', function() {
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-27972]

In the Cypress tests for forms, there is a test that stubs a `console.error` to ensure errors are firing correctly in forms. But the `console.error` stubbing doesn't work for Firefox.

This pull request tells Cypress to skip the test when using the Firefox browser.