### PR TITLE
Update outreach forms for parity form context

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -26,6 +26,14 @@ const _Model = BaseModel.extend({
   getReducers() {
     return get(this.get('options'), 'reducers', [defaultReducer]);
   },
+  getContext() {
+    return {
+      contextScripts: this.getContextScripts(),
+      reducers: this.getReducers(),
+      changeReducers: this.getChangeReducers(),
+      beforeSubmit: this.getBeforeSubmit(),
+    };
+  },
   getChangeReducers() {
     return get(this.get('options'), 'changeReducers', []);
   },

--- a/src/js/entities-service/forms.js
+++ b/src/js/entities-service/forms.js
@@ -12,6 +12,8 @@ const Entity = BaseEntity.extend({
     'fetch:forms:collection': 'fetchCollection',
     'fetch:forms:definition': 'fetchDefinition',
     'fetch:forms:fields': 'fetchFields',
+    'fetch:forms:byAction': 'fetchByAction',
+    'fetch:forms:definition:byAction': 'fetchDefinitionByAction',
   },
   fetchDefinition(formId) {
     return $.ajax(`/api/forms/${ formId }/definition`);
@@ -21,6 +23,12 @@ const Entity = BaseEntity.extend({
       return $.ajax(`/api/actions/${ actionId }/form/fields`);
     }
     return $.ajax(`/api/forms/${ formId }/fields?filter[patient]=${ patientId }`);
+  },
+  fetchByAction(actionId) {
+    return this.fetchBy(`/api/actions/${ actionId }/form`);
+  },
+  fetchDefinitionByAction(actionId) {
+    return $.ajax(`/api/actions/${ actionId }/form/definition`);
   },
 });
 

--- a/src/js/outreach/outreach.scss
+++ b/src/js/outreach/outreach.scss
@@ -100,14 +100,14 @@ html, body, .app-root {
 .dialog__button {
   font-size: 16px;
   margin-top: 40px;
-  padding: 10px 16px;
+  padding: 8px 48px;
   width: 100%;
 
   .fa-right-to-bracket {
     font-size: 20px;
     margin-left: 8px;
     vertical-align: text-top;
-    width: auto;
+    width: 20px;
   }
 }
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -110,10 +110,7 @@ export default App.extend({
         definition,
         formData: get(fields, 'data.attributes'.split('.'), {}),
         formSubmission: get(response, 'data.attributes.response.data'.split('.'), {}),
-        contextScripts: this.form.getContextScripts(),
-        reducers: this.form.getReducers(),
-        changeReducers: this.form.getChangeReducers(),
-        beforeSubmit: this.form.getBeforeSubmit(),
+        ...this.form.getContext(),
       });
     });
   },
@@ -141,10 +138,7 @@ export default App.extend({
         definition,
         formData: get(fields, 'data.attributes'.split('.'), {}),
         formSubmission: get(response, 'data', {}),
-        contextScripts: this.form.getContextScripts(),
-        reducers: this.form.getReducers(),
-        changeReducers: this.form.getChangeReducers(),
-        beforeSubmit: this.form.getBeforeSubmit(),
+        ...this.form.getContext(),
       });
     });
   },

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -29,6 +29,7 @@ context('Outreach', function() {
           },
         },
       })
+      .as('routeFormAction')
       .routeFormActionDefinition()
       .routeFormActionFields()
       .visit('/outreach/1', { noWait: true });
@@ -42,6 +43,7 @@ context('Outreach', function() {
     cy
       .get('.js-submit')
       .click()
+      .wait('@routeFormAction')
       .wait('@routeFormActionFields')
       .wait('@routeFormActionDefinition');
 


### PR DESCRIPTION
Outreach had gotten behind with new form features.  This update moves outreach to use the form entity and moves context gathering logic into it so that they're shared between form contexts.

Also fixes the broken button style

Shortcut Story ID: [sc-30330] [sc-30331]
