### PR TITLE
Load form widgets with field requests

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -8,6 +8,7 @@ import App from 'js/base/app';
 import FormsService from 'js/services/forms';
 
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
+import WidgetsHeaderApp from 'js/apps/forms/widgets/widgets_header_app';
 
 import { FormActionsView, LayoutView, IframeView, SaveView, ReadOnlyView, StatusView } from 'js/views/forms/form/form_views';
 
@@ -17,6 +18,11 @@ export default App.extend({
       AppClass: PatientSidebarApp,
       regionName: 'sidebar',
       getOptions: ['patient'],
+    },
+    widgetHeader: {
+      AppClass: WidgetsHeaderApp,
+      regionName: 'widgets',
+      getOptions: ['patient', 'form'],
     },
   },
   initFormState() {
@@ -45,17 +51,17 @@ export default App.extend({
     this.form = form;
     this.isReadOnly = this.form.isReadOnly();
 
-    const widgets = this.form.getWidgets();
-
     this.startFormService();
 
-    this.showView(new LayoutView({ model: this.form, patient, widgets }));
+    this.showView(new LayoutView({ model: this.form, patient }));
 
     this.showForm();
 
     this.showFormStatus();
     this.showFormSaveDisabled();
     this.showActions();
+
+    this.startChildApp('widgetHeader');
 
     this.showSidebar();
   },

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -8,6 +8,7 @@ import App from 'js/base/app';
 import intl from 'js/i18n';
 
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
+import WidgetsHeaderApp from 'js/apps/forms/widgets/widgets_header_app';
 
 import FormsService from 'js/services/forms';
 
@@ -28,6 +29,11 @@ export default App.extend({
       AppClass: PatientSidebarApp,
       regionName: 'sidebar',
       getOptions: ['patient'],
+    },
+    widgetHeader: {
+      AppClass: WidgetsHeaderApp,
+      regionName: 'widgets',
+      getOptions: ['patient', 'form'],
     },
   },
   initFormState() {
@@ -62,8 +68,6 @@ export default App.extend({
     this.form = this.action.getForm();
     this.isReadOnly = this.form.isReadOnly();
 
-    const widgets = this.form.getWidgets();
-
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);
       Radio.trigger('event-router', 'default');
@@ -71,13 +75,15 @@ export default App.extend({
 
     this.startFormService();
 
-    this.setView(new LayoutView({ model: this.form, patient, action, widgets }));
+    this.setView(new LayoutView({ model: this.form, patient, action }));
 
     this.setState({ responseId: !!this.responses.length && this.responses.first().id });
 
     this.showFormStatus();
     this.showFormAction();
     this.showActions();
+
+    this.startChildApp('widgetHeader');
 
     this.showSidebar();
 

--- a/src/js/apps/forms/widgets/widgets_header_app.js
+++ b/src/js/apps/forms/widgets/widgets_header_app.js
@@ -1,0 +1,25 @@
+import { get, map } from 'underscore';
+import Radio from 'backbone.radio';
+
+import collectionOf from 'js/utils/formatting/collection-of';
+import App from 'js/base/app';
+
+import { FormWidgetsHeaderView } from 'js/views/forms/form/widgets/widget_header_view';
+
+export default App.extend({
+  beforeStart({ patient, form }) {
+    const formWidgets = form.getWidgets();
+    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(get(formWidgets, 'widgets'), 'id'));
+    const requests = map(get(formWidgets, 'fields'), fieldName => patient.fetchField(fieldName));
+    requests.unshift(widgets);
+    return requests;
+  },
+  onStart({ patient }, widgets) {
+    if (!widgets.length) return;
+
+    this.showView(new FormWidgetsHeaderView({
+      model: patient,
+      collection: widgets,
+    }));
+  },
+});

--- a/src/js/apps/forms/widgets/widgets_header_app.js
+++ b/src/js/apps/forms/widgets/widgets_header_app.js
@@ -1,20 +1,19 @@
-import { get, map } from 'underscore';
+import { map } from 'underscore';
 import Radio from 'backbone.radio';
 
-import collectionOf from 'js/utils/formatting/collection-of';
 import App from 'js/base/app';
 
 import { FormWidgetsHeaderView } from 'js/views/forms/form/widgets/widget_header_view';
 
 export default App.extend({
   beforeStart({ patient, form }) {
-    const formWidgets = form.getWidgets();
-    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(get(formWidgets, 'widgets'), 'id'));
-    const requests = map(get(formWidgets, 'fields'), fieldName => patient.fetchField(fieldName));
-    requests.unshift(widgets);
-    return requests;
+    return map(form.getWidgetFields(), fieldName => {
+      return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
+    });
   },
-  onStart({ patient }, widgets) {
+  onStart({ patient, form }) {
+    const widgets = form.getWidgets();
+
     if (!widgets.length) return;
 
     this.showView(new FormWidgetsHeaderView({

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -1,7 +1,6 @@
-import { get, map } from 'underscore';
+import { map } from 'underscore';
 import Radio from 'backbone.radio';
 
-import collectionOf from 'js/utils/formatting/collection-of';
 import App from 'js/base/app';
 
 import { SidebarView } from 'js/views/patients/patient/sidebar/sidebar_views';
@@ -15,14 +14,14 @@ export default App.extend({
     this.showView(new SidebarView({ model: patient }));
   },
   beforeStart({ patient }) {
-    const sidebarWidgets = Radio.request('bootstrap', 'currentOrg:setting', 'widgets_patient_sidebar');
-    const widgets = Radio.request('entities', 'widgets:collection', collectionOf(get(sidebarWidgets, 'widgets'), 'id'));
-    const requests = map(get(sidebarWidgets, 'fields'), fieldName => patient.fetchField(fieldName));
-    requests.unshift(widgets);
-    return requests;
+    return map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
+      return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
+    });
   },
-  onStart({ patient }, widgets) {
+  onStart({ patient }) {
     this.patient = patient;
+
+    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
     this.showView(new SidebarView({
       model: this.patient,

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,7 +1,9 @@
 import { get } from 'underscore';
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
+import collectionOf from 'js/utils/formatting/collection-of';
 
 const TYPE = 'forms';
 
@@ -34,7 +36,14 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getWidgets() {
-    return get(this.get('options'), 'widgets', { fields: [], widgets: [] });
+    const formWidgets = get(this.get('options'), 'widgets', { fields: [], widgets: [] });
+
+    return Radio.request('entities', 'widgets:collection', collectionOf(get(formWidgets, 'widgets'), 'id'));
+  },
+  getWidgetFields() {
+    const formWidgets = get(this.get('options'), 'widgets', { fields: [], widgets: [] });
+
+    return get(formWidgets, 'fields');
   },
 });
 

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,9 +1,7 @@
 import { get } from 'underscore';
-import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import collectionOf from 'js/utils/formatting/collection-of';
 
 const TYPE = 'forms';
 
@@ -36,9 +34,7 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getWidgets() {
-    const widgets = get(this.get('options'), 'widgets', []);
-
-    return Radio.request('entities', 'widgets:collection', collectionOf(widgets, 'id'));
+    return get(this.get('options'), 'widgets', { fields: ['foo'], widgets: ['dob', 'sex'] });
   },
 });
 

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -36,12 +36,12 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getWidgets() {
-    const formWidgets = get(this.get('options'), 'widgets', { fields: [], widgets: [] });
+    const formWidgets = get(this.get('options'), 'widgets');
 
     return Radio.request('entities', 'widgets:collection', collectionOf(get(formWidgets, 'widgets'), 'id'));
   },
   getWidgetFields() {
-    const formWidgets = get(this.get('options'), 'widgets', { fields: [], widgets: [] });
+    const formWidgets = get(this.get('options'), 'widgets');
 
     return get(formWidgets, 'fields');
   },

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -34,7 +34,7 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getWidgets() {
-    return get(this.get('options'), 'widgets', { fields: ['foo'], widgets: ['dob', 'sex'] });
+    return get(this.get('options'), 'widgets', { fields: [], widgets: [] });
   },
 });
 

--- a/src/js/entities-service/patient-fields.js
+++ b/src/js/entities-service/patient-fields.js
@@ -11,7 +11,7 @@ const Entity = BaseEntity.extend({
   fetchPatientField(patientId, fieldName) {
     const url = `/api/patients/${ patientId }/fields/${ fieldName }`;
 
-    return this.fetchModel(fieldName, { url }).then(field => {
+    return this.fetchModel(fieldName, { url, abort: false }).then(field => {
       // NOTE: hydrate store now that the id is known
       this.getModel(field.attributes);
     });

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -1,5 +1,8 @@
 import $ from 'jquery';
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
+
+import collectionOf from 'js/utils/formatting/collection-of';
 
 import App from 'js/base/app';
 
@@ -9,6 +12,8 @@ export default App.extend({
     'currentUser': 'getCurrentUser',
     'currentOrg': 'getCurrentOrg',
     'currentOrg:setting': 'getOrgSetting',
+    'sidebarWidgets': 'getSidebarWidgets',
+    'sidebarWidgets:fields': 'getSidebarWidgetFields',
     'fetch': 'fetchBootstrap',
   },
   initialize({ name }) {
@@ -23,6 +28,14 @@ export default App.extend({
   },
   getOrgSetting(settingName) {
     return this.getCurrentOrg().getSetting(settingName);
+  },
+  getSidebarWidgets() {
+    const sidebarWidgets = get(this.getCurrentOrg().getSetting('widgets_patient_sidebar'), 'widgets');
+
+    return Radio.request('entities', 'widgets:collection', collectionOf(sidebarWidgets, 'id'));
+  },
+  getSidebarWidgetFields() {
+    return get(this.getCurrentOrg().getSetting('widgets_patient_sidebar'), 'fields');
   },
   beforeStart() {
     return [

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -30,19 +30,6 @@
   }
 }
 
-.form__widgets {
-  background-color: $white;
-  border: 1px solid $black-90;
-  border-radius: 4px;
-  margin-bottom: 16px;
-  padding: 8px 8px 0 8px;
-
-  .form__widgets-section {
-    margin-bottom: 8px;
-    padding: 0 8px;
-  }
-}
-
 .form__sidebar {
   display: flex;
   flex: initial;

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -13,8 +13,6 @@ import Tooltip from 'js/components/tooltip';
 
 import IframeFormBehavior from 'js/behaviors/iframe-form';
 
-import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
-
 import './form.scss';
 
 const ContextTrailView = View.extend({
@@ -156,11 +154,7 @@ const LayoutView = View.extend({
           </div>
         </div>
       </div>
-      {{#if hasFormWidgets}}
-        <div class="form__widgets flex">
-          <div data-widgets-region></div>
-        </div>
-      {{/if}}
+      <div data-widgets-header-region></div>
       <div data-form-region></div>
     </div>
     <div class="form__sidebar" data-sidebar-region></div>
@@ -176,30 +170,13 @@ const LayoutView = View.extend({
       replaceElement: false,
     },
     status: '[data-status-region]',
-    widgets: '[data-widgets-region]',
-  },
-  templateContext() {
-    return {
-      hasFormWidgets: this.hasFormWidgets(),
-    };
+    widgets: '[data-widgets-header-region]',
   },
   onRender() {
     this.showChildView('contextTrail', new ContextTrailView({
       patient: this.getOption('patient'),
       action: this.getOption('action'),
     }));
-
-    if (this.hasFormWidgets()) {
-      this.showChildView('widgets', new WidgetCollectionView({
-        model: this.getOption('patient'),
-        collection: this.getOption('widgets'),
-        className: 'flex flex-wrap',
-        itemClassName: 'form__widgets-section',
-      }));
-    }
-  },
-  hasFormWidgets() {
-    return this.getOption('widgets').length;
   },
 });
 

--- a/src/js/views/forms/form/widgets/form-widgets.scss
+++ b/src/js/views/forms/form/widgets/form-widgets.scss
@@ -1,11 +1,11 @@
-.form__widgets {
+.form-widgets {
   background-color: $white;
   border: 1px solid $black-90;
   border-radius: 4px;
   margin-bottom: 16px;
   padding: 8px 8px 0 8px;
 
-  .form__widgets-section {
+  .form-widgets__section {
     margin-bottom: 8px;
     padding: 0 8px;
   }

--- a/src/js/views/forms/form/widgets/widget_header.scss
+++ b/src/js/views/forms/form/widgets/widget_header.scss
@@ -1,0 +1,12 @@
+.form__widgets {
+  background-color: $white;
+  border: 1px solid $black-90;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  padding: 8px 8px 0 8px;
+
+  .form__widgets-section {
+    margin-bottom: 8px;
+    padding: 0 8px;
+  }
+}

--- a/src/js/views/forms/form/widgets/widget_header_view.js
+++ b/src/js/views/forms/form/widgets/widget_header_view.js
@@ -5,10 +5,10 @@ import 'sass/modules/widgets.scss';
 
 import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
 
-import './widget_header.scss';
+import './form-widgets.scss';
 
 const FormWidgetsHeaderView = View.extend({
-  className: 'form__widgets flex',
+  className: 'form-widgets flex',
   template: hbs`<div data-widgets-region></div>`,
   regions: {
     widgets: '[data-widgets-region]',
@@ -18,7 +18,7 @@ const FormWidgetsHeaderView = View.extend({
       model: model,
       collection: collection,
       className: 'flex flex-wrap',
-      itemClassName: 'form__widgets-section',
+      itemClassName: 'form-widgets__section',
     }));
   },
 });

--- a/src/js/views/forms/form/widgets/widget_header_view.js
+++ b/src/js/views/forms/form/widgets/widget_header_view.js
@@ -1,0 +1,28 @@
+import { View } from 'marionette';
+import hbs from 'handlebars-inline-precompile';
+
+import 'sass/modules/widgets.scss';
+
+import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
+
+import './widget_header.scss';
+
+const FormWidgetsHeaderView = View.extend({
+  className: 'form__widgets flex',
+  template: hbs`<div data-widgets-region></div>`,
+  regions: {
+    widgets: '[data-widgets-region]',
+  },
+  onRender({ model, collection }) {
+    this.showChildView('widgets', new WidgetCollectionView({
+      model: model,
+      collection: collection,
+      className: 'flex flex-wrap',
+      itemClassName: 'form__widgets-section',
+    }));
+  },
+});
+
+export {
+  FormWidgetsHeaderView,
+};

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -36,7 +36,7 @@
     "name": "Form With Widgets",
     "options": {
       "widgets": {
-        "fields": ["test-field"],
+        "fields": ["testField"],
         "widgets": ["dob", "sex", "status", "testFieldWidget"]
       }
     }

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -8,7 +8,10 @@
     "name": "Read Only Test Form",
     "options": {
       "read_only": true,
-      "widgets": ["dob", "sex"]
+      "widgets": {
+        "fields": ["foo"],
+        "widgets": ["dob", "sex"]
+      }
     }
   },
   {

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -7,11 +7,7 @@
     "id": "22222",
     "name": "Read Only Test Form",
     "options": {
-      "read_only": true,
-      "widgets": {
-        "fields": ["foo"],
-        "widgets": ["dob", "sex"]
-      }
+      "read_only": true
     }
   },
   {
@@ -33,6 +29,16 @@
       "reducers": [
         "syntaxError('foo;"
       ]
+    }
+  },
+  {
+    "id": "55555",
+    "name": "Form With Widgets",
+    "options": {
+      "widgets": {
+        "fields": ["test-field"],
+        "widgets": ["dob", "sex", "status", "testFieldWidget"]
+      }
     }
   }
 ]

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -579,6 +579,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routePatient()
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -602,7 +602,7 @@ context('Patient Action Form', function() {
       .should('be.disabled');
 
     cy
-      .get('.form__widgets')
+      .get('.form-widgets')
       .should('not.exist');
 
     cy
@@ -877,7 +877,7 @@ context('Patient Action Form', function() {
           widget_type: 'fieldWidget',
           definition: {
             display_name: 'Test Field',
-            field_name: 'test-field',
+            field_name: 'testField',
           },
         }, 'widgets');
 
@@ -904,13 +904,13 @@ context('Patient Action Form', function() {
           id: '1',
           type: 'patient-fields',
           attributes: {
-            name: 'test-field',
+            name: 'testField',
             value: 'Test field widget',
           },
         };
 
         return fx;
-      }, 'test-field');
+      }, 'testField');
 
     cy
       .visit('/patient-action/1/form/55555')
@@ -918,11 +918,11 @@ context('Patient Action Form', function() {
       .wait('@routePatientByAction')
       .wait('@routeAction')
       .wait('@routeWidgets')
-      .wait('@routePatientFieldtest-field');
+      .wait('@routePatientFieldtestField');
 
     cy
-      .get('.form__widgets')
-      .find('.form__widgets-section')
+      .get('.form-widgets')
+      .find('.form-widgets__section')
       .first()
       .should('contain', formatDate(dob, 'LONG'))
       .should('contain', `Age ${ dayjs(testDate()).diff(dob, 'years') }`)
@@ -1104,7 +1104,7 @@ context('Patient Form', function() {
       .should('be.disabled');
 
     cy
-      .get('.form__widgets')
+      .get('.form-widgets')
       .should('not.exist');
 
     cy
@@ -1290,7 +1290,7 @@ context('Patient Form', function() {
           widget_type: 'fieldWidget',
           definition: {
             display_name: 'Test Field',
-            field_name: 'test-field',
+            field_name: 'testField',
           },
         }, 'widgets');
 
@@ -1317,13 +1317,13 @@ context('Patient Form', function() {
           id: '1',
           type: 'patient-fields',
           attributes: {
-            name: 'test-field',
+            name: 'testField',
             value: 'Test field widget',
           },
         };
 
         return fx;
-      }, 'test-field');
+      }, 'testField');
 
     cy
       .visit('/patient/1/form/55555')
@@ -1331,11 +1331,11 @@ context('Patient Form', function() {
       .wait('@routeFormFields')
       .wait('@routeWidgets')
       .wait('@routePatient')
-      .wait('@routePatientFieldtest-field');
+      .wait('@routePatientFieldtestField');
 
     cy
-      .get('.form__widgets')
-      .find('.form__widgets-section')
+      .get('.form-widgets')
+      .find('.form-widgets__section')
       .first()
       .should('contain', formatDate(dob, 'LONG'))
       .should('contain', `Age ${ dayjs(testDate()).diff(dob, 'years') }`)


### PR DESCRIPTION
Shortcut Story ID: [sc-28372]

Update the form header widgets to include field requests.

The feature should look like the image below:

<img width="1325" alt="161309535-146cbb74-d72b-4a51-8de4-02f6710f7eac" src="https://user-images.githubusercontent.com/35355575/164036080-e6c6fc9d-fdc9-4e88-8390-61f6f8440da1.png">


