### PR TITLE
Fix alignment on worklist/schedule owner title button

### DIFF
--- a/src/js/views/patients/shared/components/owner-component.scss
+++ b/src/js/views/patients/shared/components/owner-component.scss
@@ -12,7 +12,8 @@
   align-items: center;
   color: color(light_blue);
   display: flex;
-  margin-left: 6px;
+  line-height: 1;
+  margin-left: 8px;
 
   .icon.fa-angle-down {
     margin-left: 8px;


### PR DESCRIPTION
Shortcut Story ID: [sc-31948]

Pertains to the alignment between the `Owned By` label and owner component button in the screenshot below.


![Screen Shot 2022-11-01 at 10 25 42 AM](https://user-images.githubusercontent.com/35355575/199271282-f4e2396b-ff13-4776-8bb2-94b566f895a6.png)
