### PR TITLE
Set prelogin content to fill entire browser width & height

### DIFF
--- a/src/js/views/globals/prelogin/prelogin.css
+++ b/src/js/views/globals/prelogin/prelogin.css
@@ -18,6 +18,10 @@
     url('/fonts/ProximaSoft/3955CC_1_0.ttf') format('truetype');
 }
 
+body {
+  margin: 0;
+}
+
 .prelogin * {
   border: 0;
   box-sizing: border-box;


### PR DESCRIPTION
Shortcut Story ID: [sc-30323]

This PR updates the prelogin page to extend to the full width and height of the window width.

Screenshot of the bug:

<img width="425" alt="Screen Shot 2022-08-17 at 09 50 59" src="https://user-images.githubusercontent.com/35355575/185187241-c450b21d-6546-4236-823e-0d77443e23f8.png">

