### PR TITLE
Build prototype of the form print app

### DIFF
--- a/src/js/formprint/formprint.scss
+++ b/src/js/formprint/formprint.scss
@@ -1,0 +1,27 @@
+.form__frame {
+  display: flex;
+  height: 100%;
+  min-width: 1200px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.form__layout {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  width: 100%;
+}
+
+.form__content {
+  background-color: $white;
+  border: 1px solid $black-90;
+  border-bottom: 0;
+  height: 100%;
+
+  iframe {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/src/js/formprint/index.js
+++ b/src/js/formprint/index.js
@@ -1,0 +1,98 @@
+import 'js/base/setup';
+import 'js/i18n';
+
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+import { View, CollectionView } from 'marionette';
+import hbs from 'handlebars-inline-precompile';
+
+import 'sass/provider-core.scss';
+import 'sass/app-root.scss';
+
+import './formprint.scss';
+
+import initPlatform from 'js/utils/platform';
+
+import App from 'js/base/app';
+
+import FormsService from 'js/services/forms';
+
+import 'js/entities-service';
+
+import BootstrapService from 'js/services/bootstrap';
+
+import IframeFormBehavior from 'js/behaviors/iframe-form';
+
+const RootView = CollectionView.extend({
+  viewComparator: false,
+  el: 'body',
+  template: hbs``,
+  initialize({ model }) {
+    this.render();
+
+    this.addChildView(new FormIframeView({ model }));
+  },
+});
+
+const FormIframeView = View.extend({
+  behaviors: [IframeFormBehavior],
+  className: 'form__frame',
+  template: hbs`
+    <div class="app-frame__content flex-region">
+      <div class="form__layout">
+        <div class="form__content">
+          <iframe src="/formapp/"></iframe>
+        </div>
+      </div>
+    </div>
+  `,
+});
+
+const FormPrintApp = App.extend({
+  channelName: 'app',
+
+  initialize() {
+    initPlatform();
+  },
+
+  onBeforeStart({ name }) {
+    new BootstrapService({ name });
+  },
+
+  beforeStart({ patientId, formId }) {
+    return [
+      Radio.request('bootstrap', 'fetch'),
+      Radio.request('entities', 'fetch:patients:model', patientId),
+      Radio.request('entities', 'forms:model', formId),
+    ];
+  },
+
+  onStart(options, currentUser, [patient], form) {
+    this.addChildApp('formsService', FormsService, {
+      patient: patient,
+      form: form,
+    });
+
+    this.setView(new RootView({ model: form }));
+  },
+});
+
+const Router = Backbone.Router.extend({
+  routes: {
+    'print/:patientId/:formId(/:responseId)': 'startResponse',
+  },
+  startResponse(patientId, formId, responseId) {
+    const formPrintApp = new FormPrintApp();
+    formPrintApp.start({ patientId, formId, responseId });
+  },
+});
+
+function startFormPrintApp() {
+  new Router();
+  Backbone.history.start({ pushState: true });
+}
+
+export {
+  startFormPrintApp,
+};
+

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,6 +21,13 @@ function startForm() {
     });
 }
 
+function startFormPrint() {
+  import(/* webpackChunkName: "formprint" */'./formprint/index')
+    .then(({ startFormPrintApp }) => {
+      startFormPrintApp();
+    });
+}
+
 function startApp({ name }) {
   import(/* webpackChunkName: "app" */'./app')
     .then(({ default: app }) => {
@@ -28,10 +35,10 @@ function startApp({ name }) {
     });
 }
 
-function startAuth() {
+function startAuth(isFormPrint) {
   import(/* webpackPrefetch: true, webpackChunkName: "auth" */ './auth')
     .then(({ login, logout }) => {
-      login(startApp);
+      login(isFormPrint ? startFormPrint : startApp);
       Radio.reply('auth', {
         logout() {
           logout();
@@ -57,6 +64,7 @@ const ajaxSetup = {
 document.addEventListener('DOMContentLoaded', () => {
   const isForm = /^\/formapp\//.test(location.pathname);
   const isOutreach = /^\/outreach\//.test(location.pathname);
+  const isFormPrint = /^\/print\//.test(location.pathname);
 
   if ((_DEVELOP_ || _E2E_) && sessionStorage.getItem('cypress')) {
     versions.frontend = 'cypress';
@@ -96,6 +104,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     $.ajaxSetup(ajaxSetup);
 
-    startAuth();
+    startAuth(isFormPrint);
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-29317]

When a URL route of `/print/:patientId/:formId(/:responseId)` is loaded in the app, it should load just the iframe content for a given form. No other elements should exist on the page.

The `responseId` is an optional URL parameter.

This page will be used by the backend team to convert forms to a PDF version when designated patient actions are completed.

