### PR TITLE
Support 401 for disabled users

### DIFF
--- a/src/js/outreach/index.js
+++ b/src/js/outreach/index.js
@@ -95,6 +95,7 @@ const LoginApp = App.extend({
               break;
             case 404:
             case 403:
+            case 401:
               region.show(new NotAvailableView());
               break;
             default:

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -134,7 +134,7 @@ context('patient page', function() {
       .server()
       .route({
         url: '/api/clinicians/me',
-        status: 403,
+        status: 401,
         response: {},
       })
       .as('routeClinicianDisabled')


### PR DESCRIPTION
Shortcut Story ID: [sc-30030]

BE is switching the disabled clinician to 401, which to my surprise is already working as expected so I just updated the test.  And I went ahead and added it to the outreach, even though it isn't currently in use.. but it certainly doesn't hurt to add it.