### PR TITLE
Update roles org setting to key/value

### DIFF
--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import { get, filter } from 'underscore';
+import { get, filter, map } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
@@ -30,7 +30,10 @@ export default App.extend({
     return this.currentUser;
   },
   getOrgRoles() {
-    const roles = this.getOrgSetting('roles');
+    const roles = map(this.getOrgSetting('roles'), (role, key) => {
+      role.name = key;
+      return role;
+    });
 
     // Neither patient or admin are settable roles
     const activeRoles = filter(roles, ({ name }) => {

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -37,18 +37,16 @@
   },
   {
     "id": "roles",
-    "value": [
-      {
-        "name": "admin",
+    "value": {
+      "admin": {
         "parents": [],
         "permissions": [
           "settings:manage"
         ]
       },
-      {
+      "manager": {
         "label": "Manager",
         "details": "Manager details",
-        "name": "manager",
         "parents": [
           "admin"
         ],
@@ -60,10 +58,9 @@
           "work:delete"
         ]
       },
-      {
+      "employee": {
         "label": "Employee",
         "details": "Able to access workspace only",
-        "name": "employee",
         "parents": [
           "manager"
         ],
@@ -75,9 +72,7 @@
           "app:schedule:clinician_filter"
         ]
       },
-      {
-        "name": "patient"
-      }
-    ]
+      "patient": {}
+    }
   }
 ]


### PR DESCRIPTION
Shortcut Story ID: [sc-30837]

The org setting changed formatting here https://github.com/RoundingWell/care-ops-backend/pull/4047/files#diff-db0b635a8870802065368db9b3a6f0e25af11e5204cc447f95e32d120f10bf3fL18

FE needs to match that implementation.

@dhrrgn @shadowhand the BE fixtures ideally include the `label` and `details` for the roles not `patient` or `admin` to prevent a blank roles menu on the clinician management page.