### PR TITLE
Update `npm run release` to set NODE_ENV=production variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "kill": "pkill -f webpack",
     "lint": "eslint --fix src/js/ && eslint --fix test/",
     "prod": "cross-env NODE_ENV=production webpack serve",
-    "release": "npm i && npm run build && node ./release/release.js",
+    "release": "npm i && npm run build && cross-env NODE_ENV=production node ./release/release.js",
     "start": "cross-env NODE_ENV=test webpack serve"
   },
   "browserslist": [


### PR DESCRIPTION
Shortcut Story ID: [sc-30301]

When running the release npm script (`npm run release`), the `NODE_ENV=production `variable is set when `npm run build` is ran. But it doesn't carry over to the `release.js` script.

This causes the wrong name to be used for the release.

This PR updates the `npm run release` script to set `NODE_ENV=production` before the `release.js` script is ran.