### PR TITLE
Schedule - Add a grey background to selected list items

### DIFF
--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -160,7 +160,11 @@ const DayItemView = View.extend({
     });
   },
   onRender() {
+    this.toggleSelected(!this.isReduced && this.state.isSelected(this.model));
     this.showDetailsTooltip();
+  },
+  toggleSelected(isSelected) {
+    this.$el.toggleClass('is-selected', isSelected);
   },
   onClickPatientSidebarButton() {
     const patient = this.model.getPatient();
@@ -168,6 +172,7 @@ const DayItemView = View.extend({
   },
   onClickSelect() {
     this.state.toggleSelected(this.model, !this.state.isSelected(this.model));
+    this.toggleSelected(this.state.isSelected(this.model));
     this.render();
   },
   onClickPatient() {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -904,6 +904,19 @@ context('schedule page', function() {
       .should('contain', 'Edit 1 Action');
 
     cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row .is-selected')
+      .should('have.length', 1)
+      .first()
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row .is-selected')
+      .should('have.length', 0);
+
+    cy
       .get('[data-select-all-region]')
       .click();
 
@@ -936,6 +949,11 @@ context('schedule page', function() {
       .should('have.length', 0);
 
     cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row .is-selected')
+      .should('have.length', 0);
+
+    cy
       .get('[data-select-all-region]')
       .find('.fa-square');
 
@@ -947,6 +965,11 @@ context('schedule page', function() {
       .get('.app-frame__content')
       .find('.schedule-list__table')
       .find('.fa-square-check')
+      .should('have.length', 20);
+
+    cy
+      .get('.schedule-list__table')
+      .find('.schedule-list__list-row .is-selected')
       .should('have.length', 20);
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-30137]

Adds a `.is-selected` classname to a schedule list item when it's selected, which gives it a grey background.

The `.is-selected` class should be toggled when a user selects/un-selects a single list item. And when a user uses the bulk select controls (select all and un-select all).

<img width="1013" alt="Screen Shot 2022-08-08 at 2 27 53 PM" src="https://user-images.githubusercontent.com/35355575/183757711-c3f20b49-5fa6-4a0a-87a4-7560a66e1cc5.png">