### PR TITLE
Custom filter sidebar tweaks

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -480,6 +480,8 @@ careOptsFrontend:
           stateLabel: Share State
       filters:
         filtersSidebarViews:
+          customFilterDropList:
+            headingText: Filter by
           customFilterView:
             defaultText: All
           groupLabelView: Group

--- a/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
+++ b/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
@@ -15,7 +15,9 @@ import FiltersSidebarTemplate from './filters-sidebar.hbs';
 
 import './filters-sidebar.scss';
 
-const groupLabelView = intl.patients.sidebar.filters.filtersSidebarViews.groupLabelView;
+const i18n = intl.patients.sidebar.filters.filtersSidebarViews;
+
+const groupLabelView = i18n.groupLabelView;
 
 const CustomFilterDropList = Droplist.extend({
   popWidth() {
@@ -25,8 +27,13 @@ const CustomFilterDropList = Droplist.extend({
     className: 'button-secondary w-100',
     template: hbs`{{ name }}`,
   },
-  picklistOptions: {
-    attr: 'name',
+  picklistOptions() {
+    return {
+      itemTemplate: hbs`<div>{{matchText name query}}</div>`,
+      isSelectlist: true,
+      headingText: i18n.customFilterDropList.headingText,
+      placeholderText: `${ this.getOption('filterTitle') }...`,
+    };
   },
 });
 
@@ -52,6 +59,7 @@ const CustomFilterView = View.extend({
     const customFilter = new CustomFilterDropList({
       collection: options,
       state: { selected },
+      filterTitle: this.model.get('name'),
     });
 
     this.listenTo(customFilter.getState(), 'change:selected', (state, { id }) => {
@@ -65,7 +73,7 @@ const CustomFilterView = View.extend({
 
     options.unshift({
       id: null,
-      name: intl.patients.sidebar.filters.filtersSidebarViews.customFilterView.defaultText,
+      name: i18n.customFilterView.defaultText,
     });
 
     return options;

--- a/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
+++ b/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
@@ -29,7 +29,7 @@ const CustomFilterDropList = Droplist.extend({
   },
   picklistOptions() {
     return {
-      itemTemplate: hbs`<div>{{matchText name query}}</div>`,
+      attr: 'name',
       isSelectlist: true,
       headingText: i18n.customFilterDropList.headingText,
       placeholderText: `${ this.getOption('filterTitle') }...`,
@@ -86,6 +86,9 @@ const CustomFiltersView = CollectionView.extend({
     return {
       state: this.getOption('state'),
     };
+  },
+  viewComparator({ model }) {
+    return String(model.get('name')).toLowerCase();
   },
 });
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -687,6 +687,11 @@ context('schedule page', function() {
       .click();
 
     cy
+      .get('.picklist')
+      .find('.js-input')
+      .should('have.attr', 'placeholder', 'Group...');
+
+    cy
       .get('.picklist__item')
       .contains('All')
       .click()
@@ -721,6 +726,11 @@ context('schedule page', function() {
       .find('[data-filter-button]')
       .eq(1)
       .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-input')
+      .should('have.attr', 'placeholder', 'Insurance Plans...');
 
     cy
       .get('.picklist__item')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -620,16 +620,28 @@ context('schedule page', function() {
       })
       .routeGroupsBootstrap(_.identity, testGroups)
       .routeDirectories(fx => {
-        fx.data = [{
-          attributes: {
-            name: 'Insurance Plans',
-            slug: 'insurance',
-            value: [
-              'BCBS PPO 100',
-              'Medicare',
-            ],
+        fx.data = [
+          {
+            attributes: {
+              name: 'Team',
+              slug: 'team',
+              value: [
+                'Coordinator',
+                'Nurse',
+              ],
+            },
           },
-        }];
+          {
+            attributes: {
+              name: 'Insurance Plans',
+              slug: 'insurance',
+              value: [
+                'BCBS PPO 100',
+                'Medicare',
+              ],
+            },
+          },
+        ];
 
         return fx;
       })
@@ -679,6 +691,13 @@ context('schedule page', function() {
       .should('contain', 'Insurance Plans')
       .get('[data-filter-button')
       .should('contain', 'Medicare');
+
+    cy
+      .get('@filtersSidebar')
+      .find('[data-filter-button]')
+      .eq(2)
+      .get('.sidebar__label')
+      .should('contain', 'Team');
 
     cy
       .get('@filtersSidebar')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1864,16 +1864,28 @@ context('worklist page', function() {
       .routeFlowActions()
       .routePatientByFlow()
       .routeDirectories(fx => {
-        fx.data = [{
-          attributes: {
-            name: 'Insurance Plans',
-            slug: 'insurance',
-            value: [
-              'BCBS PPO 100',
-              'Medicare',
-            ],
+        fx.data = [
+          {
+            attributes: {
+              name: 'Team',
+              slug: 'team',
+              value: [
+                'Coordinator',
+                'Nurse',
+              ],
+            },
           },
-        }];
+          {
+            attributes: {
+              name: 'Insurance Plans',
+              slug: 'insurance',
+              value: [
+                'BCBS PPO 100',
+                'Medicare',
+              ],
+            },
+          },
+        ];
 
         return fx;
       })
@@ -1922,6 +1934,13 @@ context('worklist page', function() {
       .should('contain', 'Insurance Plans')
       .get('[data-filter-button')
       .should('contain', 'Medicare');
+
+    cy
+      .get('@filtersSidebar')
+      .find('[data-filter-button]')
+      .eq(2)
+      .get('.sidebar__label')
+      .should('contain', 'Team');
 
     cy
       .get('@filtersSidebar')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1930,6 +1930,11 @@ context('worklist page', function() {
       .click();
 
     cy
+      .get('.picklist')
+      .find('.js-input')
+      .should('have.attr', 'placeholder', 'Group...');
+
+    cy
       .get('.picklist__item')
       .contains('All')
       .click()
@@ -1964,6 +1969,11 @@ context('worklist page', function() {
       .find('[data-filter-button]')
       .eq(1)
       .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-input')
+      .should('have.attr', 'placeholder', 'Insurance Plans...');
 
     cy
       .get('.picklist__item')


### PR DESCRIPTION
Shortcut Story ID: [sc-32018]

Two changes in this PR:

1. Set `isSelected: true` for each filter's droplist in the filters sidebar. (This adds an input field where the picklist items can be filtered)
2. Sort the filters alphabetically by their name. But keep the `Groups` filter at the top.
