### PR TITLE
Prevents clearing submission on add/edit of editgrid

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -66,8 +66,11 @@ async function renderForm({ definition, storedSubmission, formData, formSubmissi
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,
     data: submission,
-    onChange({ fromChangeReducers }) {
+    onChange({ fromChangeReducers }, { instance }) {
       if (fromChangeReducers) return;
+
+      // Prevents clearing submission on add/edit of editgrid
+      if (instance && instance.inEditGrid) return;
 
       updateSubmision(form.submission.data);
 


### PR DESCRIPTION
There’s no other information form.io supplies to understand this context.  FWIW the tree component could possibly be fixed with a similar solution.

Shortcut Story ID: [sc-28842]
