### PR TITLE
Move worklist no owner button to the list title section

### DIFF
--- a/src/js/apps/patients/worklist/filters_app.js
+++ b/src/js/apps/patients/worklist/filters_app.js
@@ -6,7 +6,7 @@ import App from 'js/base/app';
 
 import AllFiltersApp from 'js/apps/patients/sidebar/filters-sidebar_app';
 
-import { FiltersView, GroupsDropList, NoOwnerToggleView, AllFiltersButtonView } from 'js/views/patients/worklist/filters_views';
+import { FiltersView, GroupsDropList, AllFiltersButtonView } from 'js/views/patients/worklist/filters_views';
 
 const i18n = intl.patients.worklist.filtersApp;
 
@@ -17,10 +17,9 @@ export default App.extend({
   stateEvents: {
     'change:groupId': 'showGroupsFilterView',
   },
-  onStart({ shouldShowOwnerToggle }) {
+  onStart() {
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
-    this.shouldShowOwnerToggle = shouldShowOwnerToggle;
     this.groups = currentClinician.getGroups();
 
     this.showView(new FiltersView());
@@ -29,7 +28,6 @@ export default App.extend({
   showFilters() {
     this.showAllFiltersButtonView();
     this.showGroupsFilterView();
-    this.showOwnerToggleView();
   },
   showAllFiltersButtonView() {
     if (this.groups.length < 2) return;
@@ -77,17 +75,6 @@ export default App.extend({
     });
 
     this.showChildView('group', groupsFilter);
-  },
-  showOwnerToggleView() {
-    if (!this.shouldShowOwnerToggle || !this.canViewAssignedActions) return;
-
-    const ownerView = this.showChildView('ownerToggle', new NoOwnerToggleView({
-      model: this.getState(),
-    }));
-
-    this.listenTo(ownerView, 'click', () => {
-      this.toggleState('noOwner');
-    });
   },
   _getGroups() {
     const groups = this.groups.clone();

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -19,7 +19,7 @@ import DateFilterComponent from 'js/views/patients/shared/components/date-filter
 import SearchComponent from 'js/views/shared/components/list-search';
 import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
-import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, sortCreatedOptions, sortDueOptions, sortPatientOptions, sortUpdateOptions } from 'js/views/patients/worklist/worklist_views';
+import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, sortCreatedOptions, sortDueOptions, sortPatientOptions, sortUpdateOptions, NoOwnerToggleView } from 'js/views/patients/worklist/worklist_views';
 import { BulkEditButtonView, BulkEditFlowsSuccessTemplate, BulkEditActionsSuccessTemplate, BulkDeleteFlowsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 
 const i18n = intl.patients.worklist.filtersApp;
@@ -133,7 +133,6 @@ export default App.extend({
   startFiltersApp() {
     const filtersApp = this.startChildApp('filters', {
       state: this.getState().getFilters(),
-      shouldShowOwnerToggle: this.getState().id === 'shared-by',
     });
 
     this.listenTo(filtersApp.getState(), 'change', ({ attributes }) => {
@@ -316,6 +315,19 @@ export default App.extend({
             this.setState({ filters: { ...filters, clinicianId: id, teamId: null } });
           }
         },
+      });
+    }
+
+    const shouldShowOwnerToggle = this.getState().id === 'shared-by' && this.canViewAssignedActions;
+
+    if (shouldShowOwnerToggle) {
+      const ownerToggleView = listTitleView.showChildView('ownerToggle', new NoOwnerToggleView({
+        model: new Backbone.Model(filters),
+      }));
+
+      this.listenTo(ownerToggleView, 'click', () => {
+        const noOwner = this.getState().getFilters().noOwner;
+        this.setState({ filters: { ...filters, noOwner: !noOwner } });
       });
     }
   },

--- a/src/js/views/patients/worklist/filters_views.js
+++ b/src/js/views/patients/worklist/filters_views.js
@@ -40,23 +40,8 @@ const GroupsDropList = Droplist.extend({
   },
 });
 
-const NoOwnerToggleView = View.extend({
-  template: hbs`
-    <button class="button-filter-toggle {{#if noOwner}}button--blue{{/if}}">
-      {{ @intl.patients.worklist.filtersViews.noOwnerToggleView.noOwner }}{{#if noOwner}}{{far "xmark"}}{{/if}}
-    </button>
-  `,
-  modelEvents: {
-    'change:noOwner': 'render',
-  },
-  triggers: {
-    click: 'click',
-  },
-});
-
 export {
   FiltersView,
   AllFiltersButtonView,
   GroupsDropList,
-  NoOwnerToggleView,
 };

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -116,9 +116,24 @@ const TypeToggleView = View.extend({
   },
 });
 
+const NoOwnerToggleView = View.extend({
+  template: hbs`
+    <button class="button-filter-toggle {{#if noOwner}}button--blue{{/if}}">
+      {{ @intl.patients.worklist.filtersViews.noOwnerToggleView.noOwner }}{{#if noOwner}}{{far "xmark"}}{{/if}}
+    </button>
+  `,
+  modelEvents: {
+    'change:noOwner': 'render',
+  },
+  triggers: {
+    click: 'click',
+  },
+});
+
 const ListTitleView = View.extend({
   regions: {
     owner: '[data-owner-filter-region]',
+    ownerToggle: '[data-owner-toggle-region]',
   },
   className: 'flex list-page__title-filter',
   template: hbs`
@@ -132,7 +147,8 @@ const ListTitleView = View.extend({
       {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId team=team owner=owner}}
     {{/if}}
     <span class="list-page__header-icon js-title-info">{{far "circle-info"}}</span>
-  `,
+    <div class="u-margin--l-24" data-owner-toggle-region></div>
+    `,
   ui: {
     tooltip: '.js-title-info',
   },
@@ -354,4 +370,5 @@ export {
   sortDueOptions,
   sortPatientOptions,
   sortUpdateOptions,
+  NoOwnerToggleView,
 };

--- a/src/js/views/shared/components/list-search/list-search-component.scss
+++ b/src/js/views/shared/components/list-search/list-search-component.scss
@@ -1,5 +1,6 @@
 .list-search__container {
   position: relative;
+  width: 166px;
 
   &.is-disabled {
     .icon {


### PR DESCRIPTION
Shortcut Story ID: [sc-31691]

Move the `No Owner` button on the `Shared By` worklist to the list title section. Screenshot shown below.

To make room for this element, the `Filter in List...` input was reduced to a width of `166px`. 

![Screen Shot 2022-10-24 at 9 20 47 AM](https://user-images.githubusercontent.com/35355575/197548965-61154c43-6213-46fe-869f-537fdcf6ef46.png)
