### PR TITLE
Set filters sidebar `isFiltering` value to `false` when `onBeforeStop()` occurs

### DIFF
--- a/src/js/apps/patients/schedule/filters_app.js
+++ b/src/js/apps/patients/schedule/filters_app.js
@@ -15,12 +15,19 @@ export default App.extend({
   stateEvents: {
     'change:groupId': 'showGroupsFilterView',
   },
+  onBeforeStop() {
+    this.toggleFiltering(false);
+  },
   onStart() {
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     this.groups = currentClinician.getGroups();
 
     this.showView(new FiltersView());
     this.showFilters();
+  },
+  toggleFiltering(isFiltering) {
+    this.isFiltering = isFiltering;
+    this.trigger('toggle:filtersSidebar', isFiltering);
   },
   showFilters() {
     this.showAllFiltersButtonView();
@@ -39,8 +46,8 @@ export default App.extend({
   },
   showFiltersSidebar() {
     if (this.isFiltering) return;
-    this.isFiltering = true;
-    this.trigger('toggle:filtersSidebar', true);
+
+    this.toggleFiltering(true);
 
     const state = this.getState();
 
@@ -59,8 +66,7 @@ export default App.extend({
     });
 
     this.listenTo(sidebar, 'stop', () => {
-      this.isFiltering = false;
-      this.trigger('toggle:filtersSidebar', false);
+      this.toggleFiltering(false);
     });
   },
   showGroupsFilterView() {

--- a/src/js/apps/patients/worklist/filters_app.js
+++ b/src/js/apps/patients/worklist/filters_app.js
@@ -17,6 +17,9 @@ export default App.extend({
   stateEvents: {
     'change:groupId': 'showGroupsFilterView',
   },
+  onBeforeStop() {
+    this.toggleFiltering(false);
+  },
   onStart() {
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
@@ -24,6 +27,10 @@ export default App.extend({
 
     this.showView(new FiltersView());
     this.showFilters();
+  },
+  toggleFiltering(isFiltering) {
+    this.isFiltering = isFiltering;
+    this.trigger('toggle:filtersSidebar', isFiltering);
   },
   showFilters() {
     this.showAllFiltersButtonView();
@@ -42,8 +49,8 @@ export default App.extend({
   },
   showFiltersSidebar() {
     if (this.isFiltering) return;
-    this.isFiltering = true;
-    this.trigger('toggle:filtersSidebar', true);
+
+    this.toggleFiltering(true);
 
     const state = this.getState();
 
@@ -62,8 +69,7 @@ export default App.extend({
     });
 
     this.listenTo(sidebar, 'stop', () => {
-      this.isFiltering = false;
-      this.trigger('toggle:filtersSidebar', false);
+      this.toggleFiltering(false);
     });
   },
   showGroupsFilterView() {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -894,6 +894,38 @@ context('schedule page', function() {
     cy
       .get('@filtersSidebar')
       .should('not.exist');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-all-filters-region]')
+      .click();
+
+    cy
+      .get('[data-select-all-region]')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .find('.js-close')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .should('not.exist');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-all-filters-region]')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .should('exist');
   });
 
   specify('restricted employee', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2137,6 +2137,38 @@ context('worklist page', function() {
     cy
       .get('@filtersSidebar')
       .should('not.exist');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-all-filters-region]')
+      .click();
+
+    cy
+      .get('[data-select-all-region]')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .find('.js-close')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .should('not.exist');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-all-filters-region]')
+      .click();
+
+    cy
+      .get('@filtersSidebar')
+      .should('exist');
   });
 
   specify('restricted employee', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-32171]

When `onBeforeStart()` occurs for the filters app, set the `isFiltering` state value to `false` (via a new `toggleFiltering()` function).

This fixes a bug where the filters sidebar wasn't able to be opened after the bulk edit app was started. The bug occurred in this scenario:

1. Open the `All Filters` sidebar.
2. With it still open, select all items (actions or flow).
3. Close `All Filters` sidebar.
4. Deselect all items.
5. Try to re-open the `All Filters` sidebar, but it'll no longer open.
