### PR TITLE
Add grey background to selected actions on patient flow page

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -251,7 +251,11 @@ export default SubRouterApp.extend({
 
     this.listenToOnce(actionApp, {
       'start'(options, action) {
+        this.setState('actionBeingEdited', action.id);
         action.trigger('editing', true);
+      },
+      'stop'() {
+        this.setState('actionBeingEdited', null);
       },
     });
 

--- a/src/js/apps/patients/patient/flow/flow_state.js
+++ b/src/js/apps/patients/patient/flow/flow_state.js
@@ -6,10 +6,13 @@ import Radio from 'backbone.radio';
 export default Backbone.Model.extend({
   defaults() {
     return {
+      actionBeingEdited: null,
       selectedActions: {},
     };
   },
-
+  isBeingEdited(model) {
+    return this.get('actionBeingEdited') === model.id;
+  },
   getSelectedList() {
     return this.get('selectedActions');
   },

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -161,6 +161,10 @@ const ActionItemView = View.extend({
     Radio.trigger('event-router', 'flow:action', this.model.get('_flow'), this.model.id);
   },
   onEditing(isEditing) {
+    const isSelected = this.state.isSelected(this.model);
+
+    if (isSelected) return;
+
     this.$el.toggleClass('is-selected', isEditing);
   },
   onRender() {
@@ -171,14 +175,23 @@ const ActionItemView = View.extend({
     this.showDueTime();
     this.showForm();
   },
+  toggleSelected(isSelected) {
+    const isBeingEdited = this.state.isBeingEdited(this.model);
+
+    if (isBeingEdited) return;
+
+    this.$el.toggleClass('is-selected', isSelected);
+  },
   showCheck() {
     const isSelected = this.state.isSelected(this.model);
+    this.toggleSelected(isSelected);
     const checkComponent = new CheckComponent({ state: { isSelected } });
 
     this.listenTo(checkComponent, {
       'select'(domEvent) {
         this.state.toggleSelected(this.model, !this.state.isSelected(this.model));
       },
+      'change:isSelected': this.toggleSelected,
     });
 
     this.showChildView('check', checkComponent);

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1015,6 +1015,60 @@ context('patient flow page', function() {
       .click();
 
     cy
+      .get('@firstRow')
+      .should('have.class', 'is-selected');
+
+    cy
+      .get('@firstRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@firstRow')
+      .should('not.have.class', 'is-selected');
+
+    cy
+      .get('@firstRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.state.data.id = '22222';
+
+        return fx;
+      });
+
+    cy
+      .get('@firstRow')
+      .find('.patient__action-icon')
+      .click();
+
+    cy
+      .get('@firstRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@firstRow')
+      .should('have.class', 'is-selected');
+
+    cy
+      .get('@firstRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('[data-sidebar-region]')
+      .find('.js-close')
+      .click();
+
+    cy
+      .get('@firstRow')
+      .should('have.class', 'is-selected');
+
+    cy
       .get('[data-header-region]')
       .next()
       .find('.button--checkbox')


### PR DESCRIPTION
Shortcut Story ID: [sc-30382]

When a list item is selected on the patient flow page, we want to add a grey background to it via the existing `.is-selected` class name. This will follow what we currently do on the worklist and schedule page lists.

Functionality before this PR:

![Screen Shot 2022-08-18 at 9 52 44 AM (1)](https://user-images.githubusercontent.com/35355575/185702961-f1298dc3-01f3-4da5-9212-faa49668f95d.png)

Functionality after this PR:

![Screen Shot 2022-08-18 at 9 54 24 AM (2)](https://user-images.githubusercontent.com/35355575/185702989-4a5f81a2-02d6-448c-849e-c2a84b094291.png)

**Additional note**: we need to ensure that the grey background is preserved for actions that are actively being edited (i.e. edit action sidebar is open for the action). So the `.is-selected` class should remain if the action is selected or being edited.
