### PR TITLE
Extend the patient dashboard to be the full height of the page

### DIFF
--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -1,9 +1,7 @@
 .form__frame {
   background: $black-95;
   display: flex;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1
 }
 
 .form__layout {

--- a/src/js/views/globals/app-frame.scss
+++ b/src/js/views/globals/app-frame.scss
@@ -23,6 +23,7 @@ $menu-bkg-color: #1F2B33;
 
 .app-frame__content {
   min-width: 440px;
+  overflow-y: auto;
 }
 
 .app-frame__sidebar {

--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -1,8 +1,6 @@
 .patient-flow__frame {
   display: flex;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1;
 }
 
 .patient-flow__layout {

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -1,8 +1,6 @@
 .patient__frame {
   display: flex;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1;
 }
 
 .patient__layout {

--- a/src/js/views/programs/program/flow/program-flow.scss
+++ b/src/js/views/programs/program/flow/program-flow.scss
@@ -1,8 +1,6 @@
 .program-flow__frame {
   display: flex;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1;
 }
 
 .program-flow__layout {

--- a/src/js/views/programs/program/program.scss
+++ b/src/js/views/programs/program/program.scss
@@ -1,8 +1,6 @@
 .program__frame {
   display: flex;
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  flex: 1;
 }
 
 .program__layout {


### PR DESCRIPTION
Shortcut Story ID: [sc-29467]

The patient sidebar on the patient dashboard and flow page doesn't extend to the full height of the page. This was first noticed on a long version of the flow page, where its left border stopped midway (screenshot below).

This pull request updates the CSS so it extends to the full height of the browser window. Regardless of content length.

<img width="115" alt="image (1)" src="https://user-images.githubusercontent.com/35355575/176787704-7b175f01-aea6-4941-8ac7-17a5e565e992.png">
.