### PR TITLE
Make webpack watch file specific

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,7 @@ module.exports = {
     static: {
       directory: path.join(__dirname, 'dist'),
     },
-    watchFiles: ['package.json'],
+    watchFiles: [path.join(__dirname, 'package.json')],
   },
   module: {
     rules: [


### PR DESCRIPTION
Something with `bin/dev-server` caused this watch to watch all of the `package.json`s in `node_modules` as well.

Shortcut Story ID: [sc-30329]
