### PR TITLE
Clear field pojos on form submission

### DIFF
--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -483,7 +483,31 @@ context('Patient Action Form', function() {
         return fx;
       })
       .routeForm(_.identity, '11111')
-      .routeFormDefinition()
+      .routeFormDefinition(fx => {
+        fx.components.push(
+          {
+            label: 'Survey',
+            tableView: false,
+            questions: [
+              {
+                label: '',
+                value: '',
+                tooltip: '',
+              },
+            ],
+            values: [
+              {
+                label: '',
+                value: '',
+                tooltip: '',
+              },
+            ],
+            key: 'fields.survey',
+            type: 'survey',
+            input: true,
+          });
+        return fx;
+      })
       .routeFormActionFields()
       .routeFormResponse(fx => {
         fx.data.storyTime = 'Once upon a time...';
@@ -705,6 +729,7 @@ context('Patient Action Form', function() {
         expect(data.attributes.response.data.patient.last_name).to.equal('Doe');
         expect(data.attributes.response.data.patient.fields.foo).to.equal('bar');
         expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
+        expect(data.attributes.response.data.survey).to.be.undefined;
       });
 
     cy


### PR DESCRIPTION
```js
_.reduce({ foo: 1, bar: [], baz: {} }, (fields, field, key) => {
  const isEmptyPojo = !_.isArray(field) && _.isObject(field) && _.isEmpty(field);

  if (!isEmptyPojo) fields[key] = field;

  return fields;
}, {});
```
returns `{ foo: 1 bar: Array(0) }`

Shortcut Story ID: [sc-29993]
