### PR TITLE
Rename worklist due ordering to `"Due: Sooner - Later"`

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -603,8 +603,8 @@ careOptsFrontend:
         sortDroplist:
           headingText: 'Sort Options'
         sortDueOptions:
-          asc: 'Due: Oldest - Newest'
-          desc: 'Due: Newest - Oldest'
+          asc: 'Due: Sooner - Later'
+          desc: 'Due: Later - Sooner'
         sortPatientOptions:
           asc: 'Patient Last: A - Z'
           desc: 'Patient Last: Z - A'

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2598,6 +2598,8 @@ context('worklist page', function() {
       .routeAction()
       .routeActionActivity()
       .routePatientFlows()
+      .routeActionComments()
+      .routeActionFiles()
       .visit('/worklist/shared-by');
 
     cy
@@ -2686,7 +2688,7 @@ context('worklist page', function() {
       .get('.worklist-list__filter-sort')
       .click()
       .get('.picklist')
-      .contains('Due: Oldest - Newest')
+      .contains('Due: Sooner - Later')
       .click();
 
     cy
@@ -2708,7 +2710,7 @@ context('worklist page', function() {
       .get('.worklist-list__filter-sort')
       .click()
       .get('.picklist')
-      .contains('Due: Newest - Oldest')
+      .contains('Due: Later - Sooner')
       .click();
 
     cy
@@ -2751,7 +2753,7 @@ context('worklist page', function() {
 
     cy
       .get('.worklist-list__filter-sort')
-      .contains('Due: Newest - Oldest');
+      .contains('Due: Later - Sooner');
   });
 
   specify('action sorting - patient', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-32517]

On the worklist, rename the due order sorting label from `Due: Oldest - Newest` to `Due: Sooner - Later`.