### PR TITLE
Add date of birth & identifiers to patient search help text ('Or search for patients by')

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -214,7 +214,7 @@ export default App.extend({
     this.showChildView('navContent', navView);
   },
   showSearch(prefillText) {
-    if (!Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings')) {
+    if (!Radio.request('bootstrap', 'currentOrg:setting', 'patient_search')) {
       const navView = this.getChildView('navContent');
 
       const patientSearchModal = new PatientSearchModal({

--- a/src/js/apps/globals/search_app.js
+++ b/src/js/apps/globals/search_app.js
@@ -6,7 +6,7 @@ import { PatientSearchModal } from 'js/views/globals/search/patient-search_views
 
 export default App.extend({
   onStart({ prefillText }) {
-    const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search_settings');
+    const settings = Radio.request('bootstrap', 'currentOrg:setting', 'patient_search');
 
     this.showSearch(prefillText, settings);
   },

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -190,7 +190,7 @@ careOptsFrontend:
         picklistEmptyView:
           noResults: No results match your query
           searching: Searching...
-          searchTip: Search by first name or last name with 3 or more characters.
+          searchTip: Search by first name, last name with 3 or more characters.
           shortcut: "Keyboard Shortcut: /"
   patients:
     patient:

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -6,7 +6,7 @@
 
 .patient-search__close {
   position: absolute;
-  right: 24px;
+  right: 16px;
   top: 24px;
   z-index: 10;
 
@@ -33,12 +33,14 @@
 
 .patient-search__header {
   border-bottom: 1px solid $black-90;
+  margin: 0 8px;
+  padding-left: 16px;
 }
 
 .patient-search__picklist-item {
   color: $black-20;
   font-size: 16px;
-  padding: 4px 56px;
+  padding: 4px 64px;
 }
 
 .patient-search__picklist-item-meta {
@@ -68,4 +70,42 @@
   margin: 0 8px;
   padding: 16px 0;
   text-align: center;
+}
+
+.patient-search__tip {
+  border-bottom: 1px solid $black-90;
+  padding-bottom: 16px;
+  padding-left: 60px;
+  text-align: left;
+}
+
+.patient-search__search-by {
+  padding: 16px 0;
+  padding-left: 60px;
+  text-align: left;
+}
+
+.patient-search__search-by-title {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.patient-search__search-by-label {
+  background-color: color(light_blue, light);
+  border-radius: 4px;
+  color: $black-20;
+  display: inline-block;
+  font-weight: 600;
+  margin-right: 8px;
+  padding: 4px 12px;
+}
+
+.patient-search__shortcut {
+  bottom: 0;
+  left: 0;
+  margin-bottom: 24px;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  width: 100%;
 }

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -19,10 +19,20 @@
     "value": true
   },
   {
-    "id": "patient_search_settings",
+    "id": "patient_search",
     "value": {
-      "result_identifiers": ["SSN", "MRN"],
-      "identifiers": []
+      "identifiers": [
+        {
+          "type": "MRN",
+          "label": "Medical Record Number",
+          "example": "A234567"
+        },
+        {
+          "type": "PID",
+          "label": "Health Plan ID",
+          "example": "123456789"
+        }
+      ]
     }
   },
   {

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -8,12 +8,11 @@ context('Patient Quick Search', function() {
       patient.id = `${ index }`;
       patient.first_name = 'Test';
       patient.last_name = `${ index } Patient`;
-      patient.identifiers = [{ type: 'SSN', value: '123-45-6789' }, { type: 'MRN', value: '' }];
       return patient;
     });
 
     const data = _.map(patients, patient => {
-      const { id, first_name, last_name, birth_date, identifiers } = patient;
+      const { id, first_name, last_name, birth_date } = patient;
 
       return {
         id,
@@ -22,7 +21,6 @@ context('Patient Quick Search', function() {
           first_name,
           last_name,
           birth_date,
-          identifiers,
         },
         relationships: {
           patient: {
@@ -53,7 +51,7 @@ context('Patient Quick Search', function() {
   specify('Legacy Modal', function() {
     cy
       .routeSettings(fx => {
-        fx.data = _.reject(fx.data, { id: 'patient_search_settings' });
+        fx.data = _.reject(fx.data, { id: 'patient_search' });
 
         return fx;
       })
@@ -201,7 +199,37 @@ context('Patient Quick Search', function() {
       .as('searchModal')
       .should('contain', 'Search by')
       .find('.patient-search__input')
-      .should('have.attr', 'placeholder', 'Search for patients')
+      .should('have.attr', 'placeholder', 'Search for patients');
+
+    cy
+      .get('@searchModal')
+      .find('.qa-search-option')
+      .should('have.length', 3);
+
+    cy
+      .get('@searchModal')
+      .find('.qa-search-option')
+      .first()
+      .should('contain', 'Date of Birth')
+      .should('contain', 'For example: MM/DD/YYYY');
+
+    cy
+      .get('@searchModal')
+      .find('.qa-search-option')
+      .eq(1)
+      .should('contain', 'Medical Record Number')
+      .should('contain', 'For example: A234567');
+
+    cy
+      .get('@searchModal')
+      .find('.qa-search-option')
+      .last()
+      .should('contain', 'Health Plan ID')
+      .should('contain', 'For example: 123456789');
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
       .type('Test');
 
     cy
@@ -214,22 +242,6 @@ context('Patient Quick Search', function() {
       .get('@searchModal')
       .find('.js-picklist-item')
       .should('have.length', 10);
-
-    cy
-      .get('@searchModal')
-      .find('.js-picklist-item')
-      .first()
-      .find('.patient-search__picklist-item-meta')
-      .eq(1)
-      .should('contain', '123-45-6789');
-
-    cy
-      .get('@searchModal')
-      .find('.js-picklist-item')
-      .first()
-      .find('.patient-search__picklist-item-meta')
-      .last()
-      .hasBeforeContent('–');
 
     cy
       .get('@searchModal')


### PR DESCRIPTION
Shortcut Story ID: [sc-30727]

In the patient search modal, this adds a section to the help text labeled `Or search for patients by` that looks like the screenshot below. It will show users that they can search by a patient's date of birth or one/multiple identifiers.

The `Date of Birth` option will always be shown by default.

The identifiers are based on a `patient_search` organization setting:

```js
{
  "identifiers": [
    {
        "type": "MRN",
        "label": "Medical Record Number",
        "example": "A234567"
    },
    {
        "type": "PID",
        "label": "Health Plan ID",
        "example": "123456789"
    }
  ]
}
```

Where `label` is shown in the blue button and the `example` is shown in the `Example: {{example}}` text.

<img width="542" alt="Screen Shot 2022-09-08 at 10 10 13 AM" src="https://user-images.githubusercontent.com/35355575/189180042-4580dc24-000c-42e3-a1db-37b1d5bda3e5.png">
