### PR TITLE
Pull prefill form response data from attributes

### DIFF
--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -98,7 +98,7 @@ export default App.extend({
       channel.request('send', 'fetch:form:data', {
         definition,
         formData: fields.data.attributes || {},
-        formSubmission: response && response.data || {},
+        formSubmission: response && response.data.attributes.response.data || {},
         contextScripts: this.form.getContextScripts(),
         reducers: this.form.getReducers(),
         changeReducers: this.form.getChangeReducers(),

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -270,10 +270,14 @@ context('Patient Action Form', function() {
       .routeActionActivity()
       .routePatientByAction()
       .routeLatestFormResponseByPatient(fx => {
-        fx.data = {
-          familyHistory: 'Prefilled family history',
-          storyTime: 'Prefilled story time',
-          patient: { fields: { foo: 'bar' } },
+        fx.data.attributes = {
+          response: {
+            data: {
+              familyHistory: 'Prefilled family history',
+              storyTime: 'Prefilled story time',
+              patient: { fields: { foo: 'bar' } },
+            },
+          },
         };
 
         return fx;
@@ -317,10 +321,14 @@ context('Patient Action Form', function() {
       .routeActionActivity()
       .routePatientByAction()
       .routeLatestFormResponseByPatient(fx => {
-        fx.data = {
-          familyHistory: 'Prefilled family history',
-          storyTime: 'Prefilled story time',
-          patient: { fields: { foo: 'bar' } },
+        fx.data.attributes = {
+          response: {
+            data: {
+              familyHistory: 'Prefilled family history',
+              storyTime: 'Prefilled story time',
+              patient: { fields: { foo: 'bar' } },
+            },
+          },
         };
 
         return fx;


### PR DESCRIPTION
Shortcut Story ID: [sc-29156]

Update the prefill form response data to pull from `response.data.attributes.response.data`. And also update the Cypress tests to accommodate that change when loading fixture route data.

This is a bug fix related to when we added the prefill form response functionality: https://github.com/RoundingWell/care-ops-frontend/pull/698.

