### PR TITLE
Change "Last Active" to "Last Sign In" in the /clinicians page table header

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -16,7 +16,7 @@ careOptsFrontend:
         attributesHeader: State, Role, Team
         clinicianHeader: Clinician
         groupsHeader: Groups
-        lastActiveHeader: Last Active
+        lastActiveHeader: Last Sign In
         title: Clinicians
     shared:
       clinicianViews:

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -60,7 +60,7 @@ context('clinicians list', function() {
       .next()
       .should('contain', 'Role, Team')
       .next()
-      .should('contain', 'Last Active');
+      .should('contain', 'Last Sign In');
 
     cy
       .get('.table-list')


### PR DESCRIPTION
Shortcut Story ID: [sc-31453]

We used to keep track of the date of a clinician's last action (whenever they made a request). And we'd use that to display a "Last Active" date on the `/clinicians` page.

But now we only track the last time the clinician has signed in. Therefore, we need to switch the wording to "Last Sign In" to indicate what we're actually tracking.