### PR TITLE
Fix worklist actions alignment bug

### DIFF
--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -27,6 +27,7 @@
   color: #999;
   display: inline-block;
   vertical-align: middle;
+  width: 16px;
 }
 
 .work-list__item:hover {


### PR DESCRIPTION
Shortcut Story ID: [sc-32560]

Fix a bug where the `State, Owner, Due, Form` section for worklist actions don't align.

Before:

![Screen Shot 2022-12-13 at 3 40 47 PM](https://user-images.githubusercontent.com/35355575/207451366-a0932d6f-220c-4d3b-a951-267b4d0339d2.png)

After:

![Screen Shot 2022-12-13 at 3 41 10 PM](https://user-images.githubusercontent.com/35355575/207451381-99733851-6bc4-4f55-a0c7-d01ef85e6653.png)
