### PR TITLE
Move list item checkbox to component 

### DIFF
--- a/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
@@ -147,6 +147,7 @@ export default App.extend({
     });
   },
   onSubmit() {
+    this.modal.disableSubmit();
     this.triggerMethod('save', this.getState().getData());
   },
   onStop() {

--- a/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
@@ -90,6 +90,7 @@ export default App.extend({
     });
   },
   onSubmit() {
+    this.modal.disableSubmit();
     const applyOwner = !!this.getState('applyOwner');
     if (applyOwner) {
       this.triggerMethod('applyOwner', this.getState('owner'));

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -1,4 +1,4 @@
-<td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
+<td class="table-list__cell table-list__item-check js-no-click"><span data-check-region></span></td>
 <td class="table-list__cell">
   <span class="patient__action-icon">{{far icon}}</span>{{~ remove_whitespace ~}}
   <span class="patient__action-name">

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -185,57 +185,57 @@ const ActionItemView = View.extend({
   },
   showState() {
     const isDisabled = this.flow.isDone();
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true, state: { isDisabled } });
+    this.stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true, state: { isDisabled } });
 
-    this.listenTo(stateComponent, 'change:state', state => {
+    this.listenTo(this.stateComponent, 'change:state', state => {
       this.model.saveState(state);
     });
 
-    this.showChildView('state', stateComponent);
+    this.showChildView('state', this.stateComponent);
   },
   showOwner() {
     const isDisabled = this.model.isDone() || this.flow.isDone();
-    const ownerComponent = new OwnerComponent({
+    this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
       groups: this.model.getPatient().getGroups(),
       isCompact: true,
       state: { isDisabled },
     });
 
-    this.listenTo(ownerComponent, 'change:owner', owner => {
+    this.listenTo(this.ownerComponent, 'change:owner', owner => {
       this.model.saveOwner(owner);
     });
 
-    this.showChildView('owner', ownerComponent);
+    this.showChildView('owner', this.ownerComponent);
   },
   showDueDay() {
     const isDisabled = this.model.isDone() || this.flow.isDone();
-    const dueDayComponent = new DueComponent({
+    this.dueDayComponent = new DueComponent({
       date: this.model.get('due_date'),
       isCompact: true,
       state: { isDisabled },
       isOverdue: this.model.isOverdue(),
     });
 
-    this.listenTo(dueDayComponent, 'change:due', date => {
+    this.listenTo(this.dueDayComponent, 'change:due', date => {
       this.model.saveDueDate(date);
     });
 
-    this.showChildView('dueDay', dueDayComponent);
+    this.showChildView('dueDay', this.dueDayComponent);
   },
   showDueTime() {
     const isDisabled = this.model.isDone() || this.flow.isDone() || !this.model.get('due_date');
-    const dueTimeComponent = new TimeComponent({
+    this.dueTimeComponent = new TimeComponent({
       time: this.model.get('due_time'),
       isCompact: true, state: { isDisabled },
       isOverdue: this.model.isOverdue(),
     });
 
-    this.listenTo(dueTimeComponent, 'change:time', time => {
+    this.listenTo(this.dueTimeComponent, 'change:time', time => {
       this.model.saveDueTime(time);
     });
 
-    this.showChildView('dueTime', dueTimeComponent);
+    this.showChildView('dueTime', this.dueTimeComponent);
   },
   showForm() {
     if (!this.model.getForm()) return;

--- a/src/js/views/patients/shared/actions_views.js
+++ b/src/js/views/patients/shared/actions_views.js
@@ -10,6 +10,7 @@ import Tooltip from 'js/components/tooltip';
 
 import trim from 'js/utils/formatting/trim';
 
+import CheckComponent from './components/check_component';
 import StateComponent from './components/state_component';
 import OwnerComponent from './components/owner_component';
 import DueComponent from './components/due_component';
@@ -60,6 +61,7 @@ const DetailsTooltip = View.extend({
 });
 
 export {
+  CheckComponent,
   StateComponent,
   OwnerComponent,
   DueComponent,

--- a/src/js/views/patients/shared/components/check_component.js
+++ b/src/js/views/patients/shared/components/check_component.js
@@ -1,0 +1,33 @@
+import hbs from 'handlebars-inline-precompile';
+import { Component } from 'marionette.toolkit';
+
+import 'sass/modules/buttons.scss';
+
+export default Component.extend({
+  stateEvents: {
+    'change:isSelected': 'onStateChangeIsSelected',
+  },
+  viewEvents: {
+    'click': 'onClick',
+  },
+  viewOptions() {
+    const isSelected = this.getState('isSelected');
+    const template = isSelected ? hbs`{{fas "check-square"}}` : hbs`{{fal "square"}}`;
+    return {
+      tagName: 'button',
+      className: 'button--checkbox js-select',
+      template,
+      triggers: {
+        'click': 'click',
+      },
+    };
+  },
+  onClick(view, domEvent) {
+    this.toggleState('isSelected');
+    this.triggerMethod('select', domEvent);
+  },
+  onStateChangeIsSelected(state, isSelected) {
+    this.show();
+    this.triggerMethod('change:isSelected', isSelected);
+  },
+});

--- a/src/js/views/patients/shared/components/check_component.js
+++ b/src/js/views/patients/shared/components/check_component.js
@@ -13,6 +13,7 @@ export default Component.extend({
   viewOptions() {
     const isSelected = this.getState('isSelected');
     const template = isSelected ? hbs`{{fas "check-square"}}` : hbs`{{fal "square"}}`;
+
     return {
       tagName: 'button',
       className: 'button--checkbox js-select',

--- a/src/js/views/patients/shared/components/state_component.js
+++ b/src/js/views/patients/shared/components/state_component.js
@@ -42,8 +42,11 @@ function getStateLists() {
 export default Droplist.extend({
   isCompact: false,
   initialize({ stateId }) {
-    const states = getStates();
     this.lists = getStateLists();
+    this.setSelected(stateId);
+  },
+  setSelected(stateId) {
+    const states = getStates();
     this.setState({ selected: states.get(stateId) });
   },
   onChangeSelected(selected) {

--- a/src/js/views/patients/shared/flows_views.js
+++ b/src/js/views/patients/shared/flows_views.js
@@ -4,6 +4,7 @@ import 'sass/modules/buttons.scss';
 
 import intl from 'js/i18n';
 
+import CheckComponent from './components/check_component';
 import StateComponent from './components/state_component';
 import OwnerComponent from './components/owner_component';
 
@@ -58,6 +59,7 @@ const FlowStateComponent = StateComponent.extend({
 });
 
 export {
+  CheckComponent,
   FlowStateComponent,
   OwnerComponent,
 };

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -1,4 +1,4 @@
-<td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
+<td class="table-list__cell table-list__item-check js-no-click"><span data-check-region></span></td>
 <td class="table-list__cell w-15">
   <span class="worklist-list__patient-sidebar-icon">
     <button class="button-secondary--compact js-patient-sidebar-button">

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -53,8 +53,7 @@ const ActionItemView = View.extend({
     });
   },
   modelEvents: {
-    'change:due_date': 'onChangeDueDateTime',
-    'change:due_time': 'onChangeDueDateTime',
+    'change': 'render',
   },
   triggers: {
     'click': 'click',
@@ -72,10 +71,6 @@ const ActionItemView = View.extend({
   },
   onClickPatient() {
     Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
-  },
-  onChangeDueDateTime() {
-    this.showDueDate();
-    this.showDueTime();
   },
   onRender() {
     this.showCheck();
@@ -104,58 +99,58 @@ const ActionItemView = View.extend({
     this.showChildView('check', checkComponent);
   },
   showState() {
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    this.stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
 
-    this.listenTo(stateComponent, 'change:state', state => {
+    this.listenTo(this.stateComponent, 'change:state', state => {
       this.model.saveState(state);
     });
 
-    this.showChildView('state', stateComponent);
+    this.showChildView('state', this.stateComponent);
   },
   showOwner() {
     const isDisabled = this.model.isDone();
-    const ownerComponent = new OwnerComponent({
+    this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
       groups: this.model.getPatient().getGroups(),
       isCompact: true,
       state: { isDisabled },
     });
 
-    this.listenTo(ownerComponent, 'change:owner', owner => {
+    this.listenTo(this.ownerComponent, 'change:owner', owner => {
       this.model.saveOwner(owner);
     });
 
-    this.showChildView('owner', ownerComponent);
+    this.showChildView('owner', this.ownerComponent);
   },
   showDueDate() {
     const isDisabled = this.model.isDone();
-    const dueDateComponent = new DueComponent({
+    this.dueDateComponent = new DueComponent({
       date: this.model.get('due_date'),
       isCompact: true,
       state: { isDisabled },
       isOverdue: this.model.isOverdue(),
     });
 
-    this.listenTo(dueDateComponent, 'change:due', date => {
+    this.listenTo(this.dueDateComponent, 'change:due', date => {
       this.model.saveDueDate(date);
     });
 
-    this.showChildView('dueDate', dueDateComponent);
+    this.showChildView('dueDate', this.dueDateComponent);
   },
   showDueTime() {
     const isDisabled = this.model.isDone() || !this.model.get('due_date');
-    const dueTimeComponent = new TimeComponent({
+    this.dueTimeComponent = new TimeComponent({
       time: this.model.get('due_time'),
       isCompact: true,
       state: { isDisabled },
       isOverdue: this.model.isOverdue(),
     });
 
-    this.listenTo(dueTimeComponent, 'change:time', time => {
+    this.listenTo(this.dueTimeComponent, 'change:time', time => {
       this.model.saveDueTime(time);
     });
 
-    this.showChildView('dueTime', dueTimeComponent);
+    this.showChildView('dueTime', this.dueTimeComponent);
   },
   showForm() {
     if (!this.model.getForm()) return;

--- a/src/js/views/patients/worklist/flow-item.hbs
+++ b/src/js/views/patients/worklist/flow-item.hbs
@@ -1,4 +1,4 @@
-<td class="table-list__cell table-list__item-check js-no-click"><button class="button--checkbox js-select">{{#if isSelected}}{{fas "check-square"}}{{else}}{{fal "square"}}{{/if}}</button></td>
+<td class="table-list__cell table-list__item-check js-no-click"><span data-check-region></span></td>
 <td class="table-list__cell w-15">
   <span class="worklist-list__patient-sidebar-icon">
     <button class="button-secondary--compact js-patient-sidebar-button">

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -52,6 +52,9 @@ const FlowItemView = View.extend({
       state: this.model.getState().get('name'),
     };
   },
+  modelEvents: {
+    'change': 'render',
+  },
   triggers: {
     'click': 'click',
     'click .js-patient-sidebar-button': 'click:patientSidebarButton',
@@ -114,18 +117,18 @@ const FlowItemView = View.extend({
   },
   showOwner() {
     const isDisabled = this.model.isDone();
-    const ownerComponent = new OwnerComponent({
+    this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
       groups: this.model.getPatient().getGroups(),
       isCompact: true,
       state: { isDisabled },
     });
 
-    this.listenTo(ownerComponent, 'change:owner', owner => {
+    this.listenTo(this.ownerComponent, 'change:owner', owner => {
       this.model.saveOwner(owner);
     });
 
-    this.showChildView('owner', ownerComponent);
+    this.showChildView('owner', this.ownerComponent);
   },
 });
 

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -206,15 +206,13 @@ const ListView = CollectionView.extend({
     const lastSelectedIndex = this.state.get('lastSelectedIndex');
 
     if (isShiftKeyPressed && lastSelectedIndex !== null && !isSelected) {
-      this.handleClickShiftMultiSelect(selectedIndex);
+      this.handleClickShiftMultiSelect(selectedIndex, lastSelectedIndex);
       return;
     }
 
     this.state.toggleSelected(selectedView.model, !isSelected, selectedIndex);
   },
-  handleClickShiftMultiSelect(selectedIndex) {
-    const lastSelectedIndex = this.state.get('lastSelectedIndex');
-
+  handleClickShiftMultiSelect(selectedIndex, lastSelectedIndex) {
     const minIndex = Math.min(selectedIndex, lastSelectedIndex);
     const maxIndex = Math.max(selectedIndex, lastSelectedIndex);
 

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -826,6 +826,11 @@ context('Worklist bulk editing', function() {
 
     cy
       .get('.app-frame__content')
+      .find('.table-list__item .fa-circle-check')
+      .should('have.length', 3);
+
+    cy
+      .get('.app-frame__content')
       .find('.table-list__item')
       .last()
       .find('.js-select')
@@ -1280,6 +1285,11 @@ context('Worklist bulk editing', function() {
     cy
       .get('.alert-box')
       .should('contain', '4 Actions have been updated');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item .fa-circle-exclamation')
+      .should('have.length', 4);
 
     cy
       .get('.table-list')


### PR DESCRIPTION
Shortcut Story ID: [sc-29967]

The checkbox re-rendering the whole item row caused all of the components to re-render.  Not terrible per-row, but in a multiselect situation, it really stacked up.  I _think_ we might still have a memory leak somewhere, but I'm still looking into that, and can measure better once this makes it to QA.