### PR TITLE
Fix picklist checkmark alignment

### DIFF
--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -59,7 +59,7 @@ const PicklistItem = View.extend({
   tagName: 'li',
   itemTemplate: hbs`
     <div class="flex-grow">{{#if icon}}{{fa icon.type icon.icon classes=icon.classes}}{{/if}}<span>{{matchText text query}}</span></div>
-    <div>{{#if isChecked}}{{fas "circle-check" classes="u-icon--12 u-margin--l-16"}}{{/if}}</div>
+    {{#if isChecked}}{{fas "check" classes="u-icon--12 u-margin--l-16"}}{{/if}}
   `,
   itemClassName() {
     const classNames = [];

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -54,6 +54,11 @@
   .icon:first-child {
     margin-right: 8px;
   }
+
+  .icon.fa-check {
+    margin-left: auto;
+    margin-right: 0;
+  }
 }
 
 .picklist--no-results {

--- a/src/js/views/patients/shared/components/date-filter/date-filter_views.js
+++ b/src/js/views/patients/shared/components/date-filter/date-filter_views.js
@@ -188,7 +188,7 @@ const LayoutView = View.extend({
 
 const DateRanges = Picklist.extend({
   className: 'date-filter__ranges',
-  itemTemplate: hbs`{{formatMessage (intlGet "patients.shared.components.dateFilterComponent.relativeDate") relativeTo=id}}{{#if isSelected}}{{fas "check" classes="u-float--right"}}{{/if}}`,
+  itemTemplate: hbs`{{formatMessage (intlGet "patients.shared.components.dateFilterComponent.relativeDate") relativeTo=id}}{{#if isSelected}}{{fas "check"}}{{/if}}`,
   itemTemplateContext() {
     return {
       isSelected: this.model === this.state.get('selected'),

--- a/test/integration/components/droplist.js
+++ b/test/integration/components/droplist.js
@@ -210,7 +210,7 @@ context('Droplist', function() {
       .find('.js-picklist-item')
       .first()
       .find('.icon')
-      .should('have.class', 'fa-circle-check');
+      .should('have.class', 'fa-check');
 
     cy
       .get('.picklist')


### PR DESCRIPTION
Shortcut Story ID: [sc-31509]

Fixes alignment for the checkmark that's used for some picklist items.

Sets the right alignment of checkmarks on selected `Filter by Date...` picklist items:

![Screen Shot 2022-10-11 at 1 37 19 PM (1)](https://user-images.githubusercontent.com/35355575/196334673-4b746bd7-afa4-4eb6-97fd-7a0cf91cc628.png)

And fixes the vertical alignment for the checkmark used for the `Save + Go Back` form button droplist:

![Screen Shot 2022-10-17 at 11 22 22 PM](https://user-images.githubusercontent.com/35355575/196334924-d799066e-005e-45db-9685-c1adc3e84489.png)

Also, the fontawesome icon for this button was changed from `circle-check` to `check`.
