### PR TITLE
Display identifiers in patient quick search results

### DIFF
--- a/src/js/apps/globals/search_app.js
+++ b/src/js/apps/globals/search_app.js
@@ -6,13 +6,15 @@ import { PatientSearchModal } from 'js/views/globals/search/patient-search_views
 
 export default App.extend({
   onStart({ prefillText }) {
-    // const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings');
-    this.showSearch(prefillText);
+    const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings');
+
+    this.showSearch(prefillText, settings);
   },
-  showSearch(prefillText) {
+  showSearch(prefillText, settings) {
     const patientSearchModal = new PatientSearchModal({
       collection: Radio.request('entities', 'searchPatients:collection'),
       prefillText,
+      settings,
     });
 
     this.listenTo(patientSearchModal, {

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -47,6 +47,13 @@
   margin-left: 16px;
 }
 
+.patient-search__picklist-item-meta:empty::before {
+  color: $black-60;
+
+  // &ndash;
+  content: '–';
+}
+
 .is-highlighted {
   .patient-search__picklist-item,
   .patient-search__picklist-item-meta {

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -29,7 +29,7 @@
   {
     "id": "patient_search_settings",
     "value": {
-      "result_identifiers": [],
+      "result_identifiers": ["SSN", "MRN"],
       "identifiers": []
     }
   }

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -8,11 +8,12 @@ context('Patient Quick Search', function() {
       patient.id = `${ index }`;
       patient.first_name = 'Test';
       patient.last_name = `${ index } Patient`;
+      patient.identifiers = [{ type: 'SSN', value: '123-45-6789' }, { type: 'MRN', value: '' }];
       return patient;
     });
 
     const data = _.map(patients, patient => {
-      const { id, first_name, last_name, birth_date } = patient;
+      const { id, first_name, last_name, birth_date, identifiers } = patient;
 
       return {
         id,
@@ -21,6 +22,7 @@ context('Patient Quick Search', function() {
           first_name,
           last_name,
           birth_date,
+          identifiers,
         },
         relationships: {
           patient: {
@@ -212,6 +214,29 @@ context('Patient Quick Search', function() {
       .get('@searchModal')
       .find('.js-picklist-item')
       .should('have.length', 10);
+
+    cy
+      .get('@searchModal')
+      .find('.js-picklist-item')
+      .first()
+      .find('.patient-search__picklist-item-meta')
+      .eq(1)
+      .should('contain', '123-45-6789');
+
+    cy.window().then(win => {
+      cy
+        .get('@searchModal')
+        .find('.js-picklist-item')
+        .first()
+        .find('.patient-search__picklist-item-meta')
+        .last()
+        .then($el => {
+          const before = win.getComputedStyle($el[0], '::before');
+          const beforeContent = before.getPropertyValue('content');
+
+          expect(beforeContent).to.equal('"–"');
+        });
+    });
 
     cy
       .get('@searchModal')

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -223,20 +223,13 @@ context('Patient Quick Search', function() {
       .eq(1)
       .should('contain', '123-45-6789');
 
-    cy.window().then(win => {
-      cy
-        .get('@searchModal')
-        .find('.js-picklist-item')
-        .first()
-        .find('.patient-search__picklist-item-meta')
-        .last()
-        .then($el => {
-          const before = win.getComputedStyle($el[0], '::before');
-          const beforeContent = before.getPropertyValue('content');
-
-          expect(beforeContent).to.equal('"–"');
-        });
-    });
+    cy
+      .get('@searchModal')
+      .find('.js-picklist-item')
+      .first()
+      .find('.patient-search__picklist-item-meta')
+      .last()
+      .hasBeforeContent('–');
 
     cy
       .get('@searchModal')

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -130,3 +130,12 @@ Cypress.Commands.overwrite('route', (originalFn, options) => {
   };
   return cy.intercept(routeMatcher, staticResponse);
 });
+
+Cypress.Commands.add('hasBeforeContent', { prevSubject: true }, ($el, content) => {
+  cy.window().then(win => {
+    const before = win.getComputedStyle($el[0], '::before');
+    const beforeContent = before.getPropertyValue('content');
+
+    expect(beforeContent).to.equal(`"${ content }"`);
+  });
+});


### PR DESCRIPTION
Shortcut Story ID: [sc-30415]

Display one or more patient identifier values (e.g. `MRN`, `SSN`, etc.) in the patient quick search results.

These will be based on a `patient_search_settings` tenant organizational setting that contains an array of identifiers to show (e.g. `["MRN", "SSN"]`). 

The identifiers should be displayed in the same order they are listed in the organization setting array. And they won't be shown if the organizational setting doesn't exist or is empty, or if a patient's data doesn't contain the given identifier.

For patient identifiers that don't exist or have an empty value, a `-` will be shown in its place. The same as we do for empty widget values.

<img width="394" alt="Screen Shot 2022-08-22 at 11 19 35 PM" src="https://user-images.githubusercontent.com/35355575/186272675-e907b516-dd81-4a3d-b8cf-103d5b75ecef.png">

