### PR TITLE
Prevent stored submissions on read only forms

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -122,7 +122,7 @@ export default App.extend({
   showContent() {
     const { updated } = Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
 
-    if (updated) {
+    if (!this.isReadOnly && updated) {
       const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
 
       this.listenTo(storedSubmissionView, {

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -175,7 +175,7 @@ export default App.extend({
     const responseId = this.getState('responseId');
     const { updated } = Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
 
-    if (!responseId && updated) {
+    if (!this.isReadOnly && !responseId && updated) {
       const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
 
       this.listenTo(storedSubmissionView, {

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -47,6 +47,9 @@ export default App.extend({
     return store.get(this.getStoreId()) || {};
   },
   updateStoredSubmission(submission) {
+    /* istanbul ignore if: difficult to test read only submission change */
+    if (this.form.isReadOnly()) return;
+
     const updated = dayjs().format();
     try {
       store.set(this.getStoreId(), { submission, updated });
@@ -117,7 +120,7 @@ export default App.extend({
   fetchFormPrefill() {
     const storedSubmission = this.getStoredSubmission();
 
-    if (storedSubmission.updated) {
+    if (!this.form.isReadOnly() && storedSubmission.updated) {
       return this.fetchFormStoreSubmission(storedSubmission);
     }
 

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -843,25 +843,37 @@ context('Patient Action Form', function() {
   });
 
   specify('read only form', function() {
+    localStorage.setItem('form-subm-11111-1-22222-1', JSON.stringify({
+      updated: testTs(),
+      submission: {
+        patient: { fields: { foo: 'foo' } },
+      },
+    }));
     cy
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '22222' };
         fx.data.relationships['form-responses'].data = [];
+        fx.data.relationships['program-action'] = { data: { id: '11111' } };
 
         return fx;
       })
       .routePatient()
-      .routeForm(_.identity, '11111')
+      .routeForm(_.identity, '22222')
       .routeFormDefinition()
       .routeActionActivity()
       .routePatientByAction()
-      .routeFormActionFields()
+      .routeFormActionFields(fx => {
+        fx.data.attributes = { patient: { fields: { foo: 'bar' } } };
+
+        return fx;
+      })
       .visit('/patient-action/1/form/22222')
       .wait('@routeAction')
       .wait('@routePatientByAction')
       .wait('@routeForm')
-      .wait('@routeFormDefinition');
+      .wait('@routeFormDefinition')
+      .wait('@routeFormActionFields');
 
     cy
       .get('[data-status-region]')
@@ -879,7 +891,8 @@ context('Patient Action Form', function() {
 
     cy
       .iframe()
-      .find('textarea[name="data[storyTime]"]');
+      .find('[name="data[patient.fields.foo]"]')
+      .should('have.value', 'bar');
   });
 
   specify('form error', function() {
@@ -1427,14 +1440,24 @@ context('Patient Form', function() {
 
 
   specify('read only form', function() {
+    localStorage.setItem('form-subm-11111-1-22222', JSON.stringify({
+      updated: testTs(),
+      submission: {
+        patient: { fields: { foo: 'foo' } },
+      },
+    }));
     cy
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;
       })
-      .routeForm(_.identity, '11111')
+      .routeForm(_.identity, '22222')
       .routeFormDefinition()
-      .routeFormFields()
+      .routeFormFields(fx => {
+        fx.data.attributes = { patient: { fields: { foo: 'bar' } } };
+
+        return fx;
+      })
       .visit('/patient/1/form/22222')
       .wait('@routePatient')
       .wait('@routeForm')
@@ -1457,7 +1480,8 @@ context('Patient Form', function() {
 
     cy
       .iframe()
-      .find('textarea[name="data[storyTime]"]');
+      .find('[name="data[patient.fields.foo]"]')
+      .should('have.value', 'bar');
   });
 
   specify('form scripts and reducers', function() {

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -292,7 +292,7 @@ context('patient sidebar', function() {
             widget_type: 'formWidget',
             definition: {
               display_name: 'Form',
-              form_id: '1',
+              form_id: '11111',
               form_name: 'Test Form',
             },
           }),
@@ -301,7 +301,7 @@ context('patient sidebar', function() {
             widget_type: 'formWidget',
             definition: {
               display_name: 'Modal Form',
-              form_id: '1',
+              form_id: '11111',
               form_name: 'Test Modal Form',
               is_modal: true,
             },
@@ -311,7 +311,7 @@ context('patient sidebar', function() {
             widget_type: 'formWidget',
             definition: {
               display_name: 'Modal Form',
-              form_id: '1',
+              form_id: '11111',
               form_name: 'Test Modal Form Small',
               is_modal: true,
               modal_size: 'small',
@@ -322,7 +322,7 @@ context('patient sidebar', function() {
             widget_type: 'formWidget',
             definition: {
               display_name: 'Modal Form',
-              form_id: '1',
+              form_id: '11111',
               form_name: 'Test Modal Form Large',
               is_modal: true,
               modal_size: 'large',

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -26,7 +26,7 @@ Cypress.Commands.add('routeForm', (mutator = _.identity, formId = '11111') => {
     url: '/api/forms/*',
     response() {
       return mutator({
-        data: _.find(this.fxTestForms, { formId }),
+        data: getResource(_.find(this.fxTestForms, { id: formId }), 'forms'),
         included: [],
       });
     },


### PR DESCRIPTION
Shortcut Story ID: [sc-30716]

This work disables the localstorage form submission prefill on forms marked read only.

New forms are updating the form submission to store user state for what they're viewing.

This however was very hard to test for.. I can recreate the issue on the live form, but can't get it to happen in cypress.

Additionally this unfortunately is not only preventing storing the changed submission, but it's also preventing displaying the form submission since we have some out in the wild and deem this a necessary quick fix.  Otherwise we could presumably just prevent updating the localstorage.