### PR TITLE
Show patient sidebar with widgets via worklist page

### DIFF
--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -18,11 +18,11 @@ export default App.extend({
 
     return [patientModel, ...fields];
   },
-  onStart({ patient }, [patientModel]) {
+  onStart({ patient }) {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
     this.showChildView('widgets', new WidgetCollectionView({
-      model: patientModel,
+      model: patient,
       collection: widgets,
       itemClassName: 'patient-sidebar__section',
     }));

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -4,20 +4,28 @@ import Radio from 'backbone.radio';
 import App from 'js/base/app';
 
 import { LayoutView } from 'js/views/patients/sidebar/patient/patient-sidebar_views';
+import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
 
 export default App.extend({
+  onBeforeStart({ patient }) {
+    this.showView(new LayoutView({ model: patient }));
+  },
   beforeStart({ patient }) {
     const patientModel = Radio.request('entities', 'fetch:patients:model', patient.id);
     const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
 
-    return [patientModel, fields];
+    return [patientModel, ...fields];
   },
   onStart({ patient }, [patientModel]) {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
-    this.showView(new LayoutView({ patient: patientModel, widgets }));
+    this.showChildView('widgets', new WidgetCollectionView({
+      model: patientModel,
+      collection: widgets,
+      itemClassName: 'patient-sidebar__section',
+    }));
   },
   viewEvents: {
     'close': 'stop',

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -3,8 +3,7 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import { LayoutView } from 'js/views/patients/sidebar/patient/patient-sidebar_views';
-import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
+import { LayoutView, SidebarWidgetsView } from 'js/views/patients/sidebar/patient/patient-sidebar_views';
 
 export default App.extend({
   onBeforeStart({ patient }) {
@@ -21,10 +20,9 @@ export default App.extend({
   onStart({ patient }) {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
-    this.showChildView('widgets', new WidgetCollectionView({
+    this.showChildView('widgets', new SidebarWidgetsView({
       model: patient,
       collection: widgets,
-      itemClassName: 'patient-sidebar__section',
     }));
   },
   viewEvents: {

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -1,0 +1,28 @@
+import { map } from 'underscore';
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+import { LayoutView } from 'js/views/patients/sidebar/patient/patient-sidebar_views';
+
+export default App.extend({
+  beforeStart({ patient }) {
+    const patientModel = Radio.request('entities', 'fetch:patients:model', patient.id);
+    const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
+      return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
+    });
+
+    return [patientModel, fields];
+  },
+  onStart({ patient }, [patientModel]) {
+    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
+
+    this.showView(new LayoutView({ patient: patientModel, widgets }));
+  },
+  viewEvents: {
+    'close': 'stop',
+  },
+  onStop() {
+    Radio.request('sidebar', 'close');
+  },
+});

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -58,6 +58,7 @@ export default App.extend({
   },
   onBeforeStart({ worklistId }) {
     if (this.isRestarting()) {
+      Radio.request('sidebar', 'close');
       this.showListTitle();
       this.showTypeToggleView();
       this.showSortDroplist();

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -104,6 +104,10 @@ export default App.extend({
       this.toggleBulkSelect();
     });
 
+    this.listenTo(collectionView, 'click:patientSidebarButton', patient => {
+      Radio.request('sidebar', 'start', 'patient', { patient });
+    });
+
     this.showChildView('list', collectionView);
 
     this.showSearchView();

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -104,7 +104,8 @@ export default App.extend({
       this.toggleBulkSelect();
     });
 
-    this.listenTo(collectionView, 'click:patientSidebarButton', patient => {
+    this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
+      const patient = model.getPatient();
       Radio.request('sidebar', 'start', 'patient', { patient });
     });
 

--- a/src/js/services/sidebar.js
+++ b/src/js/services/sidebar.js
@@ -8,6 +8,7 @@ import ProgramSidebarApp from 'js/apps/programs/sidebar/program-sidebar_app';
 import ProgramFlowSidebarApp from 'js/apps/programs/sidebar/flow-sidebar_app';
 import ProgramActionSidebarApp from 'js/apps/programs/sidebar/action-sidebar_app';
 import ClinicianSidebarApp from 'js/apps/clinicians/sidebar/clinician-sidebar_app';
+import PatientSidebarApp from 'js/apps/patients/sidebar/patient-sidebar_app';
 
 export default App.extend({
   channelName: 'sidebar',
@@ -24,6 +25,7 @@ export default App.extend({
     programFlow: ProgramFlowSidebarApp,
     programAction: ProgramActionSidebarApp,
     clinician: ClinicianSidebarApp,
+    patient: PatientSidebarApp,
   },
 
   startSidebarApp(appName, appOptions) {

--- a/src/js/views/globals/app-frame.scss
+++ b/src/js/views/globals/app-frame.scss
@@ -29,7 +29,6 @@ $menu-bkg-color: #1F2B33;
   background: #fff;
   height: 100%;
   min-height: 0;
-  min-width: 400px;
   position: absolute;
   right: 0;
   top: 0;

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -13,27 +13,3 @@
   right: 24px;
   top: 8px;
 }
-
-.patient-sidebar__section {
-  flex: none;
-  margin-top: 16px;
-  max-width: 256px;
-  overflow: hidden;
-
-  &:last-of-type {
-    padding-bottom: 32px;
-  }
-
-  /* NOTE: context-specific widget styles */
-  .widgets__item + .widgets__item {
-    margin-top: 4px;
-  }
-
-  .widgets__heading {
-    margin-top: 8px;
-
-    &:first-child {
-      margin-top: 0;
-    }
-  }
-}

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -6,6 +6,7 @@ import hbs from 'handlebars-inline-precompile';
 import intl from 'js/i18n';
 
 import 'sass/modules/widgets.scss';
+import 'sass/domain/patient-sidebar.scss';
 
 import Optionlist from 'js/components/optionlist';
 

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -6,12 +6,12 @@ import hbs from 'handlebars-inline-precompile';
 import intl from 'js/i18n';
 
 import 'sass/modules/widgets.scss';
-import 'sass/domain/patient-sidebar.scss';
 
 import Optionlist from 'js/components/optionlist';
 
 import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
 
+import 'sass/domain/patient-sidebar.scss';
 import './patient-sidebar.scss';
 
 const i18n = intl.patients.patient.sidebar.sidebarViews;

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -7,10 +7,10 @@
       <button class="button--icon js-close">{{fas "times"}}</button>
     </div>
   </div>
-  <div class="worklist-patient-sidebar__patient-info">
+  <div class="worklist-patient-sidebar__patient-info js-patient">
     <div class="worklist-patient-sidebar__patient-name">{{ first_name }} {{ last_name }}</div>
     <div>
-      <button class="button--link js-patient">View Patient Dashboard</button>
+      <button class="button--link">View Patient Dashboard</button>
     </div>
   </div>
   <div data-widgets-region></div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -1,0 +1,17 @@
+<div class="flex-grow">
+  <div class="flex">
+    <div class="flex-grow">
+      <span>{{far "address-card"}}</span>
+    </div>
+    <div>
+      <button class="button--icon js-close">{{fas "times"}}</button>
+    </div>
+  </div>
+  <div class="patient-sidebar__patient-info">
+    <div class="name">{{ firstName }} {{ lastName }}</div>
+    <div class="dashboard-link">
+      <span class="js-patient">View Patient Dashboard</span>
+    </div>
+  </div>
+  <div data-widgets-region></div>
+</div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -1,16 +1,16 @@
 <div class="flex-grow">
   <div class="flex">
     <div class="flex-grow">
-      <span>{{far "address-card"}}</span>
+      <span class="patient-sidebar__user-icon">{{far "address-card"}}</span>
     </div>
-    <div>
+    <div class="patient-sidebar__close-icon">
       <button class="button--icon js-close">{{fas "times"}}</button>
     </div>
   </div>
   <div class="patient-sidebar__patient-info">
-    <div class="name">{{ firstName }} {{ lastName }}</div>
-    <div class="dashboard-link">
-      <span class="js-patient">View Patient Dashboard</span>
+    <div class="patient-sidebar__patient-name">{{ firstName }} {{ lastName }}</div>
+    <div>
+      <span class="patient-sidebar__dashboard-link js-patient">View Patient Dashboard</span>
     </div>
   </div>
   <div data-widgets-region></div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="patient-sidebar__patient-info">
-    <div class="patient-sidebar__patient-name">{{ firstName }} {{ lastName }}</div>
+    <div class="patient-sidebar__patient-name">{{ first_name }} {{ last_name }}</div>
     <div>
       <span class="patient-sidebar__dashboard-link js-patient">View Patient Dashboard</span>
     </div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -1,16 +1,16 @@
 <div class="flex-grow">
   <div class="flex">
     <div class="flex-grow">
-      <span class="patient-sidebar__user-icon">{{far "address-card"}}</span>
+      <span class="worklist-patient-sidebar__user-icon">{{far "address-card"}}</span>
     </div>
-    <div class="patient-sidebar__close-icon">
+    <div class="worklist-patient-sidebar__close-icon">
       <button class="button--icon js-close">{{fas "times"}}</button>
     </div>
   </div>
-  <div class="patient-sidebar__patient-info">
-    <div class="patient-sidebar__patient-name">{{ first_name }} {{ last_name }}</div>
+  <div class="worklist-patient-sidebar__patient-info">
+    <div class="worklist-patient-sidebar__patient-name">{{ first_name }} {{ last_name }}</div>
     <div>
-      <span class="patient-sidebar__dashboard-link js-patient">View Patient Dashboard</span>
+      <button class="button--link js-patient">View Patient Dashboard</button>
     </div>
   </div>
   <div data-widgets-region></div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -1,21 +1,16 @@
-.patient-sidebar__user-icon svg,
-.patient-sidebar__close-icon svg {
-  font-size: 20px !important;
+.worklist-patient-sidebar__user-icon,
+.worklist-patient-sidebar__close-icon {
+  .icon {
+    font-size: 20px;
+  }
 }
 
-.patient-sidebar__patient-info {
+.worklist-patient-sidebar__patient-info {
   border-bottom: 1px solid $black-90;
   padding: 16px 0;
 }
 
-.patient-sidebar__patient-name {
+.worklist-patient-sidebar__patient-name {
   font-size: 24px;
   margin-bottom: 8px;
-}
-
-.patient-sidebar__dashboard-link {
-  color: #0582DA;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
 }

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -7,6 +7,7 @@
 
 .worklist-patient-sidebar__patient-info {
   border-bottom: 1px solid $black-90;
+  cursor: pointer;
   padding: 16px 0;
 }
 

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -1,0 +1,14 @@
+.patient-sidebar__patient-info {
+  border-bottom: 1px solid $black-90;
+  padding: 16px 0;
+
+  .name {
+    font-size: 24px;
+    margin-bottom: 16px;
+  }
+
+  .dashboard-link span {
+    color: #0582DA;
+    cursor: pointer;
+  }
+}

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -1,14 +1,21 @@
+.patient-sidebar__user-icon svg,
+.patient-sidebar__close-icon svg {
+  font-size: 20px !important;
+}
+
 .patient-sidebar__patient-info {
   border-bottom: 1px solid $black-90;
   padding: 16px 0;
+}
 
-  .name {
-    font-size: 24px;
-    margin-bottom: 16px;
-  }
+.patient-sidebar__patient-name {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
 
-  .dashboard-link span {
-    color: #0582DA;
-    cursor: pointer;
-  }
+.patient-sidebar__dashboard-link {
+  color: #0582DA;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
 }

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -6,12 +6,9 @@ import 'sass/modules/sidebar.scss';
 
 import PatientSidebarTemplate from './patient-sidebar.hbs';
 
-import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
-
 import './patient-sidebar.scss';
 
 const LayoutView = View.extend({
-  childViewTriggers: {},
   className: 'sidebar sidebar--small flex-region',
   template: PatientSidebarTemplate,
   regions: {
@@ -21,25 +18,8 @@ const LayoutView = View.extend({
     'click .js-close': 'close',
     'click .js-patient': 'click:patient',
   },
-  templateContext() {
-    return {
-      firstName: this.patient.get('first_name'),
-      lastName: this.patient.get('last_name'),
-    };
-  },
-  initialize({ patient, widgets }) {
-    this.patient = patient;
-    this.widgets = widgets;
-  },
-  onRender() {
-    this.showChildView('widgets', new WidgetCollectionView({
-      model: this.patient,
-      collection: this.widgets,
-      itemClassName: 'patient-sidebar__section',
-    }));
-  },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
+    Radio.trigger('event-router', 'patient:dashboard', this.model.id);
   },
 });
 

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -3,7 +3,6 @@ import { View } from 'marionette';
 
 import 'sass/modules/buttons.scss';
 import 'sass/modules/sidebar.scss';
-import 'sass/domain/patient-sidebar.scss';
 
 import { animSidebar } from 'js/anim';
 
@@ -11,6 +10,7 @@ import PatientSidebarTemplate from './patient-sidebar.hbs';
 
 import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
 
+import 'sass/domain/patient-sidebar.scss';
 import './patient-sidebar.scss';
 
 const SidebarWidgetsView = WidgetCollectionView.extend({

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -1,0 +1,50 @@
+import Radio from 'backbone.radio';
+import { View } from 'marionette';
+
+import 'sass/modules/buttons.scss';
+import 'sass/modules/forms.scss';
+import 'sass/modules/textarea-flex.scss';
+import 'sass/modules/sidebar.scss';
+
+import PatientSidebarTemplate from './patient-sidebar.hbs';
+
+import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
+
+import './patient-sidebar.scss';
+
+const LayoutView = View.extend({
+  childViewTriggers: {},
+  className: 'sidebar flex-region',
+  template: PatientSidebarTemplate,
+  regions: {
+    widgets: '[data-widgets-region]',
+  },
+  triggers: {
+    'click .js-close': 'close',
+    'click .js-patient': 'click:patient',
+  },
+  templateContext() {
+    return {
+      firstName: this.patient.get('first_name'),
+      lastName: this.patient.get('last_name'),
+    };
+  },
+  initialize({ patient, widgets }) {
+    this.patient = patient;
+    this.widgets = widgets;
+  },
+  onRender() {
+    this.showChildView('widgets', new WidgetCollectionView({
+      model: this.patient,
+      collection: this.widgets,
+      itemClassName: 'patient-sidebar__section',
+    }));
+  },
+  onClickPatient() {
+    Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
+  },
+});
+
+export {
+  LayoutView,
+};

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -3,10 +3,17 @@ import { View } from 'marionette';
 
 import 'sass/modules/buttons.scss';
 import 'sass/modules/sidebar.scss';
+import 'sass/domain/patient-sidebar.scss';
 
 import PatientSidebarTemplate from './patient-sidebar.hbs';
 
+import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
+
 import './patient-sidebar.scss';
+
+const SidebarWidgetsView = WidgetCollectionView.extend({
+  itemClassName: 'patient-sidebar__section',
+});
 
 const LayoutView = View.extend({
   className: 'sidebar sidebar--small flex-region',
@@ -25,4 +32,5 @@ const LayoutView = View.extend({
 
 export {
   LayoutView,
+  SidebarWidgetsView,
 };

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -2,8 +2,6 @@ import Radio from 'backbone.radio';
 import { View } from 'marionette';
 
 import 'sass/modules/buttons.scss';
-import 'sass/modules/forms.scss';
-import 'sass/modules/textarea-flex.scss';
 import 'sass/modules/sidebar.scss';
 
 import PatientSidebarTemplate from './patient-sidebar.hbs';
@@ -14,7 +12,7 @@ import './patient-sidebar.scss';
 
 const LayoutView = View.extend({
   childViewTriggers: {},
-  className: 'sidebar flex-region',
+  className: 'sidebar sidebar--small flex-region',
   template: PatientSidebarTemplate,
   regions: {
     widgets: '[data-widgets-region]',

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -5,6 +5,8 @@ import 'sass/modules/buttons.scss';
 import 'sass/modules/sidebar.scss';
 import 'sass/domain/patient-sidebar.scss';
 
+import { animSidebar } from 'js/anim';
+
 import PatientSidebarTemplate from './patient-sidebar.hbs';
 
 import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
@@ -24,6 +26,9 @@ const LayoutView = View.extend({
   triggers: {
     'click .js-close': 'close',
     'click .js-patient': 'click:patient',
+  },
+  onAttach() {
+    animSidebar(this.el);
   },
   onClickPatient() {
     Radio.trigger('event-router', 'patient:dashboard', this.model.id);

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -1,9 +1,11 @@
 <td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
-<td class="table-list__cell w-15 worklist-list__patient-name">
+<td class="table-list__cell w-15">
   <span class="worklist-list__patient-sidebar-icon js-patient-sidebar-button">
-    {{far "address-card"}}&#8203;
+    <button class="button-secondary--compact">
+      {{far "address-card"}}&#8203;
+    </button>
   </span>
-  <div class="js-patient">
+  <div class="worklist-list__patient-name js-patient">
     {{ patient.first_name }} {{ patient.last_name }}&#8203;
   </div>
 </td>

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -1,7 +1,7 @@
 <td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
 <td class="table-list__cell w-15">
-  <span class="worklist-list__patient-sidebar-icon js-patient-sidebar-button">
-    <button class="button-secondary--compact">
+  <span class="worklist-list__patient-sidebar-icon">
+    <button class="button-secondary--compact js-patient-sidebar-button">
       {{far "address-card"}}&#8203;
     </button>
   </span>

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -1,5 +1,12 @@
 <td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
-<td class="table-list__cell w-15 worklist-list__patient-name js-patient">{{ patient.first_name }} {{ patient.last_name }}&#8203;</td>
+<td class="table-list__cell w-15 worklist-list__patient-name">
+  <span class="worklist-list__patient-sidebar-icon js-patient-sidebar-button">
+    {{far "address-card"}}&#8203;
+  </span>
+  <div class="js-patient">
+    {{ patient.first_name }} {{ patient.last_name }}&#8203;
+  </div>
+</td>
 <td class="table-list__cell worklist-list__item-name">
   <span class="worklist-list__action-icon">{{far icon}}</span>{{~ remove_whitespace ~}}
   <div class="worklist-list__name">

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -58,6 +58,7 @@ const ActionItemView = View.extend({
   },
   triggers: {
     'click': 'click',
+    'click .js-patient-sidebar-button': 'click:patientSidebarButton',
     'click .js-patient': 'click:patient',
     'click .js-select': 'click:select',
     'click .js-no-click': 'prevent-row-click',

--- a/src/js/views/patients/worklist/flow-item.hbs
+++ b/src/js/views/patients/worklist/flow-item.hbs
@@ -1,5 +1,14 @@
 <td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
-<td class="table-list__cell w-15 worklist-list__patient-name js-patient">{{ patient.first_name }} {{ patient.last_name }}&#8203;</td>
+<td class="table-list__cell w-15">
+  <span class="worklist-list__patient-sidebar-icon js-patient-sidebar-button">
+    <button class="button-secondary--compact">
+      {{far "address-card"}}&#8203;
+    </button>
+  </span>
+  <div class="worklist-list__patient-name js-patient">
+    {{ patient.first_name }} {{ patient.last_name }}&#8203;
+  </div>
+</td>
 <td class="table-list__cell w-30">
   <span class="worklist-list__flow-icon">{{fas "folder"}}</span>{{~ remove_whitespace ~}}
   <div class="worklist-list__name">

--- a/src/js/views/patients/worklist/flow-item.hbs
+++ b/src/js/views/patients/worklist/flow-item.hbs
@@ -1,7 +1,7 @@
 <td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
 <td class="table-list__cell w-15">
-  <span class="worklist-list__patient-sidebar-icon js-patient-sidebar-button">
-    <button class="button-secondary--compact">
+  <span class="worklist-list__patient-sidebar-icon">
+    <button class="button-secondary--compact js-patient-sidebar-button">
       {{far "address-card"}}&#8203;
     </button>
   </span>

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -54,6 +54,7 @@ const FlowItemView = View.extend({
   },
   triggers: {
     'click': 'click',
+    'click .js-patient-sidebar-button': 'click:patientSidebarButton',
     'click .js-patient': 'click:patient',
     'click .js-select': 'click:select',
     'click .js-no-click': 'prevent-row-click',

--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -15,4 +15,3 @@
   <table class="worklist__header w-100 js-list-header" data-table-region></table>
 </div>
 <div class="flex-region list-page__list js-list" data-list-region></div>
-<div data-sidebar-region></div>

--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -15,3 +15,4 @@
   <table class="worklist__header w-100 js-list-header" data-table-region></table>
 </div>
 <div class="flex-region list-page__list js-list" data-list-region></div>
+<div data-sidebar-region></div>

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -6,6 +6,19 @@
   table-layout: fixed;
 }
 
+.worklist-list__patient-sidebar-icon {
+  display: table-cell;
+  position: relative;
+  vertical-align: middle;
+}
+
+.worklist-list__patient-name {
+  display: table-cell;
+  padding-left: 8px;
+  vertical-align: middle;
+  white-space: normal;
+}
+
 .worklist-list__patient-name:hover {
   color: color(blue);
 }

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -179,15 +179,10 @@ const ListView = CollectionView.extend({
   },
   childViewTriggers: {
     'render': 'listItem:render',
-    'click:patientSidebarButton': 'patientSidebarButton:click',
+    'click:patientSidebarButton': 'click:patientSidebarButton',
   },
   onListItemRender(view) {
     view.searchString = view.$el.text();
-  },
-  onPatientSidebarButtonClick(view) {
-    const patient = view.model.getPatient().attributes;
-
-    this.triggerMethod('click:patientSidebarButton', patient);
   },
   initialize({ state }) {
     this.state = state;

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -179,9 +179,15 @@ const ListView = CollectionView.extend({
   },
   childViewTriggers: {
     'render': 'listItem:render',
+    'click:patientSidebarButton': 'patientSidebarButton:click',
   },
   onListItemRender(view) {
     view.searchString = view.$el.text();
+  },
+  onPatientSidebarButtonClick(view) {
+    const patient = view.model.getPatient().attributes;
+
+    this.triggerMethod('click:patientSidebarButton', patient);
   },
   initialize({ state }) {
     this.state = state;

--- a/src/sass/domain/patient-sidebar.scss
+++ b/src/sass/domain/patient-sidebar.scss
@@ -1,0 +1,23 @@
+.patient-sidebar__section {
+  flex: none;
+  margin-top: 16px;
+  max-width: 256px;
+  overflow: hidden;
+
+  &:last-of-type {
+    padding-bottom: 32px;
+  }
+
+  /* NOTE: context-specific widget styles */
+  .widgets__item + .widgets__item {
+    margin-top: 4px;
+  }
+
+  .widgets__heading {
+    margin-top: 8px;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/sass/modules/sidebar.scss
+++ b/src/sass/modules/sidebar.scss
@@ -1,16 +1,14 @@
 .sidebar {
   border-left: 1px solid $black-90;
-  max-width: 400px;
-  min-width: 400px;
   overflow-y: auto;
   padding: 16px 20px;
+  width: 400px;
 }
 
 .sidebar--small {
   @extend .sidebar;
 
-  max-width: 256px;
-  min-width: 256px;
+  width: 256px;
 }
 
 .sidebar__details {

--- a/src/sass/modules/sidebar.scss
+++ b/src/sass/modules/sidebar.scss
@@ -1,8 +1,16 @@
 .sidebar {
   border-left: 1px solid $black-90;
   max-width: 400px;
+  min-width: 400px;
   overflow-y: auto;
   padding: 16px 20px;
+}
+
+.sidebar--small {
+  @extend .sidebar;
+
+  max-width: 256px;
+  min-width: 256px;
 }
 
 .sidebar__details {

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -31,10 +31,13 @@ context('Worklist bulk editing', function() {
 
         fx.data[0].relationships.patient = { data: { id: '1' } };
         fx.data[0].relationships.state = { data: { id: '22222' } };
+        fx.data[0].attributes.created_at = testTs();
         fx.data[1].relationships.patient = { data: { id: '2' } };
         fx.data[1].relationships.state = { data: { id: '22222' } };
+        fx.data[1].attributes.created_at = testTsSubtract(1);
         fx.data[2].relationships.patient = { data: { id: '3' } };
         fx.data[2].relationships.state = { data: { id: '22222' } };
+        fx.data[2].attributes.created_at = testTsSubtract(2);
 
         fx.included = fx.included.concat([
           {
@@ -86,15 +89,15 @@ context('Worklist bulk editing', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient One')
-      .prev()
+      .first()
+      .find('.js-select')
       .click();
 
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient Two')
-      .prev()
+      .eq(1)
+      .find('.js-select')
       .click();
 
     cy
@@ -133,8 +136,8 @@ context('Worklist bulk editing', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient Three')
-      .prev()
+      .last()
+      .find('.js-select')
       .click();
 
     cy
@@ -173,10 +176,13 @@ context('Worklist bulk editing', function() {
 
         fx.data[0].relationships.patient = { data: { id: '1' } };
         fx.data[0].relationships.state = { data: { id: '22222' } };
+        fx.data[0].attributes.created_at = testTs();
         fx.data[1].relationships.patient = { data: { id: '2' } };
         fx.data[1].relationships.state = { data: { id: '22222' } };
+        fx.data[1].attributes.created_at = testTsSubtract(1);
         fx.data[2].relationships.patient = { data: { id: '3' } };
         fx.data[2].relationships.state = { data: { id: '22222' } };
+        fx.data[2].attributes.created_at = testTsSubtract(2);
 
         fx.included = fx.included.concat([
           {
@@ -234,15 +240,15 @@ context('Worklist bulk editing', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient One')
-      .prev()
+      .first()
+      .find('.js-select')
       .click();
 
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient Two')
-      .prev()
+      .eq(1)
+      .find('.js-select')
       .click();
 
     cy
@@ -281,8 +287,8 @@ context('Worklist bulk editing', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .contains('Patient Three')
-      .prev()
+      .last()
+      .find('.js-select')
       .click();
 
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2918,6 +2918,15 @@ context('worklist page', function() {
       .get('@patientSidebar')
       .find('.worklist-patient-sidebar__patient-name')
       .should('contain', 'Test Patient');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('button.js-prev')
+      .click();
+
+    cy
+      .get('@patientSidebar')
+      .should('not.exist');
   });
 
   specify('empty flows view', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2840,11 +2840,30 @@ context('worklist page', function() {
       .get('.app-frame__sidebar .sidebar')
       .as('patientSidebar')
       .find('.worklist-patient-sidebar__patient-name')
+      .should('contain', 'Test Patient')
+      .click();
+
+    cy
+      .url()
+      .should('contain', 'patient/dashboard/1');
+
+    cy
+      .get('.patient-sidebar')
+      .find('.patient-sidebar__name')
       .should('contain', 'Test Patient');
 
     cy
+      .go('back');
+
+    cy
+      .get('@firstRow')
+      .find('.worklist-list__patient-sidebar-icon .js-patient-sidebar-button')
+      .click();
+
+    cy
       .get('@patientSidebar')
-      .find('.worklist-patient-sidebar__patient-info .js-patient')
+      .find('.worklist-patient-sidebar__patient-info .button--link')
+      .should('contain', 'View Patient Dashboard')
       .click();
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-28989] [sc-29095] [sc-29115] [sc-29116]

This allows users to open and view a patient sidebar from the worklist page. The sidebar contains the patient's name, a link to the patient's dashboard page, and widgets that contain information about the patient.

Each action/flow item in the worklist is given a button that opens the patient sidebar when clicked.

https://user-images.githubusercontent.com/35355575/170591415-717ffa69-d83e-4cff-baed-d18cc6bc1972.mov

