### PR TITLE
Add reduced patients schedule app

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -8,6 +8,7 @@ import SidebarService from 'js/services/sidebar';
 import NavApp from './nav_app';
 import FormsApp from 'js/apps/forms/forms-main_app';
 import PatientsMainApp from 'js/apps/patients/patients-main_app';
+import ReducedPatientsMainApp from 'js/apps/patients/reduced-patients-main_app.js';
 import CliniciansMainApp from 'js/apps/clinicians/clinicians-main_app';
 import DashboardsMainApp from 'js/apps/dashboards/dashboards-main_app';
 import ProgramsMainApp from 'js/apps/programs/programs-main_app';
@@ -18,7 +19,8 @@ export default App.extend({
 
     new SidebarService({ region: this.getRegion('sidebar') });
     new NavApp({ region: this.getRegion('nav') });
-    new PatientsMainApp({ region: this.getRegion('content') });
+
+    this.startPatientsMain(currentUser);
 
     if (currentUser.can('admin')) {
       new CliniciansMainApp({ region: this.getRegion('content') });
@@ -27,6 +29,14 @@ export default App.extend({
     }
 
     this.initFormsApp();
+  },
+  startPatientsMain(currentUser) {
+    if (currentUser.can('reduced:patient:schedule')) {
+      new ReducedPatientsMainApp({ region: this.getRegion('content') });
+      return;
+    }
+
+    new PatientsMainApp({ region: this.getRegion('content') });
   },
   initFormsApp() {
     const formsApp = new FormsApp({ region: this.getRegion('content') });

--- a/src/js/apps/patients/reduced-patients-main_app.js
+++ b/src/js/apps/patients/reduced-patients-main_app.js
@@ -6,50 +6,38 @@ import RouterApp from 'js/base/routerapp';
 
 import FlowApp from 'js/apps/patients/patient/flow/flow_app';
 import PatientApp from 'js/apps/patients/patient/patient_app';
-import WorklistApp from 'js/apps/patients/worklist/worklist_app';
-import ScheduleApp from 'js/apps/patients/schedule/schedule_app';
+import ReducedScheduleApp from 'js/apps/patients/schedule/reduced_schedule_app';
 
 export default RouterApp.extend({
   routerAppName: 'PatientsApp',
-
   childApps() {
-    const worklistApp = WorklistApp;
-
     return {
       flow: FlowApp,
       patient: PatientApp,
-      ownedBy: worklistApp,
-      forRole: worklistApp,
-      newPastDay: worklistApp,
-      pastThree: worklistApp,
-      lastThirty: worklistApp,
-      schedule: ScheduleApp,
+      schedule: ReducedScheduleApp,
     };
   },
-
   defaultRoute() {
-    const defaultRoute = 'worklist';
-    const defaultWorklist = 'owned-by';
+    const defaultRoute = 'schedule';
 
     this.routeAction(defaultRoute, () => {
       defer(()=> {
-        this.navigateRoute(defaultRoute, defaultWorklist);
-        Radio.request('nav', 'select', this.routerAppName, defaultRoute, [defaultWorklist]);
-        this.setLatestList(defaultRoute, [defaultWorklist]);
-        this.showPatientsWorklist(defaultWorklist);
+        this.navigateRoute(defaultRoute);
+        Radio.request('nav', 'select', this.routerAppName, defaultRoute);
+        this.setLatestList(defaultRoute);
+        this.showSchedule();
       });
     });
   },
-
   eventRoutes() {
     return {
       'default': {
         action: 'defaultRoute',
         route: '',
       },
-      'worklist': {
-        action: 'showPatientsWorklist',
-        route: 'worklist/:id',
+      'schedule': {
+        action: 'showSchedule',
+        route: 'schedule',
         isList: true,
       },
       'patient:dashboard': {
@@ -76,40 +64,14 @@ export default RouterApp.extend({
         action: 'showFlow',
         route: 'flow/:id/action/:id',
       },
-      'schedule': {
-        action: 'showSchedule',
-        route: 'schedule',
-        isList: true,
-      },
-
     };
   },
-
   showPatient(patientId) {
     this.startRoute('patient', { patientId });
   },
-
-  showPatientsWorklist(worklistId) {
-    const worklistsById = {
-      'owned-by': 'ownedBy',
-      'shared-by': 'forRole',
-      'new-past-day': 'newPastDay',
-      'updated-past-three-days': 'pastThree',
-      'done-last-thirty-days': 'lastThirty',
-    };
-
-    if (!worklistsById[worklistId]) {
-      Radio.trigger('event-router', 'notFound');
-      return;
-    }
-
-    this.startCurrent(worklistsById[worklistId], { worklistId });
-  },
-
   showFlow(flowId) {
     this.startRoute('flow', { flowId });
   },
-
   showSchedule() {
     this.startCurrent('schedule');
   },

--- a/src/js/apps/patients/schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced_schedule_app.js
@@ -1,0 +1,84 @@
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+import { STATE_STATUS } from 'js/static';
+
+import SearchComponent from 'js/views/patients/shared/components/list-search';
+
+import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
+
+export default App.extend({
+  onBeforeStart() {
+    if (this.isRestarting()) {
+      this.showScheduleTitle();
+      this.getRegion('list').startPreloader();
+      return;
+    }
+
+    this.setState({ isReduced: true });
+
+    this.showView(new LayoutView({
+      state: this.getState(),
+    }));
+
+    this.getRegion('list').startPreloader();
+
+    this.showScheduleTitle();
+    this.showSearchView();
+    this.showTableHeaders();
+  },
+  beforeStart() {
+    const currentClinician = Radio.request('bootstrap', 'currentUser');
+
+    const filter = {
+      clinician: currentClinician.id,
+      status: [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(','),
+      group: currentClinician.getGroups().pluck('id').join(','),
+    };
+
+    return Radio.request('entities', 'fetch:actions:collection', { filter });
+  },
+  onStart(options, collection) {
+    this.collection = collection;
+
+    this.showScheduleList();
+    this.showSearchView();
+  },
+  showScheduleList() {
+    const collectionView = new ScheduleListView({
+      collection: this.collection.groupByDate(),
+      state: this.getState(),
+    });
+
+    this.showChildView('list', collectionView);
+  },
+  showScheduleTitle() {
+    const currentClinician = Radio.request('bootstrap', 'currentUser');
+    const owner = Radio.request('entities', 'clinicians:model', currentClinician.id);
+
+    this.showChildView('title', new ScheduleTitleView({
+      model: owner,
+    }));
+  },
+  showSearchView() {
+    const searchComponent = this.showChildView('search', new SearchComponent({
+      state: {
+        query: this.getState('searchQuery'),
+        isDisabled: !this.collection || !this.collection.length,
+      },
+    }));
+
+    this.listenTo(searchComponent.getState(), 'change:query', this.setSearchState);
+  },
+  showTableHeaders() {
+    const tableHeadersView = new TableHeaderView();
+
+    this.showChildView('table', tableHeadersView);
+  },
+  setSearchState(state, searchQuery) {
+    this.setState({
+      searchQuery: searchQuery.length > 2 ? searchQuery : '',
+    });
+  },
+});

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -88,7 +88,7 @@ const DayItemView = View.extend({
   className: 'schedule-list__day-list-row',
   template: hbs`
     <td class="schedule-list__action-list-cell schedule-list__due-time {{#if isOverdue}}is-overdue{{/if}}">
-      <button class="button--checkbox u-margin--r-8 js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button>
+      {{#unless isReduced}}<button class="button--checkbox u-margin--r-8 js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button>{{/unless}}
       {{#if due_time}}
         {{formatDateTime due_time "TIME" inputFormat="HH:mm:ss"}}&#8203;
       {{else}}
@@ -116,15 +116,18 @@ const DayItemView = View.extend({
   templateContext() {
     const state = this.model.getState();
 
+    const isReduced = this.state.get('isReduced');
+
     return {
       isOverdue: this.model.isOverdue(),
       state: state.get('name'),
       stateOptions: state.get('options'),
       patient: this.model.getPatient().attributes,
       form: this.model.getForm(),
-      isSelected: this.state.isSelected(this.model),
+      isSelected: !isReduced && this.state.isSelected(this.model),
       flow: this.model.getFlow() && this.model.getFlow().get('name'),
       hasOutreach: this.model.hasOutreach(),
+      isReduced: isReduced,
     };
   },
   ui: {

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -28,6 +28,26 @@ context('patient page', function() {
       .should('contain', 'worklist/owned-by');
   });
 
+  specify('current clinician has reduced patient schedule access', function() {
+    cy
+      .server()
+      .routeCurrentClinician(fx => {
+        fx.data.attributes.access = 'employee';
+        return fx;
+      })
+      .routeSettings(fx => {
+        const reducedPatientSchedule = _.find(fx.data, setting => setting.id === 'reduced_patient_schedule');
+        reducedPatientSchedule.attributes.value = true;
+
+        return fx;
+      })
+      .visit('/');
+
+    cy
+      .url()
+      .should('contain', 'schedule');
+  });
+
   specify('current clinician has no groups', function() {
     cy
       .server()

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -595,8 +595,12 @@ context('schedule page', function() {
         return fx;
       })
       .routeActions()
-      .visit('/schedule')
+      .visit('/')
       .wait('@routeActions');
+
+    cy
+      .url()
+      .should('contain', 'schedule');
 
     cy
       .get('[data-nav-content-region]')
@@ -614,6 +618,34 @@ context('schedule page', function() {
       .get('@worklists')
       .find('.app-nav__link')
       .should('have.length', 1);
+
+    cy
+      .get('[data-select-all-region]')
+      .find('.button--checkbox')
+      .should('not.exist');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.schedule__filters')
+      .should('not.exist');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('div')
+      .should('not.exist');
+
+    cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row')
+      .its('length')
+      .should('be.gt', 0);
+
+    cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row .schedule-list__day-list')
+      .first()
+      .find('.schedule-list__day-list-row .js-select')
+      .should('not.exist');
   });
 
   specify('bulk edit', function() {
@@ -843,7 +875,6 @@ context('schedule page', function() {
         response: {},
       })
       .as('patchActionFail');
-
 
     cy
       .get('[data-select-all-region]')


### PR DESCRIPTION
Shortcut Story ID: [sc-28115]

If a clinician has the `reduced_patient_schedule = true` setting, we'll show them a reduced version of the Schedule app. In this scenario, the nav sidebar will only contain the `Schedule` element and the bulk edit and filter options will be disabled and not shown to the user.

Also, the `"/schedule"` URL route will be used by default for these clinicians. Instead of the conventional `"/worklist/owned-by"`.

**Note**: The `reduced_patient_schedule` setting will eventually be replaced by RBAC.