### PR TITLE
Add search by birth date functionality to patient search

### DIFF
--- a/src/js/apps/globals/search_app.js
+++ b/src/js/apps/globals/search_app.js
@@ -1,10 +1,23 @@
+import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
 import { PatientSearchModal } from 'js/views/globals/search/patient-search_views';
 
+const StateModel = Backbone.Model.extend({
+  defaults() {
+    return {
+      searchType: 'name',
+    };
+  },
+});
+
 export default App.extend({
+  StateModel,
+  stateEvents: {
+    'change:searchType': 'restart',
+  },
   onStart({ prefillText }) {
     const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings');
 
@@ -15,12 +28,16 @@ export default App.extend({
       collection: Radio.request('entities', 'searchPatients:collection'),
       prefillText,
       settings,
+      searchType: this.getState('searchType'),
     });
 
     this.listenTo(patientSearchModal, {
       'item:select'({ model }) {
         Radio.trigger('event-router', 'patient:dashboard', model.get('_patient'));
         patientSearchModal.destroy();
+      },
+      'select:search:type'(newSearchType) {
+        this.setState('searchType', newSearchType);
       },
       'destroy'() {
         this.stop();

--- a/src/js/entities-service/entities/patient-search-results.js
+++ b/src/js/entities-service/entities/patient-search-results.js
@@ -1,4 +1,5 @@
 import { debounce } from 'underscore';
+import dayjs from 'dayjs';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
@@ -16,11 +17,18 @@ const Collection = BaseCollection.extend({
   },
   search(
     /* istanbul ignore next */
-    search = '') {
+    search = '', searchType) {
     if (search.length < 3) {
       if (!search.length) this.reset();
       this.isSearching = false;
       return;
+    }
+
+    if (searchType === 'dob') {
+      // strict valid date check: https://day.js.org/docs/en/parse/is-valid
+      const isValidDate = dayjs(search, 'YYYY-MM-DD', true).isValid();
+
+      if (!isValidDate) return;
     }
 
     this.isSearching = true;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -186,11 +186,17 @@ careOptsFrontend:
     search:
       patientSearchViews:
         patientSearchPicklist:
-          placeholderText: Search for patients
+          searchByDOB:
+            placeholderText: MM/DD/YYYY
+          searchByName:
+            placeholderText: Search for patients
         picklistEmptyView:
           noResults: No results match your query
           searching: Searching...
-          searchTip: Search by first name or last name with 3 or more characters.
+          searchByDOB:
+            searchTip: Search for patients by date of birth with MM/DD/YYYY format.
+          searchByName:
+            searchTip: Search by first name or last name with 3 or more characters.
           shortcut: "Keyboard Shortcut: /"
   patients:
     patient:

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -15,16 +15,41 @@
   }
 }
 
+.patient-search__clear-type-button {
+  background-color: color(light_blue, light);
+  border: none;
+  color: $black-20;
+  font-size: 14px;
+  height: 28px;
+  margin-right: 8px;
+  padding: 4px 12px;
+
+  .patient-search__clear-type-button-label {
+    vertical-align: middle;
+  }
+
+  .icon {
+    font-size: 14px;
+    margin-left: 8px;
+    vertical-align: bottom;
+    width: 1em;
+  }
+}
+
 .patient-search__input {
   border: none;
   display: flex;
+  flex-grow: 1; // tells <input /> to fill width regardless of button size
   font-size: 24px;
   font-weight: normal;
 
   // height = line-height: 1.2
   height: 28px;
   padding-right: 24px;
-  width: 100%;
+
+  &[type='date']::-webkit-calendar-picker-indicator {
+    display: none;
+  }
 
   &:focus {
     box-shadow: none;
@@ -33,6 +58,20 @@
 
 .patient-search__header {
   border-bottom: 1px solid $black-90;
+}
+
+.patient-search__search-by-button {
+  background-color: color(light_blue, light);
+  border: none;
+  color: $black-20;
+  font-size: 14px;
+  height: 28px;
+  margin-right: 16px;
+  padding: 4px 12px;
+
+  .patient-search__search-by-button-label {
+    vertical-align: middle;
+  }
 }
 
 .patient-search__picklist-item {
@@ -61,11 +100,40 @@
   }
 }
 
-.patient-search__no-results {
+.patient-search__info {
   color: $black-60;
   font-size: 14px;
   font-style: normal;
-  margin: 0 8px;
   padding: 16px 0;
   text-align: center;
+}
+
+.patient-search__tip {
+  border-bottom: 1px solid $black-90;
+  padding-bottom: 16px;
+  padding-left: 64px;
+  text-align: left;
+}
+
+.patient-search__search-by {
+  padding: 16px 0;
+  padding-left: 64px;
+  text-align: left;
+}
+
+.patient-search__search-by-title {
+  color: #999;
+  font-size: 12px;
+}
+
+.patient-search__search-by-buttons {
+  padding: 8px 0;
+}
+
+.patient-search__shortcut {
+  bottom: 0;
+  padding-bottom: 24px;
+  position: absolute;
+  text-align: center;
+  width: 100%;
 }

--- a/src/js/views/globals/search/search-by-dob_views.js
+++ b/src/js/views/globals/search/search-by-dob_views.js
@@ -1,0 +1,196 @@
+import { noop, find, get, map, debounce, each, extend, pick } from 'underscore';
+import dayjs from 'dayjs';
+import hbs from 'handlebars-inline-precompile';
+import { View, CollectionView } from 'marionette';
+
+import hasAllText from 'js/utils/formatting/has-all-text';
+
+import PicklistComponent from 'js/components/picklist';
+
+import InputWatcherBehavior from 'js/behaviors/input-watcher';
+import PicklistBehavior from 'js/behaviors/picklist-transport';
+
+const CLASS_OPTIONS = [
+  'childView',
+  'childViewEventPrefix',
+  'className',
+  'lists',
+];
+
+const CLASS_OPTIONS_ITEM = [
+  'itemClassName',
+  'itemTemplate',
+  'itemTemplateContext',
+];
+
+const Picklist = CollectionView.extend({
+  className: 'picklist__group',
+  tagName: 'li',
+  template: hbs`<ul></ul>`,
+  serializeCollection: noop,
+  childViewContainer: 'ul',
+  childViewEventPrefix: 'item',
+  modelEvents: {
+    'change:query': 'filter',
+  },
+  viewFilter(view) {
+    view.render();
+    const query = this.model.get('query');
+    return !query || !view.searchText || hasAllText(view.searchText, query);
+  },
+  initialize(options) {
+    this.mergeOptions(options, CLASS_OPTIONS_ITEM);
+  },
+  childViewOptions() {
+    const opts = pick(this, ...CLASS_OPTIONS_ITEM);
+    return extend({ state: this.model }, opts);
+  },
+});
+
+const PicklistsCollectionView = CollectionView.extend({
+  behaviors: [
+    InputWatcherBehavior,
+    PicklistBehavior,
+  ],
+  template: hbs`
+    <div class="modal__header patient-search__header">
+      <span class="modal__header-icon">{{far "magnifying-glass"}}</span>
+      <div class="js-clear-search-type button-primary patient-search__clear-type-button">
+        <span class="patient-search__clear-type-button-label">Date of Birth</span>{{far "xmark"}}
+      </div>
+      <input
+        type="date"
+        class="js-input patient-search__input"
+        placeholder="{{ @intl.globals.search.patientSearchViews.patientSearchPicklist.searchByDOB.placeholderText }}"
+        value="{{ search }}"
+      >
+    </div>
+    <ul class="flex-region picklist__scroll js-picklist-scroll"></ul>
+`,
+  triggers: {
+    'click .js-clear-search-type': 'click:clear:search:type',
+  },
+  serializeCollection: noop,
+  childViewContainer: 'ul',
+  initialize(options) {
+    this.mergeOptions(options, CLASS_OPTIONS);
+    this.mergeOptions(options, CLASS_OPTIONS_ITEM);
+
+    this.debouncedFilter = debounce(this.filter, 1);
+
+    each(this.lists, this.addList, this);
+  },
+  addList(list) {
+    const options = extend({
+      model: this.model,
+      childView: this.childView,
+    }, pick(this, ...CLASS_OPTIONS_ITEM), list);
+
+    const picklist = new Picklist(options);
+
+    picklist.render();
+
+    this.addChildView(picklist);
+  },
+  viewFilter(childView) {
+    return !!childView.children.length;
+  },
+  childViewEvents: {
+    'before:render:children'() {
+      return this.debouncedFilter();
+    },
+  },
+  onRenderChildren() {
+    this.$('.js-picklist-item').removeClass('is-highlighted');
+
+    if (!this.model.get('query')) return;
+
+    this.$('.js-picklist-item').first().addClass('is-highlighted');
+  },
+});
+
+const TipTemplate = hbs`
+  <div class="patient-search__tip">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.searchByDOB.searchTip }}</div>
+  <div class="patient-search__search-by">
+    <div class="patient-search__search-by-title">I'm looking for patients by...</div>
+    <div class="patient-search__search-by-buttons">
+      <div class="js-name-button button-primary patient-search__search-by-button">
+        <span class="patient-search__search-by-button-label">Name</span>
+      </div>
+    </div>
+  </div>
+  <div class="patient-search__shortcut">{{fas "keyboard"}}<strong class="u-margin--l-8">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.shortcut }}</strong></div>
+`;
+
+const SearchingTemplate = hbs`<div class="patient-search__searching">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.searching }}</div>`;
+const NoResultsTemplate = hbs`<div class="patient-search__no-results">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.noResults }}</div>`;
+
+const EmptyView = View.extend({
+  collectionEvents: {
+    'search': 'render',
+  },
+  tagName: 'li',
+  className: 'patient-search__info',
+  triggers: {
+    'click .js-name-button': 'select:name:type',
+  },
+  initialize({ state }) {
+    this.state = state;
+    this.listenTo(this.state, 'change:search', this.render);
+  },
+  getTemplate() {
+    const search = this.state.get('search');
+
+    const isValidDate = dayjs(search, 'YYYY-MM-DD', true).isValid();
+
+    if (!search || !isValidDate || search.length < 3) {
+      return TipTemplate;
+    }
+
+    if (this.collection.isSearching) return SearchingTemplate;
+
+    return NoResultsTemplate;
+  },
+  onSelectNameType() {
+    this.state.set('searchType', 'name');
+  },
+});
+
+const PatientSearchByDOBPicklist = PicklistComponent.extend({
+  className: 'patient-search__picklist',
+  itemClassName: 'patient-search__picklist-item',
+  itemTemplate: hbs`
+    <span>{{first_name}} {{last_name}}</span>{{~ remove_whitespace ~}}
+    <span class="patient-search__picklist-item-meta">{{formatDateTime birth_date "MM/DD/YYYY"}}</span>
+    {{#each identifiers}}<span class="patient-search__picklist-item-meta">{{this}}</span>{{/each}}
+  `,
+  ViewClass: PicklistsCollectionView,
+  itemTemplateContext() {
+    const settings = this.state.get('settings');
+    const settingsIdentifiers = get(settings, 'result_identifiers');
+
+    const patientIdentifiers = this.model.get('identifiers');
+
+    const identifiers = map(settingsIdentifiers, settingsIdentifier => {
+      const identifierToShow = find(patientIdentifiers, { type: settingsIdentifier });
+
+      return identifierToShow && identifierToShow.value;
+    });
+
+    return {
+      search: this.state.get('search'),
+      identifiers,
+    };
+  },
+  emptyView: EmptyView,
+  onWatchChange(search) {
+    this.setState('search', search);
+  },
+  initialize() {
+    this.listenTo(this.collection, 'search', this.renderView);
+  },
+});
+
+export {
+  PatientSearchByDOBPicklist,
+};

--- a/src/js/views/globals/search/search-by-name_views.js
+++ b/src/js/views/globals/search/search-by-name_views.js
@@ -1,0 +1,97 @@
+import { find, get, map } from 'underscore';
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import PicklistComponent from 'js/components/picklist';
+
+const TipTemplate = hbs`
+  <div class="patient-search__tip">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.searchByName.searchTip }}</div>
+  <div class="patient-search__search-by">
+    <div class="patient-search__search-by-title">I'm looking for patients by...</div>
+    <div class="patient-search__search-by-buttons">
+      <div class="js-dob-button button-primary patient-search__search-by-button">
+        <span class="patient-search__search-by-button-label">Date of Birth</span>
+      </div>
+    </div>
+  </div>
+  <div class="patient-search__shortcut">{{fas "keyboard"}}<strong class="u-margin--l-8">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.shortcut }}</strong></div>
+`;
+
+const SearchingTemplate = hbs`<div class="patient-search__searching">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.searching }}</div>`;
+const NoResultsTemplate = hbs`<div class="patient-search__no-results">{{ @intl.globals.search.patientSearchViews.picklistEmptyView.noResults }}</div>`;
+
+const EmptyView = View.extend({
+  collectionEvents: {
+    'search': 'render',
+  },
+  tagName: 'li',
+  className: 'patient-search__info',
+  triggers: {
+    'click .js-dob-button': 'select:dob:type',
+  },
+  initialize({ state }) {
+    this.state = state;
+    this.listenTo(this.state, 'change:search', this.render);
+  },
+  getTemplate() {
+    const search = this.state.get('search');
+
+    if (!search || search.length < 3) return TipTemplate;
+
+    if (this.collection.isSearching) return SearchingTemplate;
+
+    return NoResultsTemplate;
+  },
+  onSelectDobType() {
+    this.state.set('searchType', 'dob');
+  },
+});
+
+const PatientSearchByNamePicklist = PicklistComponent.extend({
+  className: 'patient-search__picklist',
+  getItemSearchText() {
+    return `${ this.model.get('first_name') } ${ this.model.get('last_name') }`;
+  },
+  itemClassName: 'patient-search__picklist-item',
+  itemTemplate: hbs`
+    {{matchText text search}}{{~ remove_whitespace ~}}
+    <span class="patient-search__picklist-item-meta">{{formatDateTime birth_date "MM/DD/YYYY"}}</span>
+    {{#each identifiers}}<span class="patient-search__picklist-item-meta">{{this}}</span>{{/each}}
+  `,
+  itemTemplateContext() {
+    const settings = this.state.get('settings');
+    const settingsIdentifiers = get(settings, 'result_identifiers');
+
+    const patientIdentifiers = this.model.get('identifiers');
+
+    const identifiers = map(settingsIdentifiers, settingsIdentifier => {
+      const identifierToShow = find(patientIdentifiers, { type: settingsIdentifier });
+
+      return identifierToShow && identifierToShow.value;
+    });
+
+    return {
+      text: this.getItemSearchText(),
+      search: this.state.get('search'),
+      identifiers,
+    };
+  },
+  template: hbs`
+    <div class="modal__header patient-search__header">
+      <span class="modal__header-icon">{{far "magnifying-glass"}}</span>
+      <input type="text" class="js-input patient-search__input" placeholder="{{ @intl.globals.search.patientSearchViews.patientSearchPicklist.searchByName.placeholderText }}" value="{{ search }}">
+    </div>
+    <ul class="flex-region picklist__scroll js-picklist-scroll"></ul>
+  `,
+  emptyView: EmptyView,
+  onWatchChange(search) {
+    this.setState('search', search);
+  },
+  initialize() {
+    this.listenTo(this.collection, 'search', this.renderView);
+  },
+});
+
+export {
+  PatientSearchByNamePicklist,
+};


### PR DESCRIPTION
Shortcut Story ID: [sc-30513]

Add ability to search by date of birth to the patient search modal.

Includes adding `Name` and `Date of Birth` buttons to the patient search modal for users to switch between searching for patients by name or birth date.