### PR TITLE
Prevent submission update event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "backbone.radio": "^2.0.0",
         "backbone.store": "^1.1.1",
         "dayjs": "^1.10.6",
-        "formiojs": "4.14.0",
+        "formiojs": "4.14.6",
         "handlebars": "^4.7.7",
         "handlebars-intl": "^1.1.2",
         "jquery": "^3.6.0",
@@ -1877,9 +1877,9 @@
       }
     },
     "node_modules/@formio/bootstrap3": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.0.tgz",
-      "integrity": "sha512-l1KRCmQFw68c9LtNzysVQ7XXeUgfg1G3roQgY4tn1hFbKXcm3yMhOSrY6xcBDJHW/PN4n5ENwbBCfRjrJVkl0Q==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
+      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"
       }
@@ -2096,6 +2096,15 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@roundingwellos/babel-plugin-handlebars-inline-precompile": {
       "version": "3.0.1",
@@ -6126,45 +6135,45 @@
       }
     },
     "node_modules/formiojs": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.0.tgz",
-      "integrity": "sha512-q20EgDLRxLYuZKyeEDaMFPtnG27h8k/8O4CzlJ1oUpYKJ8XTkiwmLl1N0yYZqd3cVxthPh5ZxhmiJxijqefFcQ==",
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.6.tgz",
+      "integrity": "sha512-k7ouqAz2WPkPjqNIF2Z5190RzIz4Yp31Hh0NImMgtsF4fbFAE+ZZ6Wi2+0TCvMRUnDbttarN02VSaRvZh0YIng==",
       "dependencies": {
-        "@formio/bootstrap3": "^2.12.0",
+        "@formio/bootstrap3": "^2.12.2",
         "@formio/choices.js": "^9.0.1",
         "@formio/semantic": "^2.6.0",
         "@formio/vanilla-text-mask": "^5.1.1",
         "autocompleter": "^6.1.2",
         "browser-cookies": "^1.2.0",
         "compare-versions": "^3.6.0",
-        "core-js": "^3.18.3",
+        "core-js": "^3.19.3",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.3.3",
+        "dompurify": "^2.3.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
         "fast-json-patch": "^3.1.0",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^21.3.3",
+        "i18next": "^21.6.0",
         "idb": "^6.1.5",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^2.0.0",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.33",
+        "moment": "^2.29.2",
+        "moment-timezone": "^0.5.34",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
         "resize-observer-polyfill": "^1.5.1",
         "signature_pad": "^2.3.2",
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
-        "tooltip.js": "^1.3.3",
+        "tippy.js": "^6.3.7",
         "uuid": "^8.3.2",
-        "vanilla-picker": "^2.11.2"
+        "vanilla-picker": "^2.12.1"
       }
     },
     "node_modules/forwarded": {
@@ -8994,9 +9003,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
       "engines": {
         "node": "*"
       }
@@ -9895,16 +9904,6 @@
       "integrity": "sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=",
       "dev": true
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -9920,9 +9919,9 @@
       }
     },
     "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -13102,6 +13101,14 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -13142,15 +13149,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tooltip.js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
-      "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-      "deprecated": "Tooltip.js is not supported anymore, please migrate to tippy.js",
-      "dependencies": {
-        "popper.js": "^1.0.2"
       }
     },
     "node_modules/totalist": {
@@ -15799,9 +15797,9 @@
       }
     },
     "@formio/bootstrap3": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.0.tgz",
-      "integrity": "sha512-l1KRCmQFw68c9LtNzysVQ7XXeUgfg1G3roQgY4tn1hFbKXcm3yMhOSrY6xcBDJHW/PN4n5ENwbBCfRjrJVkl0Q==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
+      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
@@ -15978,6 +15976,11 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@roundingwellos/babel-plugin-handlebars-inline-precompile": {
       "version": "3.0.1",
@@ -19129,45 +19132,45 @@
       }
     },
     "formiojs": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.0.tgz",
-      "integrity": "sha512-q20EgDLRxLYuZKyeEDaMFPtnG27h8k/8O4CzlJ1oUpYKJ8XTkiwmLl1N0yYZqd3cVxthPh5ZxhmiJxijqefFcQ==",
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.6.tgz",
+      "integrity": "sha512-k7ouqAz2WPkPjqNIF2Z5190RzIz4Yp31Hh0NImMgtsF4fbFAE+ZZ6Wi2+0TCvMRUnDbttarN02VSaRvZh0YIng==",
       "requires": {
-        "@formio/bootstrap3": "^2.12.0",
+        "@formio/bootstrap3": "^2.12.2",
         "@formio/choices.js": "^9.0.1",
         "@formio/semantic": "^2.6.0",
         "@formio/vanilla-text-mask": "^5.1.1",
         "autocompleter": "^6.1.2",
         "browser-cookies": "^1.2.0",
         "compare-versions": "^3.6.0",
-        "core-js": "^3.18.3",
+        "core-js": "^3.19.3",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.3.3",
+        "dompurify": "^2.3.4",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
         "fast-json-patch": "^3.1.0",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^21.3.3",
+        "i18next": "^21.6.0",
         "idb": "^6.1.5",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^2.0.0",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
-        "moment-timezone": "^0.5.33",
+        "moment": "^2.29.2",
+        "moment-timezone": "^0.5.34",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
         "resize-observer-polyfill": "^1.5.1",
         "signature_pad": "^2.3.2",
         "string-hash": "^1.1.3",
         "text-mask-addons": "^3.8.0",
-        "tooltip.js": "^1.3.3",
+        "tippy.js": "^6.3.7",
         "uuid": "^8.3.2",
-        "vanilla-picker": "^2.11.2"
+        "vanilla-picker": "^2.12.1"
       }
     },
     "forwarded": {
@@ -21210,9 +21213,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "moment-timezone": {
       "version": "0.5.34",
@@ -21889,11 +21892,6 @@
       "integrity": "sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=",
       "dev": true
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -21906,9 +21904,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -24279,6 +24277,14 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -24308,14 +24314,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
-    },
-    "tooltip.js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
-      "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-      "requires": {
-        "popper.js": "^1.0.2"
-      }
     },
     "totalist": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "backbone.radio": "^2.0.0",
     "backbone.store": "^1.1.1",
     "dayjs": "^1.10.6",
-    "formiojs": "4.14.0",
+    "formiojs": "4.14.6",
     "handlebars": "^4.7.7",
     "handlebars-intl": "^1.1.2",
     "jquery": "^3.6.0",

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -50,12 +50,12 @@ const onChange = debounce(function(form, changeReducers) {
 
   const data = getChangeReducers(form, changeReducers, structuredClone(form.submission.data), prevSubmission);
 
-  form.setSubmission({ data });
+  form.setSubmission({ data }, { noUpdateEvent: true });
 
   prevSubmission = structuredClone(form.submission.data);
 
   isChanging = false;
-}, 300);
+}, 100);
 
 const updateSubmision = debounce(function(submission) {
   router.request('update:storedSubmission', submission);
@@ -70,16 +70,12 @@ async function renderForm({ definition, storedSubmission, formData, formSubmissi
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,
     data: submission,
-    onChange({ fromSubmission }) {
+    onChange() {
       if (isChanging) return;
 
-      // NOTE: root.triggerChange does some conditional checking
-      if (fromSubmission) {
-        if (this.root) this.root.triggerChange(...arguments);
-        return;
-      }
-
       updateSubmision(form.submission.data);
+
+      form.triggerChange(...arguments);
 
       onChange(form, changeReducers);
     },

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -43,18 +43,13 @@ function getContext(contextScripts) {
 }
 
 let prevSubmission;
-let isChanging = false;
 
 const onChange = debounce(function(form, changeReducers) {
-  isChanging = true;
-
   const data = getChangeReducers(form, changeReducers, structuredClone(form.submission.data), prevSubmission);
 
-  form.setSubmission({ data }, { noUpdateEvent: true });
+  form.setSubmission({ data }, { fromChangeReducers: true, fromSubmission: false });
 
   prevSubmission = structuredClone(form.submission.data);
-
-  isChanging = false;
 }, 100);
 
 const updateSubmision = debounce(function(submission) {
@@ -70,12 +65,10 @@ async function renderForm({ definition, storedSubmission, formData, formSubmissi
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,
     data: submission,
-    onChange() {
-      if (isChanging) return;
+    onChange({ fromChangeReducers }) {
+      if (fromChangeReducers) return;
 
       updateSubmision(form.submission.data);
-
-      form.triggerChange(...arguments);
 
       onChange(form, changeReducers);
     },


### PR DESCRIPTION
The latest in the attempt to update correctly in all cases without starting infinite loops.

`fromSubmission` is not reliable.

Speed up the debounce and call triggerChange consistently

Shortcut Story ID: [sc-28622]
