### PR TITLE
Fix flaky reduced patient schedule test

### DIFF
--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -649,6 +649,16 @@ context('schedule page', function() {
 
         return fx;
       })
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.patient.data.id = '1';
+        fx.data.relationships.state.data.id = states[0];
+        fx.data.relationships.form = { data: { id: '11111' } };
+
+        return fx;
+      })
+      .routePatientByAction()
+      .routePatient()
       .visit('/')
       .wait('@routeActions');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-28733]

Adds some additional endpoint stubbing to the Cypress test for the reduced patient schedule. This should fix the flakiness we've been seeing with that test. 