### PR TITLE
Cypress intercept

### DIFF
--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -34,7 +34,6 @@ context('clinician sidebar', function() {
     };
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -327,7 +326,6 @@ context('clinician sidebar', function() {
     };
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -429,7 +427,6 @@ context('clinician sidebar', function() {
 
   specify('add clinician', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -684,7 +681,6 @@ context('clinician sidebar', function() {
 
   specify('clinician does not exist', function() {
     cy
-      .server()
       .visit('clinicians/2');
 
     cy
@@ -699,7 +695,6 @@ context('clinician sidebar', function() {
 
   specify('view clinician', function() {
     cy
-      .server()
       .routeClinicians(fx => {
         fx.data[0].id = 1;
         fx.data[0].attributes.name = 'Test Clinician';

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -6,7 +6,6 @@ import { testTs } from 'helpers/test-timestamp';
 context('clinicians list', function() {
   specify('display clinicians list', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -208,7 +207,6 @@ context('clinicians list', function() {
 
   specify('empty clinicians list', function() {
     cy
-      .server()
       .routeGroupsBootstrap()
       .visit()
       .routeClinicians(fx => {
@@ -226,7 +224,6 @@ context('clinicians list', function() {
 
   specify('new clinician', function() {
     cy
-      .server()
       .routeGroupsBootstrap()
       .visit()
       .routeClinicians()
@@ -254,7 +251,6 @@ context('clinicians list', function() {
 
   specify('find in list', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -1,7 +1,6 @@
 context('dashboard', function() {
   specify('display dashboard', function() {
     cy
-      .server()
       .routeDashboards()
       .routeDashboard(fx => {
         fx.data.id = '1';
@@ -36,7 +35,6 @@ context('dashboard', function() {
 
   specify('dashboard does not exist', function() {
     cy
-      .server()
       .routeDashboards()
       .route({
         url: '/api/dashboards/1',

--- a/test/integration/dashboards/dashboards-all.js
+++ b/test/integration/dashboards/dashboards-all.js
@@ -1,7 +1,6 @@
 context('dashboards all list', function() {
   specify('display dashboards list', function() {
     cy
-      .server()
       .routeDashboards()
       .routeDashboard()
       .visit('/dashboards')
@@ -26,7 +25,6 @@ context('dashboards all list', function() {
 
   specify('empty dashboards list', function() {
     cy
-      .server()
       .routeDashboards(fx => {
         fx.data = [];
 

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -9,7 +9,6 @@ import { getResource } from 'helpers/json-api';
 context('Patient Action Form', function() {
   specify('deleted action', function() {
     cy
-      .server()
       .route({
         url: '/api/actions/1*',
         status: 404,
@@ -40,7 +39,6 @@ context('Patient Action Form', function() {
 
   specify('directory', function() {
     cy
-      .server()
       .route({
         method: 'GET',
         url: '/appconfig.json',
@@ -119,7 +117,6 @@ context('Patient Action Form', function() {
 
   specify('update a form', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -167,7 +164,6 @@ context('Patient Action Form', function() {
 
   specify('storing stored submission', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -213,7 +209,6 @@ context('Patient Action Form', function() {
       },
     }));
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -258,7 +253,6 @@ context('Patient Action Form', function() {
       },
     }));
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -303,7 +297,6 @@ context('Patient Action Form', function() {
 
   specify('prefill a form with latest submission', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -356,7 +349,6 @@ context('Patient Action Form', function() {
 
   specify('prefill a form with latest submission from another form', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '66666' };
@@ -413,7 +405,6 @@ context('Patient Action Form', function() {
 
   specify('update a form with response field', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -470,7 +461,6 @@ context('Patient Action Form', function() {
     let printStub;
 
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -850,7 +840,6 @@ context('Patient Action Form', function() {
 
   specify('read only form', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '22222' };
@@ -891,7 +880,6 @@ context('Patient Action Form', function() {
 
   specify('form error', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '11111' };
@@ -960,7 +948,6 @@ context('Patient Action Form', function() {
 
   specify('routing to form-response', function() {
     cy
-      .server()
       .routeFlows()
       .routeActions(fx => {
         fx.data = _.sample(fx.data, 1);
@@ -1036,7 +1023,6 @@ context('Patient Action Form', function() {
 
   specify('routing to form', function() {
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.patient.data = { id: '1' };
@@ -1075,7 +1061,6 @@ context('Patient Action Form', function() {
     localStorage.setItem('form-state_11111', JSON.stringify({ isExpanded: false }));
 
     cy
-      .server()
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '22222' };
@@ -1143,7 +1128,6 @@ context('Patient Action Form', function() {
     const dob = testDateSubtract(10, 'years');
 
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeActionActivity()
@@ -1228,7 +1212,6 @@ context('Patient Form', function() {
     let printStub;
 
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields(fx => {
@@ -1374,7 +1357,6 @@ context('Patient Form', function() {
       },
     }));
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routePatient(fx => {
@@ -1408,7 +1390,6 @@ context('Patient Form', function() {
       },
     }));
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routePatient(fx => {
@@ -1443,7 +1424,6 @@ context('Patient Form', function() {
 
   specify('read only form', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
@@ -1478,7 +1458,6 @@ context('Patient Form', function() {
 
   specify('form scripts and reducers', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
@@ -1533,7 +1512,6 @@ context('Patient Form', function() {
 
   specify('form error', function() {
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
@@ -1599,7 +1577,6 @@ context('Patient Form', function() {
     localStorage.setItem('form-state_11111', JSON.stringify({ isExpanded: false }));
 
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
@@ -1656,7 +1633,6 @@ context('Patient Form', function() {
     const dob = testDateSubtract(10, 'years');
 
     cy
-      .server()
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
       .routeFormFields()
@@ -1731,7 +1707,6 @@ context('Patient Form', function() {
 context('Preview Form', function() {
   specify('routing to form', function() {
     cy
-      .server()
       .fixture('test/form-kitchen-sink.json').as('fxTestFormKitchenSink')
       .routeFlows()
       .route({

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1484,7 +1484,6 @@ context('Patient Form', function() {
   if (Cypress.browser.name !== 'firefox') {
     specify('form reducer error', function() {
       cy
-        .server()
         .routePatient(fx => {
           fx.data.id = '1';
           return fx;

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -98,8 +98,11 @@ context('Patient Action Form', function() {
 
     cy
       .wait('@routeDirectory')
-      .its('url')
-      .should('contain', 'foo?filter[foo]=bar');
+      .itsUrl()
+      .should(({ search, pathname }) => {
+        expect(search).to.contain('?filter[foo]=bar');
+        expect(pathname).to.equal('/api/directory/foo');
+      });
 
     cy
       .iframe()
@@ -384,7 +387,8 @@ context('Patient Action Form', function() {
 
     cy
       .wait('@routeLatestFormResponseByPatient')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[form]=11111');
 
     cy

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -7,7 +7,6 @@ context('App Nav', function() {
   specify('display non-manager nav', function() {
     let windowStub;
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -44,7 +43,6 @@ context('App Nav', function() {
   specify('display nav', function() {
     let logoutStub;
     cy
-      .server()
       .routeFlows()
       .routePrograms()
       .routeDashboards()
@@ -231,7 +229,6 @@ context('App Nav', function() {
     };
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, clinicianGroups)
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 1);
@@ -425,7 +422,6 @@ context('App Nav', function() {
     };
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, clinicianGroups)
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 1);
@@ -665,7 +661,6 @@ context('App Nav', function() {
 
   specify('manual add patient disabled', function() {
     cy
-      .server()
       .routeSettings(fx => {
         const manualAddPatient = _.find(fx.data, setting => setting.id === 'manual_patient_creation');
         manualAddPatient.attributes.value = false;

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 context('patient page', function() {
   specify('default route', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .visit();
@@ -30,7 +29,6 @@ context('patient page', function() {
 
   specify('current clinician has reduced patient schedule access', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.attributes.access = 'employee';
         return fx;
@@ -50,7 +48,6 @@ context('patient page', function() {
 
   specify('current clinician has no groups', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, null, fx => {
         const currentClinician = _.find(fx.data, clinician => clinician.id === '11111');
 
@@ -67,7 +64,6 @@ context('patient page', function() {
 
   specify('current clinician has no team', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, null, fx => {
         const currentClinician = _.find(fx.data, clinician => clinician.id === '11111');
 
@@ -88,7 +84,6 @@ context('patient page', function() {
 
   specify('current clinician has never been active', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.attributes.last_active_at = null;
         return fx;
@@ -110,7 +105,6 @@ context('patient page', function() {
   // Server should return 403, but for good measure
   specify('current clinician is not enabled', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.attributes.enabled = false;
         return fx;
@@ -131,7 +125,6 @@ context('patient page', function() {
 
   specify('current clinician has been disabled', function() {
     cy
-      .server()
       .route({
         url: '/api/clinicians/me',
         status: 401,

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -20,7 +20,6 @@ context('Global Error Page', function() {
 
   specify('500 error', function() {
     cy
-      .server()
       .route({
         url: '/api/clinicians/me',
         status: 500,

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -276,9 +276,8 @@ context('Outreach', function() {
 
     cy
       .wait('@routeFormError')
-      .then(({ requestHeaders }) => {
-        expect(requestHeaders.Authorization).to.eql('Bearer token-success');
-      });
+      .its('request.headers')
+      .should('have.property', 'authorization', 'Bearer token-success');
   });
 
   specify('General Error', function() {

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -4,7 +4,6 @@ context('Outreach', function() {
   });
   specify('Form', function() {
     cy
-      .server()
       .route({
         method: 'POST',
         url: '/api/patient-tokens',
@@ -119,7 +118,6 @@ context('Outreach', function() {
 
   specify('Read-only Form', function() {
     cy
-      .server()
       .route({
         method: 'POST',
         url: '/api/patient-tokens',
@@ -187,7 +185,6 @@ context('Outreach', function() {
 
   specify('Login', function() {
     cy
-      .server()
       .visit('/outreach/1', { noWait: true });
 
     cy
@@ -286,7 +283,6 @@ context('Outreach', function() {
 
   specify('General Error', function() {
     cy
-      .server()
       .visit('/outreach/1', { noWait: true });
 
     cy
@@ -330,7 +326,6 @@ context('Outreach', function() {
 
   specify('Already Submitted', function() {
     cy
-      .server()
       .visit('/outreach/1', { noWait: true });
 
     cy
@@ -374,7 +369,6 @@ context('Outreach', function() {
 
   specify('Unavailable', function() {
     cy
-      .server()
       .visit('/outreach/1', { noWait: true });
 
     cy
@@ -418,7 +412,6 @@ context('Outreach', function() {
 
   specify('Not Found', function() {
     cy
-      .server()
       .visit('/outreach/1', { noWait: true });
 
     cy

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -86,7 +86,7 @@ context('patient dashboard page', function() {
         fx.data[1].attributes.updated_at = testTsSubtract(5);
 
         return fx;
-      }, '1')
+      })
       .routePatientFlows(fx => {
         fx.data = _.sample(fx.data, 3);
 
@@ -110,7 +110,7 @@ context('patient dashboard page', function() {
         fx.data[1].attributes.updated_at = testTsSubtract(5);
 
         return fx;
-      }, '1')
+      })
       .routeAction(fx => {
         fx.data = actionData;
         return fx;
@@ -498,7 +498,7 @@ context('patient dashboard page', function() {
         fx.data[4].relationships.program = { data: { id: 3 } };
 
         return fx;
-      }, 1)
+      })
       .visit('/patient/dashboard/1')
       .wait('@routePatient')
       .wait('@routePatientActions')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -56,7 +56,6 @@ context('patient dashboard page', function() {
     cy.clock(testTime, ['Date']);
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -378,7 +377,6 @@ context('patient dashboard page', function() {
 
   specify('add action and flow', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
 

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -64,7 +64,7 @@ context('patient data and events page', function() {
         fx.data[1].attributes.updated_at = testTsSubtract(6);
 
         return fx;
-      }, '1')
+      })
       .routePatientFlows(fx => {
         fx.data = _.sample(fx.data, 3);
 
@@ -82,7 +82,7 @@ context('patient data and events page', function() {
         fx.data[1].attributes.updated_at = testTsSubtract(6);
 
         return fx;
-      }, '1')
+      })
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.state = { data: { id: '55555' } };

--- a/test/integration/patients/patient/data-and-events.js
+++ b/test/integration/patients/patient/data-and-events.js
@@ -11,7 +11,6 @@ context('patient data and events page', function() {
     cy.clock(testTime, ['Date']);
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -180,7 +180,7 @@ context('patient flow page', function() {
         fx.included.push({ id: '11111', type: 'forms', attributes: { name: 'Test Form' } });
 
         return fx;
-      }, '1')
+      })
       .route({
         status: 204,
         method: 'PATCH',
@@ -613,7 +613,7 @@ context('patient flow page', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActionActivity()
       .route({
         status: 204,
@@ -784,7 +784,7 @@ context('patient flow page', function() {
         fx.included = _.reject(fx.included, { type: 'flows' });
 
         return fx;
-      }, '1')
+      })
       .route({
         status: 204,
         method: 'PATCH',
@@ -992,7 +992,7 @@ context('patient flow page', function() {
         fx.included.push({ id: '11111', type: 'forms', attributes: { name: 'Test Form' } });
 
         return fx;
-      }, '1')
+      })
       .route({
         status: 204,
         method: 'PATCH',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -8,7 +8,6 @@ const tomorrow = testDateAdd(1);
 context('patient flow page', function() {
   specify('context trail', function() {
     cy
-      .server()
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 1);
 
@@ -90,7 +89,6 @@ context('patient flow page', function() {
 
   specify('patient flow action sidebar', function() {
     cy
-      .server()
       .routeFlow()
       .routeFlowActions()
       .routeAction(fx => {
@@ -116,7 +114,6 @@ context('patient flow page', function() {
 
   specify('flow actions list', function() {
     cy
-      .server()
       .routeFlow(fx => {
         fx.data.id = '1';
 
@@ -388,7 +385,6 @@ context('patient flow page', function() {
 
   specify('add action', function() {
     cy
-      .server()
       .routeFlow(fx => {
         fx.data.id = '1';
         fx.data.relationships['program-flow'] = { data: { id: '1' } };
@@ -516,7 +512,6 @@ context('patient flow page', function() {
 
   specify('failed flow', function() {
     cy
-      .server()
       .visit('/flow/1');
 
     cy
@@ -526,7 +521,6 @@ context('patient flow page', function() {
 
   specify('empty view', function() {
     cy
-      .server()
       .routeFlow(fx => {
         fx.data.id = '1';
 
@@ -540,7 +534,7 @@ context('patient flow page', function() {
         fx.data = [];
 
         return fx;
-      }, '1')
+      })
       .visit('/flow/1')
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -553,7 +547,6 @@ context('patient flow page', function() {
 
   specify('flow owner assignment', function() {
     cy
-      .server()
       .routeFlow(fx => {
         fx.data.id = '1';
 
@@ -761,7 +754,6 @@ context('patient flow page', function() {
 
   specify('flow progress bar', function() {
     cy
-      .server()
       .routeFlow(fx => {
         const flowActions = _.sample(fx.data.relationships.actions.data, 3);
 
@@ -936,7 +928,6 @@ context('patient flow page', function() {
 
   specify('bulk edit actions', function() {
     cy
-      .server()
       .routeFlow(fx => {
         fx.data.id = '1';
 

--- a/test/integration/patients/patient/patient.js
+++ b/test/integration/patients/patient/patient.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 context('patient page', function() {
   specify('context trail', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes.first_name = 'First';
@@ -47,7 +46,6 @@ context('patient page', function() {
 
   specify('patient routing', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
 
@@ -92,7 +90,6 @@ context('patient page', function() {
 
   specify('action routing', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
 

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -89,7 +89,6 @@ context('patient sidebar', function() {
     };
 
     cy
-      .server()
       .routePatientActions(_.identity, '2')
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
@@ -790,7 +789,6 @@ context('patient sidebar', function() {
 
   specify('patient groups', function() {
     cy
-      .server()
       .routePatientActions(_.identity, '2')
       .routePatient(fx => {
         fx.data.relationships.groups.data = collectionOf(['1', '2'], 'id');
@@ -847,7 +845,6 @@ context('patient sidebar', function() {
 
   specify('edit patient modal', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes.source = 'manual';
@@ -900,7 +897,6 @@ context('patient sidebar', function() {
 
   specify('view patient modal', function() {
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes.first_name = 'Test';

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -10,7 +10,6 @@ const stateColors = Cypress.env('stateColors');
 context('action sidebar', function() {
   specify('display new action sidebar', function() {
     cy
-      .server()
       .routePatientActions()
       .routePatientFlows()
       .routeActionActivity()
@@ -305,7 +304,6 @@ context('action sidebar', function() {
     cy.clock(testTime, ['Date']);
 
     cy
-      .server()
       .routeTeams(fx => {
         fx.data.push({
           id: 'not-included',
@@ -745,7 +743,6 @@ context('action sidebar', function() {
 
   specify('action comments', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()
@@ -1010,7 +1007,6 @@ context('action sidebar', function() {
 
   specify('display action from program action', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()
@@ -1092,7 +1088,6 @@ context('action sidebar', function() {
 
   specify('deleted action', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()
@@ -1133,7 +1128,6 @@ context('action sidebar', function() {
 
   specify('outreach', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()
@@ -1202,7 +1196,6 @@ context('action sidebar', function() {
 
   specify('outreach error', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()
@@ -1259,7 +1252,6 @@ context('action sidebar', function() {
 
   specify('outreach form', function() {
     cy
-      .server()
       .routePatient()
       .routePatientActions()
       .routePatientFlows()

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -359,12 +359,12 @@ context('action sidebar', function() {
         fx.included = _.reject(fx.included, { type: 'patients' });
 
         return fx;
-      }, '1')
+      })
       .routePatientFlows(fx => {
         fx.included = _.reject(fx.included, { type: 'patients' });
 
         return fx;
-      }, '1')
+      })
       .routeActionActivity(fx => {
         fx.data = [...this.fxEvents, {}];
         fx.data[0].relationships.editor.data = null;

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -269,7 +269,8 @@ context('action sidebar', function() {
 
     cy
       .wait('@routeDeleteAction')
-      .its('url')
+      .itsUrl()
+      .its('pathname')
       .should('contain', 'api/actions/1');
 
     cy

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -6,7 +6,6 @@ import { testDateSubtract } from 'helpers/test-date';
 context('flow sidebar', function() {
   specify('display flow sidebar', function() {
     cy
-      .server()
       .routeFlow(fx => {
         const flowActions = _.sample(fx.data.relationships.actions.data, 3);
         fx.data.id = '1';
@@ -434,7 +433,6 @@ context('flow sidebar', function() {
 
   specify('done actions required', function() {
     cy
-      .server()
       .routeSettings(fx => {
         const requiredDoneFlow = _.find(fx.data, setting => setting.id === 'require_done_flow');
         requiredDoneFlow.attributes.value = true;

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -73,7 +73,7 @@ context('flow sidebar', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeGroupsBootstrap(_.identity, [
         {
           id: '1',
@@ -490,7 +490,7 @@ context('flow sidebar', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeFlowActivity()
       .routePatient()
       .routePatientActions()

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -81,7 +81,7 @@ context('Worklist bulk editing', function() {
         ]);
 
         return fx;
-      }, '1')
+      })
       .visit('/worklist/owned-by')
       .wait('@routeFlows');
 
@@ -225,7 +225,7 @@ context('Worklist bulk editing', function() {
         ]);
 
         return fx;
-      }, '1')
+      })
       .visit('/worklist/owned-by')
       .wait('@routeFlows');
 
@@ -363,7 +363,7 @@ context('Worklist bulk editing', function() {
         fx.included.push(flowInclude);
 
         return fx;
-      }, '1')
+      })
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()
@@ -598,7 +598,7 @@ context('Worklist bulk editing', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActions()
       .routeFlow()
       .routeFlowActions()
@@ -1012,7 +1012,7 @@ context('Worklist bulk editing', function() {
         fx.included.push(flowInclude);
 
         return fx;
-      }, '1')
+      })
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()
@@ -1439,7 +1439,7 @@ context('Worklist bulk editing', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActions()
       .routeFlow()
       .routeFlowActions()
@@ -1514,7 +1514,7 @@ context('Worklist bulk editing', function() {
         fx.included.push(flowInclude);
 
         return fx;
-      }, '1')
+      })
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -24,7 +24,6 @@ const testGroups = [
 context('Worklist bulk editing', function() {
   specify('displaying common groups - flows', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -168,7 +167,6 @@ context('Worklist bulk editing', function() {
 
   specify('displaying common groups - actions', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeActions(fx => {
@@ -319,7 +317,6 @@ context('Worklist bulk editing', function() {
 
   specify('date and time components', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeActions(fx => {
@@ -516,7 +513,6 @@ context('Worklist bulk editing', function() {
 
   specify('bulk flows editing', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -940,7 +936,6 @@ context('Worklist bulk editing', function() {
 
   specify('bulk actions editing', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeActions(fx => {
@@ -1408,7 +1403,6 @@ context('Worklist bulk editing', function() {
 
   specify('bulk flow editing completed', function() {
     cy
-      .server()
       .routeSettings(fx => {
         const requiredDoneFlow = _.find(fx.data, setting => setting.id === 'require_done_flow');
         requiredDoneFlow.attributes.value = true;
@@ -1498,7 +1492,6 @@ context('Worklist bulk editing', function() {
 
   specify('bulk action editing completed', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeActions(fx => {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -41,7 +41,6 @@ context('schedule page', function() {
     cy.clock(testDateTime, ['Date']);
 
     cy
-      .server()
       .routeGroupsBootstrap(fx => {
         fx.data[0].relationships.clinicians.data.push({
           id: 'test-id',
@@ -338,7 +337,6 @@ context('schedule page', function() {
     const testTime = dayjs().hour(10).utc().valueOf();
 
     cy
-      .server()
       .routeGroupsBootstrap(fx => {
         fx.data[0].relationships.clinicians.data.push({
           id: 'test-id',
@@ -595,7 +593,6 @@ context('schedule page', function() {
 
   specify('restricted employee', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -619,7 +616,6 @@ context('schedule page', function() {
 
   specify('reduced patient schedule employee', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -885,7 +881,6 @@ context('schedule page', function() {
       selectedActions: [{ '1': true }, { '4444': true }],
     }));
     cy
-      .server()
       .routeActions(fx => {
         fx.data[0].id = '1';
         _.each(fx.data, (action, idx) => {
@@ -1143,7 +1138,6 @@ context('schedule page', function() {
 
   specify('empty schedule', function() {
     cy
-      .server()
       .routeActions(fx => {
         fx.data = [];
 
@@ -1164,7 +1158,6 @@ context('schedule page', function() {
 
   specify('filter in list', function() {
     cy
-      .server()
       .routeGroupsBootstrap()
       .routeActions(fx => {
         fx.data[0].attributes = {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -378,7 +378,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[clinician]=test-id');
 
     cy
@@ -399,7 +400,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1');
 
     cy
@@ -426,7 +428,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ testDate() },${ testDate() }`);
 
     cy
@@ -448,7 +451,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ testDateSubtract(1) },${ testDateSubtract(1) }`);
 
     cy
@@ -475,7 +479,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ testDate() },${ testDate() }`);
 
     cy
@@ -507,7 +512,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ formatDate(dayjs(testDateAdd(1, 'month')).startOf('month'), 'YYYY-MM-DD') },${ formatDate(dayjs(testDateAdd(1, 'month')).endOf('month'), 'YYYY-MM-DD') }`);
 
     cy
@@ -534,7 +540,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ formatDate(dayjs(testDate()).startOf('month'), 'YYYY-MM-DD') },${ formatDate(dayjs(testDate()).endOf('month'), 'YYYY-MM-DD') }`);
 
     cy
@@ -562,7 +569,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ formatDate(dayjs(testDate()).startOf('week'), 'YYYY-MM-DD') },${ formatDate(dayjs(testDate()).endOf('week'), 'YYYY-MM-DD') }`);
 
     cy
@@ -580,7 +588,8 @@ context('schedule page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ formatDate(dayjs(testDateSubtract(1, 'week')).startOf('week'), 'YYYY-MM-DD') },${ formatDate(dayjs(testDateSubtract(1, 'week')).endOf('week'), 'YYYY-MM-DD') }`);
 
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -122,7 +122,7 @@ context('worklist page', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActions()
       .routeFlow()
       .routeFlowActions()
@@ -323,7 +323,7 @@ context('worklist page', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActions()
       .routeFlow()
       .routeFlowActions()
@@ -489,7 +489,7 @@ context('worklist page', function() {
         fx.included.push(flowInclude);
 
         return fx;
-      }, '1')
+      })
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
@@ -2151,7 +2151,7 @@ context('worklist page', function() {
         fx.data[7].attributes.created_at = testTsSubtract(10);
 
         return fx;
-      }, '1')
+      })
       .routePatient()
       .routePatientActions()
       .routeAction()
@@ -2478,7 +2478,7 @@ context('worklist page', function() {
           },
         });
         return fx;
-      }, 100)
+      })
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
@@ -2946,7 +2946,7 @@ context('worklist page', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeActions(fx => {
         fx.data = [{
           id: '1',

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -39,7 +39,6 @@ context('worklist page', function() {
     }));
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -301,7 +300,6 @@ context('worklist page', function() {
 
   specify('done flow list', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -460,7 +458,6 @@ context('worklist page', function() {
       .fixture('collections/flows').as('fxFlows');
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeActions(fx => {
         const flowInclude = {
@@ -902,7 +899,6 @@ context('worklist page', function() {
 
   specify('clinician filtering', function() {
     cy
-      .server()
       .routeGroupsBootstrap(
         fx => {
           _.each(fx.data, group => {
@@ -1032,7 +1028,6 @@ context('worklist page', function() {
 
   specify('group filtering', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeFlow()
@@ -1086,7 +1081,6 @@ context('worklist page', function() {
 
   specify('group filtering - new flows', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .visit('/worklist/new-past-day')
@@ -1118,7 +1112,6 @@ context('worklist page', function() {
 
   specify('owner filtering', function() {
     cy
-      .server()
       .routeGroupsBootstrap(
         fx => {
           _.each(fx.data, group => {
@@ -1258,7 +1251,6 @@ context('worklist page', function() {
     cy.clock(testTime, ['Date']);
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows()
       .routeActions()
@@ -1805,7 +1797,6 @@ context('worklist page', function() {
 
   specify('restricted employee', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -1830,7 +1821,6 @@ context('worklist page', function() {
 
   specify('restricted employee -  shared by role', function() {
     cy
-      .server()
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
         fx.data.attributes.access = 'employee';
@@ -1861,7 +1851,6 @@ context('worklist page', function() {
 
   specify('clinician in only one group', function() {
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, [testGroups[0]])
       .routeFlows()
       .routeActions()
@@ -1916,7 +1905,6 @@ context('worklist page', function() {
 
   specify('flow sorting', function() {
     cy
-      .server()
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 4);
 
@@ -2023,7 +2011,6 @@ context('worklist page', function() {
 
   specify('flow sorting - patient', function() {
     cy
-      .server()
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
 
@@ -2104,7 +2091,6 @@ context('worklist page', function() {
 
   specify('action sorting', function() {
     cy
-      .server()
       .routeActions(fx => {
         fx.data = _.sample(fx.data, 8);
 
@@ -2329,7 +2315,6 @@ context('worklist page', function() {
 
   specify('action sorting - patient', function() {
     cy
-      .server()
       .routeActions(fx => {
         fx.data = _.sample(fx.data, 3);
 
@@ -2438,7 +2423,6 @@ context('worklist page', function() {
     }));
 
     cy
-      .server()
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeFlows(fx => {
         _.each(fx.data, function(flow) {
@@ -2705,7 +2689,6 @@ context('worklist page', function() {
 
   specify('click+shift multiselect', function() {
     cy
-      .server()
       .routeGroupsBootstrap()
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -2921,7 +2904,6 @@ context('worklist page', function() {
     };
 
     cy
-      .server()
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes = {
@@ -3141,7 +3123,6 @@ context('worklist page', function() {
 
   specify('empty flows view', function() {
     cy
-      .server()
       .routeFlows(fx => {
         fx.data = [];
 
@@ -3162,7 +3143,6 @@ context('worklist page', function() {
 
   specify('empty actions view', function() {
     cy
-      .server()
       .routeFlows()
       .routeActions(fx => {
         fx.data = [];

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -944,7 +944,8 @@ context('worklist page', function() {
       .routeActions()
       .visit('/worklist/owned-by')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
       .should('contain', 'filter[status]=queued,started');
@@ -972,7 +973,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=test-clinician')
       .should('contain', 'filter[status]=queued,started');
@@ -995,7 +997,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
       .should('contain', 'filter[status]=queued,started');
@@ -1022,7 +1025,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[clinician]=test-clinician');
   });
 
@@ -1035,7 +1039,8 @@ context('worklist page', function() {
       .routePatientByFlow()
       .visit('/worklist/owned-by')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
       .should('contain', 'filter[status]=queued,started');
@@ -1050,7 +1055,8 @@ context('worklist page', function() {
       .contains('Another Group')
       .click()
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=2')
       .should('contain', 'filter[clinician]=11111')
       .should('contain', 'filter[status]=queued,started');
@@ -1085,7 +1091,8 @@ context('worklist page', function() {
       .routeFlows()
       .visit('/worklist/new-past-day')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[created_at]=')
       .should('contain', 'filter[status]=queued,started');
@@ -1104,7 +1111,8 @@ context('worklist page', function() {
       .contains('Another Group')
       .click()
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=2')
       .should('contain', 'filter[created_at]=')
       .should('contain', 'filter[status]=queued,started');
@@ -1171,7 +1179,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[team]=33333');
 
     cy
@@ -1187,7 +1196,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[clinician]=1');
 
     cy
@@ -1209,7 +1219,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[clinician]=${ NIL_UUID }`)
       .should('contain', 'filter[team]=22222');
 
@@ -1221,7 +1232,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('not.contain', `filter[clinician]=${ NIL_UUID }`)
       .should('contain', 'filter[team]=22222');
   });
@@ -1259,7 +1271,8 @@ context('worklist page', function() {
       .routePatientByFlow()
       .visit('/worklist/owned-by')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[created_at]=${ dayjs(testTs()).startOf('month').format() },${ dayjs(testTs()).endOf('month').format() }`);
 
     cy
@@ -1413,7 +1426,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[updated_at]=${ dayjs(testTs()).startOf('month').format() },${ dayjs(testTs()).endOf('month').format() }`);
 
     cy
@@ -1442,7 +1456,8 @@ context('worklist page', function() {
     const lastMonth = testTsSubtract(1, 'month');
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[updated_at]=${ dayjs(lastMonth).startOf('month').format() },${ dayjs(lastMonth).endOf('month').format() }`);
 
     cy
@@ -1504,7 +1519,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[due_date]=${ testDate() },${ testDate() }`);
 
     cy
@@ -1573,7 +1589,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[created_at]=${ dayjs(testTsAdd(1)).startOf('day').format() },${ dayjs(testTsAdd(1)).endOf('day').format() }`);
 
     cy
@@ -1595,7 +1612,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[created_at]=${ dayjs(testTsSubtract(1)).startOf('day').format() },${ dayjs(testTsSubtract(1)).endOf('day').format() }`);
 
     cy
@@ -1679,7 +1697,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeActions')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', `filter[created_at]=${ dayjs(testTs()).startOf('month').format() },${ dayjs(testTs()).endOf('month').format() }`);
 
     cy
@@ -1837,7 +1856,8 @@ context('worklist page', function() {
       .routeActions()
       .visit('/worklist/shared-by')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[clinician]=00000000-0000-0000-0000-000000000000');
 
     cy
@@ -1856,7 +1876,8 @@ context('worklist page', function() {
       .routeActions()
       .visit('/worklist/shared-by')
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[group]=1');
 
     cy
@@ -1889,7 +1910,8 @@ context('worklist page', function() {
 
     cy
       .wait('@routeFlows')
-      .its('url')
+      .itsUrl()
+      .its('search')
       .should('contain', 'filter[team]=33333');
 
     cy

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -5,7 +5,6 @@ import { testTs } from 'helpers/test-timestamp';
 context('program flow page', function() {
   specify('context trail', function() {
     cy
-      .server()
       .routeProgramFlow(fx => {
         fx.data.id = '1';
 
@@ -64,7 +63,6 @@ context('program flow page', function() {
 
   specify('program sidebar', function() {
     cy
-      .server()
       .routeProgramFlow()
       .routeProgramFlowActions()
       .routeProgramByProgramFlow(fx => {
@@ -124,7 +122,6 @@ context('program flow page', function() {
 
   specify('flow header', function() {
     cy
-      .server()
       .routeProgramFlow(fx => {
         fx.data.id = '1';
 
@@ -369,7 +366,6 @@ context('program flow page', function() {
 
   specify('Flow does not exist', function() {
     cy
-      .server()
       .routeProgramByProgramFlow()
       .route({
         url: '/api/program-flows/1',
@@ -396,7 +392,6 @@ context('program flow page', function() {
 
   specify('flow actions list', function() {
     cy
-      .server()
       .routeAction()
       .routeProgramFlow(fx => {
         fx.data.id = '1';

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -150,7 +150,7 @@ context('program flow page', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .routeProgramByProgramFlow()
       .route({
         status: 204,
@@ -433,7 +433,7 @@ context('program flow page', function() {
         fx.included.push({ id: '11111', type: 'forms', attributes: { name: 'Test Form' } });
 
         return fx;
-      }, '1')
+      })
       .routePrograms()
       .routeProgramByProgramFlow()
       .route({

--- a/test/integration/programs/program/program.js
+++ b/test/integration/programs/program/program.js
@@ -3,7 +3,6 @@ import { testTs } from 'helpers/test-timestamp';
 context('program page', function() {
   specify('context trail', function() {
     cy
-      .server()
       .routePrograms(fx => {
         fx.data[0].id = '1';
 
@@ -44,7 +43,6 @@ context('program page', function() {
 
   specify('read only sidebar', function() {
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
         fx.data.attributes.name = 'Test Program';
@@ -103,7 +101,6 @@ context('program page', function() {
 
   specify('new flow sidebar', function() {
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
 

--- a/test/integration/programs/program/workflows.js
+++ b/test/integration/programs/program/workflows.js
@@ -45,7 +45,7 @@ context('program workflows page', function() {
 
 
         return fx;
-      }, '1')
+      })
       .routeProgramAction(fx => {
         fx.data = testAction;
         return fx;
@@ -58,7 +58,7 @@ context('program workflows page', function() {
         fx.data[0].attributes.updated_at = testTsSubtract(3);
 
         return fx;
-      }, '1')
+      })
       .visit('/program/1')
       .wait('@routeProgram')
       .wait('@routeProgramActions')
@@ -219,7 +219,7 @@ context('program workflows page', function() {
         fx.data[0].relationships.owner.data = null;
 
         return fx;
-      }, '1')
+      })
       .routeProgramByProgramFlow()
       .routeProgramFlowActions()
       .routeProgramFlow()

--- a/test/integration/programs/program/workflows.js
+++ b/test/integration/programs/program/workflows.js
@@ -28,7 +28,6 @@ context('program workflows page', function() {
     };
 
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
 
@@ -206,7 +205,6 @@ context('program workflows page', function() {
 
   specify('flow in list', function() {
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
 
@@ -282,7 +280,6 @@ context('program workflows page', function() {
 
   specify('add action', function() {
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
 
@@ -351,7 +348,6 @@ context('program workflows page', function() {
   });
   specify('add flow', function() {
     cy
-      .server()
       .routeProgram(fx => {
         fx.data.id = '1';
 

--- a/test/integration/programs/programs-all.js
+++ b/test/integration/programs/programs-all.js
@@ -5,7 +5,6 @@ import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 context('program all list', function() {
   specify('display programs list', function() {
     cy
-      .server()
       .routePrograms(fx => {
         fx.data = _.sample(fx.data, 3);
 

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -303,7 +303,7 @@ context('program action sidebar', function() {
         fx.data[0] = actionData;
 
         return fx;
-      }, '1')
+      })
       .routeProgramAction(fx => {
         fx.data = actionData;
 

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -6,7 +6,6 @@ import { testTs } from 'helpers/test-timestamp';
 context('program action sidebar', function() {
   specify('display new action sidebar', function() {
     cy
-      .server()
       .routeProgramActions(_.identity, '1')
       .routeProgramFlows(() => [])
       .routeProgram(fx => {
@@ -284,7 +283,6 @@ context('program action sidebar', function() {
     };
 
     cy
-      .server()
       .routeProgramFlow(fx => {
         fx.data.id = '1';
         fx.data.attributes.status = 'draft';
@@ -670,7 +668,6 @@ context('program action sidebar', function() {
 
   specify('display action sidebar with no org forms', function() {
     cy
-      .server()
       .routeProgramAction()
       .routeProgramActions()
       .routeProgramFlows(() => [])
@@ -699,7 +696,6 @@ context('program action sidebar', function() {
 
   specify('deleted action', function() {
     cy
-      .server()
       .routeProgram()
       .routeProgramActions(_.identity, '1')
       .routeProgramFlows(() => [])
@@ -734,7 +730,6 @@ context('program action sidebar', function() {
 
   specify('outreach disabled', function() {
     cy
-      .server()
       .routeSettings(fx => {
         const careTeamOutreach = _.find(fx.data, setting => setting.id === 'care_team_outreach');
         careTeamOutreach.attributes.value = false;

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -240,7 +240,8 @@ context('program action sidebar', function() {
 
     cy
       .wait('@routeDeleteActionSucceed')
-      .its('url')
+      .itsUrl()
+      .its('pathname')
       .should('contain', 'api/program-actions/1');
 
     cy

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -410,7 +410,8 @@ context('flow sidebar', function() {
 
     cy
       .wait('@routeDeleteFlow')
-      .its('url')
+      .itsUrl()
+      .its('pathname')
       .should('contain', 'api/program-flows/1');
 
     cy

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -6,7 +6,6 @@ import { testTs } from 'helpers/test-timestamp';
 context('flow sidebar', function() {
   specify('display new flow sidebar', function() {
     cy
-      .server()
       .routeProgramActions(_.identity, '1')
       .routeProgramFlows(() => [])
       .routeProgram(fx => {
@@ -151,7 +150,6 @@ context('flow sidebar', function() {
 
   specify('display flow sidebar', function() {
     cy
-      .server()
       .routeProgramByProgramFlow()
       .routeProgramFlow(fx => {
         fx.data.id = '1';

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -173,7 +173,7 @@ context('flow sidebar', function() {
         });
 
         return fx;
-      }, '1')
+      })
       .visit('/program-flow/1')
       .wait('@routeProgramByProgramFlow')
       .wait('@routeProgramFlow')

--- a/test/integration/programs/sidebar/program-sidebar.js
+++ b/test/integration/programs/sidebar/program-sidebar.js
@@ -10,7 +10,6 @@ const stateColors = Cypress.env('stateColors');
 context('program sidebar', function() {
   specify('display new program sidebar', function() {
     cy
-      .server()
       .routePrograms()
       .visit('/programs')
       .wait('@routePrograms');
@@ -176,7 +175,6 @@ context('program sidebar', function() {
     };
 
     cy
-      .server()
       .routeProgram(fx => {
         fx.data = programData;
 

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -39,8 +39,9 @@ context('Patient Quick Search', function() {
 
     cy
       .wait('@routePatientSearch')
-      .its('url')
-      .should('contain', '?filter[search]=Te');
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[search]=Te');
 
     cy
       .get('@searchModal')

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 context('Patient Quick Search', function() {
   specify('Modal', function() {
     cy
-      .routeFlows(_.identity, '1')
+      .routeFlows(_.identity, 1)
       .routePatient()
       .routePatientActions()
       .routeAction()

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -3,7 +3,6 @@ import _ from 'underscore';
 context('Patient Quick Search', function() {
   specify('Modal', function() {
     cy
-      .server()
       .routeFlows(_.identity, '1')
       .routePatient()
       .routePatientActions()

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -110,11 +110,10 @@ Cypress.Commands.add('routeFlowActions', (mutator = _.identity, flowId = '1') =>
     .as('routeFlowActions');
 });
 
-Cypress.Commands.add('routeActions', (mutator = _.identity, delay) => {
+Cypress.Commands.add('routeActions', (mutator = _.identity) => {
   actionFixtures();
 
   cy.route({
-    delay,
     url: '/api/actions?*',
     response() {
       return mutator(generateData.call(this, _.sample(this.fxPatients, 5)));

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -97,11 +97,10 @@ Cypress.Commands.add('routePatientFlows', (mutator = _.identity, patientId = '1'
 });
 
 
-Cypress.Commands.add('routeFlows', (mutator = _.identity, delay) => {
+Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
   flowFixtures();
 
   cy.route({
-    delay,
     url: '/api/flows?*',
     response() {
       return mutator(generateData.call(this, _.sample(this.fxPatients, 5)));

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -76,7 +76,7 @@ Cypress.Commands.add('routePatientSearch', (mutator = _.identity) => {
     .fixture('collections/patients').as('fxPatients');
 
   cy.route({
-    url: /api\/patients\?filter\[search\]/,
+    url: 'api/patients?filter*',
     response() {
       const patients = _.sample(this.fxPatients, 10);
 

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 // ***********************************************
 // This example commands.js shows you how to
 // create the custom command: 'login'.
@@ -102,4 +104,17 @@ Cypress.Commands.add('typeEnter', { prevSubject: true }, $el => {
     .blur()
     // Need force because Cypress does not recognize the element is typeable
     .type('{enter}', { force: true });
+});
+
+Cypress.Commands.overwrite('route', (originalFn, options) => {
+  const routeMatcher = {
+    method: options.method || 'GET',
+    url: options.url,
+  };
+  const staticResponse = {
+    statusCode: options.status || 200,
+    body: _.isFunction(options.response) ? options.response.call(Cypress.state('runnable').ctx, options) : options.response,
+    delay: options.delay || 0,
+  };
+  return cy.intercept(routeMatcher, staticResponse);
 });

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -106,6 +106,18 @@ Cypress.Commands.add('typeEnter', { prevSubject: true }, $el => {
     .type('{enter}', { force: true });
 });
 
+// Exposes the hostname and decoded pathname and search query of an alias
+Cypress.Commands.add('itsUrl', { prevSubject: true }, alias => {
+  cy
+    .wrap(alias)
+    .its('request.url')
+    .then(url => {
+      const { hostname, pathname, search } = new URL(url);
+
+      return { hostname, pathname: decodeURI(pathname), search: decodeURIComponent(search) };
+    });
+});
+
 Cypress.Commands.overwrite('route', (originalFn, options) => {
   const routeMatcher = {
     method: options.method || 'GET',

--- a/test/support/defaults.js
+++ b/test/support/defaults.js
@@ -20,7 +20,6 @@ Cypress.on('window:before:load', function(win) {
 
 beforeEach(function() {
   cy
-    .server()
     .routeStates()
     .routeTeams()
     .routeForms()


### PR DESCRIPTION
Shortcut Story ID: [sc-30273]

This is the first step towards migrating to `cy.intercept`

It adds a temporary `cy.route` overwrite that uses `cy.intercept` under the hood.  We should work to remove this

This does allow us to remove the `cy.server()` everywhere and it provides a path to upgrade.

The biggest issue to fully refactoring is removing `cy.fixture` putting fixture data in context and rather `import`ing the fixture files directly and utilizing them with an `intercept function setup.

This also adds an `itsUrl` command which decodes the urls to normalize tests which is how `route` was working.  Without this, we'd have to encode for testing which can get hairy quick.