### PR TITLE
Remove actions with no due date from the schedule worklist

### DIFF
--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -294,6 +294,7 @@ const ScheduleListView = CollectionView.extend({
       return !view.isEmpty();
     }
 
+    // 'null' string is a key from groupBy
     if (view.model.get('date') === 'null') {
       return false;
     }

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -294,6 +294,10 @@ const ScheduleListView = CollectionView.extend({
       return !view.isEmpty();
     }
 
+    if (view.model.get('date') === 'null') {
+      return false;
+    }
+
     return true;
   },
   initialize({ state }) {


### PR DESCRIPTION
Shortcut Story ID: [sc-28337]

This pull request excludes unscheduled actions from being included in the schedule worklist. It does so by filtering out any actions that have a due date value equal to `"null"`.

This is a bug that resulting from this pull request: https://github.com/RoundingWell/care-ops-frontend/pull/659.