### PR TITLE
Create a patient identifier widget

### DIFF
--- a/src/js/views/patients/widgets/README.md
+++ b/src/js/views/patients/widgets/README.md
@@ -413,3 +413,41 @@ Will display:
 ```
 <p>Bar</p>
 ```
+
+### Patient Identifier Widget
+
+This widget displays a patient identifier value (such as a MRN or SSN number).
+
+As an example, this is how you'd display a patient's MRN number:
+
+```json
+{
+  "widget_type": "patientIdentifiers",
+  "definition": {
+    "default_html": "Not Found",
+    "display_name": "MRN Number",
+    "identifier_type": "mrn",
+  },
+}
+```
+
+This would display:
+
+```
+MRN Number
+A5432112345
+```
+
+If the patient identifier is null/empty, the `default_html` value will display instead. Using the example above, it would display `Not found`.
+
+```
+MRN Number
+Not Found
+```
+
+If the patient identifier is null/empty and no `default_html` value is supplied, a dash (`-`) will be shown.
+
+```
+MRN Number
+-
+```

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -1,4 +1,4 @@
-import { each, map, propertyOf, reduce, extend, isFunction, filter, reject } from 'underscore';
+import { each, map, propertyOf, reduce, extend, isFunction, filter, reject, find } from 'underscore';
 import Radio from 'backbone.radio';
 import { View, CollectionView } from 'marionette';
 import dayjs from 'dayjs';
@@ -81,6 +81,22 @@ const widgets = {
     templateContext() {
       return {
         groups: map(this.model.getGroups().models, 'attributes'),
+      };
+    },
+  },
+  patientIdentifiers: {
+    className: 'widgets-value',
+    template: hbs`{{ displayValue }}{{#unless displayValue}}{{{ defaultHtml }}}{{/unless}}`,
+    templateContext() {
+      const defaultHtml = this.getOption('default_html');
+      const identifiersArray = this.model.get('identifiers');
+      const identifierType = this.getOption('identifier_type');
+
+      const identifier = find(identifiersArray, { type: identifierType });
+
+      return {
+        displayValue: identifier && identifier.value,
+        defaultHtml,
       };
     },
   },

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -131,6 +131,8 @@ context('patient sidebar', function() {
               'arrayWidget-child-custom-deep',
               'arrayWidget-filter',
               'arrayWidget-reject',
+              'patientMRNIdentifier',
+              'patientSSNIdentifier',
             ],
             fields: _.keys(fields),
           },
@@ -451,6 +453,23 @@ context('patient sidebar', function() {
               },
             },
           }),
+          addWidget({
+            id: 'patientMRNIdentifier',
+            widget_type: 'patientIdentifiers',
+            definition: {
+              display_name: 'Patient Identifier',
+              identifier_type: 'mrn',
+            },
+          }),
+          addWidget({
+            id: 'patientSSNIdentifier',
+            widget_type: 'patientIdentifiers',
+            definition: {
+              default_html: 'No Identifier Found',
+              display_name: 'Patient Identifier With Empty Value',
+              identifier_type: 'ssn',
+            },
+          }),
         ]);
 
         return fx;
@@ -463,6 +482,12 @@ context('patient sidebar', function() {
           birth_date: dob,
           sex: 'f',
           status: 'active',
+          identifiers: [
+            {
+              type: 'mrn',
+              value: 'A5432112345',
+            },
+          ],
         };
 
         fx.data.relationships['patient-fields'].data = _.map(_.values(fields), field => {
@@ -638,7 +663,13 @@ context('patient sidebar', function() {
       .should('contain', 'Reject Array')
       .should('not.contain', '2')
       .should('contain', 'three')
-      .should('contain', 'baz');
+      .should('contain', 'baz')
+      .next()
+      .should('contain', 'Patient Identifier')
+      .should('contain', 'A5432112345')
+      .next()
+      .should('contain', 'Patient Identifier With Empty Value')
+      .should('contain', 'No Identifier Found');
 
     cy
       .get('@patientSidebar')


### PR DESCRIPTION
Shortcut Story ID: [sc-29930]

Create a new custom widget that displays a patient identifier value (such as a MRN or SSN number).



