### PR TITLE
Add click+shift multi-select to the patient flow page

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -220,7 +220,7 @@ export default SubRouterApp.extend({
       return;
     }
 
-    this.getState().selectAll(this.actions);
+    this.getState().selectMultiple(this.actions.map('id'));
   },
 
   onAddProgramAction(programAction) {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1440,4 +1440,74 @@ context('patient flow page', function() {
       .get('.alert-box')
       .should('contain', 'Something went wrong. Please try again.');
   });
+
+  specify('click+shift multiselect', function() {
+    cy
+      .routeFlow()
+      .routePatientByFlow()
+      .routeFlowActions(fx => {
+        fx.data = _.first(fx.data, 3);
+
+        return fx;
+      })
+      .routePatientField()
+      .routeActionActivity()
+      .visit('/flow/1')
+      .wait('@routeFlow')
+      .wait('@routePatientByFlow')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 3);
+
+    cy
+      .get('.patient-flow__actions')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 3 Actions');
+
+    cy
+      .get('.patient-flow__actions')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 3);
+
+    cy
+      .get('.patient-flow__actions')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 3 Actions');
+  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-30377]

When an action is selected in the list of the patient flow page, allow a user to `shift`+`click` to select multiple list items between the two.

This replicates the functionality that already exists on the worklist. Created in this past PR: https://github.com/RoundingWell/care-ops-frontend/pull/745.