### PR TITLE
Add styles for consistent table borders in PDF

### DIFF
--- a/src/scss/formapp/print.scss
+++ b/src/scss/formapp/print.scss
@@ -1,5 +1,10 @@
 // NOTE: This is used by the form PDF generator.
 @media print {
+  html {
+    filter: opacity(1);
+    print-color-adjust: exact;
+  }
+
   .rw-page-break {
     page-break-before: always;
   }


### PR DESCRIPTION
[sc-32070]
The PDF output has been displaying inconsistent table borders at different zoom levels:

100%: 
![image](https://user-images.githubusercontent.com/69738608/200604938-aab7f04f-9b9b-4060-822b-df4c562dd147.png)

300%:
![image](https://user-images.githubusercontent.com/69738608/200605041-c9e67fae-c42f-4832-9123-c3666fa967f4.png)

After adding this CSS to `@media print`, the table displays like this at 100%:
![image](https://user-images.githubusercontent.com/69738608/200605278-be0f49e4-3be4-4a38-ada4-df6cdc91cf91.png)
