### PR TITLE
Filter array widget

### DIFF
--- a/src/js/utils/patient-template.js
+++ b/src/js/utils/patient-template.js
@@ -4,15 +4,15 @@ import { each, first, propertyOf, reduce, escape } from 'underscore';
 export const _ = { propertyOf, escape };
 
 // {{ fields.field_name.deep_nest }}
-const fieldRegEx = /{{\s*fields.([\w-.]+?)\s*}}/g;
+const fieldRegEx = /{{\s*fields.([\w\-.]+?)\s*}}/g;
 // {{ patient.first_name }}
-const patientRegEx = /{{\s*patient.([\w-.]+?)\s*}}/g;
+const patientRegEx = /{{\s*patient.([\w\-.]+?)\s*}}/g;
 // {{ value }}
 const valueRegEx = /({{\s*value\s*}})/g;
 // {{ value.deep.nest }}
 const valueDeepRegEx = /{{\s*value(?:\.([\w\-.]+?))?\s*}}/g;
 // {{ widget.widget_name-id }}
-const widgetRegEx = /{{\s*widget.([\w-.]+?)\s*}}/g;
+const widgetRegEx = /{{\s*widget.([\w\-.]+?)\s*}}/g;
 
 // Certain characters need to be escaped so that they can be put into a
 // string literal.

--- a/src/js/views/patients/widgets/README.md
+++ b/src/js/views/patients/widgets/README.md
@@ -339,3 +339,77 @@ with widget:
   }
 }
 ```
+
+#### arrayWidget with filter_value
+
+Uses [underscore's filter](http://underscorejs.org/#filter) to mutate array values
+
+
+For field data:
+```json
+[
+  {
+    "type": "foo",
+    "label": "Foo"
+  },
+  {
+    "type": "bar",
+    "label": "Bar"
+  }
+]
+```
+
+```json
+{
+  "display_name": "Array of Objects",
+  "key": "patient_array",
+  "filter_value" { "type": "foo" },
+  "child_widget": {
+    "widget_type": "templateWidget",
+    "definition": {
+      "template": "<p>{{ value.label }}</p>"
+    }
+  }
+}
+```
+Will display:
+```
+<p>Foo</p>
+```
+
+#### arrayWidget with reject_value
+
+Uses [underscore's reject](http://underscorejs.org/#reject) to mutate array values
+
+
+For field data:
+```json
+[
+  {
+    "type": "foo",
+    "label": "Foo"
+  },
+  {
+    "type": "bar",
+    "label": "Bar"
+  }
+]
+```
+
+```json
+{
+  "display_name": "Array of Objects",
+  "key": "patient_array",
+  "reject_value" { "type": "foo" },
+  "child_widget": {
+    "widget_type": "templateWidget",
+    "definition": {
+      "template": "<p>{{ value.label }}</p>"
+    }
+  }
+}
+```
+Will display:
+```
+<p>Bar</p>
+```

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -1,4 +1,4 @@
-import { each, map, propertyOf, reduce, extend, isFunction } from 'underscore';
+import { each, map, propertyOf, reduce, extend, isFunction, filter, reject } from 'underscore';
 import Radio from 'backbone.radio';
 import { View, CollectionView } from 'marionette';
 import dayjs from 'dayjs';
@@ -173,19 +173,28 @@ const widgets = {
       widget_type: 'fieldWidget',
       definition: {},
     },
-    initialize(options) {
+    getArrayValue(arrayValue) {
+      const filterValue = this.getOption('filter_value');
+      if (filterValue) arrayValue = filter(arrayValue, filterValue);
+
+      const rejectValue = this.getOption('reject_value');
+      if (rejectValue) arrayValue = reject(arrayValue, rejectValue);
+
+      return arrayValue;
+    },
+    initialize({ child_widget, field_name, key, childValue }) {
       const arrayValue = getWidgetValue({
         fields: this.model.getFields(),
-        name: this.getOption('field_name'),
-        key: this.getOption('key'),
-        childValue: this.getOption('childValue'),
+        name: field_name,
+        key,
+        childValue,
       });
 
-      each(arrayValue, childValue => {
-        const widgetModel = Radio.request('entities', 'widgets:model', options.child_widget || this.childWidget);
+      each(this.getArrayValue(arrayValue), value => {
+        const widgetModel = Radio.request('entities', 'widgets:model', child_widget || this.childWidget);
         const widget = widgets[widgetModel.get('widget_type')];
 
-        this.addChildView(buildWidget(widget, this.model, widgetModel, { childValue }));
+        this.addChildView(buildWidget(widget, this.model, widgetModel, { childValue: value }));
       });
     },
     template: hbs`{{ defaultHtml }}`,

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -129,6 +129,8 @@ context('patient sidebar', function() {
               'arrayWidget-child',
               'arrayWidget-child-custom',
               'arrayWidget-child-custom-deep',
+              'arrayWidget-filter',
+              'arrayWidget-reject',
             ],
             fields: _.keys(fields),
           },
@@ -419,6 +421,36 @@ context('patient sidebar', function() {
               key: 'date',
             },
           }),
+          addWidget({
+            id: 'arrayWidget-filter',
+            widget_type: 'arrayWidget',
+            definition: {
+              display_name: 'Filter Array',
+              field_name: 'nested-array',
+              filter_value: 'date',
+              child_widget: {
+                widget_type: 'templateWidget',
+                definition: {
+                  template: '<b>{{ value.foo.bar }}  {{ widget.arrayWidget-child-custom-sub-template }}</b>',
+                },
+              },
+            },
+          }),
+          addWidget({
+            id: 'arrayWidget-reject',
+            widget_type: 'arrayWidget',
+            definition: {
+              display_name: 'Reject Array',
+              field_name: 'nested-array',
+              reject_value: 'date',
+              child_widget: {
+                widget_type: 'templateWidget',
+                definition: {
+                  template: '<b>{{ value.foo.bar }}</b>',
+                },
+              },
+            },
+          }),
         ]);
 
         return fx;
@@ -596,6 +628,16 @@ context('patient sidebar', function() {
       .should('contain', 'Jan 1')
       .should('contain', 'three')
       .should('contain', 'No Date')
+      .should('contain', 'baz')
+      .next()
+      .should('contain', 'Filter Array')
+      .should('contain', '2')
+      .should('contain', 'Jan 1')
+      .should('not.contain', 'three')
+      .next()
+      .should('contain', 'Reject Array')
+      .should('not.contain', '2')
+      .should('contain', 'three')
       .should('contain', 'baz');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-29691]

This doesn't allow for anything beyond basic filter/reject to avoid exposing `eval` to the auth'd app, but it's probably better than nothing.

We could do the same thing for `_.first` and `_.last` if that seems useful such that we want to limit to only the first 5 of some array or last 1 of some array.  @wweaver4th 