### PR TITLE
Update form title padding

### DIFF
--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -18,7 +18,7 @@
 .form__title {
   font-size: 24px;
   line-height: 1.2;
-  padding: 16px;
+  padding: 16px 16px 16px 0;
 }
 
 .form__title-icon {


### PR DESCRIPTION
Shortcut Story ID: [sc-28726]

Removes the `16px` of left padding from the form title.

This changes its current appearance from this:

<img width="879" alt="Screen Shot 2022-04-28 at 2 33 38 PM" src="https://user-images.githubusercontent.com/35355575/165987589-6a2f475a-c319-45b9-a0b4-5dc6807172e0.png">

To look like this:

<img width="714" alt="Screen Shot 2022-04-28 at 2 35 52 PM" src="https://user-images.githubusercontent.com/35355575/165987610-b983cc65-cdb8-4bd8-912d-980aa4a82b1b.png">
