### PR TITLE
Stop tooltip clicks from bubbling up to parent row elements in worklist/schedule lists

### DIFF
--- a/src/js/views/patients/shared/actions_views.js
+++ b/src/js/views/patients/shared/actions_views.js
@@ -30,6 +30,9 @@ const FormButton = View.extend({
 
 const DetailsTooltip = View.extend({
   template: hbs`{{far "info-circle"}}`,
+  triggers: {
+    'click': 'prevent-row-click',
+  },
   onRender() {
     const template = hbs`
       {{#if flowName}}<p class="action-tooltip__flow"><span class="action-tooltip__flow-icon">{{fas "folder"}}</span>{{ flowName }}</p>{{/if}}


### PR DESCRIPTION
Shortcut Story ID: [sc-28103]

This is a bug fix.

When a tooltip is clicked on inside a row of the worklist/schedule table list, its click event bubbles up to its parent element. This causes the click event to happen on the table row and, therefore, navigate to a new page when it was not the user's intent to do so.

The click event should be contained to only the tooltip. This applies on both desktop and Ipad environments.

To implement this, a `'click': 'prevent-row-click'` trigger was added to the `DetailsTooltip` component.