### PR TITLE
Fix styling bug in schedule list

### DIFF
--- a/src/js/views/patients/schedule/schedule-list.scss
+++ b/src/js/views/patients/schedule/schedule-list.scss
@@ -96,7 +96,6 @@
 
 .schedule-list__action-list-cell {
   padding: 4px 8px;
-  width: calc(68% - 84px);
 
   &.is-overdue {
     color: color(red);
@@ -124,7 +123,7 @@
 }
 
 .schedule-list__patient-details,
-.schedule-list__action-list-cell {
+.schedule-list__action-state-name {
   display: inline-block;
   max-width: 100%;
   overflow: hidden;

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -112,9 +112,11 @@ const DayItemView = View.extend({
       </div>
     </td>
     <td class="schedule-list__action-list-cell">
-      <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
-      <span class="{{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
-      <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;{{~ remove_whitespace ~}}
+      <div class="schedule-list__action-state-name">
+        <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
+        <span class="{{#unless isReduced}}js-action{{/unless}}">{{ name }}</span>&#8203;{{~ remove_whitespace ~}}
+        <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;{{~ remove_whitespace ~}}
+      </div>
     </td>
     <td class="schedule-list__action-list-cell schedule-list__action-details" data-details-region></td>
     <td class="schedule-list__action-list-cell schedule-list__action-form">


### PR DESCRIPTION
Shortcut Story ID: [sc-29992]

This PR fixes a CSS styling bug in the schedule list where the form link table column is pushed to a new line (screenshot below).

It was introduced in this pull request: https://github.com/RoundingWell/care-ops-frontend/pull/763.

<img width="1512" alt="Screen Shot 2022-08-09 at 3 58 17 PM (1)" src="https://user-images.githubusercontent.com/35355575/183942575-bcdc01c9-fb88-409c-8dbb-dfd7aabf45ea.png">
l