### PR TITLE
Move patient name from breadcrumbs to form title

### DIFF
--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -15,17 +15,10 @@
   width: 100%;
 }
 
-.form__crumbs-title-section {
-  overflow: hidden;
-}
-
 .form__title {
   font-size: 24px;
   line-height: 1.2;
-  overflow: hidden;
   padding: 16px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .form__title-icon {

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -15,10 +15,17 @@
   width: 100%;
 }
 
+.form__crumbs-title-section {
+  overflow: hidden;
+}
+
 .form__title {
   font-size: 24px;
   line-height: 1.2;
+  overflow: hidden;
   padding: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .form__title-icon {

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -17,14 +17,8 @@ import './form.scss';
 
 const ContextTrailView = View.extend({
   className: 'form__context-trail',
-  actionTemplate: hbs`
-    <a class="js-back form__context-link">{{fas "chevron-left" }}{{ @intl.forms.form.formViews.contextTrailView.backBtn }}</a>
-    {{~fas "chevron-right"}}{{ patient.first_name }} {{ patient.last_name }}
-  `,
-  patientTemplate: hbs`
-    <a class="js-dashboard form__context-link">{{fas "chevron-left" }}{{ @intl.forms.form.formViews.contextTrailView.backDashboard }}</a>
-    {{~fas "chevron-right"}}{{ patient.first_name }} {{ patient.last_name }}
-  `,
+  actionTemplate: hbs`<a class="js-back form__context-link">{{fas "chevron-left" }}{{ @intl.forms.form.formViews.contextTrailView.backBtn }}</a>`,
+  patientTemplate: hbs`<a class="js-dashboard form__context-link">{{fas "chevron-left" }}{{ @intl.forms.form.formViews.contextTrailView.backDashboard }}</a>`,
   getTemplate() {
     if (!this.action) return this.patientTemplate;
 
@@ -43,11 +37,6 @@ const ContextTrailView = View.extend({
   },
   onClickDashboard() {
     Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
-  },
-  templateContext() {
-    return {
-      patient: this.patient && this.patient.pick('first_name', 'last_name'),
-    };
   },
 });
 
@@ -142,9 +131,9 @@ const LayoutView = View.extend({
   template: hbs`
     <div class="form__layout">
       <div class="flex">
-        <div class="flex-grow">
+        <div class="form__crumbs-title-section flex-grow">
           <div data-context-trail-region></div>
-          <div class="form__title"><span class="form__title-icon">{{far "poll-h"}}</span>{{ name }}</div>
+          <div class="form__title"><span class="form__title-icon">{{far "poll-h"}}</span>{{patient.first_name}} {{patient.last_name}} — {{ name }}</div>
         </div>
         <div class="flex-grow">
           <div data-status-region>&nbsp;</div>
@@ -171,6 +160,11 @@ const LayoutView = View.extend({
     },
     status: '[data-status-region]',
     widgets: '[data-widgets-header-region]',
+  },
+  templateContext() {
+    return {
+      patient: this.getOption('patient').pick('first_name', 'last_name'),
+    };
   },
   onRender() {
     this.showChildView('contextTrail', new ContextTrailView({

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -131,9 +131,9 @@ const LayoutView = View.extend({
   template: hbs`
     <div class="form__layout">
       <div class="flex">
-        <div class="form__crumbs-title-section flex-grow">
+        <div class="overflow--hidden flex-grow">
           <div data-context-trail-region></div>
-          <div class="form__title"><span class="form__title-icon">{{far "poll-h"}}</span>{{patient.first_name}} {{patient.last_name}} — {{ name }}</div>
+          <div class="form__title u-text--overflow"><span class="form__title-icon">{{far "poll-h"}}</span>{{patient.first_name}} {{patient.last_name}} — {{ name }}</div>
         </div>
         <div class="flex-grow">
           <div data-status-region>&nbsp;</div>

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -240,6 +240,7 @@ context('Patient Action Form', function() {
       .routeActionActivity()
       .routePatientByAction(fx => {
         fx.data.attributes.first_name = 'Testin';
+        fx.data.attributes.last_name = 'Mctester';
 
         return fx;
       })
@@ -286,11 +287,8 @@ context('Patient Action Form', function() {
       });
 
     cy
-      .get('.form__context-trail')
-      .should('contain', 'Testin');
-
-    cy
       .get('.form__title')
+      .should('contain', 'Testin Mctester')
       .should('contain', 'Test Form');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-28568]

Move the patient name from the breadcrumbs section to the form title.

It should look like the image below:

<img width="1301" alt="Screen Shot 2022-04-19 at 10 27 35 AM" src="https://user-images.githubusercontent.com/35355575/164043466-5ac6ca7c-2ec0-489a-aa46-1fe0dfb474e4.png">

The form title should use an ellipsis text overflow instead of wrapping to a new line.

The ellipsis text overflow should look like this:

<img width="1295" alt="Screen Shot 2022-04-19 at 10 26 47 AM" src="https://user-images.githubusercontent.com/35355575/164043785-45f6f556-55b7-4998-81e0-33a46c4b3f8d.png">

