### PR TITLE
Cast custom sort fields to strings

### DIFF
--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -5,10 +5,11 @@ import Radio from 'backbone.radio';
 import { alphaSort } from 'js/utils/sorting';
 import { i18n } from 'js/views/patients/worklist/worklist_views';
 
+// Casts values to String for alpha sort
 function getEntityFieldValue(entity, fieldName, keys) {
   const patientField = entity.getPatient().getField(fieldName);
-  if (!patientField) return null;
-  return get(patientField.getValue(), keys);
+  if (!patientField) return '';
+  return String(get(patientField.getValue(), keys, ''));
 }
 
 // field_key may include a path for the model_attr.deeply_nested.value

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2555,7 +2555,7 @@ context('worklist page', function() {
           type: 'patients',
           attributes: {
             first_name: 'Patient',
-            last_name: 'Field A',
+            last_name: 'Field 1',
           },
           relationships: { 'patient-fields': { data: [{ id: '1' }] } },
         });
@@ -2563,7 +2563,7 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'patient-fields',
-          attributes: { value: { value: 'A' }, name: 'foo' },
+          attributes: { value: { value: 1 }, name: 'foo' },
         });
 
         fx.included.push({


### PR DESCRIPTION
We’ll want this until we legitimately have a sort that requires something other than casting to alpha

Shortcut Story ID: [sc-32656]
