### PR TITLE
Add a preload spinner to the worklist patient sidebar

### DIFF
--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -8,6 +8,8 @@ import { LayoutView, SidebarWidgetsView } from 'js/views/patients/sidebar/patien
 export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new LayoutView({ model: patient }));
+
+    this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
     const patientModel = Radio.request('entities', 'fetch:patients:model', patient.id);

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.hbs
@@ -13,5 +13,5 @@
       <button class="button--link">View Patient Dashboard</button>
     </div>
   </div>
-  <div data-widgets-region></div>
+  <div class="worklist-patient-sidebar__widgets" data-widgets-region></div>
 </div>

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -15,3 +15,9 @@
   font-size: 24px;
   margin-bottom: 8px;
 }
+
+.worklist-patient-sidebar__widgets {
+  .spinner {
+    margin-top: 60px;
+  }
+}

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -6,6 +6,8 @@ import 'sass/modules/sidebar.scss';
 
 import { animSidebar } from 'js/anim';
 
+import PreloadRegion from 'js/regions/preload_region';
+
 import PatientSidebarTemplate from './patient-sidebar.hbs';
 
 import { WidgetCollectionView } from 'js/views/patients/widgets/widgets_views';
@@ -21,7 +23,10 @@ const LayoutView = View.extend({
   className: 'sidebar sidebar--small flex-region',
   template: PatientSidebarTemplate,
   regions: {
-    widgets: '[data-widgets-region]',
+    widgets: {
+      el: '[data-widgets-region]',
+      regionClass: PreloadRegion,
+    },
   },
   triggers: {
     'click .js-close': 'close',


### PR DESCRIPTION
Shortcut Story ID: [sc-29213]

Add a preload spinner for the widgets section of the worklist patient sidebar. Video of the preloader is included below.

When the worklist patient sidebar is opened, there is often a delay for the widgets data to load into the sidebar. During that delay, we want to show a loading icon instead of just a blank section.

https://user-images.githubusercontent.com/35355575/172242653-66fe178e-c073-4f61-aa53-dc2bb0a0206f.mov

