### PR TITLE
Add icon margin to the loading version of the add patient action/flow button

### DIFF
--- a/src/js/views/patients/patient/dashboard/layout.hbs
+++ b/src/js/views/patients/patient/dashboard/layout.hbs
@@ -8,7 +8,10 @@
 </div>
 <div class="patient__actions" data-add-workflow-region>
   <span class="button-primary">
-    <span class="js-loading">{{far "circle-plus"}}{{ @intl.patients.patient.dashboard.dashboardViews.actionLoading }}</span>
+    <span class="js-loading">
+      {{far "circle-plus"}}
+      <span>{{ @intl.patients.patient.dashboard.dashboardViews.actionLoading }}</span>
+    </span>
   </span>
 </div>
 <div data-content-region></div>


### PR DESCRIPTION
Shortcut Story ID: [sc-31965]

This applies the the `Loading...` version of the `Add` button on the patient dashboard page.

Before:

![Screen Shot 2022-10-31 at 4 26 48 PM (1)](https://user-images.githubusercontent.com/35355575/199264106-9df13269-8942-4d30-b295-c138eb698b0e.png)

After:

![Screen Shot 2022-10-31 at 5 05 49 PM](https://user-images.githubusercontent.com/35355575/199264166-a6beedcd-ae51-4610-a4cf-81fcf81f5340.png)
