### PR TITLE
Invert preloader animation

### DIFF
--- a/src/js/regions/preload.scss
+++ b/src/js/regions/preload.scss
@@ -34,7 +34,8 @@
 
 @keyframes infinite-loader {
   0% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(144px, 0, 0);
+    width: 48px;
   }
 
   25% {
@@ -42,7 +43,7 @@
   }
 
   50% {
-    transform: translate3d(144px, 0, 0);
+    transform: translate3d(0, 0, 0);
     width: 48px;
   }
 
@@ -51,7 +52,7 @@
   }
 
   100% {
-    transform: translate3d(0, 0, 0);
+    transform: translate3d(144px, 0, 0);
     width: 48px;
   }
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-32466]

When the preloader quick loads, users often only see the pill going backwards. This PR changes the animation to begin left to right. When the preloader quick loads, a user will now see the pill go from left to right once.