### PR TITLE
Move _buildMatchers function to the utils directory

### DIFF
--- a/src/js/utils/formatting/build-matchers-array.js
+++ b/src/js/utils/formatting/build-matchers-array.js
@@ -1,0 +1,13 @@
+import { map } from 'underscore';
+
+import words from 'js/utils/formatting/words';
+
+export default query => {
+  const searchWords = words(query);
+
+  return map(searchWords, function(word) {
+    word = RegExp.escape(word);
+
+    return new RegExp(`\\b${ word }`, 'i');
+  });
+};

--- a/src/js/utils/formatting/build-matchers-array.js
+++ b/src/js/utils/formatting/build-matchers-array.js
@@ -3,11 +3,9 @@ import { map } from 'underscore';
 import words from 'js/utils/formatting/words';
 
 export default query => {
-  const searchWords = words(query);
+  const searchWords = map(words(query), RegExp.escape);
 
   return map(searchWords, function(word) {
-    word = RegExp.escape(word);
-
     return new RegExp(`\\b${ word }`, 'i');
   });
 };

--- a/src/js/views/clinicians/clinicians-all_views.js
+++ b/src/js/views/clinicians/clinicians-all_views.js
@@ -3,7 +3,7 @@ import hbs from 'handlebars-inline-precompile';
 import Radio from 'backbone.radio';
 import { View, CollectionView, Behavior } from 'marionette';
 
-import words from 'js/utils/formatting/words';
+import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
 import PreloadRegion from 'js/regions/preload_region';
 import { AccessComponent, RoleComponent, StateComponent } from 'js/views/clinicians/shared/clinicians_views';
@@ -205,21 +205,12 @@ const ListView = CollectionView.extend({
       return;
     }
 
-    const matchers = this._buildMatchers(searchQuery);
+    const matchers = buildMatchersArray(searchQuery);
 
     this.setFilter(function({ searchString }) {
       return every(matchers, function(matcher) {
         return matcher.test(searchString);
       });
-    });
-  },
-  _buildMatchers(searchQuery) {
-    const searchWords = words(searchQuery);
-
-    return map(searchWords, function(word) {
-      word = RegExp.escape(word);
-
-      return new RegExp(`\\b${ word }`, 'i');
     });
   },
 });

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -1,12 +1,12 @@
-import { debounce, every, map } from 'underscore';
+import { debounce, every } from 'underscore';
 import Radio from 'backbone.radio';
 import { View, CollectionView } from 'marionette';
 import dayjs from 'dayjs';
 import hbs from 'handlebars-inline-precompile';
 
 import { alphaSort } from 'js/utils/sorting';
-import words from 'js/utils/formatting/words';
 import intl from 'js/i18n';
+import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
 import 'sass/modules/list-pages.scss';
 import 'sass/modules/table-list.scss';
@@ -234,21 +234,12 @@ const DayListView = CollectionView.extend({
       return;
     }
 
-    const matchers = this._buildMatchers(searchQuery);
+    const matchers = buildMatchersArray(searchQuery);
 
     this.setFilter(function({ searchString }) {
       return every(matchers, function(matcher) {
         return matcher.test(searchString);
       });
-    });
-  },
-  _buildMatchers(searchQuery) {
-    const searchWords = words(searchQuery);
-
-    return map(searchWords, function(word) {
-      word = RegExp.escape(word);
-
-      return new RegExp(`\\b${ word }`, 'i');
     });
   },
 });

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -1,12 +1,12 @@
-import { every, map } from 'underscore';
+import { every } from 'underscore';
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
 
 import { alphaSort } from 'js/utils/sorting';
-import words from 'js/utils/formatting/words';
 import intl, { renderTemplate } from 'js/i18n';
 import underscored from 'js/utils/formatting/underscored';
+import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
 import 'sass/modules/buttons.scss';
 import 'sass/modules/list-pages.scss';
@@ -205,21 +205,12 @@ const ListView = CollectionView.extend({
       return;
     }
 
-    const matchers = this._buildMatchers(searchQuery);
+    const matchers = buildMatchersArray(searchQuery);
 
     this.setFilter(function({ searchString }) {
       return every(matchers, function(matcher) {
         return matcher.test(searchString);
       });
-    });
-  },
-  _buildMatchers(searchQuery) {
-    const searchWords = words(searchQuery);
-
-    return map(searchWords, function(word) {
-      word = RegExp.escape(word);
-
-      return new RegExp(`\\b${ word }`, 'i');
     });
   },
 });

--- a/test/unit/utils/formatting.js
+++ b/test/unit/utils/formatting.js
@@ -1,4 +1,5 @@
 import buildMatcher from 'js/utils/formatting/build-matcher';
+import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 import collectionOf from 'js/utils/formatting/collection-of';
 import hasAllText from 'js/utils/formatting/has-all-text';
 import matchText from 'js/utils/formatting/match-text';
@@ -11,8 +12,15 @@ import words from 'js/utils/formatting/words';
 
 context('formatting', function() {
   specify('buildMatcher', function() {
-    const matcher = buildMatcher('test');
-    expect(matcher).to.eql(/\btest/gi);
+    const matcher = buildMatcher('test string');
+
+    expect(matcher).to.eql(/\btest|string/gi);
+  });
+
+  specify('buildMatchersArray', function() {
+    const matchersArray = buildMatchersArray('test string');
+
+    expect(matchersArray).to.eql([/\btest/i, /\bstring/i]);
   });
 
   specify('collectionOf', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-28864]

We currently use an identical function called `_buildMatchers()` in the worklist, schedule, and clinicians views. This function builds an array of regular expressions that is used for filtering items in the lists on those pages (`"Find in list..."`).

This pull request moves that `_buildMatchers()` function to the `/src/js/utils/formatting` directory and then imports it into the worklist, schedule, and clinicians view files to be used.

This will make things cleaner and more maintainable in the future.
