### PR TITLE
Lower icon font size for the nav search button

### DIFF
--- a/src/js/views/globals/app-nav/app-nav.scss
+++ b/src/js/views/globals/app-nav/app-nav.scss
@@ -51,7 +51,9 @@ $menu-hover-color: #375467;
 
 .app-nav__search {
   .icon {
+    font-size: 12px;
     margin-right: 8px;
+    vertical-align: -0.0825em;
   }
 
   &:hover, &.is-active {


### PR DESCRIPTION
Shortcut Story ID: [sc-30432]

Lower the font size for the icon used in the nav search button from `16px` to `12px`.

Before this PR:

<img width="198" alt="Screen Shot 2022-08-24 at 5 04 29 PM" src="https://user-images.githubusercontent.com/35355575/186697947-05a72c5c-2111-4914-a326-4e6ce7d3eb4a.png">

This PR updates it to this:

<img width="199" alt="Screen Shot 2022-08-24 at 5 04 15 PM" src="https://user-images.githubusercontent.com/35355575/186698001-5b51d95f-0d91-45cf-9dbc-41eba55d97a0.png">
