### PR TITLE
Use separate `_view` and `_download` links for action file attachments

### DIFF
--- a/src/js/entities-service/files.js
+++ b/src/js/entities-service/files.js
@@ -8,7 +8,7 @@ const Entity = BaseEntity.extend({
     'fetch:files:collection:byAction': 'fetchFilesByAction',
   },
   fetchFilesByAction(actionId) {
-    const url = `/api/actions/${ actionId }/relationships/files?urls=download`;
+    const url = `/api/actions/${ actionId }/relationships/files?urls=download,view`;
 
     return this.fetchCollection({ url });
   },

--- a/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
@@ -10,7 +10,7 @@ import './action-sidebar.scss';
 const AttachmentView = View.extend({
   className: 'u-margin--t-16',
   template: hbs`
-    <a class="action-sidebar__attachment-filename" target="_blank" href="{{_download}}">{{filename}}</a>
+    <a class="action-sidebar__attachment-filename" target="_blank" href="{{_view}}">{{filename}}</a>
     <div>
       <a class="action-sidebar__attachment-download" href="{{_download}}" download>
         {{far "download"}} <span>{{ @intl.patients.sidebar.action.attachmentsViews.attachmentView.downloadText }}</span>

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -792,7 +792,8 @@ context('action sidebar', function() {
               created_at: '2019-08-24T14:15:22Z',
             },
             meta: {
-              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA.pdf',
+              view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
+              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
             },
           },
           {
@@ -802,7 +803,8 @@ context('action sidebar', function() {
               created_at: '2019-08-25T14:15:22Z',
             },
             meta: {
-              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf',
+              view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA%20v2.pdf',
+              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA%20v2.pdf',
             },
           },
         ];
@@ -834,7 +836,7 @@ context('action sidebar', function() {
       .find('.action-sidebar__attachment-filename')
       .should('contain', 'HRA v2.pdf')
       .should('have.attr', 'href')
-      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf');
+      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA%20v2.pdf');
 
     cy
       .get('@attachmentItems')
@@ -848,7 +850,7 @@ context('action sidebar', function() {
       .first()
       .find('.action-sidebar__attachment-download')
       .should('have.attr', 'href')
-      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/HRA%20v2.pdf');
+      .and('contain', 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA%20v2.pdf');
 
     cy
       .get('@attachmentItems')

--- a/test/support/api/files.js
+++ b/test/support/api/files.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 
 Cypress.Commands.add('routeActionFiles', (mutator = _.identity) => {
   cy.route({
-    url: '/api/actions/**/relationships/files?urls=download',
+    url: '/api/actions/**/relationships/files?urls=download,view',
     response() {
       return mutator({
         data: [],


### PR DESCRIPTION
Shortcut Story ID: [sc-32343]

Use the `file.meta._view` URL for the filename link. And use the `file.meta._download` URL for the download button link.

Also, update the API request parameters to `?urls=download,view`.