### PR TITLE
Remove linking from the reduced schedule

### DIFF
--- a/src/js/views/patients/schedule/schedule-list.scss
+++ b/src/js/views/patients/schedule/schedule-list.scss
@@ -79,7 +79,11 @@
     background: $greyed;
   }
 
-  &:hover:not(.is-selected) {
+  &.is-reduced {
+    cursor: default;
+  }
+
+  &:hover:not(.is-selected, .is-reduced) {
     background-color: color(light_blue, light);
   }
 }
@@ -166,7 +170,11 @@
 .schedule-list__action-form-icon {
   cursor: pointer;
 
-  &:hover {
+  &.is-reduced {
+    cursor: default;
+  }
+
+  &:hover:not(.is-reduced) {
     color: color(blue);
   }
 }

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -98,11 +98,11 @@ const DayItemView = View.extend({
     <td class="schedule-list__action-list-cell schedule-list__patient">
       <div class="schedule-list__state-patient">
         <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
-        <span class="schedule-list__patient-name js-patient">{{ patient.first_name }} {{ patient.last_name }}</span>&#8203;
+        <span class="schedule-list__patient-name {{#unless isReduced}}js-patient{{/unless}} {{#if isReduced}}is-reduced{{/if}}">{{ patient.first_name }} {{ patient.last_name }}</span>&#8203;
       </div>
     </td>
     <td class="schedule-list__action-list-cell">
-      <span class="schedule-list__action-name js-action">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
+      <span class="schedule-list__action-name {{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
       <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;{{~ remove_whitespace ~}}
     </td>
     <td class="schedule-list__action-list-cell schedule-list__action-details" data-details-region></td>
@@ -116,18 +116,16 @@ const DayItemView = View.extend({
   templateContext() {
     const state = this.model.getState();
 
-    const isReduced = this.state.get('isReduced');
-
     return {
       isOverdue: this.model.isOverdue(),
       state: state.get('name'),
       stateOptions: state.get('options'),
       patient: this.model.getPatient().attributes,
       form: this.model.getForm(),
-      isSelected: !isReduced && this.state.isSelected(this.model),
+      isSelected: !this.isReduced && this.state.isSelected(this.model),
       flow: this.model.getFlow() && this.model.getFlow().get('name'),
       hasOutreach: this.model.hasOutreach(),
-      isReduced: isReduced,
+      isReduced: this.isReduced,
     };
   },
   ui: {
@@ -142,6 +140,7 @@ const DayItemView = View.extend({
   initialize({ state }) {
     this.state = state;
     this.flow = this.model.getFlow();
+    this.isReduced = state.get('isReduced');
 
     this.listenTo(state, {
       'select:all': this.render,
@@ -149,6 +148,8 @@ const DayItemView = View.extend({
     });
   },
   onRender() {
+    if (this.isReduced) this.$el.addClass('is-reduced');
+
     this.showDetailsTooltip();
   },
   onClickSelect() {
@@ -162,6 +163,8 @@ const DayItemView = View.extend({
     Radio.trigger('event-router', 'form:patientAction', this.model.id, this.model.getForm().id);
   },
   onClick() {
+    if (this.isReduced) return;
+
     if (this.flow) {
       Radio.trigger('event-router', 'flow:action', this.flow.id, this.model.id);
       return;

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -85,7 +85,13 @@ const TableHeaderView = View.extend({
 
 const DayItemView = View.extend({
   tagName: 'tr',
-  className: 'schedule-list__day-list-row',
+  className() {
+    const className = 'schedule-list__day-list-row';
+
+    if (this.getOption('state').get('isReduced')) return `${ className } is-reduced`;
+
+    return className;
+  },
   template: hbs`
     <td class="schedule-list__action-list-cell schedule-list__due-time {{#if isOverdue}}is-overdue{{/if}}">
       {{#unless isReduced}}<button class="button--checkbox u-margin--r-8 js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button>{{/unless}}
@@ -98,7 +104,7 @@ const DayItemView = View.extend({
     <td class="schedule-list__action-list-cell schedule-list__patient">
       <div class="schedule-list__state-patient">
         <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
-        <span class="schedule-list__patient-name {{#unless isReduced}}js-patient{{/unless}} {{#if isReduced}}is-reduced{{/if}}">{{ patient.first_name }} {{ patient.last_name }}</span>&#8203;
+        <span class="schedule-list__patient-name {{#if isReduced}}is-reduced{{else}}js-patient{{/if}}">{{ patient.first_name }} {{ patient.last_name }}</span>&#8203;
       </div>
     </td>
     <td class="schedule-list__action-list-cell">
@@ -148,8 +154,6 @@ const DayItemView = View.extend({
     });
   },
   onRender() {
-    if (this.isReduced) this.$el.addClass('is-reduced');
-
     this.showDetailsTooltip();
   },
   onClickSelect() {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -582,7 +582,13 @@ context('schedule page', function() {
   specify('reduced patient schedule employee', function() {
     cy
       .server()
-      .routePatient()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.first_name = 'First';
+        fx.data.attributes.last_name = 'Last';
+
+        return fx;
+      })
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -650,6 +656,20 @@ context('schedule page', function() {
 
         return fx;
       })
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.name = 'Test Action';
+
+        fx.data.relationships.flow = { data: { id: '1' } };
+
+        return fx;
+      })
+      .routePatientActions(_.identity, '2')
+      .routePatientFlows(_.identity, '2')
+      .routeFlow()
+      .routeFlowActions()
+      .routePatientByFlow()
+      .routeActionActivity()
       .visit('/')
       .wait('@routeActions');
 
@@ -782,74 +802,19 @@ context('schedule page', function() {
       .url()
       .should('contain', 'schedule');
 
-    cy
-      .server()
-      .routePatient(fx => {
-        fx.data.id = '1';
-        fx.data.attributes.first_name = 'First';
-        fx.data.attributes.last_name = 'Last';
-
-        return fx;
-      })
-      .routePatientActions(_.identity, '2')
-      .routePatientFlows(_.identity, '2')
-      .visit('/patient/dashboard/1')
-      .wait('@routePatient')
-      .wait('@routePatientActions')
-      .wait('@routePatientFlows');
+    cy.navigate('/patient/dashboard/1');
 
     cy
       .get('.patient__context-trail')
       .should('contain', 'First Last');
 
-    cy
-      .server()
-      .routePatient(fx => {
-        fx.data.id = '1';
-
-        return fx;
-      })
-      .routeAction(fx => {
-        fx.data.id = '1';
-        fx.data.relationships.state = { data: { id: '55555' } };
-
-        return fx;
-      })
-      .routePatientActions(_.identity, '1')
-      .routePatientFlows(_.identity, '1')
-      .routeActionActivity()
-      .routePrograms()
-      .routeAllProgramActions()
-      .routeAllProgramFlows()
-      .routeFlow()
-      .visit('/patient/1/action/1')
-      .wait('@routePatientActions')
-      .wait('@routePatient')
-      .wait('@routeAction');
+    cy.navigate('/patient/1/action/1');
 
     cy
-      .get('.patient__layout')
-      .find('.patient__tab--selected')
-      .contains('Data & Events');
+      .get('.patient__context-trail')
+      .should('contain', 'First Last');
 
-    cy
-      .server()
-      .routeFlow()
-      .routeFlowActions()
-      .routeAction(fx => {
-        fx.data.id = '1';
-        fx.data.attributes.name = 'Test Action';
-
-        fx.data.relationships.flow = { data: { id: '1' } };
-
-        return fx;
-      })
-      .routePatientByFlow()
-      .routeActionActivity()
-      .visit('/flow/1/action/1')
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
+    cy.navigate('/flow/1/action/1');
 
     cy
       .get('.sidebar')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -582,13 +582,6 @@ context('schedule page', function() {
   specify('reduced patient schedule employee', function() {
     cy
       .server()
-      .routePatient(fx => {
-        fx.data.id = '1';
-        fx.data.attributes.first_name = 'First';
-        fx.data.attributes.last_name = 'Last';
-
-        return fx;
-      })
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -656,20 +649,6 @@ context('schedule page', function() {
 
         return fx;
       })
-      .routeAction(fx => {
-        fx.data.id = '1';
-        fx.data.attributes.name = 'Test Action';
-
-        fx.data.relationships.flow = { data: { id: '1' } };
-
-        return fx;
-      })
-      .routePatientActions(_.identity, '2')
-      .routePatientFlows(_.identity, '2')
-      .routeFlow()
-      .routeFlowActions()
-      .routePatientByFlow()
-      .routeActionActivity()
       .visit('/')
       .wait('@routeActions');
 
@@ -802,19 +781,40 @@ context('schedule page', function() {
       .url()
       .should('contain', 'schedule');
 
-    cy.navigate('/patient/dashboard/1');
+    cy
+      .routePatient(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.first_name = 'First';
+        fx.data.attributes.last_name = 'Last';
+
+        return fx;
+      })
+      .navigate('/patient/dashboard/1');
 
     cy
       .get('.patient__context-trail')
       .should('contain', 'First Last');
 
-    cy.navigate('/patient/1/action/1');
+    cy
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.name = 'Test Action';
+        fx.data.relationships.flow = { data: { id: '1' } };
+
+        return fx;
+      })
+      .routePatientByAction()
+      .navigate('/patient/1/action/1');
 
     cy
       .get('.patient__context-trail')
       .should('contain', 'First Last');
 
-    cy.navigate('/flow/1/action/1');
+    cy
+      .routeFlow()
+      .routeFlowActions()
+      .routePatientByFlow()
+      .navigate('/flow/1/action/1');
 
     cy
       .get('.sidebar')


### PR DESCRIPTION
Shortcut Story ID: [sc-28553]

Remove row linking and patient name linking from the reduced version of the schedule. Link/hover CSS styling should also be removed.

Only the form link should be functioning for each day item in the schedule list.

Although links to the patient/flow are removed from the schedule list, clinicians should still be able to access those pages via direct link, search, or otherwise.