### PR TITLE
Trigger keydown user activity events from the form app

### DIFF
--- a/src/js/behaviors/top-region.js
+++ b/src/js/behaviors/top-region.js
@@ -29,6 +29,11 @@ export default Behavior.extend({
     this.$el.removeClass(this.className);
   },
   onUserActivity({ target }) {
+    if (!target) {
+      this.region.empty();
+      return;
+    }
+
     if (!this.region.hasView() || topRegionCh.request('contains', this.view, target)) return;
 
     this.region.empty();

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -172,6 +172,12 @@ const Router = Backbone.Router.extend({
       this.trigger(data.message, data.args);
     }, false);
 
+    const self = this;
+
+    $(document).on('pointerdown', function(evt) {
+      self.request('user-activity', { eventType: 'body:down' });
+    });
+
     this.request('version', versions.frontend);
   },
   request(message, args = {}) {

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -29,6 +29,10 @@ export default App.extend({
     'get:storedSubmission': 'getStoredSubmission',
     'clear:storedSubmission': 'clearStoredSubmission',
     'version': 'checkVersion',
+    'user-activity': 'triggerUserActivityEvent',
+  },
+  triggerUserActivityEvent({ eventType }) {
+    Radio.trigger('user-activity', eventType, { target: null });
   },
   readyForm() {
     this.trigger('ready');


### PR DESCRIPTION
Shortcut Story ID: [sc-31196]

Trigger a `pointerdown` event from the formapp so pop regions close when a user clicks in a form.

An example of the `Save + Go Back` button droplist closing when a user clicks into the form:

https://user-images.githubusercontent.com/35355575/193350089-c93d35fe-7d13-4acd-a9ba-229cc08ce683.mov

