### PR TITLE
Close sidebars via the ESC keyboard shortcut

### DIFF
--- a/src/js/behaviors/sidebar.js
+++ b/src/js/behaviors/sidebar.js
@@ -1,0 +1,26 @@
+import $ from 'jquery';
+import Radio from 'backbone.radio';
+import { Behavior } from 'marionette';
+
+import keyCodes from 'js/utils/formatting/key-codes';
+
+import KeyListenerBehavior from './key-listener';
+
+const { ESCAPE_KEY } = keyCodes;
+
+export default Behavior.extend({
+  behaviors: [
+    {
+      behaviorClass: KeyListenerBehavior,
+      keyEvents: {
+        'escape': [ESCAPE_KEY],
+      },
+    },
+  ],
+
+  onEscape() {
+    const isPicklistOpen = $('.picklist, .datepicker, .date-filter').length;
+
+    if (!isPicklistOpen) Radio.request('sidebar', 'close');
+  },
+});

--- a/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
+++ b/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
@@ -7,6 +7,8 @@ import 'sass/modules/sidebar.scss';
 
 import { animSidebar } from 'js/anim';
 
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import { GroupsComponent, RoleComponent, AccessComponent, StateComponent } from 'js/views/clinicians/shared/clinicians_views';
 
 import ClinicianSidebarTemplate from './clinician-sidebar.hbs';
@@ -92,6 +94,7 @@ const InfoView = View.extend({
 
 const SidebarView = View.extend({
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: ClinicianSidebarTemplate,
   triggers: {
     'click .js-close': 'close',

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -20,6 +20,8 @@ import { animSidebar } from 'js/anim';
 import PreloadRegion from 'js/regions/preload_region';
 
 import InputWatcherBehavior from 'js/behaviors/input-watcher';
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import Optionlist from 'js/components/optionlist';
 
 import { StateComponent, OwnerComponent, DueComponent, TimeComponent, DurationComponent } from 'js/views/patients/shared/actions_views';
@@ -191,6 +193,7 @@ const LayoutView = View.extend({
     'click:undoCancelShare': 'click:undoCancelShare',
   },
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: ActionSidebarTemplate,
   regions: {
     name: '[data-name-region]',

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -7,6 +7,8 @@ import intl from 'js/i18n';
 
 import { animSidebar } from 'js/anim';
 
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import PreloadRegion from 'js/regions/preload_region';
 
 import Optionlist from 'js/components/optionlist';
@@ -33,6 +35,7 @@ const LayoutView = View.extend({
     'cancel': 'cancel',
   },
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: FlowSidebarTemplate,
   regions: {
     state: '[data-state-region]',

--- a/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar_views.js
@@ -6,6 +6,8 @@ import 'sass/modules/sidebar.scss';
 
 import { animSidebar } from 'js/anim';
 
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import PreloadRegion from 'js/regions/preload_region';
 
 import PatientSidebarTemplate from './patient-sidebar.hbs';
@@ -21,6 +23,7 @@ const SidebarWidgetsView = WidgetCollectionView.extend({
 
 const LayoutView = View.extend({
   className: 'sidebar sidebar--small flex-region',
+  behaviors: [SidebarBehavior],
   template: PatientSidebarTemplate,
   regions: {
     widgets: {

--- a/src/js/views/programs/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/programs/sidebar/action/action-sidebar_views.js
@@ -17,6 +17,8 @@ import trim from 'js/utils/formatting/trim';
 import { animSidebar } from 'js/anim';
 
 import InputWatcherBehavior from 'js/behaviors/input-watcher';
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import Optionlist from 'js/components/optionlist';
 import Tooltip from 'js/components/tooltip';
 
@@ -180,6 +182,7 @@ const LayoutView = View.extend({
     'cancel': 'cancel',
   },
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: ActionSidebarTemplate,
   regions: {
     heading: '[data-heading-region]',

--- a/src/js/views/programs/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/programs/sidebar/flow/flow-sidebar_views.js
@@ -17,6 +17,8 @@ import trim from 'js/utils/formatting/trim';
 import { animSidebar } from 'js/anim';
 
 import InputWatcherBehavior from 'js/behaviors/input-watcher';
+import SidebarBehavior from 'js/behaviors/sidebar';
+
 import Optionlist from 'js/components/optionlist';
 import Tooltip from 'js/components/tooltip';
 
@@ -138,6 +140,7 @@ const LayoutView = View.extend({
     'cancel': 'cancel',
   },
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: FlowSidebarTemplate,
   regions: {
     name: '[data-name-region]',

--- a/src/js/views/programs/sidebar/program/programs-sidebar_views.js
+++ b/src/js/views/programs/sidebar/program/programs-sidebar_views.js
@@ -11,8 +11,8 @@ import trim from 'js/utils/formatting/trim';
 
 import { animSidebar } from 'js/anim';
 
-
 import InputWatcherBehavior from 'js/behaviors/input-watcher';
+import SidebarBehavior from 'js/behaviors/sidebar';
 
 import ProgramDetailsTemplate from './program-details.hbs';
 import ProgramNameTemplate from './program-name.hbs';
@@ -114,6 +114,7 @@ const LayoutView = View.extend({
     'toggle': 'toggle',
   },
   className: 'sidebar flex-region',
+  behaviors: [SidebarBehavior],
   template: ProgramSidebarTemplate,
   regions: {
     name: '[data-name-region]',


### PR DESCRIPTION
Shortcut Story ID: [sc-29153]

Close the sidebar when a user presses the ESC keyboard shortcut.

Picklists also close via the ESC keyboard shortcut. And should take precedent over sidebars closing via the ESC keypress. In other words, if a sidebar and picklist are open at the same time, an ESC keypress should close the picklist and keep the sidebar open.
