### PR TITLE
Replace NPM package: `handlebars-template-loader` => `handlebars-loader`

### DIFF
--- a/config/webpack.rules.js
+++ b/config/webpack.rules.js
@@ -15,7 +15,7 @@ const babelLoader = {
 const hbsLoader = {
   test: /\.hbs?$/,
   exclude: /node_modules/,
-  loader: 'handlebars-template-loader',
+  loader: 'handlebars-loader',
 };
 
 const nullLoader = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "eslint": "^8.14.0",
         "eslint-plugin-mocha": "^10.1.0",
         "eslint-webpack-plugin": "^3.0.1",
-        "handlebars-template-loader": "^1.0.0",
+        "handlebars-loader": "^1.7.3",
         "html-webpack-plugin": "^5.3.2",
         "istanbul-lib-coverage": "^3.0.2",
         "lodash.camelcase": "^4.3.0",
@@ -6826,53 +6826,45 @@
         "intl-relativeformat": "1.1.0"
       }
     },
-    "node_modules/handlebars-template-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars-template-loader/-/handlebars-template-loader-1.0.0.tgz",
-      "integrity": "sha512-GRikDO4BrmNs8KV5XDzAQaIH5r4eC6fpMCYfYK96viiGIoHODxxPH7+tCFMp3AVMv3Sokk70yG9tLLD3Zzyi4Q==",
+    "node_modules/handlebars-loader": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.3.tgz",
+      "integrity": "sha512-dDb+8D51vE3OTSE2wuGPWRAegtsEuw8Mk8hCjtRu/pNcBfN5q+M8ZG3kVJxBuOeBrVElpFStipGmaxSBTRR1mQ==",
       "dev": true,
       "dependencies": {
-        "fastparse": "^1.1.1",
-        "loader-utils": "^0.2.15"
+        "async": "^3.2.2",
+        "fastparse": "^1.0.0",
+        "loader-utils": "1.4.x",
+        "object-assign": "^4.1.0"
+      },
+      "peerDependencies": {
+        "handlebars": ">= 1.3.0 < 5"
       }
     },
-    "node_modules/handlebars-template-loader/node_modules/big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+    "node_modules/handlebars-loader/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/handlebars-template-loader/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/handlebars-template-loader/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
       "bin": {
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/handlebars-template-loader/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
+    "node_modules/handlebars-loader/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -19067,44 +19059,36 @@
         "intl-relativeformat": "1.1.0"
       }
     },
-    "handlebars-template-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars-template-loader/-/handlebars-template-loader-1.0.0.tgz",
-      "integrity": "sha512-GRikDO4BrmNs8KV5XDzAQaIH5r4eC6fpMCYfYK96viiGIoHODxxPH7+tCFMp3AVMv3Sokk70yG9tLLD3Zzyi4Q==",
+    "handlebars-loader": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars-loader/-/handlebars-loader-1.7.3.tgz",
+      "integrity": "sha512-dDb+8D51vE3OTSE2wuGPWRAegtsEuw8Mk8hCjtRu/pNcBfN5q+M8ZG3kVJxBuOeBrVElpFStipGmaxSBTRR1mQ==",
       "dev": true,
       "requires": {
-        "fastparse": "^1.1.1",
-        "loader-utils": "^0.2.15"
+        "async": "^3.2.2",
+        "fastparse": "^1.0.0",
+        "loader-utils": "1.4.x",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-          "dev": true
-        },
         "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "eslint": "^8.14.0",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-webpack-plugin": "^3.0.1",
-    "handlebars-template-loader": "^1.0.0",
+    "handlebars-loader": "^1.7.3",
     "html-webpack-plugin": "^5.3.2",
     "istanbul-lib-coverage": "^3.0.2",
     "lodash.camelcase": "^4.3.0",


### PR DESCRIPTION
Shortcut Story ID: [sc-32351]

[handlebars-template-loader](https://www.npmjs.com/package/handlebars-template-loader) relies on an older version of [loader-utils](https://www.npmjs.com/package/loader-utils) that was causing a NPM security issue to be shown when doing `npm i`.

This PR switches the app over to use [handlebars-loader](https://www.npmjs.com/package/handlebars-loader) instead. Which updated their dependencies to use the newer version of `loader-utils` that doesn't cause the security issue.