### PR TITLE
Use NIL_UUID to check if a clinician has a team

### DIFF
--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -36,14 +36,18 @@ const _Model = BaseModel.extend({
     return Radio.request('entities', 'groups:collection', this.get('_groups'));
   },
   getTeam() {
-    const team = this.get('_team');
-    if (!team || team === NIL_UUID) {
+    if (!this.hasTeam()) {
       return Radio.request('entities', 'teams:model', {
         name: intl.patients.sidebar.action.activityViews.systemTeam,
       });
     }
 
     return Radio.request('entities', 'teams:model', this.get('_team'));
+  },
+  hasTeam() {
+    const team = this.get('_team');
+
+    return team && team !== NIL_UUID;
   },
   can(prop) {
     const permissions = this.get('permissions');
@@ -70,13 +74,12 @@ const _Model = BaseModel.extend({
     return !this.get('last_active_at');
   },
   isActive() {
-    const hasTeam = !!this.get('_team');
+    const hasTeam = this.hasTeam();
     const hasGroups = !!size(this.get('_groups'));
     const lastActive = this.get('last_active_at');
 
     return hasTeam && hasGroups && lastActive;
   },
-
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
+++ b/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
@@ -228,7 +228,7 @@ const SidebarView = View.extend({
   showInfo() {
     if (this.clinician.isNew()) return;
 
-    if (!this.clinician.get('_team') || this.clinician.getGroups().length === 0) {
+    if (!this.clinician.hasTeam() || this.clinician.getGroups().length === 0) {
       this.showChildView('info', new InfoView());
       return;
     }

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -68,15 +68,11 @@ context('patient page', function() {
 
   specify('current clinician has no team', function() {
     cy
-      .routeGroupsBootstrap(_.identity, null, fx => {
-        const currentClinician = _.find(fx.data, clinician => clinician.id === '11111');
-
-        currentClinician.relationships.team = { data: null };
-
-        return fx;
-      })
       .routeCurrentClinician(fx => {
-        fx.data.relationships.team = { data: null };
+        fx.data.relationships.team = {
+          data: { id: '00000000-0000-0000-0000-000000000000' },
+        };
+
         return fx;
       })
       .visit('/');


### PR DESCRIPTION
Shortcut Story ID: [sc-30997]

When a clinician is created, it's given a `nil_uuid` team `id` by default (i.e. `id: '00000000-0000-0000-0000-000000000000'`).

To determine if a clinician has been put on a team, we were simply checking that a clinician has a team assigned (i.e. that it's not `null`). Not what that assigned team is. Which means in some cases the app wrongly thinks a clinician has a team, even though their assigned team is the default `nil_uuid` instead of an actual team.

This PR updates the app to check whether a clinician's assigned team is a `nil_uuid` or not.

_This caused problems in the app where the clinicians `active` state was being determined. Clinicians with a `nil_uuid` team `id` were showing as `active` they shouldn't have._ 