### PR TITLE
Add "up-right-and-down-left-from-center" fontawesome icon to the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
       "toggle-off",
       "traffic-cone",
       "trash-can",
+      "up-right-and-down-left-from-center",
       "user",
       "user-plus",
       "users",


### PR DESCRIPTION
Shortcut Story ID: [sc-30314] [sc-30308]

When updating the fontawesome icons in a previous PR (https://github.com/RoundingWell/care-ops-frontend/pull/769), we missed adding the `up-right-and-down-left-from-center` icon to the `"far": []` section of the `package.json` file.