### PR TITLE
Use work:own permission for owner filtering

### DIFF
--- a/src/js/entities-service/entities/groups.js
+++ b/src/js/entities-service/entities/groups.js
@@ -9,14 +9,14 @@ const TYPE = 'groups';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/groups',
-  getActiveClinicians() {
+  getAssignableClinicians() {
     const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
 
-    const activeClinicians = clinicians.filter(clinician => {
-      return clinician.isActive() && clinician.get('enabled');
+    const assignableClinicians = clinicians.filter(clinician => {
+      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
     });
 
-    clinicians.reset(activeClinicians);
+    clinicians.reset(assignableClinicians);
 
     return clinicians;
   },

--- a/src/js/views/patients/shared/components/owner_component.js
+++ b/src/js/views/patients/shared/components/owner_component.js
@@ -29,7 +29,7 @@ let groupCache = {};
 
 function getGroupClinicians(group) {
   if (groupCache[group.id]) return groupCache[group.id];
-  groupCache[group.id] = group.getActiveClinicians();
+  groupCache[group.id] = group.getAssignableClinicians();
   return groupCache[group.id];
 }
 

--- a/test/fixtures/config/clinicians.js
+++ b/test/fixtures/config/clinicians.js
@@ -7,7 +7,6 @@ module.exports = {
       id: faker.datatype.uuid(),
       name: faker.name.findName(),
       email: faker.internet.email(),
-      role: faker.random.arrayElement(['employee', 'manager']),
       enabled: true,
       last_active_at: faker.date.between(
         dayjs().subtract(1, 'week').format(),

--- a/test/fixtures/test/clinicians.json
+++ b/test/fixtures/test/clinicians.json
@@ -2,7 +2,6 @@
   {
     "id": "11111",
     "name": "Clinician McTester",
-    "role": "manager",
     "enabled": true,
     "last_active_at": "2021-10-18T04:25:22.961Z"
   }

--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -60,7 +60,8 @@
       "work:authored:delete",
       "work:manage",
       "work:owned:manage",
-      "app:schedule:reduced"
+      "app:schedule:reduced",
+      "work:own"
     ]
   },
   {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -938,6 +938,10 @@ context('worklist page', function() {
           fx.data[2].attributes.name = 'A Clinician';
           fx.data[3].id = '3';
           fx.data[3].attributes.name = 'B Clinician';
+          // NOTE: fx.data[4] is the current clinician
+          fx.data[5].id = '5';
+          fx.data[5].attributes.name = 'Admin Clinician';
+          fx.data[5].relationships.role.data.id = '22222';
 
           return fx;
         })
@@ -958,6 +962,11 @@ context('worklist page', function() {
       .get('[data-owner-filter-region]')
       .should('contain', 'Clinician McTester')
       .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group .js-picklist-item')
+      .should('not.contain', 'Admin Clinician');
 
     cy
       .get('.picklist')

--- a/test/support/api/groups.js
+++ b/test/support/api/groups.js
@@ -11,6 +11,7 @@ function makeResources(groups, clinicians, fxPatients, fxTeams) {
     const teamIndex = (i >= fxTeams.length) ? i - fxTeams.length : i;
     const team = getRelationship(fxTeams[teamIndex], 'teams');
     clinician.relationships.team = { data: team };
+    clinician.relationships.role = { data: { id: '11111', type: 'roles' } };
   });
 
   mutateGroup(groups[0], clinicians, fxPatients);


### PR DESCRIPTION
Shortcut Story ID: [sc-31667]

Moves from role based filtering to permission based filtering for the owner droplist.

Also a bit of clean up from the last role change in the tests is included