### PR TITLE
Add a user icon & left border to the patient dashboard sidebar

### DIFF
--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -26,7 +26,7 @@
   background: $white;
   color: $black-20;
   line-height: 1;
-  padding: 16px 0 8px 0;
+  padding: 16px 0 16px;
   position: sticky;
   top: 0;
   z-index: 1;

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -10,16 +10,15 @@
   flex: 1;
   flex-direction: column;
   min-width: 744px;
-  padding-left: 24px;
+  padding: 0 24px;
   width: 100%;
 }
 
 .patient__sidebar {
   display: flex;
   flex: initial;
-  max-width: 400px;
   min-height: 0;
-  min-width: 256px;
+  width: 256px;
 }
 
 .patient__content {
@@ -30,7 +29,7 @@
   background: $white;
   color: $black-20;
   line-height: 1;
-  padding: 16px 0;
+  padding: 16px 0 24px;
   position: sticky;
   top: 0;
   z-index: 1;

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -29,7 +29,9 @@
   background: $white;
   color: $black-20;
   line-height: 1;
-  padding: 16px 0 24px;
+  // NOTE: Margin added for alignment with sidebar icon & patient name.
+  margin-bottom: 6px;
+  padding: 16px 0;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -57,7 +59,7 @@
 .patient__tab--selected {
   display: inline-block;
   font-size: 24px;
-  line-height: 0.9;
+  line-height: 1;
   margin-right: 4px;
   padding: 0 16px 16px;
 }

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -57,7 +57,7 @@
 .patient__tab--selected {
   display: inline-block;
   font-size: 24px;
-  line-height: 1;
+  line-height: 0.9;
   margin-right: 4px;
   padding: 0 16px 16px;
 }

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -1,6 +1,6 @@
 .patient-sidebar {
-  border-left: 1px solid #e6e6e6;
-  padding: 54px 24px 0;
+  border-left: 1px solid $black-90;
+  padding: 52px 24px 0;
   position: relative;
 }
 

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -1,15 +1,27 @@
 .patient-sidebar {
-  padding: 40px 24px 0;
+  border-left: 1px solid #e6e6e6;
+  padding: 54px 24px 0;
   position: relative;
 }
 
 .patient-sidebar__name {
+  border-bottom: 1px solid $black-90;
   font-size: 24px;
   line-height: 1em;
+  padding-bottom: 16px;
+}
+
+.patient-sidebar__icon {
+  position: absolute;
+  top: 16px;
+
+  .icon {
+    font-size: 20px;
+  }
 }
 
 .patient-sidebar__menu {
   position: absolute;
   right: 24px;
-  top: 8px;
+  top: 16px;
 }

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -29,6 +29,7 @@ const SidebarView = View.extend({
   className: 'patient-sidebar flex-region',
   template: hbs`
     <div data-name-region></div>
+    <span class="patient-sidebar__icon">{{far "address-card"}}</span>
     <button class="button--icon patient-sidebar__menu js-menu">{{far "ellipsis-h"}}</button>
     <div data-widgets-region></div>
   `,


### PR DESCRIPTION
Shortcut Story ID: [sc-29273]

Add the Font Awesome [address-card](https://fontawesome.com/icons/address-card?s=regular) icon to the patient dashboard sidebar. And also add a left-border to the sidebar.

To accommodate these changes, the styles for both the sidebar and overall patient dashboard page were updated.

Screenshot of the patient dashboard sidebar after these changes are made.

![Screen Shot 2022-06-09 at 2 50 48 PM](https://user-images.githubusercontent.com/35355575/172932573-7b298508-f031-48aa-bf48-d85e63b6df06.png)
