### PR TITLE
Add quick search org settings for new UI

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -4,6 +4,7 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
+import SearchApp from './search_app';
 import { AppNavView, AppNavCollectionView, MainNavDroplist, PatientsAppNav, i18n } from 'js/views/globals/app-nav/app-nav_views';
 import { PatientSearchModal } from 'js/views/globals/search/patient-search_views';
 import { getPatientModal, ErrorView } from 'js/views/globals/patient-modal/patient-modal_views';
@@ -126,6 +127,9 @@ export default App.extend({
   viewEvents: {
     'click:addPatient': 'onClickAddPatient',
   },
+  childApps: {
+    search: SearchApp,
+  },
   selectNav(appName, event, eventArgs) {
     this.setState('currentApp', appName);
 
@@ -200,24 +204,37 @@ export default App.extend({
     this.showChildView('navContent', navView);
   },
   showSearch(prefillText) {
+    if (!Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings')) {
+      const navView = this.getChildView('navContent');
+
+      const patientSearchModal = new PatientSearchModal({
+        collection: Radio.request('entities', 'searchPatients:collection'),
+        prefillText,
+      });
+
+      this.listenTo(patientSearchModal, {
+        'item:select'({ model }) {
+          Radio.trigger('event-router', 'patient:dashboard', model.get('_patient'));
+          patientSearchModal.destroy();
+        },
+        'destroy'() {
+          navView.triggerMethod('search:active', false);
+        },
+      });
+
+      Radio.request('modal', 'show:custom', patientSearchModal);
+
+      navView.triggerMethod('search:active', true);
+      return;
+    }
+
     const navView = this.getChildView('navContent');
 
-    const patientSearchModal = new PatientSearchModal({
-      collection: Radio.request('entities', 'searchPatients:collection'),
-      prefillText,
-    });
+    const searchApp = this.startChildApp('search', { prefillText });
 
-    this.listenTo(patientSearchModal, {
-      'item:select'({ model }) {
-        Radio.trigger('event-router', 'patient:dashboard', model.get('_patient'));
-        patientSearchModal.destroy();
-      },
-      'destroy'() {
-        navView.triggerMethod('search:active', false);
-      },
+    this.listenTo(searchApp, 'stop', () => {
+      navView.triggerMethod('search:active', false);
     });
-
-    Radio.request('modal', 'show:custom', patientSearchModal);
 
     navView.triggerMethod('search:active', true);
   },

--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -116,7 +116,7 @@ export default App.extend({
   startAfterInitialized: true,
   channelName: 'nav',
   radioRequests: {
-    'search': 'showSearchModal',
+    'search': 'showSearch',
     'patient': 'showPatientModal',
     'select': 'selectNav',
   },
@@ -188,18 +188,18 @@ export default App.extend({
     navView.showChildView('worklists', workflowsCollectionView);
 
     this.listenTo(navView, 'search', () => {
-      this.showSearchModal();
+      this.showSearch();
     });
 
     const hotkeyCh = Radio.channel('hotkey');
     navView.listenTo(hotkeyCh, 'search', evt => {
       evt.preventDefault();
-      this.showSearchModal();
+      this.showSearch();
     });
 
     this.showChildView('navContent', navView);
   },
-  showSearchModal(prefillText) {
+  showSearch(prefillText) {
     const navView = this.getChildView('navContent');
 
     const patientSearchModal = new PatientSearchModal({
@@ -267,7 +267,7 @@ export default App.extend({
 
             patientModal.listenTo(errorView, 'click:search', () => {
               const query = `${ patientClone.get('first_name') } ${ patientClone.get('last_name') }`;
-              this.showSearchModal(query);
+              this.showSearch(query);
             });
 
             patientModal.showChildView('info', errorView);

--- a/src/js/apps/globals/search_app.js
+++ b/src/js/apps/globals/search_app.js
@@ -1,0 +1,30 @@
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+import { PatientSearchModal } from 'js/views/globals/search/patient-search_views';
+
+export default App.extend({
+  onStart({ prefillText }) {
+    // const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings');
+    this.showSearch(prefillText);
+  },
+  showSearch(prefillText) {
+    const patientSearchModal = new PatientSearchModal({
+      collection: Radio.request('entities', 'searchPatients:collection'),
+      prefillText,
+    });
+
+    this.listenTo(patientSearchModal, {
+      'item:select'({ model }) {
+        Radio.trigger('event-router', 'patient:dashboard', model.get('_patient'));
+        patientSearchModal.destroy();
+      },
+      'destroy'() {
+        this.stop();
+      },
+    });
+
+    Radio.request('modal', 'show:custom', patientSearchModal);
+  },
+});

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -25,5 +25,12 @@
   {
     "id": "reduced_patient_schedule",
     "value": false
+  },
+  {
+    "id": "patient_search_settings",
+    "value": {
+      "result_identifiers": [],
+      "identifiers": []
+    }
   }
 ]

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -1,21 +1,65 @@
 import _ from 'underscore';
+import patientFixture from 'fixtures/collections/patients.json';
+import { getRelationship, getIncluded } from 'helpers/json-api';
 
 context('Patient Quick Search', function() {
-  specify('Modal', function() {
+  beforeEach(function() {
+    const patients = _.map(_.sample(patientFixture, 10), (patient, index) => {
+      patient.id = `${ index }`;
+      patient.first_name = 'Test';
+      patient.last_name = `${ index } Patient`;
+      return patient;
+    });
+
+    const data = _.map(patients, patient => {
+      const { id, first_name, last_name, birth_date } = patient;
+
+      return {
+        id,
+        type: 'patient-search-results',
+        attributes: {
+          first_name,
+          last_name,
+          birth_date,
+        },
+        relationships: {
+          patient: {
+            data: getRelationship(patient, 'patients'),
+          },
+        },
+      };
+    });
+
     cy
+      .intercept({
+        method: 'GET',
+        url: 'api/patients?filter*',
+      }, req => {
+        if (req.url.includes('None')) {
+          req.reply({ data: [] });
+          req.alias = 'routeEmptyPatientSearch';
+          return;
+        }
+        req.reply({
+          data,
+          includes: getIncluded([], patients, 'patients'),
+        });
+        req.alias = 'routePatientSearch';
+      });
+  });
+
+  specify('Legacy Modal', function() {
+    cy
+      .routeSettings(fx => {
+        fx.data = _.reject(fx.data, { id: 'patient_search_settings' });
+
+        return fx;
+      })
       .routeFlows(_.identity, 1)
       .routePatient()
       .routePatientActions()
       .routeAction()
       .routeActionActivity()
-      .routePatientSearch(fx => {
-        _.each(fx.data, (patient, index) => {
-          patient.attributes.first_name = 'Test';
-          patient.attributes.last_name = `${ index } Patient`;
-        });
-
-        return fx;
-      })
       .visit('/')
       .wait('@routeFlows');
 
@@ -51,13 +95,14 @@ context('Patient Quick Search', function() {
     cy
       .get('@searchModal')
       .find('.patient-search__input')
-      .type(' 1');
+      .type(' 2')
+      .wait('@routePatientSearch')
+      .wait(100); // wait for debounce
 
     cy
       .get('@searchModal')
-      .find('.js-picklist-item')
-      .should('have.length', 1)
-      .first()
+      .find('.js-picklist-item strong')
+      .contains('2')
       .click();
 
     cy
@@ -71,7 +116,129 @@ context('Patient Quick Search', function() {
     cy
       .get('@searchModal')
       .find('.patient-search__input')
-      .type('Foo');
+      .type('None')
+      .wait('@routeEmptyPatientSearch');
+
+    cy
+      .get('@searchModal')
+      .should('contain', 'No results match your query');
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
+      .clear();
+
+    cy
+      .get('@searchModal')
+      .should('contain', 'Search by');
+
+    cy
+      .get('@searchModal')
+      .find('.js-close')
+      .click();
+
+    cy
+      .get('@searchModal')
+      .should('not.exist');
+
+    cy
+      .get('.app-nav__header')
+      .should('contain', 'Cypress Clinic')
+      .as('mainNav')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Programs')
+      .click();
+
+    cy
+      .get('@mainNav')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Workspace')
+      .click()
+      .wait('@routeFlows');
+
+    cy
+      .get('body')
+      .type('/');
+
+    cy
+      .get('@searchModal')
+      .should('contain', 'Search by');
+
+    cy
+      .go('back');
+  });
+
+  specify('Modal', function() {
+    cy
+      .routeFlows(_.identity, 1)
+      .routePatient()
+      .routePatientActions()
+      .routeAction()
+      .routeActionActivity()
+      .visit('/')
+      .wait('@routeFlows');
+
+    cy
+      .get('.app-frame__nav')
+      .find('.js-search')
+      .as('search')
+      .click();
+
+    cy
+      .get('@search')
+      .should('have.class', 'is-active');
+
+    cy
+      .get('.modal')
+      .as('searchModal')
+      .should('contain', 'Search by')
+      .find('.patient-search__input')
+      .should('have.attr', 'placeholder', 'Search for patients')
+      .type('Test');
+
+    cy
+      .wait('@routePatientSearch')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[search]=Te');
+
+    cy
+      .get('@searchModal')
+      .find('.js-picklist-item')
+      .should('have.length', 10);
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
+      .type(' 2')
+      .wait('@routePatientSearch')
+      .wait(100); // wait for debounce
+
+    cy
+      .get('@searchModal')
+      .find('.js-picklist-item strong')
+      .contains('2')
+      .click();
+
+    cy
+      .url()
+      .should('contain', 'patient/dashboard/2');
+
+    cy
+      .get('@search')
+      .click();
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
+      .type('None')
+      .wait('@routeEmptyPatientSearch');
 
     cy
       .get('@searchModal')

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -71,36 +71,3 @@ Cypress.Commands.add('routePatientByFlow', (mutator = _.identity) => {
     .as('routePatientByFlow');
 });
 
-Cypress.Commands.add('routePatientSearch', (mutator = _.identity) => {
-  cy
-    .fixture('collections/patients').as('fxPatients');
-
-  cy.route({
-    url: 'api/patients?filter*',
-    response() {
-      const patients = _.sample(this.fxPatients, 10);
-
-      _.each(patients, (patient, index) => {
-        patient.id = `${ index + 1 }`;
-      });
-
-      const data = getResource(_.clone(patients), 'patient-search-results');
-
-      _.map(data, (result, index) => {
-        result.id = `${ index + 1 }`;
-        result.attributes = _.pick(result.attributes, 'first_name', 'last_name', 'birth_date');
-        result.relationships = {
-          'patient': {
-            data: getRelationship(patients[index], 'patients'),
-          },
-        };
-      });
-
-      return mutator({
-        data,
-        included: getIncluded([], patients, 'patients'),
-      });
-    },
-  })
-    .as('routePatientSearch');
-});


### PR DESCRIPTION
Shortcut Story ID: [sc-30412] [sc-30413]

This PR does two things.  It removes the frontend filtering from the quick search component and it adds a fork in the ui based on the existence of the `patient_search_settings` org setting.  In the future this setting will include configuration for this search component and when we're done we'll pull out the old one