### PR TITLE
Support custom sorting by numerical order

### DIFF
--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -2,14 +2,14 @@ import { get, union, map, uniq, compact } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
-import { alphaSort } from 'js/utils/sorting';
+import { alphaSort, numSort } from 'js/utils/sorting';
 import { i18n } from 'js/views/patients/worklist/worklist_views';
 
 // Casts values to String for alpha sort
 function getEntityFieldValue(entity, fieldName, keys) {
   const patientField = entity.getPatient().getField(fieldName);
-  if (!patientField) return '';
-  return String(get(patientField.getValue(), keys, ''));
+  if (!patientField) return null;
+  return get(patientField.getValue(), keys);
 }
 
 // field_key may include a path for the model_attr.deeply_nested.value
@@ -26,12 +26,17 @@ const SortOption = Backbone.Model.extend({
     const fieldName = this.get('field_name');
     const keys = this.get('field_key').split('.');
     const direction = this.get('direction');
+    const type = this.get('type');
 
     return (a, b) => {
       const aValue = getEntityFieldValue(a.model, fieldName, keys);
       const bValue = getEntityFieldValue(b.model, fieldName, keys);
 
-      return alphaSort(direction, aValue, bValue);
+      if (type === 'numeric') {
+        return numSort(direction, aValue ?? 0, bValue ?? 0);
+      }
+
+      return alphaSort(direction, aValue ?? '', bValue ?? '');
     };
   },
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2555,7 +2555,7 @@ context('worklist page', function() {
           type: 'patients',
           attributes: {
             first_name: 'Patient',
-            last_name: 'Field 1',
+            last_name: 'Field A',
           },
           relationships: { 'patient-fields': { data: [{ id: '1' }] } },
         });
@@ -2563,7 +2563,7 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'patient-fields',
-          attributes: { value: { value: 1 }, name: 'foo' },
+          attributes: { value: { value: 'A' }, name: 'foo' },
         });
 
         fx.included.push({


### PR DESCRIPTION
Shortcut Story ID: [sc-32716]

If the custom sort org setting has a `type: 'numeric'` property, use `numSort()` instead of `alphaSort()`. `alphaSort()` will continue to be used by default.