### PR TITLE
Hide tooltip for schedule list actions when their details field is empty

### DIFF
--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -177,7 +177,7 @@ const DayItemView = View.extend({
     Radio.trigger('event-router', 'patient:action', this.model.get('_patient'), this.model.id);
   },
   showDetailsTooltip() {
-    if (!this.model.get('details') && !this.model.getFlow()) return;
+    if (!this.model.get('details')) return;
 
     this.showChildView('details', new DetailsTooltip({ model: this.model }));
   },


### PR DESCRIPTION
Shortcut Story ID: [sc-29611]

This configures the tooltip for each action in the schedule list to only show if it has content in its details field.

Currently, the tooltip is shown if it has either a details field or a flow is attached to it. In some scenarios, this means the tooltip is shown even though the details field for that action is empty. This pull request makes it so the tooltip is hidden in those scenarios.