### PR TITLE
Remove PreloadRegion from formapp for simpler html spinner

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -24,13 +24,13 @@ import {
 
 import 'js/formapp/components';
 
-import PreloadRegion from 'js/regions/preload_region';
-
 import 'scss/formapp/comment.scss';
 import 'scss/formapp/form.scss';
 import 'scss/formapp/formio-overrides.scss';
 import 'scss/formapp/print.scss';
 import 'scss/formapp/pdf.scss';
+
+import 'js/regions/preload.scss';
 
 let router;
 
@@ -217,8 +217,7 @@ const Router = Backbone.Router.extend({
 });
 
 function startFormApp() {
-  const preloadRegion = new PreloadRegion({ el: '#root' });
-  preloadRegion.startPreloader();
+  $('#root').append(`<div class="spinner"><div class="spinner-circle">${ '<div class="spinner-child"></div>'.repeat(12) }</div></div>`);
   router = new Router();
   Backbone.history.start({ pushState: true });
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-29468]

In the formapp, we currently import and use a `PreloadRegion` view. It does some fading in and waiting for other use cases that aren't needed in the formapp iframe. And it also adds more dependencies to the formapp than are necessary.

This PR removes the `PreloadRegion` import from the formapp and uses a pure HTML version of the spinner instead. The same CSS is used to style the spinner (`js/regions/preload.scss`).

The formapp loading spinner should behave and look the same as before.
