### PR TITLE
Change app nav down-arrow icon size from 16px to 12px

### DIFF
--- a/src/js/views/globals/app-nav/app-nav.scss
+++ b/src/js/views/globals/app-nav/app-nav.scss
@@ -38,8 +38,10 @@ $menu-hover-color: #375467;
 }
 
 .app-nav__header-arrow .icon {
+  font-size: 12px;
   margin-left: 4px;
   padding-top: 4px;
+  vertical-align: -0.125em;
 }
 
 .app-nav__title,


### PR DESCRIPTION
Shortcut Story ID: [sc-32141]

Before (`font-size: 16px`):

![Screen Shot 2022-11-09 at 12 37 38 PM](https://user-images.githubusercontent.com/35355575/200913647-d5846a82-00fa-44d6-9dbf-d078efd69ebe.png)

After (`font-size: 12px`):

![Screen Shot 2022-11-09 at 12 37 51 PM](https://user-images.githubusercontent.com/35355575/200913555-931a241b-ce9e-426a-a700-cc527b5b96ff.png)