### PR TITLE
Fix broken action file attachments download links

### DIFF
--- a/src/js/entities-service/files.js
+++ b/src/js/entities-service/files.js
@@ -8,7 +8,7 @@ const Entity = BaseEntity.extend({
     'fetch:files:collection:byAction': 'fetchFilesByAction',
   },
   fetchFilesByAction(actionId) {
-    const url = `/api/actions/${ actionId }/relationships/files`;
+    const url = `/api/actions/${ actionId }/relationships/files?urls=download`;
 
     return this.fetchCollection({ url });
   },

--- a/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
@@ -10,9 +10,9 @@ import './action-sidebar.scss';
 const AttachmentView = View.extend({
   className: 'u-margin--t-16',
   template: hbs`
-    <a class="action-sidebar__attachment-filename" target="_blank" href={{path}}>{{filename}}</a>
+    <a class="action-sidebar__attachment-filename" target="_blank" href="{{_download}}">{{filename}}</a>
     <div>
-      <a class="action-sidebar__attachment-download" href={{path}} download>
+      <a class="action-sidebar__attachment-download" href="{{_download}}" download>
         {{far "download"}} <span>{{ @intl.patients.sidebar.action.attachmentsViews.attachmentView.downloadText }}</span>
       </a>
     </div>

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -788,15 +788,21 @@ context('action sidebar', function() {
           {
             id: '1',
             attributes: {
-              path: 'https://www.bucket_name.s3.amazonaws.com/HRA_v1.pdf',
+              path: 'patients/1/HRA.pdf',
               created_at: '2019-08-24T14:15:22Z',
+            },
+            meta: {
+              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA.pdf',
             },
           },
           {
             id: '2',
             attributes: {
-              path: 'https://www.bucket_name.s3.amazonaws.com/HRA_v2.pdf',
+              path: 'patients/1/HRA v2.pdf',
               created_at: '2019-08-25T14:15:22Z',
+            },
+            meta: {
+              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf',
             },
           },
         ];
@@ -826,9 +832,9 @@ context('action sidebar', function() {
       .get('@attachmentItems')
       .first()
       .find('.action-sidebar__attachment-filename')
-      .should('contain', 'HRA_v2.pdf')
+      .should('contain', 'HRA v2.pdf')
       .should('have.attr', 'href')
-      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/HRA_v2.pdf');
+      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf');
 
     cy
       .get('@attachmentItems')
@@ -842,7 +848,7 @@ context('action sidebar', function() {
       .first()
       .find('.action-sidebar__attachment-download')
       .should('have.attr', 'href')
-      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/HRA_v2.pdf');
+      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf');
 
     cy
       .get('@attachmentItems')

--- a/test/support/api/files.js
+++ b/test/support/api/files.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 
 Cypress.Commands.add('routeActionFiles', (mutator = _.identity) => {
   cy.route({
-    url: '/api/actions/**/relationships/files',
+    url: '/api/actions/**/relationships/files?urls=download',
     response() {
       return mutator({
         data: [],


### PR DESCRIPTION
Shortcut Story ID: [sc-32337]

Use `file.meta._download` instead of `file.attributes.path` for downloading action file attachments. And update the handlebars template to accommodate spaces in the download `href` links.