### PR TITLE
Move clinician filter to header for worklist & schedule

### DIFF
--- a/src/js/apps/patients/schedule/filters_app.js
+++ b/src/js/apps/patients/schedule/filters_app.js
@@ -4,19 +4,18 @@ import App from 'js/base/app';
 
 import intl from 'js/i18n';
 
-import { FiltersView, GroupsDropList, OwnerDroplist } from 'js/views/patients/schedule/filters_views';
+import { FiltersView, GroupsDropList } from 'js/views/patients/schedule/filters_views';
 
 export default App.extend({
   onStart() {
-    this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.groups = this.currentClinician.getGroups();
+    const currentClinician = Radio.request('bootstrap', 'currentUser');
+    this.groups = currentClinician.getGroups();
 
     this.showView(new FiltersView());
     this.showFilters();
   },
   showFilters() {
     this.showGroupsFilterView();
-    this.showOwnerFilterView();
   },
   showGroupsFilterView() {
     if (this.groups.length < 2) return;
@@ -34,26 +33,6 @@ export default App.extend({
     });
 
     this.showChildView('group', groupsFilter);
-  },
-  showOwnerFilterView() {
-    const currentClinician = Radio.request('bootstrap', 'currentUser');
-    if (!currentClinician.can('app:schedule:clinician_filter')) return;
-
-    const owner = Radio.request('entities', 'clinicians:model', this.getState('clinicianId'));
-
-    const ownerFilter = new OwnerDroplist({
-      owner,
-      groups: this.groups,
-      isFilter: true,
-      hasTeams: false,
-      headingText: intl.patients.schedule.filtersApp.ownerFilterHeadingText,
-    });
-
-    this.listenTo(ownerFilter, 'change:owner', ({ id }) => {
-      this.setState({ clinicianId: id });
-    });
-
-    this.showChildView('owner', ownerFilter);
   },
   _getGroups() {
     const groups = this.groups.clone();

--- a/src/js/apps/patients/worklist/filters_app.js
+++ b/src/js/apps/patients/worklist/filters_app.js
@@ -4,27 +4,22 @@ import intl from 'js/i18n';
 
 import App from 'js/base/app';
 
-import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 import { FiltersView, GroupsDropList, NoOwnerToggleView } from 'js/views/patients/worklist/filters_views';
 
 const i18n = intl.patients.worklist.filtersApp;
 
 export default App.extend({
-  onStart({ shouldShowClinician, shouldShowTeam, shouldShowOwnerToggle }) {
+  onStart({ shouldShowOwnerToggle }) {
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
-    this.shouldShowClinician = shouldShowClinician;
-    this.shouldShowTeam = shouldShowTeam;
     this.shouldShowOwnerToggle = shouldShowOwnerToggle;
-    this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.groups = this.currentClinician.getGroups();
+    this.groups = currentClinician.getGroups();
 
     this.showView(new FiltersView());
     this.showFilters();
   },
   showFilters() {
     this.showGroupsFilterView();
-    this.showOwnerFilterView();
     this.showOwnerToggleView();
   },
   showGroupsFilterView() {
@@ -43,39 +38,6 @@ export default App.extend({
     });
 
     this.showChildView('group', groupsFilter);
-  },
-  getOwnerFilterOpts() {
-    const owner = this.shouldShowClinician && this.getState('clinicianId') ?
-      Radio.request('entities', 'clinicians:model', this.getState('clinicianId')) :
-      Radio.request('entities', 'teams:model', this.getState('teamId'));
-
-    const opts = {
-      owner,
-      groups: this.shouldShowClinician && this.canViewAssignedActions ? this.groups : null,
-      isFilter: true,
-      headingText: this.shouldShowClinician ? i18n.ownerFilterHeadingText : i18n.teamsFilterHeadingText,
-      hasTeams: this.shouldShowTeam,
-      hasCurrentClinician: this.shouldShowClinician,
-    };
-
-    if (!this.shouldShowClinician) opts.placeholderText = i18n.teamsFilterPlaceholderText;
-
-    return opts;
-  },
-  showOwnerFilterView() {
-    if (!(this.shouldShowClinician && this.canViewAssignedActions) && !this.shouldShowTeam) return;
-
-    const ownerFilter = new OwnerDroplist(this.getOwnerFilterOpts());
-
-    this.listenTo(ownerFilter, 'change:owner', ({ id, type }) => {
-      if (type === 'teams') {
-        this.setState({ teamId: id, clinicianId: null });
-      } else {
-        this.setState({ clinicianId: id, teamId: null });
-      }
-    });
-
-    this.showChildView('owner', ownerFilter);
   },
   showOwnerToggleView() {
     if (!this.shouldShowOwnerToggle || !this.canViewAssignedActions) return;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -249,6 +249,7 @@ careOptsFrontend:
         emptyView:
           noScheduledActions: No Scheduled Actions
         scheduleTitleView:
+          label: Schedule for
           title: Schedule for { owner }
           tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team). States included are To Do and In Progress.
         tableHeaderView:
@@ -550,13 +551,21 @@ careOptsFrontend:
         emptyFindInListView:
           noResults: No results match your Find in List search
         listTitleView:
+          listLabels: |
+            {title, select,
+              owned_by {Owned By}
+              shared_by {Shared By}
+              new_past_day {New < 24 hrs: }
+              updated_past_three_days {Updated < 3 Days: }
+              done_last_thirty_days {Done < 30 Days: }
+            }
           listTitles: |
             {title, select,
               owned_by {Owned By { owner }}
               shared_by {Shared By { team } Team}
-              new_past_day {New < 24 hrs}
-              updated_past_three_days {Updated < 3 Days}
-              done_last_thirty_days {Done < 30 Days}
+              new_past_day {New < 24 hrs: { owner }}
+              updated_past_three_days {Updated < 3 Days: {owner}}
+              done_last_thirty_days {Done < 30 Days: {owner}}
             }
         sortCreatedOptions:
           asc: 'Added: Oldest - Newest'

--- a/src/js/views/clinicians/clinicians-all_views.js
+++ b/src/js/views/clinicians/clinicians-all_views.js
@@ -134,7 +134,7 @@ const LayoutView = View.extend({
   template: hbs`
     <div class="list-page__header">
       <div class="flex list-page__title">
-        <div>
+        <div class="flex list-page__title-filter">
           <span class="list-page__title-icon">{{far "users-gear"}}</span>{{ @intl.clinicians.cliniciansAllViews.layoutView.title }}
         </div>
         <div class="clinicians__list-search" data-search-region></div>

--- a/src/js/views/dashboards/dashboards-all_views.js
+++ b/src/js/views/dashboards/dashboards-all_views.js
@@ -39,7 +39,11 @@ const LayoutView = View.extend({
   className: 'flex-region',
   template: hbs`
   <div class="list-page__header">
-    <div class="list-page__title"><span class="list-page__title-icon">{{far "gauge"}}</span>{{ @intl.dashboards.dashboardsAllViews.layoutView.title }}</div>
+    <div class="flex list-page__title">
+      <div class="flex list-page__title-filter">
+        <span class="list-page__title-icon">{{far "gauge"}}</span>{{ @intl.dashboards.dashboardsAllViews.layoutView.title }}
+      </div>
+    </div>
   </div>
   <div class="flex-region list-page__list">
     <table class="w-100"><tr>

--- a/src/js/views/patients/schedule/filters_views.js
+++ b/src/js/views/patients/schedule/filters_views.js
@@ -4,7 +4,6 @@ import { View } from 'marionette';
 import 'scss/modules/buttons.scss';
 
 import Droplist from 'js/components/droplist';
-import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
 import './schedule.scss';
 
@@ -12,11 +11,9 @@ const FiltersView = View.extend({
   className: 'schedule__filters',
   template: hbs`
     <div class="schedule__filter" data-group-filter-region></div>
-    <div class="schedule__filter" data-owner-filter-region></div>
   `,
   regions: {
     group: '[data-group-filter-region]',
-    owner: '[data-owner-filter-region]',
   },
 });
 
@@ -33,5 +30,4 @@ const GroupsDropList = Droplist.extend({
 export {
   FiltersView,
   GroupsDropList,
-  OwnerDroplist,
 };

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -32,19 +32,39 @@ const LayoutView = View.extend({
       regionClass: PreloadRegion,
     },
     selectAll: '[data-select-all-region]',
-    title: '[data-title-region]',
+    title: {
+      el: '[data-title-region]',
+      replaceElement: true,
+    },
     dateFilter: '[data-date-filter-region]',
     search: '[data-search-region]',
   },
 });
 
 const ScheduleTitleView = View.extend({
+  regions: {
+    owner: '[data-owner-filter-region]',
+  },
+  className: 'flex list-page__title-filter',
   template: hbs`
-    <span class="list-page__title-icon">{{far "calendar-star"}}</span>{{formatMessage (intlGet "patients.schedule.scheduleViews.scheduleTitleView.title") owner=name}}{{~ remove_whitespace ~}}
-    <span class="list-page__header-icon js-title-info">{{fas "circle-info"}}</span>
+    <span class="list-page__title-icon">{{far "calendar-star"}}</span>
+    {{#if showOwnerDroplist}}
+      <div class="u-text--nowrap">
+        {{ @intl.patients.schedule.scheduleViews.scheduleTitleView.label }}
+      </div>
+      <div data-owner-filter-region></div>
+    {{else}}
+      {{formatMessage (intlGet "patients.schedule.scheduleViews.scheduleTitleView.title") owner=name}}
+    {{/if}}
+    <span class="list-page__header-icon js-title-info">{{far "circle-info"}}</span>
   `,
   ui: {
     tooltip: '.js-title-info',
+  },
+  templateContext() {
+    return {
+      showOwnerDroplist: this.getOption('showOwnerDroplist'),
+    };
   },
   onRender() {
     new Tooltip({

--- a/src/js/views/patients/shared/components/owner-component.scss
+++ b/src/js/views/patients/shared/components/owner-component.scss
@@ -8,6 +8,26 @@
   color: $white;
 }
 
+.owner-component__title-filter-button {
+  align-items: center;
+  color: color(light_blue);
+  display: flex;
+  margin-left: 6px;
+
+  .icon.fa-angle-down {
+    margin-left: 8px;
+    vertical-align: -0.0825em;
+    width: 1em;
+  }
+}
+
+.owner-component__title-filter-name {
+  max-width: 268px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .owner-component--compact {
   max-width: 80px;
   width: 80px;

--- a/src/js/views/patients/shared/components/owner_component.js
+++ b/src/js/views/patients/shared/components/owner_component.js
@@ -13,7 +13,7 @@ import './owner-component.scss';
 const i18n = intl.patients.shared.components.ownerComponent;
 
 const OwnerItemTemplate = hbs`<div>{{matchText name query}} <span class="owner-component__team">{{matchText short query}}</span></div>`;
-const FilterButtonTemplate = hbs`{{far "circle-user"}}<span>{{ name }}</span>{{far "angle-down"}}`;
+const TitleOwnerFilterTemplate = hbs`<div><span class="owner-component__title-filter-name">{{ name }}</span>{{far "angle-down"}}</div>`;
 
 let teamsCollection;
 
@@ -35,16 +35,15 @@ function getGroupClinicians(group) {
 
 export default Droplist.extend({
   isCompact: false,
-  isFilter: false,
   headingText: i18n.headingText,
   placeholderText: i18n.placeholderText,
   hasTeams: true,
   hasCurrentClinician: true,
   popWidth() {
-    const isFilter = this.getOption('isFilter');
     const isCompact = this.getOption('isCompact');
+    const isTitleFilter = this.getOption('isTitleFilter');
 
-    return (isFilter || isCompact) ? null : this.getView().$el.outerWidth();
+    return (isCompact || isTitleFilter) ? null : this.getView().$el.outerWidth();
   },
   picklistOptions() {
     return {
@@ -64,14 +63,7 @@ export default Droplist.extend({
   viewOptions() {
     const icon = { type: 'far', icon: 'circle-user' };
     const isCompact = this.getOption('isCompact');
-    const isFilter = this.getOption('isFilter');
-
-    if (isFilter) {
-      return {
-        className: 'button-filter',
-        template: FilterButtonTemplate,
-      };
-    }
+    const isTitleFilter = this.getOption('isTitleFilter');
 
     if (isCompact) {
       const selected = this.getState('selected');
@@ -83,6 +75,13 @@ export default Droplist.extend({
           attr: isTeam ? 'short' : 'name',
           icon,
         },
+      };
+    }
+
+    if (isTitleFilter) {
+      return {
+        className: 'owner-component__title-filter-button',
+        template: TitleOwnerFilterTemplate,
       };
     }
 

--- a/src/js/views/patients/worklist/filters_views.js
+++ b/src/js/views/patients/worklist/filters_views.js
@@ -11,12 +11,10 @@ const FiltersView = View.extend({
   className: 'worklist-list__filters',
   template: hbs`
     <div class="worklist-list__filter" data-group-filter-region></div>
-    <div class="worklist-list__filter" data-owner-filter-region></div>
     <div class="worklist-list__filter" data-owner-toggle-region></div>
   `,
   regions: {
     group: '[data-group-filter-region]',
-    owner: '[data-owner-filter-region]',
     ownerToggle: '[data-owner-toggle-region]',
   },
 });

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -40,7 +40,10 @@ const LayoutView = View.extend({
       regionClass: PreloadRegion,
     },
     selectAll: '[data-select-all-region]',
-    title: '[data-title-region]',
+    title: {
+      el: '[data-title-region]',
+      replaceElement: true,
+    },
     search: '[data-search-region]',
   },
   childViewEvents: {
@@ -114,9 +117,21 @@ const TypeToggleView = View.extend({
 });
 
 const ListTitleView = View.extend({
+  regions: {
+    owner: '[data-owner-filter-region]',
+  },
+  className: 'flex list-page__title-filter',
   template: hbs`
-    <span class="list-page__title-icon">{{far "list"}}</span>{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId team=team owner=owner}}{{~ remove_whitespace ~}}
-    <span class="list-page__header-icon js-title-info">{{fas "circle-info"}}</span>
+    <span class="list-page__title-icon">{{far "list"}}</span>
+    {{#if showOwnerDroplist}}
+      <div class="u-text--nowrap">
+        {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listLabels") title=worklistId}}
+      </div>
+      <div data-owner-filter-region></div>
+    {{else}}
+      {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId team=team owner=owner}}
+    {{/if}}
+    <span class="list-page__header-icon js-title-info">{{far "circle-info"}}</span>
   `,
   ui: {
     tooltip: '.js-title-info',
@@ -127,6 +142,7 @@ const ListTitleView = View.extend({
       owner: this.getOption('owner').get('name'),
       worklistId: underscored(this.getOption('worklistId')),
       isFlowList: this.getOption('isFlowList'),
+      showOwnerDroplist: this.getOption('showOwnerDroplist'),
     };
   },
   onRender() {

--- a/src/js/views/programs/programs-all_views.js
+++ b/src/js/views/programs/programs-all_views.js
@@ -42,7 +42,11 @@ const LayoutView = View.extend({
   className: 'flex-region',
   template: hbs`
     <div class="list-page__header">
-      <div class="list-page__title"><span class="list-page__title-icon">{{far "screwdriver-wrench"}}</span>{{ @intl.programs.programsAllViews.layoutView.title }}</div>
+      <div class="flex list-page__title">
+        <div class="flex list-page__title-filter">
+          <span class="list-page__title-icon">{{far "screwdriver-wrench"}}</span>{{ @intl.programs.programsAllViews.layoutView.title }}
+        </div>
+      </div>
       <button class="u-margin--b-16 button-primary js-add">{{far "circle-plus"}}<span>{{ @intl.programs.programsAllViews.addProgramBtn }}</span></button>
     </div>
     <div class="flex-region list-page__list">

--- a/src/scss/modules/list-pages.scss
+++ b/src/scss/modules/list-pages.scss
@@ -5,7 +5,7 @@
 .list-page__header-icon {
   color: $black-60;
   font-size: 16px;
-  margin-left: 8px;
+  margin-left: 16px;
   vertical-align: bottom;
 }
 
@@ -15,18 +15,24 @@
 }
 
 .list-page__title {
+  align-items: center;
   border-bottom: 1px solid $black-90;
   font-size: 24px;
   margin-bottom: 16px;
   padding-bottom: 16px;
 }
 
+.list-page__title-filter {
+  align-items: center;
+  margin-right: 16px;
+}
+
 .list-page__title-icon {
   margin-right: 16px;
-  vertical-align: bottom;
 
   .icon {
     font-size: 20px;
+    vertical-align: middle;
   }
 }
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -221,8 +221,7 @@ context('schedule page', function() {
       .should('contain', 'Test Patient');
 
     cy
-      .get('[data-filters-region]')
-      .find('[data-owner-filter-region]')
+      .get('[data-owner-filter-region]')
       .click();
 
     cy
@@ -236,8 +235,7 @@ context('schedule page', function() {
       .should('not.exist');
 
     cy
-      .get('[data-filters-region]')
-      .find('[data-owner-filter-region]')
+      .get('[data-owner-filter-region]')
       .click();
 
     cy
@@ -364,9 +362,7 @@ context('schedule page', function() {
     cy.clock(testTime, ['Date']);
 
     cy
-      .get('[data-filters-region]')
-      .as('filterRegion')
-      .find('[data-owner-filter-region]')
+      .get('[data-owner-filter-region]')
       .click();
 
     cy
@@ -391,7 +387,8 @@ context('schedule page', function() {
       .should('contain', 'filter[clinician]=test-id');
 
     cy
-      .get('@filterRegion')
+      .get('[data-filters-region]')
+      .as('filterRegion')
       .find('[data-group-filter-region]')
       .click();
 
@@ -627,7 +624,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-owner-filter-region]')
-      .should('be.empty');
+      .should('not.exist');
   });
 
   specify('reduced patient schedule employee', function() {
@@ -731,6 +728,10 @@ context('schedule page', function() {
       .get('@worklists')
       .find('.app-nav__link')
       .should('have.length', 1);
+
+    cy
+      .get('[data-owner-filter-region]')
+      .should('not.exist');
 
     cy
       .get('[data-select-all-region]')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1854,7 +1854,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-owner-filter-region]')
-      .should('be.empty');
+      .should('not.exist');
   });
 
   specify('restricted employee -  shared by', function() {
@@ -1904,7 +1904,13 @@ context('worklist page', function() {
 
     cy
       .get('.list-page__title')
-      .should('contain', 'Shared By Nurse Team');
+      .should('contain', 'Shared By');
+
+    cy
+      .get('[data-owner-filter-region]')
+      .find('button')
+      .should('contain', 'Nurse')
+      .click();
 
     cy
       .get('[data-date-filter-region]')
@@ -1915,12 +1921,6 @@ context('worklist page', function() {
       .should('be.empty');
 
     cy
-      .get('[data-owner-filter-region]')
-      .find('button')
-      .should('contain', 'Nurse')
-      .click();
-
-    cy
       .get('.picklist')
       .find('.js-picklist-item')
       .contains('Pharmacist')
@@ -1928,7 +1928,12 @@ context('worklist page', function() {
 
     cy
       .get('.list-page__title')
-      .should('contain', 'Shared By Pharmacist Team');
+      .should('contain', 'Shared By');
+
+    cy
+      .get('[data-owner-filter-region]')
+      .find('button')
+      .should('contain', 'Pharmacist');
 
     cy
       .wait('@routeFlows')
@@ -1944,7 +1949,12 @@ context('worklist page', function() {
 
     cy
       .get('.list-page__title')
-      .should('contain', 'Shared By Pharmacist Team');
+      .should('contain', 'Shared By');
+
+    cy
+      .get('[data-owner-filter-region]')
+      .find('button')
+      .should('contain', 'Pharmacist');
   });
 
   specify('flow sorting', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-31233]

Move the clinician filter to the header for all worklist and schedule pages.

![Screen Shot 2022-10-07 at 9 45 33 AM](https://user-images.githubusercontent.com/35355575/194581385-8fc3adef-d9fb-4089-a2fc-d554adb82111.png)

