### PR TITLE
Form Save + Go Back Animation

### DIFF
--- a/config/webpack.rules.js
+++ b/config/webpack.rules.js
@@ -47,7 +47,11 @@ const sassLoader = {
   options: {
     // Must import global variables/configs with each file
     // https://github.com/webpack-contrib/sass-loader/issues/218#issuecomment-266669156
-    additionalData: `@use 'sass:math'; @import '${ sassRoot }/provider-variables.scss';`,
+    additionalData: `
+      @use 'sass:math';
+      @use 'sass:color';
+      @import '${ sassRoot }/provider-variables.scss';
+    `,
   },
 };
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -76,6 +76,7 @@ const Application = App.extend({
       modalRegion: this.getRegion('modal'),
       modalSmallRegion: this.getRegion('modalSmall'),
       modalSidebarRegion: this.getRegion('modalSidebar'),
+      modalLoadingRegion: this.getRegion('modalLoading'),
     });
   },
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -168,6 +168,8 @@ export default App.extend({
       _action: this.action,
     });
 
+    this.trigger('submit');
+
     formResponse.saveAll()
       .then(() => {
         this.clearStoredSubmission();

--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -3,7 +3,7 @@ import App from 'js/base/app';
 
 import FormsService from 'js/services/forms';
 
-import { ModalView, SidebarModalView, SmallModalView, IframeFormView } from 'js/views/globals/modal/modal_views';
+import { ModalView, SidebarModalView, SmallModalView, IframeFormView, LoadingModalView } from 'js/views/globals/modal/modal_views';
 
 export default App.extend({
   channelName: 'modal',
@@ -13,11 +13,13 @@ export default App.extend({
     'show:custom': 'showCustom',
     'show:sidebar': 'showSidebar',
     'show:form': 'showForm',
+    'show:loading': 'showLoading',
   },
-  initialize({ modalRegion, modalSmallRegion, modalSidebarRegion }) {
+  initialize({ modalRegion, modalSmallRegion, modalSidebarRegion, modalLoadingRegion }) {
     this.modalRegion = modalRegion;
     this.modalSmallRegion = modalSmallRegion;
     this.modalSidebarRegion = modalSidebarRegion;
+    this.modalLoadingRegion = modalLoadingRegion;
   },
   showModal(options) {
     const ConfirmModal = ModalView.extend(options);
@@ -76,6 +78,13 @@ export default App.extend({
         modal.disableSubmit(false);
       },
     });
+
+    return modal;
+  },
+  showLoading(options) {
+    const modal = new LoadingModalView(options);
+
+    this.modalLoadingRegion.show(modal);
 
     return modal;
   },

--- a/src/js/views/globals/app-frame.scss
+++ b/src/js/views/globals/app-frame.scss
@@ -1,5 +1,3 @@
-$menu-bkg-color: #1F2B33;
-
 .app-frame {
   display: flex;
   height: 100%;
@@ -9,7 +7,7 @@ $menu-bkg-color: #1F2B33;
 }
 
 .app-frame__nav {
-  background-color: $menu-bkg-color;
+  background-color: $bkg-color;
   height: 100%;
   min-height: 0;
   min-width: 200px;
@@ -27,7 +25,7 @@ $menu-bkg-color: #1F2B33;
 }
 
 .app-frame__sidebar {
-  background: #FFF;
+  background: $white;
   height: 100%;
   min-height: 0;
   position: absolute;

--- a/src/js/views/globals/modal/loading/loading_modal.hbs
+++ b/src/js/views/globals/modal/loading/loading_modal.hbs
@@ -1,0 +1,6 @@
+<div class="loading-modal__content is-animated">
+  <div>Saving your work...</div>
+  <div class="loading-modal__bar">
+    <div class="loading-modal__bar-progress"></div>
+  </div>
+</div>

--- a/src/js/views/globals/modal/loading/loading_modal.scss
+++ b/src/js/views/globals/modal/loading/loading_modal.scss
@@ -1,0 +1,95 @@
+@keyframes reveal-modal {
+  0% {
+    opacity: 0;
+    transform: scale(0.5) translateY(30%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0%);
+  }
+}
+
+@keyframes progress-loader {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+
+  5% {
+    width: 100px;
+  }
+
+  10% {
+    transform: translate3d(192px, 0, 0);
+    width: 64px;
+  }
+
+  15% {
+    width: 100px;
+  }
+
+  20% {
+    transform: translate3d(0, 0, 0);
+    width: 64px;
+  }
+
+  25% {
+    width: 100px;
+  }
+
+  30% {
+    transform: translate3d(200px, 0, 0);
+    width: 64px;
+  }
+
+  35% {
+    width: 100px;
+  }
+
+  40% {
+    transform: translate3d(0, 0, 0);
+    width: 64px;
+  }
+
+  95% {
+    width: 256px;
+  }
+
+  100% {
+    width: 256px;
+  }
+}
+
+.loading-modal__content {
+  background-color: $white;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1;
+  min-height: 262px;
+  text-align: center;
+  width: 524px;
+
+  &.is-animated {
+    animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0.5s reveal-modal forwards;
+    opacity: 0;
+  }
+}
+
+.loading-modal__bar {
+  background: $black-90;
+  border-radius: 8px;
+  height: 16px;
+  margin: 32px auto 0;
+  width: 256px;
+}
+
+.loading-modal__bar-progress {
+  animation: 4s ease-in-out 0.5s progress-loader forwards;
+  background: color(green);
+  border-radius: 8px;
+  height: 16px;
+  transform: translate3d(0, 0, 0) scale(1);
+  width: 64px;
+}

--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -1,9 +1,11 @@
-import { extend } from 'underscore';
+import { extend, delay } from 'underscore';
 import hbs from 'handlebars-inline-precompile';
 import { View, Region } from 'marionette';
 
 import 'scss/modules/buttons.scss';
 import 'scss/modules/modals.scss';
+
+import './loading/loading_modal.scss';
 
 import intl from 'js/i18n';
 
@@ -14,6 +16,7 @@ import PreloadRegion from 'js/regions/preload_region';
 import IframeFormBehavior from 'js/behaviors/iframe-form';
 
 import ModalTemplate from './modal.hbs';
+import LoadingModalTemplate from './loading/loading_modal.hbs';
 
 const i18n = intl.globals.modal.modalViews;
 
@@ -100,9 +103,21 @@ const IframeFormView = View.extend({
   template: hbs`<iframe src="/formapp/"></iframe>`,
 });
 
+
+const LoadingModalView = View.extend({
+  className: 'pos--absolute',
+  template: LoadingModalTemplate,
+  onAttach() {
+    delay(() => {
+      this.destroy();
+    }, 5000);
+  },
+});
+
 export {
   ModalView,
   SidebarModalView,
   SmallModalView,
   IframeFormView,
+  LoadingModalView,
 };

--- a/src/scss/modules/fill-window.scss
+++ b/src/scss/modules/fill-window.scss
@@ -15,9 +15,21 @@
   }
 }
 
+@keyframes darken {
+  0% {
+    background: rgb(0 0 0 / 0%);
+  }
+
+  100% {
+    background: rgb(0 0 0 / 70%);
+  }
+}
+
 .fill-window--dark {
   @extend .fill-window;
 
-  background: rgb(0 0 0 / 50%);
-  pointer-events: all;
+  &.is-shown {
+    animation: darken 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+    pointer-events: all;
+  }
 }

--- a/src/scss/provider-variables.scss
+++ b/src/scss/provider-variables.scss
@@ -57,7 +57,7 @@ $colors: (
     base: #9013FE
   )
 );
-
+$bkg-color: #1F2B33;
 
 // -------------------------------------
 //   Black, White & Neutral Colors

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1208,6 +1208,8 @@ context('Patient Action Form', function() {
   specify('save and go back button', function() {
     localStorage.setItem('form-state_11111', JSON.stringify({ saveButtonType: 'saveAndGoBack' }));
 
+    cy.clock();
+
     cy
       .routeAction(fx => {
         fx.data.id = '1';
@@ -1314,6 +1316,18 @@ context('Patient Action Form', function() {
       .click();
 
     cy
+      .get('.fill-window--dark.is-shown')
+      .should('contain', 'Saving your work...');
+
+    cy
+      .get('.app-frame__content')
+      .click('left', { force: true });
+
+    cy
+      .get('.fill-window--dark.is-shown')
+      .should('exist');
+
+    cy
       .get('.form__controls')
       .find('.js-save-button')
       .should('be.disabled');
@@ -1334,9 +1348,96 @@ context('Patient Action Form', function() {
         expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
       });
 
+    cy.tick(5000);
+
     cy
       .url()
       .should('contain', 'worklist/owned-by');
+
+    cy
+      .clock()
+      .then(clock => {
+        clock.restore();
+      });
+  });
+
+  specify('save and go back button - form response error', function() {
+    cy
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.form.data = { id: '11111' };
+        fx.data.relationships['form-responses'].data = [];
+
+        return fx;
+      })
+      .routeForm(_.identity, '11111')
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routeActionActivity()
+      .routePatientByAction()
+      .visit('/patient-action/1/form/11111')
+      .wait('@routeAction')
+      .wait('@routeForm')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition');
+
+    cy
+      .route({
+        status: 403,
+        method: 'POST',
+        delay: 100,
+        url: '/api/form-responses',
+        response: {
+          errors: [
+            {
+              id: '1',
+              status: 403,
+              title: 'Forbidden',
+              detail: 'Insufficient permissions',
+            },
+          ],
+        },
+      })
+      .as('postFormResponse');
+
+    cy
+      .iframe()
+      .as('iframe');
+
+    cy
+      .get('@iframe')
+      .find('textarea[name="data[familyHistory]"]')
+      .clear()
+      .type('New typing');
+
+    cy
+      .get('@iframe')
+      .find('textarea[name="data[storyTime]"]')
+      .clear()
+      .type('New typing');
+
+    cy
+      .get('.form__controls')
+      .find('.button__drop-list-select')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .eq(1)
+      .click();
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Save')
+      .click()
+      .wait('@postFormResponse');
+
+    cy
+      .get('@iframe')
+      .find('.alert')
+      .contains('Insufficient permissions');
   });
 });
 
@@ -1829,6 +1930,219 @@ context('Patient Form', function() {
       .should('contain', 'Test Field')
       .should('contain', 'Test field widget');
   });
+
+  specify('save and go back button', function() {
+    localStorage.setItem('form-state_11111', JSON.stringify({ saveButtonType: 'saveAndGoBack' }));
+
+    cy.clock();
+
+    cy
+      .routeForm(_.identity, '11111')
+      .routeFormDefinition()
+      .routeFormFields(fx => {
+        fx.data.attributes.storyTime = 'Once upon a time...';
+
+        return fx;
+      })
+      .routeFormResponse()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .visit('/patient/1/form/11111')
+      .wait('@routeForm')
+      .wait('@routePatient')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
+
+    cy
+      .iframe()
+      .find('textarea[name="data[familyHistory]"]')
+      .type('Here is some typing');
+
+    cy
+      .route({
+        status: 201,
+        method: 'POST',
+        delay: 100,
+        url: '/api/form-responses',
+        response: { data: { id: '12345' } },
+      })
+      .as('routePostResponse');
+
+    cy
+      .get('.form__controls')
+      .find('.js-save-button')
+      .should('not.be.disabled')
+      .should('contain', 'Save + Go Back');
+
+    cy
+      .get('.form__controls')
+      .find('.button__drop-list-select')
+      .should('not.be.disabled')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .should('have.length', 2)
+      .first()
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+
+        expect(storage.saveButtonType).to.equal('save');
+      });
+
+    cy
+      .get('.form__controls')
+      .find('.js-save-button')
+      .should('contain', 'Save')
+      .should('not.contain', 'Go Back');
+
+    cy
+      .get('.form__controls')
+      .find('.button__drop-list-select')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .should('have.length', 2)
+      .eq(1)
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
+
+        expect(storage.saveButtonType).to.equal('saveAndGoBack');
+      });
+
+    cy
+      .get('.form__controls')
+      .find('.js-save-button')
+      .click();
+
+    cy
+      .get('.fill-window--dark.is-shown')
+      .should('contain', 'Saving your work...');
+
+    cy
+      .get('.app-frame__content')
+      .click('left', { force: true });
+
+    cy
+      .get('.fill-window--dark.is-shown')
+      .should('exist');
+
+    cy
+      .get('.form__controls')
+      .find('.js-save-button')
+      .should('be.disabled');
+
+    cy
+      .get('.form__controls')
+      .find('.button__drop-list-select')
+      .should('be.disabled');
+
+    cy
+      .wait('@routePostResponse')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.relationships.action).to.be.undefined;
+        expect(data.relationships.form.data.id).to.equal('11111');
+        expect(data.attributes.response.data.storyTime).to.equal('Once upon a time...');
+        expect(data.attributes.response.data.patient.first_name).to.equal('John');
+        expect(data.attributes.response.data.patient.last_name).to.equal('Doe');
+        expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
+      });
+
+    cy.tick(5000);
+
+    cy
+      .url()
+      .should('contain', 'worklist/owned-by');
+
+    cy
+      .clock()
+      .then(clock => {
+        clock.restore();
+      });
+  });
+
+  specify('save and go back button - form response error', function() {
+    cy
+      .routeForm(_.identity, '11111')
+      .routeFormDefinition()
+      .routeFormFields()
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .visit('/patient/1/form/11111')
+      .wait('@routeForm')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields')
+      .wait('@routePatient');
+
+    cy
+      .route({
+        status: 403,
+        method: 'POST',
+        delay: 100,
+        url: '/api/form-responses',
+        response: {
+          errors: [
+            {
+              id: '1',
+              status: 403,
+              title: 'Forbidden',
+              detail: 'Insufficient permissions',
+            },
+          ],
+        },
+      })
+      .as('postFormResponse');
+
+    cy
+      .iframe()
+      .as('iframe');
+
+    cy
+      .get('@iframe')
+      .find('textarea[name="data[familyHistory]"]')
+      .clear()
+      .type('New typing');
+
+    cy
+      .get('@iframe')
+      .find('textarea[name="data[storyTime]"]')
+      .clear()
+      .type('New typing');
+
+    cy
+      .get('.form__controls')
+      .find('.button__drop-list-select')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .should('have.length', 2)
+      .eq(1)
+      .click();
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Save')
+      .click()
+      .wait('@postFormResponse');
+
+    cy
+      .get('@iframe')
+      .find('.alert')
+      .contains('Insufficient permissions');
+  });
 });
 
 context('Preview Form', function() {
@@ -1931,121 +2245,5 @@ context('Preview Form', function() {
 
     cy
       .go('back');
-  });
-
-  specify('save and go back button', function() {
-    localStorage.setItem('form-state_11111', JSON.stringify({ saveButtonType: 'saveAndGoBack' }));
-
-    cy
-      .routeForm(_.identity, '11111')
-      .routeFormDefinition()
-      .routeFormFields(fx => {
-        fx.data.attributes.storyTime = 'Once upon a time...';
-
-        return fx;
-      })
-      .routeFormResponse()
-      .routePatient(fx => {
-        fx.data.id = '1';
-        return fx;
-      })
-      .visit('/patient/1/form/11111')
-      .wait('@routeForm')
-      .wait('@routePatient')
-      .wait('@routeFormDefinition')
-      .wait('@routeFormFields');
-
-    cy
-      .iframe()
-      .find('textarea[name="data[familyHistory]"]')
-      .type('Here is some typing');
-
-    cy
-      .route({
-        status: 201,
-        method: 'POST',
-        delay: 100,
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
-      })
-      .as('routePostResponse');
-
-    cy
-      .get('.form__controls')
-      .find('.js-save-button')
-      .should('not.be.disabled')
-      .should('contain', 'Save + Go Back');
-
-    cy
-      .get('.form__controls')
-      .find('.button__drop-list-select')
-      .should('not.be.disabled')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .should('have.length', 2)
-      .first()
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-
-        expect(storage.saveButtonType).to.equal('save');
-      });
-
-    cy
-      .get('.form__controls')
-      .find('.js-save-button')
-      .should('contain', 'Save')
-      .should('not.contain', 'Go Back');
-
-    cy
-      .get('.form__controls')
-      .find('.button__drop-list-select')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .should('have.length', 2)
-      .eq(1)
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem('form-state_11111'));
-
-        expect(storage.saveButtonType).to.equal('saveAndGoBack');
-      });
-
-    cy
-      .get('.form__controls')
-      .find('.js-save-button')
-      .click();
-
-    cy
-      .get('.form__controls')
-      .find('.js-save-button')
-      .should('be.disabled');
-
-    cy
-      .get('.form__controls')
-      .find('.button__drop-list-select')
-      .should('be.disabled');
-
-    cy
-      .wait('@routePostResponse')
-      .its('request.body')
-      .should(({ data }) => {
-        expect(data.relationships.action).to.be.undefined;
-        expect(data.relationships.form.data.id).to.equal('11111');
-        expect(data.attributes.response.data.storyTime).to.equal('Once upon a time...');
-        expect(data.attributes.response.data.patient.first_name).to.equal('John');
-        expect(data.attributes.response.data.patient.last_name).to.equal('Doe');
-        expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
-      });
-
-    cy
-      .url()
-      .should('contain', 'worklist/owned-by');
   });
 });

--- a/test/integration/services/modal.js
+++ b/test/integration/services/modal.js
@@ -145,7 +145,7 @@ context('Modal Service', function() {
 
     // click the overlay, modal should stll be there
     cy
-      .get('.fill-window--dark')
+      .get('.fill-window--dark.is-shown')
       .last()
       .click('left')
       .get('.modal--small')
@@ -154,7 +154,7 @@ context('Modal Service', function() {
     cy
       .get('.modal')
       .contains('Modal')
-      .get('.fill-window--dark')
+      .get('.fill-window--dark.is-shown')
       .click('left')
       .get('.modal')
       .should('not.exist');
@@ -169,7 +169,7 @@ context('Modal Service', function() {
 
     cy
       .get('.spinner')
-      .get('.fill-window--dark')
+      .get('.fill-window--dark.is-shown')
       .click('right');
 
     cy
@@ -194,7 +194,7 @@ context('Modal Service', function() {
       .contains('Custom Footer');
 
     cy
-      .get('.fill-window--dark')
+      .get('.fill-window--dark.is-shown')
       .click('right');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-32340]

The `Save + Go Back` button for forms was added in this PR: https://github.com/RoundingWell/care-ops-frontend/pull/806.

When a user uses this button and is returned to the flow page, it happens before evaluations has time to finish and, therefore, the user has to reload the page to see the new flow action.

This PR shows a `Saving your work...` loading modal with a 5 second delay. This allows time for the evaluations to finish before the page is redirected.

https://user-images.githubusercontent.com/35355575/206292225-4650446a-3614-4407-a8d3-f243bc037f33.mov



