### PR TITLE
Replace preload spinner with a new loader animation

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -14,6 +14,8 @@ import Backbone from 'backbone';
 import Handlebars from 'handlebars/runtime';
 import parsePhoneNumber from 'libphonenumber-js/min';
 
+import intl from 'js/i18n';
+
 import { versions } from './config';
 
 import {
@@ -208,7 +210,12 @@ const Router = Backbone.Router.extend({
 });
 
 function startFormApp() {
-  $('#root').append(`<div class="spinner"><div class="spinner-circle">${ '<div class="spinner-child"></div>'.repeat(12) }</div></div>`);
+  $('#root').append(`
+    <div class="preloader__bar js-progress-bar">
+      <div class="preloader__bar-progress"></div>
+    </div>
+    <div class="preloader__text js-loading">${ intl.regions.preload.loading }</div>
+  `);
   router = new Router();
   Backbone.history.start({ pushState: true });
 }

--- a/src/js/regions/preload.scss
+++ b/src/js/regions/preload.scss
@@ -1,4 +1,4 @@
-.spinner {
+.preloader {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -6,54 +6,52 @@
   position: relative;
 }
 
-.spinner-circle {
-  height: 40px;
+.preloader__bar {
+  background: $black-90;
+  border-radius: 8px;
+  height: 8px;
   margin: 0 auto;
-  position: relative;
-  width: 40px;
+  width: 196px;
 }
 
-.spinner-text {
+.preloader__bar-progress {
+  animation: 0.75s ease-in-out 0s infinite alternate infinite-loader;
+  background: $black-60;
+  border-radius: 8px;
+  height: 8px;
+  position: absolute;
+  transform: translate3d(0, 0, 0) scale(1);
+  width: 48px;
+}
+
+.preloader__text {
   color: $black-60;
-  font-size: 14px;
-  margin: 16px auto 0;
+  font-size: 12px;
+  line-height: 1;
+  margin: 24px auto 0;
   text-align: center;
 }
 
-.spinner-child {
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-
-  &::before {
-    animation: circle-bounce-delay 0.8s infinite ease-in-out both;
-    background-color: $black-60;
-    border-radius: 100%;
-    content: '';
-    display: block;
-    height: 15%;
-    margin: 0 auto;
-    width: 15%;
+@keyframes infinite-loader {
+  0% {
+    transform: translate3d(0, 0, 0);
   }
 
-  @for $i from 2 through 12 {
-    &:nth-child(#{$i}) {
-      transform: rotate(math.div(360deg, 12) * ($i - 1));
-      &::before { animation-delay: - 0.8s + math.div(0.8s, 12) * ($i - 1); }
-    }
+  25% {
+    width: 56px;
   }
-}
 
-@keyframes circle-bounce-delay {
-  0%,
-  80%,
+  50% {
+    transform: translate3d(144px, 0, 0);
+    width: 48px;
+  }
+
+  75% {
+    width: 56px;
+  }
+
   100% {
-    transform: scale(0);
-  }
-
-  40% {
-    transform: scale(1);
+    transform: translate3d(0, 0, 0);
+    width: 48px;
   }
 }

--- a/src/js/regions/preload_region.js
+++ b/src/js/regions/preload_region.js
@@ -1,4 +1,3 @@
-import { range } from 'underscore';
 import anime from 'animejs';
 
 import hbs from 'handlebars-inline-precompile';
@@ -7,18 +6,18 @@ import { Region, View } from 'marionette';
 
 import './preload.scss';
 
-const SpinnerTemplate = hbs`
-  <div class="spinner-circle js-spinner" style="opacity:0">
-  {{#each dots}}<div class="spinner-child"></div>{{/each}}
+const LoadingTemplate = hbs`
+  <div class="preloader__bar js-progress-bar">
+    <div class="preloader__bar-progress"></div>
   </div>
-  <p class="spinner-text js-loading" style="opacity:0">{{ @intl.regions.preload.loading }}</p>
+  <div class="preloader__text js-loading">{{ @intl.regions.preload.loading }}</div>
 `;
 
-const SpinnerView = View.extend({
-  className: 'spinner',
-  template: SpinnerTemplate,
+const LoadingView = View.extend({
+  className: 'preloader',
+  template: LoadingTemplate,
   ui: {
-    spinner: '.js-spinner',
+    progressBar: '.js-progress-bar',
     loading: '.js-loading',
   },
   onRender() {
@@ -40,7 +39,7 @@ const SpinnerView = View.extend({
     anim
       .add({
         opacity: [0, 1],
-        targets: this.ui.spinner[0],
+        targets: this.ui.progressBar[0],
         duration,
       })
       .add({
@@ -49,14 +48,11 @@ const SpinnerView = View.extend({
         duration: duration - 100,
       }, 100);
   },
-  templateContext: {
-    dots: range(12),
-  },
 });
 
 export default Region.extend({
   timeout: 500,
   startPreloader() {
-    this.show(new SpinnerView({ timeout: this.getOption('timeout') }));
+    this.show(new LoadingView({ timeout: this.getOption('timeout') }));
   },
 });

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -27,7 +27,7 @@
 }
 
 .patient-sidebar__widgets {
-  .spinner {
+  .preloader {
     margin-top: 60px;
   }
 }

--- a/src/js/views/patients/sidebar/action/action-sidebar.scss
+++ b/src/js/views/patients/sidebar/action/action-sidebar.scss
@@ -23,7 +23,7 @@
 }
 
 .action-sidebar__activity {
-  .spinner {
+  .preloader {
     margin-top: 100px;
   }
 }

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -17,7 +17,7 @@
 }
 
 .worklist-patient-sidebar__widgets {
-  .spinner {
+  .preloader {
     margin-top: 60px;
   }
 }

--- a/src/scss/modules/sidebar.scss
+++ b/src/scss/modules/sidebar.scss
@@ -60,7 +60,7 @@
   color: $black-60;
   font-size: 12px;
 
-  .spinner {
+  .preloader {
     margin-top: 60px;
   }
 }

--- a/test/integration/services/modal.js
+++ b/test/integration/services/modal.js
@@ -168,7 +168,7 @@ context('Modal Service', function() {
       });
 
     cy
-      .get('.spinner')
+      .get('.preloader')
       .get('.fill-window--dark.is-shown')
       .click('right');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-32401]

Replace each instance of the preload spinner with a new loader animation:

![ezgif-4-e64e22bd81](https://user-images.githubusercontent.com/35355575/206285888-232b520a-2a5f-4a61-a2ff-2ffa3349d0da.gif)

