### PR TITLE
Fix async and display issue on quick search

### DIFF
--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -20,6 +20,8 @@ export default Backbone.Collection.extend(extend({
     // On success resolves the entity instead of the jqxhr success
     const d = $.Deferred();
 
+    d.abort = xhr.abort;
+
     $.when(xhr)
       .fail(bind(d.reject, d))
       .done(bind(d.resolve, d, this));

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -94,12 +94,7 @@ const PicklistItem = View.extend({
 });
 
 const ListView = CollectionView.extend({
-  className: 'flex-region',
-  behaviors: [
-    PicklistBehavior,
-  ],
-  template: hbs`<ul class="flex-region picklist__scroll js-picklist-scroll"></ul>`,
-  childViewContainer: 'ul',
+  tagName: 'ul',
   serializeCollection: noop,
   childView: PicklistItem,
   childViewOptions() {
@@ -156,6 +151,7 @@ const DialogView = View.extend({
       selector: '.js-input',
     },
     InputWatcherBehavior,
+    PicklistBehavior,
   ],
   triggers: {
     'focus @ui.input': 'focus',
@@ -173,8 +169,10 @@ const DialogView = View.extend({
       <span class="modal__header-icon">{{far "magnifying-glass"}}</span>
       <input type="text" class="js-input patient-search__input" placeholder="{{ @intl.globals.search.patientSearchViews.dialogView.placeholderText }}" value="{{ search }}">
     </div>
-    <div data-header-region></div>
-    <div data-list-region></div>
+    <div class="flex-region picklist__scroll js-picklist-scroll">
+      <div data-header-region></div>
+      <div data-list-region></div>
+    </div>
   `,
   onRender() {
     this.showHeader();


### PR DESCRIPTION
Shortcut Story ID: [sc-30964] [sc-30961]

Testing the first story in cypress is a bit complicated due to the async request needing to be timed along with the debounce.  At least it was pretty flaky.. maybe a `cy.clock` somehow would help, but nothing at first glance was specific.  That said a real world test was easy and all of the logic branches should be covered here.