### PR TITLE
Click+shift multi select for schedule items

### DIFF
--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -39,7 +39,11 @@ export default App.extend({
     const filters = this.getState('filters');
 
     // NOTE: Allows for new defaults to get added to stored filters
-    if (storedState) storedState.filters = extend({}, filters, storedState.filters);
+    if (storedState) {
+      storedState.filters = extend({}, filters, storedState.filters);
+
+      storedState.lastSelectedIndex = null;
+    }
 
     this.setState(extend({ id: `schedule_${ currentUser.id }` }, storedState));
   },
@@ -94,7 +98,7 @@ export default App.extend({
       return;
     }
 
-    this.getState().selectAll(this.filteredCollection);
+    this.getState().selectMultiple(this.filteredCollection.map('id'));
   },
   onClickBulkEdit() {
     const app = this.startChildApp('bulkEditActions', {
@@ -140,6 +144,7 @@ export default App.extend({
     const collectionView = new ScheduleListView({
       collection: this.collection.groupByDate(),
       state: this.getState(),
+      originalCollection: this.collection.clone(),
     });
 
     this.listenTo(collectionView, 'filtered', filtered => {
@@ -273,6 +278,7 @@ export default App.extend({
   setSearchState(state, searchQuery) {
     this.setState({
       searchQuery: searchQuery.length > 2 ? searchQuery : '',
+      lastSelectedIndex: null,
     });
   },
 });

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -276,7 +276,7 @@ const sortDueOptions = [
       const dueA = a.model.get('due_date');
       const dueB = b.model.get('due_date');
       if (dueA === dueB) {
-        return alphaSort('asc', a.model.get('due_time'), b.model.get('due_time'));
+        return alphaSort('asc', a.model.get('due_time'), b.model.get('due_time'), '24');
       }
       return alphaSort('asc', dueA, dueB);
     },

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1771,6 +1771,206 @@ context('schedule page', function() {
       .should('contain', 'Second Action');
   });
 
+  specify('click+shift multiselect', function() {
+    cy
+      .routeGroupsBootstrap()
+      .routeActions(fx => {
+        fx.data[0].attributes = {
+          name: 'Last Action',
+          due_date: testDate(),
+          due_time: null,
+        };
+        fx.data[0].id = '1';
+
+        fx.data[1].attributes = {
+          name: 'First Action',
+          due_date: testDate(),
+          due_time: null,
+        };
+        fx.data[1].id = '2';
+
+        fx.data[2].attributes = {
+          name: 'Second Action',
+          due_date: testDate(),
+          due_time: '10:30:00',
+        };
+        fx.data[2].id = '3';
+
+        fx.data[3].attributes = {
+          name: 'Third Action',
+          due_date: testDate(),
+          due_time: '14:00:00',
+        };
+        fx.data[3].id = '4';
+
+        _.each(fx.data.slice(4, 20), (action, idx) => {
+          action.attributes.due_date = testDateAdd(idx + 1);
+        });
+
+        return fx;
+      }, 100)
+      .visit('/schedule');
+
+    cy
+      .get('.schedule-list__table')
+      .as('scheduleList')
+      .find('.schedule-list__list-row')
+      .first()
+      .find('.schedule-list__day-list-row')
+      .first()
+      .as('firstActionRow')
+      .find('.js-select')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(0);
+      });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .eq(2)
+      .find('.schedule-list__day-list-row')
+      .first()
+      .find('.js-select')
+      .click({ shiftKey: true })
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(5);
+      });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 6);
+
+    cy
+      .get('[data-filters-region]')
+      .as('filterRegion')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 6 Actions');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .eq(2)
+      .find('.schedule-list__day-list-row')
+      .first()
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 1);
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 6);
+
+    cy
+      .get('[data-filters-region]')
+      .as('filterRegion')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 6 Actions');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('[data-select-all-region]')
+      .find('.fa-square-minus')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(null);
+      });
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(null);
+      });
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:not([disabled])')
+      .focus()
+      .type('abcd')
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(null);
+      });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:not([disabled])')
+      .next()
+      .click();
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .navigate('/worklist');
+
+    cy
+      .go('back')
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem('schedule_11111-v3'));
+
+        expect(storage.lastSelectedIndex).to.equal(null);
+      });
+  });
+
   specify('clinician in no groups', function() {
     cy
       .routeCurrentClinician(fx => {


### PR DESCRIPTION
Shortcut Story ID: [sc-32186]

When an item is selected in the schedule, allow a user to `shift`+`click` to select multiple list items between the two.