### PR TITLE
Use org settings state status for worklists/schedule

### DIFF
--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -3,8 +3,6 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import { STATE_STATUS } from 'js/static';
-
 import { LayoutView, ListView } from 'js/views/patients/patient/archive/archive_views';
 
 export default App.extend({
@@ -13,7 +11,9 @@ export default App.extend({
     this.getRegion('content').startPreloader();
   },
   beforeStart({ patient }) {
-    const filter = { status: STATE_STATUS.DONE };
+    const currentOrg = Radio.request('bootstrap', 'currentOrg');
+    const states = currentOrg.getStates();
+    const filter = { state: states.groupByDone().done.getFilterIds() };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -3,8 +3,6 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import { STATE_STATUS } from 'js/static';
-
 import AddWorkflowApp from './add-workflow_app';
 
 import { LayoutView, ListView } from 'js/views/patients/patient/dashboard/dashboard_views';
@@ -21,7 +19,10 @@ export default App.extend({
   },
 
   beforeStart({ patient }) {
-    const filter = { status: [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(',') };
+    const currentOrg = Radio.request('bootstrap', 'currentOrg');
+    const states = currentOrg.getStates();
+    const filter = { state: states.groupByDone().notDone.getFilterIds() };
+
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
       Radio.request('entities', 'fetch:flows:collection:byPatient', { patientId: patient.id, filter }),

--- a/src/js/apps/patients/schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced_schedule_app.js
@@ -2,8 +2,6 @@ import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
-import { STATE_STATUS } from 'js/static';
-
 import SearchComponent from 'js/views/shared/components/list-search';
 
 import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
@@ -25,9 +23,13 @@ export default App.extend({
   beforeStart() {
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     const groups = currentClinician.getGroups();
+
+    const currentOrg = Radio.request('bootstrap', 'currentOrg');
+    const states = currentOrg.getStates();
+
     const filter = {
       clinician: currentClinician.id,
-      status: [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(','),
+      state: states.groupByDone().notDone.getFilterIds(),
     };
 
     if (groups.length) filter.group = groups.pluck('id').join(',');

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -4,7 +4,7 @@ import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 
-import { STATE_STATUS, RELATIVE_DATE_RANGES } from 'js/static';
+import { RELATIVE_DATE_RANGES } from 'js/static';
 
 const relativeRanges = new Backbone.Collection(RELATIVE_DATE_RANGES);
 
@@ -28,6 +28,8 @@ export default Backbone.Model.extend({
     };
   },
   preinitialize() {
+    this.currentOrg = Radio.request('bootstrap', 'currentOrg');
+
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
     this.groups = this.currentClinician.getGroups();
   },
@@ -72,16 +74,17 @@ export default Backbone.Model.extend({
     };
   },
   getEntityFilter() {
+    const states = this.currentOrg.getStates();
     const filtersState = this.getFilters();
     const clinicianId = this.get('clinicianId');
     const customFilters = omit(filtersState, 'groupId');
-    const status = [STATE_STATUS.QUEUED, STATE_STATUS.STARTED].join(',');
+    const notDoneStates = states.groupByDone().notDone.getFilterIds();
 
     const dateFilter = this.getEntityDateFilter();
 
     const filters = extend({
       clinician: clinicianId,
-      status,
+      state: notDoneStates,
     }, dateFilter);
 
     if (this.groups.length) {

--- a/src/js/entities-service/entities/states.js
+++ b/src/js/entities-service/entities/states.js
@@ -17,6 +17,19 @@ const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/states',
   model: Model,
+  groupByDone() {
+    const { done, notDone } = this.groupBy(state => {
+      return state.isDone() ? 'done' : 'notDone';
+    });
+
+    return {
+      done: new Collection(done),
+      notDone: new Collection(notDone),
+    };
+  },
+  getFilterIds() {
+    return this.map('id').join(',');
+  },
 });
 
 export {

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -98,8 +98,13 @@ context('patient archive page', function() {
       .routeFormActionFields()
       .visit('/patient/archive/1')
       .wait('@routePatient')
-      .wait('@routePatientActions')
       .wait('@routePatientFlows');
+
+    cy
+      .wait('@routePatientActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=55555,66666,77777');
 
     // Filters only done id 55555
     cy

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -123,8 +123,13 @@ context('patient dashboard page', function() {
       .routeAllProgramFlows()
       .visit('/patient/dashboard/1')
       .wait('@routePatient')
-      .wait('@routePatientActions')
       .wait('@routePatientFlows');
+
+    cy
+      .wait('@routePatientActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=22222,33333');
 
     // Filters out done id 55555
     cy

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -360,8 +360,15 @@ context('schedule page', function() {
         return fx;
       })
       .routeActions()
-      .visit('/schedule')
-      .wait('@routeActions');
+      .visit('/schedule');
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[group]=1,2,3')
+      .should('contain', 'filter[clinician]=11111')
+      .should('contain', 'filter[state]=22222,33333');
 
     cy.clock(testTime, ['Date']);
 
@@ -1022,7 +1029,12 @@ context('schedule page', function() {
       .routePatientByAction()
       .routePatient()
       .visit('/')
-      .wait('@routeActions');
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[group]=11111,22222')
+      .should('contain', 'filter[clinician]=123456')
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .url()

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -333,8 +333,14 @@ context('worklist page', function() {
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()
-      .visit('/worklist/done-last-thirty-days')
-      .wait('@routeFlows');
+      .visit('/worklist/done-last-thirty-days');
+
+    cy
+      .wait('@routeFlows')
+      .itsUrl()
+      .its('search')
+      .should('contain', `filter[updated_at]=${ dayjs(testTs()).startOf('day').subtract(1, 'month').format() }`)
+      .should('contain', 'filter[state]=55555,66666,77777');
 
     cy
       .route({
@@ -963,13 +969,15 @@ context('worklist page', function() {
       .routeFlowActions()
       .routePatientByFlow()
       .routeActions()
-      .visit('/worklist/owned-by')
+      .visit('/worklist/owned-by');
+
+    cy
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('[data-owner-filter-region]')
@@ -1003,7 +1011,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=test-clinician')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('.list-page__title')
@@ -1027,7 +1035,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('.list-page__title')
@@ -1073,7 +1081,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('.list-page__filters')
@@ -1089,7 +1097,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=2')
       .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('.list-page__filters')
@@ -1129,7 +1137,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=1,2,3')
       .should('contain', 'filter[created_at]=')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
 
     cy
       .get('.list-page__filters')
@@ -1149,7 +1157,7 @@ context('worklist page', function() {
       .its('search')
       .should('contain', 'filter[group]=2')
       .should('contain', 'filter[created_at]=')
-      .should('contain', 'filter[status]=queued,started');
+      .should('contain', 'filter[state]=22222,33333');
   });
 
   specify('owner filtering', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-32452]

Worklists/schedule currently use static variables for filtering state status.

This PR updates the following pages to use `filter[state]` instead of `filter[status]` in the API requests:

- Worklist
- Schedule
- Reduced schedule
- Patient dashboard
- Patient archive