### PR TITLE
View patient sidebar from the schedule page

### DIFF
--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -139,11 +139,6 @@ export default App.extend({
       this.toggleBulkSelect();
     });
 
-    this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
-      const patient = model.getPatient();
-      Radio.request('sidebar', 'start', 'patient', { patient });
-    });
-
     this.showChildView('list', collectionView);
   },
   showScheduleTitle() {

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -44,6 +44,7 @@ export default App.extend({
   },
   onBeforeStart() {
     if (this.isRestarting()) {
+      Radio.request('sidebar', 'close');
       this.showScheduleTitle();
       this.showDateFilter();
       this.getRegion('list').startPreloader();
@@ -136,6 +137,11 @@ export default App.extend({
     this.listenTo(collectionView, 'filtered', filtered => {
       this.filteredCollection.reset(filtered);
       this.toggleBulkSelect();
+    });
+
+    this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
+      const patient = model.getPatient();
+      Radio.request('sidebar', 'start', 'patient', { patient });
     });
 
     this.showChildView('list', collectionView);

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -239,9 +239,9 @@ careOptsFrontend:
           title: Schedule for { owner }
           tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team). States included are To Do and In Progress.
         tableHeaderView:
-          actionHeader: Action
+          actionHeader: State, Action
           dueDateHeader: Due Date
-          statePatientHeader: State, Patient
+          statePatientHeader: Patient
           formheader: Form
     shared:
       addWorkflow:

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -239,9 +239,9 @@ careOptsFrontend:
           title: Schedule for { owner }
           tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team). States included are To Do and In Progress.
         tableHeaderView:
-          actionHeader: State, Action
           dueDateHeader: Due Date
-          statePatientHeader: Patient
+          patientHeader: Patient
+          stateActionHeader: State, Action
           formheader: Form
     shared:
       addWorkflow:

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -239,10 +239,10 @@ careOptsFrontend:
           title: Schedule for { owner }
           tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team). States included are To Do and In Progress.
         tableHeaderView:
+          actionHeader: State, Action
           dueDateHeader: Due Date
-          patientHeader: Patient
-          stateActionHeader: State, Action
           formheader: Form
+          patientHeader: Patient
     shared:
       addWorkflow:
         addWorkflowViews:

--- a/src/js/views/patients/schedule/schedule-list.scss
+++ b/src/js/views/patients/schedule/schedule-list.scss
@@ -83,6 +83,12 @@
     cursor: default;
   }
 
+  &:hover {
+    .js-patient-sidebar-button {
+      color: $black-20;
+    }
+  }
+
   &:hover:not(.is-selected, .is-reduced) {
     background-color: color(light_blue, light);
   }
@@ -90,6 +96,7 @@
 
 .schedule-list__action-list-cell {
   padding: 4px 8px;
+  width: calc(68% - 84px);
 
   &.is-overdue {
     color: color(red);
@@ -116,13 +123,21 @@
 }
 
 .schedule-list__state-patient,
-.schedule-list__action-name {
+.schedule-list__action-list-cell {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.schedule-list__patient-sidebar-icon {
+  margin-right: 16px;
+
+  .js-patient-sidebar-button {
+    color: $black-60;
+  }
 }
 
 .schedule-list__action-state {

--- a/src/js/views/patients/schedule/schedule-list.scss
+++ b/src/js/views/patients/schedule/schedule-list.scss
@@ -122,7 +122,7 @@
   width: 48px;
 }
 
-.schedule-list__state-patient,
+.schedule-list__patient-details,
 .schedule-list__action-list-cell {
   display: inline-block;
   max-width: 100%;

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -77,7 +77,7 @@ const TableHeaderView = View.extend({
   template: hbs`
     <td class="schedule-list__header schedule-list__header-due-date">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.dueDateHeader }}</td>
     <td class="schedule-list__header schedule-list__header-state-patient">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.patientHeader }}</td>
-    <td class="schedule-list__header schedule-list__header-action">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.stateActionHeader }}</td>
+    <td class="schedule-list__header schedule-list__header-action">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.actionHeader }}</td>
     <td class="schedule-list__header schedule-list__header-form">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.formheader }}</td>
   `,
   tagName: 'tr',

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -103,11 +103,16 @@ const DayItemView = View.extend({
     </td>
     <td class="schedule-list__action-list-cell schedule-list__patient">
       <div class="schedule-list__state-patient">
-        <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
+        <span class="schedule-list__patient-sidebar-icon">
+          <button class="js-patient-sidebar-button">
+            {{far "address-card"}}
+          </button>
+        </span>&#8203;{{~ remove_whitespace ~}}
         <span class="schedule-list__patient-name {{#if isReduced}}is-reduced{{else}}js-patient{{/if}}">{{ patient.first_name }} {{ patient.last_name }}</span>&#8203;
       </div>
     </td>
     <td class="schedule-list__action-list-cell">
+      <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
       <span class="schedule-list__action-name {{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
       <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;{{~ remove_whitespace ~}}
     </td>
@@ -139,6 +144,7 @@ const DayItemView = View.extend({
   },
   triggers: {
     'click .js-form': 'click:form',
+    'click .js-patient-sidebar-button': 'click:patientSidebarButton',
     'click .js-patient': 'click:patient',
     'click': 'click',
     'click .js-select': 'click:select',
@@ -223,6 +229,7 @@ const DayListView = CollectionView.extend({
   },
   childViewTriggers: {
     'render': 'listItem:render',
+    'click:patientSidebarButton': 'click:patientSidebarButton',
   },
   onListItemRender(view) {
     const date = dayjs(this.model.get('date'));
@@ -276,6 +283,9 @@ const ScheduleListView = CollectionView.extend({
   },
   childViewEvents: {
     'render:children': 'onChildFilter',
+  },
+  childViewTriggers: {
+    'click:patientSidebarButton': 'click:patientSidebarButton',
   },
   emptyView() {
     if (this.state.get('searchQuery')) {

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -162,6 +162,10 @@ const DayItemView = View.extend({
   onRender() {
     this.showDetailsTooltip();
   },
+  onClickPatientSidebarButton() {
+    const patient = this.model.getPatient();
+    Radio.request('sidebar', 'start', 'patient', { patient });
+  },
   onClickSelect() {
     this.state.toggleSelected(this.model, !this.state.isSelected(this.model));
     this.render();
@@ -229,7 +233,6 @@ const DayListView = CollectionView.extend({
   },
   childViewTriggers: {
     'render': 'listItem:render',
-    'click:patientSidebarButton': 'click:patientSidebarButton',
   },
   onListItemRender(view) {
     const date = dayjs(this.model.get('date'));
@@ -283,9 +286,6 @@ const ScheduleListView = CollectionView.extend({
   },
   childViewEvents: {
     'render:children': 'onChildFilter',
-  },
-  childViewTriggers: {
-    'click:patientSidebarButton': 'click:patientSidebarButton',
   },
   emptyView() {
     if (this.state.get('searchQuery')) {

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -113,7 +113,7 @@ const DayItemView = View.extend({
     </td>
     <td class="schedule-list__action-list-cell">
       <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
-      <span class="schedule-list__action-name {{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
+      <span class="{{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
       <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;{{~ remove_whitespace ~}}
     </td>
     <td class="schedule-list__action-list-cell schedule-list__action-details" data-details-region></td>

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -102,7 +102,7 @@ const DayItemView = View.extend({
       {{/if}}
     </td>
     <td class="schedule-list__action-list-cell schedule-list__patient">
-      <div class="schedule-list__state-patient">
+      <div class="schedule-list__patient-details">
         <span class="schedule-list__patient-sidebar-icon">
           <button class="js-patient-sidebar-button">
             {{far "address-card"}}

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -76,8 +76,8 @@ const SelectAllView = View.extend({
 const TableHeaderView = View.extend({
   template: hbs`
     <td class="schedule-list__header schedule-list__header-due-date">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.dueDateHeader }}</td>
-    <td class="schedule-list__header schedule-list__header-state-patient">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.statePatientHeader }}</td>
-    <td class="schedule-list__header schedule-list__header-action">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.actionHeader }}</td>
+    <td class="schedule-list__header schedule-list__header-state-patient">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.patientHeader }}</td>
+    <td class="schedule-list__header schedule-list__header-action">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.stateActionHeader }}</td>
     <td class="schedule-list__header schedule-list__header-form">{{ @intl.patients.schedule.scheduleViews.tableHeaderView.formheader }}</td>
   `,
   tagName: 'tr',

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -209,6 +209,44 @@ context('schedule page', function() {
       .get('@actionList')
       .find('tr')
       .last()
+      .find('.js-patient-sidebar-button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('.worklist-patient-sidebar__patient-name')
+      .should('contain', 'Test Patient');
+
+    cy
+      .get('[data-filters-region]')
+      .find('[data-owner-filter-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .eq(1)
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .should('not.exist');
+
+    cy
+      .get('[data-filters-region]')
+      .find('[data-owner-filter-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .contains('Clinician McTester')
+      .click();
+
+    cy
+      .get('@actionList')
+      .find('tr')
+      .last()
       .should('contain', 'No Time')
       .should('contain', 'Last Action')
       .find('.js-patient')


### PR DESCRIPTION
Shortcut Story ID: [sc-29992]

Add the ability to view the patient sidebar from the schedule page.

Similar to what we added for the worklist in this PR: https://github.com/RoundingWell/care-ops-frontend/pull/699.

This also involves moving the `State` to the `Action` column.

https://user-images.githubusercontent.com/35355575/183471560-a110b4e9-dd1c-4d30-8c22-c74b43560c74.mov


