### PR TITLE
Adjust device width for outreach for mobile devices

### DIFF
--- a/src/js/outreach/index.js
+++ b/src/js/outreach/index.js
@@ -208,6 +208,8 @@ const OutreachApp = RouterApp.extend({
 });
 
 function startOutreachApp() {
+  // Modify viewport for mobile devices at full width
+  $('meta[name=viewport]').attr('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
   new OutreachApp({ region: { el: document.getElementById('root') } });
   Backbone.history.start({ pushState: true });
 }

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -1,4 +1,7 @@
 context('Outreach', function() {
+  beforeEach(function() {
+    cy.viewport('iphone-x');
+  });
   specify('Form', function() {
     cy
       .server()


### PR DESCRIPTION
Fixes [sc-27851]

Turns out you _can_ do this after a page render.. apparently?
<img width="500" alt="Screen Shot 2022-08-12 at 5 33 41 AM" src="https://user-images.githubusercontent.com/2028470/184237200-146eb2c2-b77e-43f1-b957-bf9ca67f8fa8.png">

