### PR TITLE
Add org setting for reduced schedule

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -159,6 +159,10 @@ export default App.extend({
       appNavMenu.remove('PatientsApp');
     }
 
+    if (currentUser.can('reduced:patient:schedule')) {
+      patientsAppWorkflowsNav.reset(patientsAppWorkflowsNav.filter({ event: 'schedule' }));
+    }
+
     this.setView(new AppNavView());
 
     this.mainNav = new MainNavDroplist({ collection: appNavMenu });

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -53,6 +53,11 @@ const _Model = BaseModel.extend({
       return !(access === 'employee' && shouldRestrict);
     }
 
+    if (prop === 'reduced:patient:schedule') {
+      const shouldRestrict = Radio.request('bootstrap', 'currentOrg:setting', 'reduced_patient_schedule');
+      return access === 'employee' && shouldRestrict;
+    }
+
     /* istanbul ignore next */
     return (_DEVELOP_ && !sessionStorage.getItem('cypress'))
       || access === 'manager'

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -18,5 +18,9 @@
   {
     "id": "restrict_employee_access",
     "value": false
+  },
+  {
+    "id": "reduced_patient_schedule",
+    "value": false
   }
 ]

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -579,6 +579,43 @@ context('schedule page', function() {
       .should('be.empty');
   });
 
+  specify('reduced patient schedule employee', function() {
+    cy
+      .server()
+      .routeCurrentClinician(fx => {
+        fx.data.id = '123456';
+        fx.data.attributes.access = 'employee';
+        fx.data.attributes.enabled = true;
+        return fx;
+      })
+      .routeSettings(fx => {
+        const reducedPatientSchedule = _.find(fx.data, setting => setting.id === 'reduced_patient_schedule');
+        reducedPatientSchedule.attributes.value = true;
+
+        return fx;
+      })
+      .routeActions()
+      .visit('/schedule')
+      .wait('@routeActions');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .as('worklists');
+
+    cy
+      .get('@worklists')
+      .find('.app-nav__link')
+      .first()
+      .should('contain', 'Schedule')
+      .should('have.class', 'is-selected');
+
+    cy
+      .get('@worklists')
+      .find('.app-nav__link')
+      .should('have.length', 1);
+  });
+
   specify('bulk edit', function() {
     localStorage.setItem('schedule_11111-v2', JSON.stringify({
       filters: {


### PR DESCRIPTION
Shortcut Story ID: [sc-28114]

Add a `reduced_patient_schedule` organization setting to a clinician. When a clinician has a `reduced_patient_schedule` setting to `true`, only the `Schedule` element will be shown in the  `nav_app` sidebar.

This pull request also includes a Cypress test that verifies that the `nav_app` sidebar appears correctly for a clinician with this setting.
