### PR TITLE
Chore/add stack id to data dog env

### DIFF
--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -6,7 +6,7 @@ import { datadogConfig as config, versions, appConfig as app } from './config';
 
 function initLogs({ isForm }) {
   datadogLogs.init({
-    env: app.env,
+    env: `${ app.env }.${ app.stack_id }`,
     clientToken: config.client_token,
     site: 'datadoghq.com',
     service: isForm ? 'care-ops-forms' : 'care-ops-frontend',


### PR DESCRIPTION
Shortcut Story ID: [sc-29968]

Add stackid for easier filtering of logs for FE and forms services. DataDog does not always index certain components of logs such as host, etc which makes filtering difficult. The  `env` field does appear to be the only tag that's actually getting indexed. This will allow us to work around this limitation with minimal effort. Additionally, we've been doing this in the backend for a while now and it allowed me to transition from individual alarms for each client to a generalized monitor that can split across env for alerts and then I can do match statements in the alert configuration to route alerts to the correct channel.