### PR TITLE
Remove form print button

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
       "paper-plane",
       "pen",
       "pen-to-square",
-      "print",
       "right-left",
       "screwdriver-wrench",
       "share-from-square",

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -117,16 +117,12 @@ export default App.extend({
 
     this.listenTo(actionsView, {
       'click:expandButton': this.onClickExpandButton,
-      'click:printButton': this.onClickPrintButton,
     });
 
     this.showChildView('actions', actionsView);
   },
   onClickExpandButton() {
     this.toggleState('isExpanded');
-  },
-  onClickPrintButton() {
-    Radio.request(`form${ this.form.id }`, 'send', 'print:form');
   },
   showContent() {
     const { updated } = Radio.request(`form${ this.form.id }`, 'get:storedSubmission');

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -171,7 +171,6 @@ export default App.extend({
       'click:sidebarButton': this.onClickSidebarButton,
       'click:expandButton': this.onClickExpandButton,
       'click:historyButton': this.onClickHistoryButton,
-      'click:printButton': this.onClickPrintButton,
     });
 
     this.showChildView('actions', formActions);
@@ -189,9 +188,6 @@ export default App.extend({
   },
   onClickHistoryButton() {
     this.setState({ responseId: this.responses.first().id, shouldShowHistory: !this.getState('shouldShowHistory') });
-  },
-  onClickPrintButton() {
-    Radio.request(`form${ this.form.id }`, 'send', 'print:form');
   },
   showContent() {
     const responseId = this.getState('responseId');

--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -58,7 +58,7 @@ const PicklistEmpty = View.extend({
 const PicklistItem = View.extend({
   tagName: 'li',
   itemTemplate: hbs`
-    <div class="flex-grow">{{#if icon}}{{fa icon.type icon.icon classes=icon.classes}}{{/if}}<span>{{matchText text query}}</span></div
+    <div class="flex-grow">{{#if icon}}{{fa icon.type icon.icon classes=icon.classes}}{{/if}}<span>{{matchText text query}}</span></div>
     <div>{{#if isChecked}}{{fas "circle-check" classes="u-icon--12 u-margin--l-16"}}{{/if}}</div>
   `,
   itemClassName() {

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -172,10 +172,6 @@ const Router = Backbone.Router.extend({
       this.trigger(data.message, data.args);
     }, false);
 
-    this.on('print:form', () => {
-      window.print();
-    });
-
     this.request('version', versions.frontend);
   },
   request(message, args = {}) {

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -90,7 +90,6 @@ careOptsFrontend:
           decreaseWidth: Decrease Width
           hideActionSidebar: Hide Action Sidebar
           increaseWidth: Increase Width
-          printForm: Print Form
           responseHistory: See Form Response History
           showActionSidebar: Show Action Sidebar
         historyView:

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -46,7 +46,6 @@ const FormActionsView = View.extend({
   template: hbs`
     {{#if hasHistory}}<button class="js-history-button form__actions-icon{{#if shouldShowHistory}} is-selected{{/if}}">{{far "clock-rotate-left"}}</button>{{/if}}
     <button class="js-expand-button form__actions-icon">{{#if isExpanded}}{{far "down-left-and-up-right-to-center"}}{{else}}{{far "up-right-and-down-left-from-center"}}{{/if}}</button>
-    <button class="js-print-button form__actions-icon">{{far "print"}}</button>
     {{#if hasAction}}<button class="js-sidebar-button form__actions-icon{{#if isActionShown}} is-selected{{/if}}">{{far "file-lines"}}</button>{{/if}}
   `,
   templateContext() {
@@ -58,7 +57,6 @@ const FormActionsView = View.extend({
   },
   onRender() {
     this.renderSidebarTooltip();
-    this.renderPrintTooltip();
     this.renderExpandTooltip();
     this.renderHistoryTooltip();
   },
@@ -75,13 +73,11 @@ const FormActionsView = View.extend({
   },
   ui: {
     sidebarButton: '.js-sidebar-button',
-    printButton: '.js-print-button',
     expandButton: '.js-expand-button',
     historyButton: '.js-history-button',
   },
   triggers: {
     'click @ui.sidebarButton': 'click:sidebarButton',
-    'click @ui.printButton': 'click:printButton',
     'click @ui.expandButton': 'click:expandButton',
     'click @ui.historyButton': 'click:historyButton',
   },
@@ -96,13 +92,6 @@ const FormActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.sidebarButton,
-    });
-  },
-  renderPrintTooltip() {
-    new Tooltip({
-      message: i18n.formActionsView.printForm,
-      uiView: this,
-      ui: this.ui.printButton,
     });
   },
   renderExpandTooltip() {

--- a/src/scss/formapp/print.scss
+++ b/src/scss/formapp/print.scss
@@ -1,3 +1,4 @@
+// NOTE: This is used by the form PDF generator.
 @media print {
   .rw-page-break {
     page-break-before: always;

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -462,8 +462,6 @@ context('Patient Action Form', function() {
   });
 
   specify('submitting the form', function() {
-    let printStub;
-
     cy
       .routeAction(fx => {
         fx.data.id = '1';
@@ -548,35 +546,9 @@ context('Patient Action Form', function() {
       .should('not.be.visible');
 
     cy
-      .get('iframe')
-      .then($iframe => {
-        const contentWindow = $iframe[0].contentWindow;
-        printStub = cy.stub(contentWindow, 'print');
-      });
-
-    cy
-      .get('.js-print-button')
-      .click()
-      .then(() => {
-        expect(printStub).to.have.been.calledOnce;
-      });
-
-    cy
       .get('.form__title')
       .should('contain', 'Testin Mctester')
       .should('contain', 'Test Form');
-
-    cy
-      .get('.js-print-button')
-      .trigger('pointerover');
-
-    cy
-      .get('.tooltip')
-      .should('contain', 'Print Form');
-
-    cy
-      .get('.js-print-button')
-      .trigger('mouseout');
 
     cy
       .get('.js-expand-button')
@@ -1349,8 +1321,6 @@ context('Patient Action Form', function() {
 
 context('Patient Form', function() {
   specify('submitting the form', function() {
-    let printStub;
-
     cy
       .routeForm(_.identity, '11111')
       .routeFormDefinition()
@@ -1408,20 +1378,6 @@ context('Patient Form', function() {
     cy
       .get('.sidebar')
       .should('not.exist');
-
-    cy
-      .get('iframe')
-      .then($iframe => {
-        const contentWindow = $iframe[0].contentWindow;
-        printStub = cy.stub(contentWindow, 'print');
-      });
-
-    cy
-      .get('.js-print-button')
-      .click()
-      .then(() => {
-        expect(printStub).to.have.been.calledOnce;
-      });
 
     cy
       .iframe()


### PR DESCRIPTION
Shortcut Story ID: [sc-30764]

Remove print button from the forms page. Along with any related icons, `.scss`, and Cypress tests code.

Before removal:

![Screen Shot 2022-09-29 at 11 27 25 AM](https://user-images.githubusercontent.com/35355575/193087276-04304083-3d57-4425-a1be-eec3e85ffc86.png)

After removal:

![Screen Shot 2022-09-29 at 11 27 55 AM](https://user-images.githubusercontent.com/35355575/193087224-1ad0af21-b27d-4aa1-85a1-9f6292cce9a3.png)