### PR TITLE
Display form widgets container

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -45,8 +45,7 @@ export default App.extend({
     this.form = form;
     this.isReadOnly = this.form.isReadOnly();
 
-    const formWidgets = this.form.getWidgets();
-    const widgets = Radio.request('entities', 'widgets:collection', formWidgets);
+    const widgets = this.form.getWidgets();
 
     this.startFormService();
 

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -3,8 +3,6 @@ import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
 
-import collectionOf from 'js/utils/formatting/collection-of';
-
 import App from 'js/base/app';
 
 import FormsService from 'js/services/forms';
@@ -48,7 +46,7 @@ export default App.extend({
     this.isReadOnly = this.form.isReadOnly();
 
     const formWidgets = this.form.getWidgets();
-    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(formWidgets, 'id'));
+    const widgets = Radio.request('entities', 'widgets:collection', formWidgets);
 
     this.startFormService();
 

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -3,6 +3,8 @@ import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
 
+import collectionOf from 'js/utils/formatting/collection-of';
+
 import App from 'js/base/app';
 
 import FormsService from 'js/services/forms';
@@ -45,9 +47,12 @@ export default App.extend({
     this.form = form;
     this.isReadOnly = this.form.isReadOnly();
 
+    const formWidgets = this.form.getWidgets();
+    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(formWidgets, 'id'));
+
     this.startFormService();
 
-    this.showView(new LayoutView({ model: this.form, patient }));
+    this.showView(new LayoutView({ model: this.form, patient, widgets }));
 
     this.showForm();
 

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -62,8 +62,7 @@ export default App.extend({
     this.form = this.action.getForm();
     this.isReadOnly = this.form.isReadOnly();
 
-    const formWidgets = this.form.getWidgets();
-    const widgets = Radio.request('entities', 'widgets:collection', formWidgets);
+    const widgets = this.form.getWidgets();
 
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -3,6 +3,8 @@ import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
 
+import collectionOf from 'js/utils/formatting/collection-of';
+
 import App from 'js/base/app';
 
 import intl from 'js/i18n';
@@ -62,6 +64,9 @@ export default App.extend({
     this.form = this.action.getForm();
     this.isReadOnly = this.form.isReadOnly();
 
+    const formWidgets = this.form.getWidgets();
+    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(formWidgets, 'id'));
+
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);
       Radio.trigger('event-router', 'default');
@@ -69,7 +74,7 @@ export default App.extend({
 
     this.startFormService();
 
-    this.setView(new LayoutView({ model: this.form, patient, action }));
+    this.setView(new LayoutView({ model: this.form, patient, action, widgets }));
 
     this.setState({ responseId: !!this.responses.length && this.responses.first().id });
 

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -3,8 +3,6 @@ import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 import store from 'store';
 
-import collectionOf from 'js/utils/formatting/collection-of';
-
 import App from 'js/base/app';
 
 import intl from 'js/i18n';
@@ -65,7 +63,7 @@ export default App.extend({
     this.isReadOnly = this.form.isReadOnly();
 
     const formWidgets = this.form.getWidgets();
-    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(formWidgets, 'id'));
+    const widgets = Radio.request('entities', 'widgets:collection', formWidgets);
 
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,4 +1,5 @@
 import { get } from 'underscore';
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -36,7 +37,8 @@ const _Model = BaseModel.extend({
   },
   getWidgets() {
     const widgets = get(this.get('options'), 'widgets', []);
-    return collectionOf(widgets, 'id');
+
+    return Radio.request('entities', 'widgets:collection', collectionOf(widgets, 'id'));
   },
 });
 

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -2,6 +2,7 @@ import { get } from 'underscore';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
+import collectionOf from 'js/utils/formatting/collection-of';
 
 const TYPE = 'forms';
 
@@ -34,7 +35,8 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getWidgets() {
-    return get(this.get('options'), 'widgets', []);
+    const widgets = get(this.get('options'), 'widgets', []);
+    return collectionOf(widgets, 'id');
   },
 });
 

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -33,6 +33,9 @@ const _Model = BaseModel.extend({
   getBeforeSubmit() {
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
+  getWidgets() {
+    return get(this.get('options'), 'widgets', []);
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -37,11 +37,6 @@
   margin-bottom: 16px;
   padding: 8px 8px 0 8px;
 
-  > div:first-of-type {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
   .form__widgets-section {
     margin-bottom: 8px;
     padding: 0 8px;

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -30,6 +30,24 @@
   }
 }
 
+.form__widgets {
+  background-color: $white;
+  border: 1px solid $black-90;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  padding: 8px 8px 0 8px;
+
+  > div:first-of-type {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .form__widgets-section {
+    margin-bottom: 8px;
+    padding: 0 8px;
+  }
+}
+
 .form__sidebar {
   display: flex;
   flex: initial;
@@ -47,7 +65,7 @@
   border: 1px solid $black-90;
   border-bottom: 0;
   border-radius: 4px 4px 0 0;
-  height: calc(100% - 80px);
+  height: 100%;
   padding: 8px;
 
   iframe {

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -179,10 +179,8 @@ const LayoutView = View.extend({
     widgets: '[data-widgets-region]',
   },
   templateContext() {
-    this.hasFormWidgets = this.getOption('widgets').length;
-
     return {
-      hasFormWidgets: this.hasFormWidgets,
+      hasFormWidgets: this.hasFormWidgets(),
     };
   },
   onRender() {
@@ -191,7 +189,7 @@ const LayoutView = View.extend({
       action: this.getOption('action'),
     }));
 
-    if (this.hasFormWidgets) {
+    if (this.hasFormWidgets()) {
       this.showChildView('widgets', new WidgetCollectionView({
         model: this.getOption('patient'),
         collection: this.getOption('widgets'),
@@ -199,6 +197,9 @@ const LayoutView = View.extend({
         itemClassName: 'form__widgets-section',
       }));
     }
+  },
+  hasFormWidgets() {
+    return this.getOption('widgets').length;
   },
 });
 

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -156,7 +156,7 @@ const LayoutView = View.extend({
           </div>
         </div>
       </div>
-      {{#if formHasWidgets}}
+      {{#if hasFormWidgets}}
         <div class="form__widgets flex">
           <div data-widgets-region></div>
         </div>
@@ -179,14 +179,11 @@ const LayoutView = View.extend({
     widgets: '[data-widgets-region]',
   },
   templateContext() {
+    this.hasFormWidgets = this.getOption('widgets').length;
+
     return {
-      formHasWidgets: this.formHasWidgets,
+      hasFormWidgets: this.hasFormWidgets,
     };
-  },
-  initialize({ patient, widgets }) {
-    this.patient = patient;
-    this.widgets = widgets;
-    this.formHasWidgets = widgets && widgets.length;
   },
   onRender() {
     this.showChildView('contextTrail', new ContextTrailView({
@@ -194,10 +191,11 @@ const LayoutView = View.extend({
       action: this.getOption('action'),
     }));
 
-    if (this.formHasWidgets) {
+    if (this.hasFormWidgets) {
       this.showChildView('widgets', new WidgetCollectionView({
-        model: this.patient,
-        collection: this.widgets,
+        model: this.getOption('patient'),
+        collection: this.getOption('widgets'),
+        className: 'flex flex-wrap',
         itemClassName: 'form__widgets-section',
       }));
     }

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -13,6 +13,8 @@ import Tooltip from 'js/components/tooltip';
 
 import IframeFormBehavior from 'js/behaviors/iframe-form';
 
+import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
+
 import './form.scss';
 
 const ContextTrailView = View.extend({
@@ -154,6 +156,11 @@ const LayoutView = View.extend({
           </div>
         </div>
       </div>
+      {{#if formHasWidgets}}
+        <div class="form__widgets flex">
+          <div data-widgets-region></div>
+        </div>
+      {{/if}}
       <div data-form-region></div>
     </div>
     <div class="form__sidebar" data-sidebar-region></div>
@@ -169,12 +176,31 @@ const LayoutView = View.extend({
       replaceElement: false,
     },
     status: '[data-status-region]',
+    widgets: '[data-widgets-region]',
+  },
+  templateContext() {
+    return {
+      formHasWidgets: this.formHasWidgets,
+    };
+  },
+  initialize({ patient, widgets }) {
+    this.patient = patient;
+    this.widgets = widgets;
+    this.formHasWidgets = widgets && widgets.length;
   },
   onRender() {
     this.showChildView('contextTrail', new ContextTrailView({
       patient: this.getOption('patient'),
       action: this.getOption('action'),
     }));
+
+    if (this.formHasWidgets) {
+      this.showChildView('widgets', new WidgetCollectionView({
+        model: this.patient,
+        collection: this.widgets,
+        itemClassName: 'form__widgets-section',
+      }));
+    }
   },
 });
 

--- a/src/sass/core/_flex.scss
+++ b/src/sass/core/_flex.scss
@@ -15,3 +15,6 @@
   flex-grow: 1;
 }
 
+.flex-wrap {
+  flex-wrap: wrap;
+}

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -7,7 +7,8 @@
     "id": "22222",
     "name": "Read Only Test Form",
     "options": {
-      "read_only": true
+      "read_only": true,
+      "widgets": ["dob", "sex"]
     }
   },
   {

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -599,6 +599,12 @@ context('Patient Action Form', function() {
       .should('be.disabled');
 
     cy
+      .get('.form__widgets')
+      .find('.form__widgets-section')
+      .its('length')
+      .should('be.gte', 0);
+
+    cy
       .iframe()
       .find('textarea[name="data[storyTime]"]');
   });
@@ -1014,6 +1020,12 @@ context('Patient Form', function() {
       .find('button')
       .contains('Read Only')
       .should('be.disabled');
+
+    cy
+      .get('.form__widgets')
+      .find('.form__widgets-section')
+      .its('length')
+      .should('be.gte', 0);
 
     cy
       .iframe()

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -601,8 +601,7 @@ context('Patient Action Form', function() {
     cy
       .get('.form__widgets')
       .find('.form__widgets-section')
-      .its('length')
-      .should('be.gte', 0);
+      .should('exist');
 
     cy
       .iframe()
@@ -1024,8 +1023,7 @@ context('Patient Form', function() {
     cy
       .get('.form__widgets')
       .find('.form__widgets-section')
-      .its('length')
-      .should('be.gte', 0);
+      .should('exist');
 
     cy
       .iframe()


### PR DESCRIPTION
Shortcut Story ID: [sc-28205]

Display a widget container if there are widgets defined on a form. If there are no widgets defined for a form, the section should be hidden.

The feature should look like the image below:

<img width="1325" alt="Screen Shot 2022-03-24 at 4 43 30 PM" src="https://user-images.githubusercontent.com/35355575/161309535-146cbb74-d72b-4a51-8de4-02f6710f7eac.png">

Cypress tests were also updated to ensure a basic version of the widgets container displays properly on the page. As this feature is built out more in the future, more detailed tests will be added for the functionality of the individual widgets inside the container.
