### PR TITLE
Prefill latest form-response for designated patient-action forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "cypress": "^9.0.0",
         "cypress-plugin-tab": "^1.0.5",
         "eslint": "^8.14.0",
-        "eslint-plugin-mocha": "^10.0.4",
+        "eslint-plugin-mocha": "^9.0.0",
         "eslint-webpack-plugin": "^3.0.1",
         "handlebars-template-loader": "^1.0.0",
         "html-webpack-plugin": "^5.3.2",
@@ -5244,16 +5244,16 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
+      "integrity": "sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==",
       "dev": true,
       "dependencies": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -10720,14 +10720,10 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -18168,13 +18164,13 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.0.4.tgz",
-      "integrity": "sha512-8wzAeepVY027oBHz/TmBmUr7vhVqoC1KTFeDybFLhbaWKx+aQ7fJJVuUsqcUy+L+G+XvgQBJY+cbAf7hl5DF7Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-9.0.0.tgz",
+      "integrity": "sha512-d7knAcQj1jPCzZf3caeBIn3BnW6ikcvfz0kSqQpwPYcVGLoJV5sz0l0OJB2LR8I7dvTDbqq1oV6ylhSgzA10zg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^3.0.0",
-        "ramda": "^0.28.0"
+        "ramda": "^0.27.1"
       }
     },
     "eslint-scope": {
@@ -22076,9 +22072,9 @@
       }
     },
     "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "cypress": "^9.0.0",
     "cypress-plugin-tab": "^1.0.5",
     "eslint": "^8.14.0",
-    "eslint-plugin-mocha": "^10.0.4",
+    "eslint-plugin-mocha": "^9.0.0",
     "eslint-webpack-plugin": "^3.0.1",
     "handlebars-template-loader": "^1.0.0",
     "html-webpack-plugin": "^5.3.2",

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 import $ from 'jquery';
-import { extend, keys, reduce } from 'underscore';
+import { contains, extend, keys, reduce } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import dayjs from 'dayjs';
@@ -37,6 +37,9 @@ const _Model = BaseModel.extend({
   type: TYPE,
   validate({ name }) {
     if (!trim(name)) return 'Action name required';
+  },
+  hasTag(tagName) {
+    return contains(this.get('tags'), tagName);
   },
   getForm() {
     const formId = this.get('_form');

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -45,6 +45,13 @@ const _Model = BaseModel.extend({
 
     return get(formWidgets, 'fields');
   },
+  getPrefillFormId() {
+    const prefillFormId = get(this.get('options'), 'prefill_form_id');
+
+    if (!prefillFormId) return this.id;
+
+    return prefillFormId;
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -16,8 +16,6 @@ const Entity = BaseEntity.extend({
     return $.ajax(`/api/form-responses/${ responseId }/response`);
   },
   fetchLatestSubmission(patientId, formId) {
-    if (!patientId || !formId) return [{}];
-
     return $.ajax(`/api/patients/${ patientId }/form-responses/latest?filter[form]=${ formId }`);
   },
 });

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -9,10 +9,16 @@ const Entity = BaseEntity.extend({
     'formResponses:model': 'getModel',
     'formResponses:collection': 'getCollection',
     'fetch:formResponses:submission': 'fetchSubmission',
+    'fetch:formResponses:latestSubmission': 'fetchLatestSubmission',
   },
   fetchSubmission(responseId) {
     if (!responseId) return [{}];
     return $.ajax(`/api/form-responses/${ responseId }/response`);
+  },
+  fetchLatestSubmission(patientId, formId) {
+    if (!patientId || !formId) return [{}];
+
+    return $.ajax(`/api/patients/${ patientId }/form-responses/latest?filter[form]=${ formId }`);
   },
 });
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -114,7 +114,7 @@ export default App.extend({
     const channel = this.getChannel();
     const firstResponse = this.responses && this.responses.first();
 
-    if (!firstResponse && this.action.hasTag('prefill-latest-response')) {
+    if (!firstResponse && this.action && this.action.hasTag('prefill-latest-response')) {
       return this.fetchLatestFormSubmission();
     }
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -88,10 +88,12 @@ export default App.extend({
   fetchLatestFormSubmission() {
     const channel = this.getChannel();
 
+    const prefillFormId = this.form.getPrefillFormId();
+
     return $.when(
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:forms:fields', get(this.action, 'id'), this.patient.id, this.form.id),
-      Radio.request('entities', 'fetch:formResponses:latestSubmission', this.patient.id, this.form.id),
+      Radio.request('entities', 'fetch:formResponses:latestSubmission', this.patient.id, prefillFormId),
     ).then(([definition], [fields], [response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -40,5 +40,12 @@
         "widgets": ["dob", "sex", "status", "testFieldWidget"]
       }
     }
+  },
+  {
+    "id": "66666",
+    "name": "Test Prefill Form",
+    "options": {
+      "prefill_form_id": "11111"
+    }
   }
 ]

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -300,6 +300,53 @@ context('Patient Action Form', function() {
       .should('have.value', 'bar');
   });
 
+  specify('prefill a form with latest submission from another form', function() {
+    cy
+      .server()
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.form.data = { id: '66666' };
+        fx.data.relationships['program-action'] = { data: { id: '11111' } };
+
+        fx.data.attributes.tags = ['prefill-latest-response'];
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routeActionActivity()
+      .routePatientByAction()
+      .routeLatestFormResponseByPatient(fx => {
+        fx.data = {
+          familyHistory: 'Prefilled family history',
+          storyTime: 'Prefilled story time',
+          patient: { fields: { foo: 'bar' } },
+        };
+
+        return fx;
+      })
+      .visit('/patient-action/1/form/11111')
+      .wait('@routeAction')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition')
+      .wait('@routeLatestFormResponseByPatient');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[familyHistory]"]')
+      .should('have.value', 'Prefilled family history');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[storyTime]"]')
+      .should('have.value', 'Prefilled story time');
+
+    cy
+      .iframe()
+      .find('[name="data[patient.fields.foo]"]')
+      .should('have.value', 'bar');
+  });
+
   specify('update a form with response field', function() {
     cy
       .server()

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -253,6 +253,53 @@ context('Patient Action Form', function() {
       .should('have.value', 'bar');
   });
 
+  specify('prefill a form with latest submission', function() {
+    cy
+      .server()
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.form.data = { id: '11111' };
+        fx.data.relationships['program-action'] = { data: { id: '11111' } };
+
+        fx.data.attributes.tags = ['prefill-latest-response'];
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routeActionActivity()
+      .routePatientByAction()
+      .routeLatestFormResponseByPatient(fx => {
+        fx.data = {
+          familyHistory: 'Prefilled family history',
+          storyTime: 'Prefilled story time',
+          patient: { fields: { foo: 'bar' } },
+        };
+
+        return fx;
+      })
+      .visit('/patient-action/1/form/11111')
+      .wait('@routeAction')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition')
+      .wait('@routeLatestFormResponseByPatient');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[familyHistory]"]')
+      .should('have.value', 'Prefilled family history');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[storyTime]"]')
+      .should('have.value', 'Prefilled story time');
+
+    cy
+      .iframe()
+      .find('[name="data[patient.fields.foo]"]')
+      .should('have.value', 'bar');
+  });
+
   specify('update a form with response field', function() {
     cy
       .server()

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -325,11 +325,15 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .visit('/patient-action/1/form/11111')
+      .visit('/patient-action/1/form/66666')
       .wait('@routeAction')
       .wait('@routePatientByAction')
-      .wait('@routeFormDefinition')
-      .wait('@routeLatestFormResponseByPatient');
+      .wait('@routeFormDefinition');
+
+    cy
+      .wait('@routeLatestFormResponseByPatient')
+      .its('url')
+      .should('contain', 'filter[form]=11111');
 
     cy
       .iframe()

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -90,3 +90,16 @@ Cypress.Commands.add('routeFormActionFields', (mutator = _.identity) => {
     })
     .as('routeFormActionFields');
 });
+
+Cypress.Commands.add('routeLatestFormResponseByPatient', (mutator = _.identity) => {
+  cy
+    .fixture('test/form-response').as('fxTestFormResponse');
+
+  cy.route({
+    url: '/api/patients/**/form-responses/latest*',
+    response() {
+      return mutator(this.fxTestFormResponse);
+    },
+  })
+    .as('routeLatestFormResponseByPatient');
+});


### PR DESCRIPTION
Shortcut Story ID: [sc-28739]

A user would like to have a form on a patient-action prefill with the latest form response for that specific `form.id` and `patient.id`.

To implement this, a `tags: ["prefill-latest-response"]` attribute will be attached to patient-actions. If the patient-action has that attribute, we fetch the latest form response for the given `form.id` and `patient.id` and prefill the form if no other responses are available for the patient action.

**Includes an unrelated bug fix**:

When the Cypress browser is hot reloaded while the `npm run dev:coverage` npm script is running, the Cypress environment fails and this error is thrown:

```
Failed to load plugin 'eslint-plugin-mocha' declared in 'test/.eslintrc': Package subpath './src/find' is not defined by "exports" in /Users/nickmajor/projects/rw/care-ops-frontend/node_modules/ramda/package.json
```

To fix this for our app, `eslint-plugin-mocha` was downgraded from `10.0.4` to `9.0.0` (the previous version we were using before we updated the NPM dependencies recently https://github.com/RoundingWell/care-ops-frontend/pull/694).

There's a fix for it merged into the `ramda` repo, but it hasn't been released yet: https://github.com/ramda/ramda/pull/3270. `ramda` is a dependency used by `eslint-plugin-mocha` and where the bug resides.

Once that fix is released, we can update to the newest version of `eslint-plugin-mocha`.