### PR TITLE
Ability to see if an action has attachments on list views

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
       "lock-keyhole",
       "magnifying-glass",
       "octagon-minus",
+      "paperclip",
       "paper-plane",
       "pen",
       "pen-to-square",

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -1,6 +1,6 @@
 import Backbone from 'backbone';
 import $ from 'jquery';
-import { contains, extend, keys, reduce } from 'underscore';
+import { contains, extend, keys, reduce, size } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import dayjs from 'dayjs';
@@ -135,6 +135,9 @@ const _Model = BaseModel.extend({
     };
 
     return this.save(attrs, { relationships }, { wait: true });
+  },
+  hasAttachments() {
+    return !!size(this.get('_files'));
   },
   parseRelationship: _parseRelationship,
 });

--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -10,5 +10,6 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>{{~ remove_whitespace ~}}
 </td>

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -81,6 +81,7 @@ const ActionItemView = View.extend({
   templateContext() {
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
+      hasAttachments: this.model.hasAttachments(),
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -13,5 +13,6 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -88,6 +88,7 @@ const ActionItemView = View.extend({
   templateContext() {
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
+      hasAttachments: this.model.hasAttachments(),
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -14,5 +14,6 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -142,6 +142,7 @@ const ActionItemView = View.extend({
     return {
       hasForm: this.model.getForm(),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
+      hasAttachments: this.model.hasAttachments(),
     };
   },
   tagName: 'tr',

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -144,6 +144,13 @@
   width: 475px;
 }
 
+.patient__action-attachment {
+  color: #999;
+  display: inline-block;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .patient__flow-icon .icon {
   color: $black-60;
 }

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -17,7 +17,7 @@
   </div>
 </td>
 <td class="table-list__cell worklist-list__meta">
-  <span class="worklist-list__details" data-details-region></span>&#8203;{{~ remove_whitespace ~}}
+  <span class="worklist-list__display-icon u-margin--r-16" data-details-region></span>&#8203;{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-state-region></span>&#8203;<span class="worklist-list__search-helper">{{ state }}</span>&#8203;{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-owner-region></span>&#8203;<span class="worklist-list__search-helper">{{ owner }}</span>&#8203;{{~ remove_whitespace ~}}
   <span class="table-list__meta">{{~ remove_whitespace ~}}
@@ -25,6 +25,7 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}&#8203;
+  {{#if hasAttachments}}<span class="worklist-list__display-icon u-margin--l-8">{{far "paperclip"}}</span>{{/if}}&#8203;{{~ remove_whitespace ~}}
 </td>
 <td class="table-list__cell worklist-list__action-ts w-7-5">{{formatDateTime created_at "TIME_OR_DAY"}}&#8203;</td>
 <td class="table-list__cell worklist-list__action-ts w-7-5">{{formatDateTime updated_at "TIME_OR_DAY"}}&#8203;</td>

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -41,6 +41,7 @@ const ActionItemView = View.extend({
       owner: this.model.getOwner().get('name'),
       state: this.model.getState().get('name'),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
+      hasAttachments: this.model.hasAttachments(),
     };
   },
   initialize({ state }) {

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -23,12 +23,10 @@
   color: color(blue);
 }
 
-.worklist-list__details {
+.worklist-list__display-icon {
   color: #999;
   display: inline-block;
-  margin-right: 16px;
   vertical-align: middle;
-  width: 16px;
 }
 
 .work-list__item:hover {

--- a/src/scss/modules/table-list.scss
+++ b/src/scss/modules/table-list.scss
@@ -48,7 +48,7 @@
   color: $black-60;
 }
 
-.table-list__meta {
+.table-list__meta:not(:empty) {
   margin-right: 8px;
 }
 

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -50,6 +50,7 @@ context('patient archive page', function() {
             },
             state: { data: { id: '55555' } },
             form: { data: { id: '1' } },
+            files: { data: [{ id: '1' }] },
           },
         };
 
@@ -147,6 +148,13 @@ context('patient archive page', function() {
       .eq(2)
       .find('[data-due-time-region]')
       .find('.is-overdue')
+      .should('not.exist');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item')
+      .eq(2)
+      .find('.fa-paperclip')
       .should('not.exist');
 
     cy
@@ -292,6 +300,12 @@ context('patient archive page', function() {
       .next()
       .find('[data-form-region]')
       .should('be.empty');
+
+    cy
+      .get('.table-list__item')
+      .first()
+      .find('.fa-paperclip')
+      .should('exist');
 
     cy
       .get('.table-list__item')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -50,6 +50,7 @@ context('patient dashboard page', function() {
         },
         state: { data: { id: '22222' } },
         form: { data: { id: '1' } },
+        files: { data: [{ id: '1' }] },
       },
     };
 
@@ -347,7 +348,9 @@ context('patient dashboard page', function() {
       .next()
       .next()
       .find('[data-form-region]')
-      .should('be.empty');
+      .should('be.empty')
+      .find('.fa-paperclip')
+      .should('not.exist');
 
     // dirty hack to make sure the form button isn't offscreen
     cy
@@ -360,6 +363,12 @@ context('patient dashboard page', function() {
       .get('.datepicker')
       .contains('Clear')
       .click();
+
+    cy
+      .get('.table-list__item')
+      .first()
+      .find('.fa-paperclip')
+      .should('exist');
 
     cy
       .get('.table-list__item')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -149,6 +149,7 @@ context('patient flow page', function() {
           type: 'teams',
         };
         fx.data[0].relationships.form.data = { id: '11111' };
+        fx.data[0].relationships.files = { data: [{ id: '1' }] };
 
         fx.data[1].id = '2';
         fx.data[1].attributes.name = 'Third In List';
@@ -161,7 +162,6 @@ context('patient flow page', function() {
           id: '33333',
           type: 'teams',
         };
-
 
         fx.data[2].id = '3';
         fx.data[2].attributes.name = 'Second In List';
@@ -189,6 +189,7 @@ context('patient flow page', function() {
       })
       .as('routePatchAction')
       .routeActionActivity()
+      .routePatientField()
       .visit('/flow/1')
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -209,6 +210,7 @@ context('patient flow page', function() {
         expect($action.find('[data-owner-region]')).to.contain('NUR');
         expect($action.find('[data-due-day-region] .is-overdue')).to.exist;
         expect($action.find('[data-form-region]')).not.to.be.empty;
+        expect($action.find('.fa-paperclip')).to.exist;
       });
 
     cy
@@ -219,6 +221,7 @@ context('patient flow page', function() {
       .should($action => {
         expect($action.find('.fa-circle-dot')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('PHS');
+        expect($action.find('.fa-paperclip')).to.not.exist;
       });
 
     cy
@@ -814,6 +817,8 @@ context('patient flow page', function() {
         return fx;
       })
       .routeActionActivity()
+      .routePatientField()
+      .routeActionComments()
       .visit('/flow/1')
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -1010,6 +1015,8 @@ context('patient flow page', function() {
       })
       .as('routePatchAction')
       .routeActionActivity()
+      .routePatientField()
+      .routeActionComments()
       .visit('/flow/1')
       .wait('@routeFlow')
       .wait('@routePatientByFlow')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -126,6 +126,7 @@ context('worklist page', function() {
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()
+      .routePatientField()
       .visit('/worklist/owned-by')
       .wait('@routeFlows');
 
@@ -407,6 +408,7 @@ context('worklist page', function() {
           patient: { data: { id: '1' } },
           form: { data: { id: '11111' } },
           flow: { data: { id: '1' } },
+          files: { data: [{ id: '1' }] },
         },
       },
       {
@@ -487,7 +489,6 @@ context('worklist page', function() {
             },
           },
         });
-
 
         fx.included.push(flowInclude);
 
@@ -650,7 +651,6 @@ context('worklist page', function() {
         fx.data = actions[1];
         return fx;
       });
-
 
     cy
       .get('@secondRow')
@@ -817,6 +817,16 @@ context('worklist page', function() {
       .get('@firstRow')
       .find('[data-due-time-region] button')
       .should('be.disabled');
+
+    cy
+      .get('@firstRow')
+      .find('.fa-paperclip')
+      .should('exist');
+
+    cy
+      .get('@secondRow')
+      .find('.fa-paperclip')
+      .should('not.exist');
 
     cy
       .get('@secondRow')


### PR DESCRIPTION
Shortcut Story ID: [sc-32259]

If an action has one or more attachments, display a paperclip icon in list views that indicates it has attachments.

Icon was added to action list items on the following pages:

1. Worklist
2. Patient Dashboard
3. Patient Archive
4. Patient flow

![Screen Shot 2022-11-18 at 3 36 08 PM](https://user-images.githubusercontent.com/35355575/202807098-3f253a99-441c-4954-9f5a-a976ec329d30.png)