### PR TITLE
Emit error on form submission when form.checkValidity() fails

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -98,7 +98,10 @@ async function renderForm({ definition, storedSubmission, formData, formSubmissi
     },
     'form:submit'() {
       form.setPristine(false);
-      if (!form.checkValidity(form.submission.data, true, form.submission.data)) return;
+      if (!form.checkValidity(form.submission.data, true, form.submission.data)) {
+        form.emit('error');
+        return;
+      }
 
       form.submit();
     },
@@ -116,7 +119,10 @@ async function renderForm({ definition, storedSubmission, formData, formSubmissi
     onChangeDebounce.cancel();
     onChange(form, changeReducers);
     form.setPristine(false);
-    if (!form.checkValidity(response.data, true, response.data)) return;
+    if (!form.checkValidity(response.data, true, response.data)) {
+      form.emit('error');
+      return;
+    }
 
     const data = FormioUtils.evaluate(beforeSubmit, form.evalContext({ formSubmission: response.data })) || {};
 


### PR DESCRIPTION
Shortcut Story ID: [sc-31054]

When a form is submitted and a field is invalid, the save button becomes disabled, but the form doesn't submit. Which prevents the user from being able to correct the issue and resubmit the form.

This PR fixes that bug by emitting an error on form submission when the `form.checkValidity()` fails. This forces the save button to re-render in those situations.

@zfixler tested this on his dev sandbox and confirmed that it fixes the bug.