### PR TITLE
Add preload spinner to the patient sidebar

### DIFF
--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -12,6 +12,8 @@ export default App.extend({
   },
   onBeforeStart({ patient }) {
     this.showView(new SidebarView({ model: patient }));
+
+    this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
     return map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {

--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -17,9 +17,8 @@
 .patient-flow__sidebar {
   display: flex;
   flex: initial;
-  max-width: 400px;
   min-height: 0;
-  min-width: 256px;
+  width: 256px;
 }
 
 .patient-flow__context-trail {

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -25,3 +25,9 @@
   right: 24px;
   top: 16px;
 }
+
+.patient-sidebar__widgets {
+  .spinner {
+    margin-top: 60px;
+  }
+}

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -5,6 +5,8 @@ import hbs from 'handlebars-inline-precompile';
 
 import intl from 'js/i18n';
 
+import PreloadRegion from 'js/regions/preload_region';
+
 import 'sass/modules/widgets.scss';
 
 import Optionlist from 'js/components/optionlist';
@@ -31,11 +33,14 @@ const SidebarView = View.extend({
     <div data-name-region></div>
     <span class="patient-sidebar__icon">{{far "address-card"}}</span>
     <button class="button--icon patient-sidebar__menu js-menu">{{far "ellipsis-h"}}</button>
-    <div data-widgets-region></div>
+    <div class="patient-sidebar__widgets" data-widgets-region></div>
   `,
   regions: {
     name: '[data-name-region]',
-    widgets: '[data-widgets-region]',
+    widgets: {
+      el: '[data-widgets-region]',
+      regionClass: PreloadRegion,
+    },
   },
   onRender() {
     this.showChildView('name', new NameView({


### PR DESCRIPTION
Shortcut Story ID: [sc-29405]

Adds a preload spinner to the patient sidebars used on the patient dashboard, flow, and form pages.

I also slipped a small CSS change into this pull request that sets the width of the patient sidebar on the flow page to `256px`. This makes it match the width we're using for the patient sidebars for the worklist and on the patient dasbhoard page.