### PR TITLE
Add custom filters to worklist/schedule filters sidebar

### DIFF
--- a/src/js/apps/patients/schedule/filters_app.js
+++ b/src/js/apps/patients/schedule/filters_app.js
@@ -27,7 +27,9 @@ export default App.extend({
     this.showGroupsFilterView();
   },
   showAllFiltersButtonView() {
-    if (this.groups.length < 2) return;
+    const directories = Radio.request('bootstrap', 'currentOrg:directories');
+
+    if (!directories.length) return;
 
     const ownerView = this.showChildView('allFilters', new AllFiltersButtonView());
 
@@ -54,6 +56,10 @@ export default App.extend({
 
     this.listenTo(sidebar, 'stop', () => {
       this.trigger('toggle:filtersSidebar', false);
+    });
+
+    this.listenTo(sidebar, 'reset:filters:state', () => {
+      this.trigger('reset:filters:state');
     });
   },
   showGroupsFilterView() {

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -202,6 +202,10 @@ export default App.extend({
     this.listenTo(filtersApp, 'toggle:filtersSidebar', isSidebarOpen => {
       this.setState('isFiltering', isSidebarOpen);
     });
+
+    this.listenTo(filtersApp, 'reset:filters:state', () => {
+      this.getState().resetFilters();
+    });
   },
   showDateFilter() {
     const dateTypes = ['due_date'];

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -1,4 +1,4 @@
-import { clone, extend, keys, omit, reduce } from 'underscore';
+import { clone, extend, keys, omit, reduce, each } from 'underscore';
 import store from 'store';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
@@ -41,6 +41,9 @@ export default Backbone.Model.extend({
   getFilters() {
     return clone(this.get('filters'));
   },
+  resetFilters() {
+    this.set('filters', this.defaults().filters);
+  },
   getDateFilters() {
     return clone(this.get('dateFilters'));
   },
@@ -73,6 +76,8 @@ export default Backbone.Model.extend({
     };
   },
   getEntityFilter() {
+    const customFilters = omit(this.getFilters(), 'groupId', 'clinicianId');
+
     const { groupId, clinicianId } = this.getFilters();
     const group = groupId || this.groups.pluck('id').join(',');
     const status = [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(',');
@@ -84,6 +89,12 @@ export default Backbone.Model.extend({
       status,
       group,
     }, dateFilter);
+
+    each(customFilters, (selected, slug) => {
+      if (selected === null) return;
+
+      filters[`@${ slug }`] = selected;
+    });
 
     return filters;
   },

--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -2,43 +2,44 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import { LayoutView, GroupsFilterView } from 'js/views/patients/sidebar/filters/filters-sidebar_views';
+import { LayoutView, CustomFiltersView, groupLabelView } from 'js/views/patients/sidebar/filters/filters-sidebar_views';
 
 export default App.extend({
-  stateEvents: {
-    'change': 'onChangeFilters',
-  },
-  onStart({ state }) {
+  onStart({ state }, directories) {
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
+    this.directories = Radio.request('bootstrap', 'currentOrg:directories');
 
     this.showView(new LayoutView());
 
-    this.showGroupsFilterView();
+    this.showCustomFiltersView();
   },
   viewEvents: {
     'close': 'stop',
     'click:clear:filters': 'onClearFilters',
   },
-  onChangeFilters() {
-    this.showGroupsFilterView();
-  },
-  showGroupsFilterView() {
+  showCustomFiltersView() {
+    const collection = this.directories.clone();
     const groups = this.currentClinician.getGroups();
 
-    const groupsFilterView = new GroupsFilterView({
-      groups,
-      groupId: this.getState('groupId'),
+    if (groups.length > 1) {
+      const groupDirectory = collection.unshift({
+        name: groupLabelView,
+        slug: 'groupId',
+      });
+
+      groupDirectory.options = groups;
+    }
+
+    const customFiltersView = new CustomFiltersView({
+      collection,
+      state: this.getState(),
     });
 
-    this.listenTo(groupsFilterView, 'select:group', this.onSelectGroup);
-
-    this.showChildView('groups', groupsFilterView);
+    this.showChildView('customFilters', customFiltersView);
   },
   onClearFilters() {
-    this.setState('groupId', null);
-  },
-  onSelectGroup(id) {
-    this.setState('groupId', id);
+    this.getState().clear();
+    this.triggerMethod('reset:filters:state');
   },
   onStop() {
     Radio.request('sidebar', 'close');

--- a/src/js/apps/patients/worklist/filters_app.js
+++ b/src/js/apps/patients/worklist/filters_app.js
@@ -32,7 +32,9 @@ export default App.extend({
     this.showOwnerToggleView();
   },
   showAllFiltersButtonView() {
-    if (this.groups.length < 2) return;
+    const directories = Radio.request('bootstrap', 'currentOrg:directories');
+
+    if (!directories.length) return;
 
     const ownerView = this.showChildView('allFilters', new AllFiltersButtonView());
 
@@ -59,6 +61,10 @@ export default App.extend({
 
     this.listenTo(sidebar, 'stop', () => {
       this.trigger('toggle:filtersSidebar', false);
+    });
+
+    this.listenTo(sidebar, 'reset:filters:state', () => {
+      this.trigger('reset:filters:state');
     });
   },
   showGroupsFilterView() {

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -143,6 +143,10 @@ export default App.extend({
     this.listenTo(filtersApp, 'toggle:filtersSidebar', isSidebarOpen => {
       this.setState('isFiltering', isSidebarOpen);
     });
+
+    this.listenTo(filtersApp, 'reset:filters:state', () => {
+      this.getState().resetFilters();
+    });
   },
   toggleBulkSelect() {
     this.selected = this.getState().getSelected(this.filteredCollection);

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -1,4 +1,4 @@
-import { clone, extend, keys, omit, reduce } from 'underscore';
+import { clone, extend, keys, omit, reduce, each } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
@@ -62,6 +62,9 @@ export default Backbone.Model.extend({
   getFilters() {
     return clone(this.get('filters'));
   },
+  resetFilters() {
+    this.set('filters', this.defaults().filters);
+  },
   getType() {
     return this.get('listType');
   },
@@ -107,6 +110,8 @@ export default Backbone.Model.extend({
     };
   },
   getEntityFilter() {
+    const customFilters = omit(this.getFilters(), 'groupId', 'clinicianId', 'teamId', 'noOwner');
+
     const { groupId, clinicianId, teamId, noOwner } = this.getFilters();
     const group = groupId || this.groups.pluck('id').join(',');
     const status = [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(',');
@@ -144,6 +149,12 @@ export default Backbone.Model.extend({
     } else {
       filters[this.id].clinician = clinicianId;
     }
+
+    each(customFilters, (selected, slug) => {
+      if (selected === null) return;
+
+      filters[this.id][`@${ slug }`] = selected;
+    });
 
     return filters[this.id];
   },

--- a/src/js/entities-service/directories.js
+++ b/src/js/entities-service/directories.js
@@ -13,7 +13,7 @@ const Entity = BaseEntity.extend({
     return model.fetch({ data: query });
   },
   fetchFilterable() {
-    const data = { filterable: true };
+    const data = { filter: { filterable: true } };
 
     return this.fetchCollection({ data });
   },

--- a/src/js/entities-service/entities/directories.js
+++ b/src/js/entities-service/entities/directories.js
@@ -1,3 +1,5 @@
+import { map } from 'underscore';
+
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
@@ -7,6 +9,20 @@ const Model = BaseModel.extend({
   type: TYPE,
   url() {
     return `/api/directory/${ this.get('slug') }`;
+  },
+  getOptions() {
+    if (this.options) return this.options;
+
+    const options = map(this.get('value'), value => {
+      return {
+        name: value,
+        id: value,
+      };
+    });
+
+    this.options = new BaseCollection(options);
+
+    return this.options;
   },
 });
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -479,8 +479,10 @@ careOptsFrontend:
             }
           stateLabel: Share State
       filters:
-        groups:
-          droplistLabel: Group
+        filtersSidebarViews:
+          customFilterView:
+            defaultText: All
+          groupLabelView: Group
       flow:
         activityViews:
           clinicianAssigned: '<strong>{ name }</strong> ({ team }) changed the Owner to { to_name }'

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -13,6 +13,7 @@ export default App.extend({
     'currentOrg': 'getCurrentOrg',
     'currentOrg:setting': 'getOrgSetting',
     'currentOrg:roles': 'getOrgRoles',
+    'currentOrg:directories': 'getOrgDirectories',
     'sidebarWidgets': 'getSidebarWidgets',
     'sidebarWidgets:fields': 'getSidebarWidgetFields',
     'fetch': 'fetchBootstrap',
@@ -34,6 +35,9 @@ export default App.extend({
     });
 
     return Radio.request('entities', 'roles:collection', activeRoles);
+  },
+  getOrgDirectories() {
+    return this.getCurrentOrg().get('directories');
   },
   getCurrentOrg() {
     return this.currentOrg;
@@ -57,14 +61,15 @@ export default App.extend({
       Radio.request('entities', 'fetch:states:collection'),
       Radio.request('entities', 'fetch:forms:collection'),
       Radio.request('entities', 'fetch:settings:model'),
+      Radio.request('entities', 'fetch:directories:filterable'),
       Radio.request('entities', 'fetch:groups:collection'),
       Radio.request('entities', 'fetch:clinicians:collection'),
       Radio.request('entities', 'fetch:widgets:collection'),
     ];
   },
-  onStart(options, [currentUser], [teams], [roles], [states], [forms], [settings]) {
+  onStart(options, [currentUser], [teams], [roles], [states], [forms], [settings], [directories]) {
     this.currentUser = currentUser;
-    this.currentOrg.set({ states, teams, forms, settings, roles });
+    this.currentOrg.set({ states, teams, forms, settings, roles, directories });
     this.bootstrapPromise.resolve(currentUser);
   },
   onFail(options, ...args) {

--- a/src/js/views/patients/schedule/layout.hbs
+++ b/src/js/views/patients/schedule/layout.hbs
@@ -5,7 +5,7 @@
   </div>
   <div class="list-page__filters flex">
     <div class="flex u-margin--r-24" data-select-all-region></div>
-    <div class="w-100" data-filters-region></div>
+    <div class="flex flex-align-center w-100" data-filters-region></div>
     <div class="flex u-text--nowrap" data-date-filter-region></div>
   </div>
   <table class="w-100" data-table-region></table>

--- a/src/js/views/patients/sidebar/filters/filters-sidebar.hbs
+++ b/src/js/views/patients/sidebar/filters/filters-sidebar.hbs
@@ -10,5 +10,6 @@
   </div>
   <div class="u-margin--t-32">
     <div data-groups-region></div>
+    <div data-custom-filters-region></div>
   </div>
 </div>

--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -6,7 +6,7 @@
   </div>
   <div class="list-page__filters flex">
     <div class="flex u-margin--r-24" data-select-all-region></div>
-    <div class="worklist-list__filter-region" data-filters-region></div>
+    <div class="flex flex-align-center w-100" data-filters-region></div>
     <div class="flex">
       <span class="u-margin--r-16 u-text--nowrap" data-date-filter-region></span>
       <span class="worklist-list__filter-sort" data-sort-region></span>

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -87,10 +87,6 @@
   width: 43%;
 }
 
-.worklist-list__filter-region {
-  width: 100%;
-}
-
 .worklist-list__filter-sort .fa-arrow-down-arrow-up {
   margin-right: 8px;
 }

--- a/src/scss/modules/sidebar.scss
+++ b/src/scss/modules/sidebar.scss
@@ -45,6 +45,7 @@
   display: inline-block;
   font-size: 12px;
   font-weight: 600;
+  line-height: 1.2;
   margin-right: 8px;
   width: 84px;
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-31235]

Configure the filters sidebar to show a variable number (1 or more) of custom filters. These are set specifically for each org and are retrieved via the `/api/directories?filter[filterable]=true` api route.