### PR TITLE
Load the form model along with the form definition in the form service

### DIFF
--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -76,11 +76,9 @@ export default App.extend({
     const channel = this.getChannel();
 
     return $.when(
-      Radio.request(
-        'entities', 'fetch:forms:definition', this.form.id,
-        this.form.fetch(),
-      ),
-    ).then(definition => {
+      Radio.request('entities', 'fetch:forms:definition', this.form.id),
+      this.form.fetch(),
+    ).then(([definition]) => {
       channel.request('send', 'fetch:form:data', {
         definition,
         storedSubmission: submission,

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -64,10 +64,7 @@ export default App.extend({
   fetchForm() {
     const channel = this.getChannel();
 
-    return $.when(
-      Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      this.form.fetch(),
-    )
+    return $.when(Radio.request('entities', 'fetch:forms:definition', this.form.id))
       .then(definition => {
         channel.request('send', 'fetch:form', {
           definition,

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -64,7 +64,10 @@ export default App.extend({
   fetchForm() {
     const channel = this.getChannel();
 
-    return $.when(Radio.request('entities', 'fetch:forms:definition', this.form.id))
+    return $.when(
+      Radio.request('entities', 'fetch:forms:definition', this.form.id),
+      this.form.fetch(),
+    )
       .then(definition => {
         channel.request('send', 'fetch:form', {
           definition,
@@ -75,7 +78,12 @@ export default App.extend({
   fetchFormStoreSubmission({ submission }) {
     const channel = this.getChannel();
 
-    return $.when(Radio.request('entities', 'fetch:forms:definition', this.form.id)).then(definition => {
+    return $.when(
+      Radio.request(
+        'entities', 'fetch:forms:definition', this.form.id,
+        this.form.fetch(),
+      ),
+    ).then(definition => {
       channel.request('send', 'fetch:form:data', {
         definition,
         storedSubmission: submission,
@@ -94,6 +102,7 @@ export default App.extend({
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:forms:fields', get(this.action, 'id'), this.patient.id, this.form.id),
       Radio.request('entities', 'fetch:formResponses:latestSubmission', this.patient.id, prefillFormId),
+      this.form.fetch(),
     ).then(([definition], [fields], [response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,
@@ -124,6 +133,7 @@ export default App.extend({
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:forms:fields', get(this.action, 'id'), this.patient.id, this.form.id),
       Radio.request('entities', 'fetch:formResponses:submission', get(firstResponse, 'id')),
+      this.form.fetch(),
     ).then(([definition], [fields], [response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,
@@ -142,6 +152,7 @@ export default App.extend({
     return $.when(
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:formResponses:submission', responseId),
+      this.form.fetch(),
     ).then(([definition], [response]) => {
       channel.request('send', 'fetch:form:response', {
         definition,

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -165,7 +165,7 @@ context('Patient Action Form', function() {
       .iframe();
   });
 
-  specify('restoring stored submission', function() {
+  specify.only('restoring stored submission', function() {
     localStorage.setItem('form-subm-11111-1-11111-1', JSON.stringify({
       updated: testTs(),
       submission: {
@@ -181,6 +181,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction(fx => {
@@ -200,6 +201,7 @@ context('Patient Action Form', function() {
       .click();
 
     cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition');
 
     cy
@@ -1299,7 +1301,7 @@ context('Patient Form', function() {
       .go('back');
   });
 
-  specify('restoring stored submission', function() {
+  specify.only('restoring stored submission', function() {
     localStorage.setItem('form-subm-11111-1-11111', JSON.stringify({
       updated: testTs(),
       submission: {
@@ -1308,6 +1310,7 @@ context('Patient Form', function() {
     }));
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routePatient(fx => {
         fx.data.id = '1';
@@ -1323,6 +1326,7 @@ context('Patient Form', function() {
       .click();
 
     cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition');
 
     cy

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1661,7 +1661,6 @@ context('Preview Form', function() {
       .server()
       .fixture('test/form-kitchen-sink.json').as('fxTestFormKitchenSink')
       .routeFlows()
-      .routeForm()
       .route({
         url: '/api/forms/*/definition',
         response() {
@@ -1670,7 +1669,6 @@ context('Preview Form', function() {
       })
       .as('routeFormKitchenSink')
       .visit('/form/11111/preview')
-      .wait('@routeForm')
       // NOTE: https://github.com/formio/formio.js/issues/3489
       // Issue started at v4.12.rc-1
       .wait(500);

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -165,7 +165,7 @@ context('Patient Action Form', function() {
       .iframe();
   });
 
-  specify.only('restoring stored submission', function() {
+  specify('restoring stored submission', function() {
     localStorage.setItem('form-subm-11111-1-11111-1', JSON.stringify({
       updated: testTs(),
       submission: {
@@ -1301,7 +1301,7 @@ context('Patient Form', function() {
       .go('back');
   });
 
-  specify.only('restoring stored submission', function() {
+  specify('restoring stored submission', function() {
     localStorage.setItem('form-subm-11111-1-11111', JSON.stringify({
       updated: testTs(),
       submission: {

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -58,6 +58,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition(fx => {
         return {
           display: 'form',
@@ -92,6 +93,7 @@ context('Patient Action Form', function() {
         return fx;
       })
       .visit('/patient-action/1/form/11111')
+      .wait('@routeForm')
       .wait('@routeAction')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition');
@@ -128,6 +130,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields(fx => {
         delete fx.data.attributes;
@@ -146,6 +149,7 @@ context('Patient Action Form', function() {
         return fx;
       })
       .visit('/patient-action/1/form/11111')
+      .wait('@routeForm')
       .wait('@routeAction')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition')
@@ -225,6 +229,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction(fx => {
@@ -244,6 +249,7 @@ context('Patient Action Form', function() {
       .click();
 
     cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routeFormActionFields');
 
@@ -265,6 +271,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -284,6 +291,7 @@ context('Patient Action Form', function() {
       })
       .visit('/patient-action/1/form/11111')
       .wait('@routeAction')
+      .wait('@routeForm')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition')
       .wait('@routeLatestFormResponseByPatient');
@@ -316,6 +324,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -335,6 +344,7 @@ context('Patient Action Form', function() {
       })
       .visit('/patient-action/1/form/66666')
       .wait('@routeAction')
+      .wait('@routeForm')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition');
 
@@ -372,6 +382,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields(fx => {
         delete fx.data.attributes;
@@ -391,6 +402,7 @@ context('Patient Action Form', function() {
       })
       .visit('/patient-action/1/form/11111')
       .wait('@routeAction')
+      .wait('@routeForm')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition')
       .wait('@routeFormResponse');
@@ -428,6 +440,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields()
       .routeFormResponse(fx => {
@@ -444,6 +457,7 @@ context('Patient Action Form', function() {
       })
       .visit('/patient-action/1/form/11111')
       .wait('@routeAction')
+      .wait('@routeForm')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition')
       .wait('@routeFormResponse');
@@ -778,6 +792,7 @@ context('Patient Action Form', function() {
         return fx;
       })
       .routePatient()
+      .routeForm()
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()
@@ -785,6 +800,7 @@ context('Patient Action Form', function() {
       .visit('/patient-action/1/form/22222')
       .wait('@routeAction')
       .wait('@routePatientByAction')
+      .wait('@routeForm')
       .wait('@routeFormDefinition');
 
     cy
@@ -816,12 +832,14 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
       .routePatientByAction()
       .visit('/patient-action/1/form/11111')
       .wait('@routeAction')
+      .wait('@routeForm')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition');
 
@@ -998,6 +1016,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()
@@ -1005,6 +1024,7 @@ context('Patient Action Form', function() {
       .visit('/patient-action/1/form/22222')
       .wait('@routeAction')
       .wait('@routePatientByAction')
+      .wait('@routeForm')
       .wait('@routeFormDefinition');
 
     cy
@@ -1057,6 +1077,7 @@ context('Patient Action Form', function() {
 
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routeActionActivity()
       .routeFormActionFields()
@@ -1110,6 +1131,7 @@ context('Patient Action Form', function() {
 
     cy
       .visit('/patient-action/1/form/55555')
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routePatientByAction')
       .wait('@routeAction')
@@ -1140,6 +1162,7 @@ context('Patient Form', function() {
 
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields(fx => {
         fx.data.attributes.storyTime = 'Once upon a time...';
@@ -1152,6 +1175,7 @@ context('Patient Form', function() {
         return fx;
       })
       .visit('/patient/1/form/11111')
+      .wait('@routeForm')
       .wait('@routePatient')
       .wait('@routeFormDefinition')
       .wait('@routeFormFields');
@@ -1316,6 +1340,7 @@ context('Patient Form', function() {
     }));
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routePatient(fx => {
         fx.data.id = '1';
@@ -1336,6 +1361,7 @@ context('Patient Form', function() {
       .click();
 
     cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routeFormFields');
 
@@ -1353,12 +1379,14 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/22222')
       .wait('@routePatient')
-      .wait('@routeFormFields')
-      .wait('@routeFormDefinition');
+      .wait('@routeForm')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
 
     cy
       .get('[data-status-region]')
@@ -1386,9 +1414,11 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/33333')
+      .wait('@routeForm')
       .wait('@routePatient')
       .wait('@routeFormFields')
       .wait('@routeFormDefinition');
@@ -1407,6 +1437,7 @@ context('Patient Form', function() {
           fx.data.id = '1';
           return fx;
         })
+        .routeForm()
         .routeFormDefinition()
         .routeFormFields()
         .visit('/patient/1/form/44444');
@@ -1430,6 +1461,7 @@ context('Patient Form', function() {
   specify('form error', function() {
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .routePatient(fx => {
@@ -1437,9 +1469,10 @@ context('Patient Form', function() {
         return fx;
       })
       .visit('/patient/1/form/11111')
-      .wait('@routePatient')
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
-      .wait('@routeFormFields');
+      .wait('@routeFormFields')
+      .wait('@routePatient');
 
     cy
       .route({
@@ -1498,12 +1531,14 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/22222')
       .wait('@routePatient')
-      .wait('@routeFormFields')
-      .wait('@routeFormDefinition');
+      .wait('@routeForm')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
 
     cy
       .get('.form__sidebar')
@@ -1549,6 +1584,7 @@ context('Patient Form', function() {
 
     cy
       .server()
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .routeWidgets(fx => {
@@ -1594,6 +1630,7 @@ context('Patient Form', function() {
 
     cy
       .visit('/patient/1/form/55555')
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routeFormFields')
       .wait('@routeWidgets')
@@ -1624,6 +1661,7 @@ context('Preview Form', function() {
       .server()
       .fixture('test/form-kitchen-sink.json').as('fxTestFormKitchenSink')
       .routeFlows()
+      .routeForm()
       .route({
         url: '/api/forms/*/definition',
         response() {
@@ -1632,6 +1670,7 @@ context('Preview Form', function() {
       })
       .as('routeFormKitchenSink')
       .visit('/form/11111/preview')
+      .wait('@routeForm')
       // NOTE: https://github.com/formio/formio.js/issues/3489
       // Issue started at v4.12.rc-1
       .wait(500);

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -58,7 +58,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition(fx => {
         return {
           display: 'form',
@@ -130,7 +130,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields(fx => {
         delete fx.data.attributes;
@@ -181,7 +181,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction(fx => {
@@ -231,7 +231,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction(fx => {
@@ -273,7 +273,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -326,7 +326,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -384,7 +384,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields(fx => {
         delete fx.data.attributes;
@@ -442,7 +442,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields()
       .routeFormResponse(fx => {
@@ -794,7 +794,7 @@ context('Patient Action Form', function() {
         return fx;
       })
       .routePatient()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()
@@ -834,7 +834,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -1018,7 +1018,7 @@ context('Patient Action Form', function() {
 
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()
@@ -1079,7 +1079,7 @@ context('Patient Action Form', function() {
 
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
       .routeFormActionFields()
@@ -1164,7 +1164,7 @@ context('Patient Form', function() {
 
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields(fx => {
         fx.data.attributes.storyTime = 'Once upon a time...';
@@ -1310,7 +1310,7 @@ context('Patient Form', function() {
     }));
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routePatient(fx => {
         fx.data.id = '1';
@@ -1344,7 +1344,7 @@ context('Patient Form', function() {
     }));
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routePatient(fx => {
         fx.data.id = '1';
@@ -1383,7 +1383,7 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/22222')
@@ -1418,7 +1418,7 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/33333')
@@ -1441,7 +1441,7 @@ context('Patient Form', function() {
           fx.data.id = '1';
           return fx;
         })
-        .routeForm()
+        .routeForm(_.identity, '11111')
         .routeFormDefinition()
         .routeFormFields()
         .visit('/patient/1/form/44444');
@@ -1465,7 +1465,7 @@ context('Patient Form', function() {
   specify('form error', function() {
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .routePatient(fx => {
@@ -1535,7 +1535,7 @@ context('Patient Form', function() {
         fx.data.id = '1';
         return fx;
       })
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .visit('/patient/1/form/22222')
@@ -1588,7 +1588,7 @@ context('Patient Form', function() {
 
     cy
       .server()
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .routeWidgets(fx => {

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -91,7 +91,7 @@ context('patient sidebar', function() {
     cy
       .server()
       .routePatientActions(_.identity, '2')
-      .routeForm()
+      .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
       .routeSettings(fx => {

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -91,6 +91,7 @@ context('patient sidebar', function() {
     cy
       .server()
       .routePatientActions(_.identity, '2')
+      .routeForm()
       .routeFormDefinition()
       .routeFormFields()
       .routeSettings(fx => {
@@ -609,6 +610,7 @@ context('patient sidebar', function() {
       .should('be.disabled');
 
     cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition');
 
     cy

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -18,6 +18,19 @@ Cypress.Commands.add('routeForms', (mutator = _.identity) => {
     .as('routeForms');
 });
 
+Cypress.Commands.add('routeForm', (mutator = _.identity) => {
+  cy
+    .fixture('test/forms').as('fxTestForms');
+
+  cy.route({
+    url: '/api/forms/*',
+    response() {
+      return mutator(this.fxForms);
+    },
+  })
+    .as('routeForm');
+});
+
 Cypress.Commands.add('routeFormDefinition', (mutator = _.identity) => {
   cy
     .fixture('test/form-definition').as('fxTestFormDefinition');

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -19,9 +19,6 @@ Cypress.Commands.add('routeForms', (mutator = _.identity) => {
 });
 
 Cypress.Commands.add('routeForm', (mutator = _.identity) => {
-  cy
-    .fixture('test/forms').as('fxTestForms');
-
   cy.route({
     url: '/api/forms/*',
     response() {

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -25,7 +25,7 @@ Cypress.Commands.add('routeForm', (mutator = _.identity) => {
   cy.route({
     url: '/api/forms/*',
     response() {
-      return mutator(this.fxForms);
+      return mutator({});
     },
   })
     .as('routeForm');

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -18,11 +18,17 @@ Cypress.Commands.add('routeForms', (mutator = _.identity) => {
     .as('routeForms');
 });
 
-Cypress.Commands.add('routeForm', (mutator = _.identity) => {
+Cypress.Commands.add('routeForm', (mutator = _.identity, formId = '11111') => {
+  cy
+    .fixture('test/forms').as('fxTestForms');
+
   cy.route({
     url: '/api/forms/*',
     response() {
-      return mutator({});
+      return mutator({
+        data: _.find(this.fxTestForms, { formId }),
+        included: [],
+      });
     },
   })
     .as('routeForm');


### PR DESCRIPTION
Shortcut Story ID: [sc-29502]

Update the form service so that the form model is always retrieved alongside the form definition. This will ensure that all form data is synced without having to do a hard refresh of the application.

This code change broke several form related tests. So this pull request also includes fixes to those.