### PR TITLE
Change custom sort org setting to `sort_type` & remove duplicate `intSort()` utility

### DIFF
--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -26,13 +26,13 @@ const SortOption = Backbone.Model.extend({
     const fieldName = this.get('field_name');
     const keys = this.get('field_key').split('.');
     const direction = this.get('direction');
-    const type = this.get('type');
+    const sortType = this.get('sort_type');
 
     return (a, b) => {
       const aValue = getEntityFieldValue(a.model, fieldName, keys);
       const bValue = getEntityFieldValue(b.model, fieldName, keys);
 
-      if (type === 'numeric') {
+      if (sortType === 'numeric') {
         return numSort(direction, aValue ?? 0, bValue ?? 0);
       }
 
@@ -143,4 +143,3 @@ function getSortOptions(listType) {
 export {
   getSortOptions,
 };
-

--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -33,10 +33,10 @@ const SortOption = Backbone.Model.extend({
       const bValue = getEntityFieldValue(b.model, fieldName, keys);
 
       if (sortType === 'numeric') {
-        return numSort(direction, aValue ?? 0, bValue ?? 0);
+        return numSort(direction, aValue, bValue);
       }
 
-      return alphaSort(direction, aValue ?? '', bValue ?? '');
+      return alphaSort(direction, aValue, bValue);
     };
   },
 });

--- a/src/js/utils/sorting.js
+++ b/src/js/utils/sorting.js
@@ -30,16 +30,9 @@ function intSortBy(sortDir, val, nullVal) {
   return sortByDir(sortDir, parseInt(int, 10));
 }
 
-function intSort(sort, fieldA, fieldB, nullVal) {
-  const sortVal = getSortNum(fieldA, nullVal) > getSortNum(fieldB, nullVal) ? 1 : -1;
-  return sortByDir(sort, sortVal);
-}
-
-
 export {
   alphaSort,
   intSortBy,
   numSortBy,
-  intSort,
   numSort,
 };

--- a/src/js/utils/sorting.js
+++ b/src/js/utils/sorting.js
@@ -20,9 +20,11 @@ function numSortBy(sortDir, val, nullVal) {
   return sortByDir(sortDir, num);
 }
 
-function numSort(sort, fieldA, fieldB, nullVal) {
-  const sortVal = getSortNum(fieldA, nullVal) > getSortNum(fieldB, nullVal) ? 1 : -1;
-  return sortByDir(sort, sortVal);
+function numSort(sortDir, a, b, nullVal = Number.NEGATIVE_INFINITY) {
+  if (!a) a = nullVal;
+  if (!b) b = nullVal;
+  const sortVal = getSortNum(a, nullVal) > getSortNum(b, nullVal) ? 1 : -1;
+  return sortByDir(sortDir, sortVal);
 }
 
 function intSortBy(sortDir, val, nullVal) {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2541,7 +2541,7 @@ context('worklist page', function() {
       .should('contain', 'APatient AName');
   });
 
-  specify('flow sorting - patient field', function() {
+  specify('flow sorting alphabetical - patient field', function() {
     cy
       .routeFlows(fx => {
         fx.data = _.sample(fx.data, 3);
@@ -2633,6 +2633,108 @@ context('worklist page', function() {
       .find('.table-list__item')
       .last()
       .should('contain', 'Patient Field B');
+  });
+
+  specify('flow sorting numerical - patient field', function() {
+    cy
+      .routeSettings(fx => {
+        const sortingSettings = _.find(fx.data, setting => setting.id === 'sorting');
+        _.each(sortingSettings.attributes.value, function(sortMethod) {
+          sortMethod.sort_type = 'numeric';
+        });
+
+        return fx;
+      })
+      .routeFlows(fx => {
+        fx.data = _.sample(fx.data, 3);
+
+        fx.data[0].relationships.patient = { data: { id: '2' } };
+        fx.data[1].relationships.patient = { data: { id: '3' } };
+        fx.data[2].relationships.patient = { data: { id: '1' } };
+
+        fx.included.push({
+          id: '1',
+          type: 'patients',
+          attributes: {
+            first_name: 'Patient',
+            last_name: 'Field 1',
+          },
+          relationships: { 'patient-fields': { data: [{ id: '1' }] } },
+        });
+
+        fx.included.push({
+          id: '1',
+          type: 'patient-fields',
+          attributes: { value: { value: 1 }, name: 'foo' },
+        });
+
+        fx.included.push({
+          id: '2',
+          type: 'patients',
+          attributes: {
+            first_name: 'Patient',
+            last_name: 'Field None',
+          },
+        });
+
+        fx.included.push({
+          id: '3',
+          type: 'patients',
+          attributes: {
+            first_name: 'Patient',
+            last_name: 'Field 2',
+          },
+          relationships: { 'patient-fields': { data: [{ id: '3' }] } },
+        });
+
+        fx.included.push({
+          id: '3',
+          type: 'patient-fields',
+          attributes: { value: { value: 2 }, name: 'foo' },
+        });
+
+        return fx;
+      })
+      .visit('/worklist/shared-by')
+      .wait('@routeFlows');
+
+    cy
+      .get('.worklist-list__filter-sort')
+      .click()
+      .get('.picklist')
+      .contains('Foo: Highest - Lowest')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .should('contain', 'Patient Field 2');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .should('contain', 'Patient Field None');
+
+    cy
+      .get('.worklist-list__filter-sort')
+      .click()
+      .get('.picklist')
+      .contains('Foo: Lowest - Highest')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .should('contain', 'Patient Field None');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .should('contain', 'Patient Field 2');
   });
 
   specify('action sorting', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -339,7 +339,7 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[updated_at]=${ dayjs(testTs()).startOf('day').subtract(1, 'month').format() }`)
+      .should('contain', `filter[updated_at]=${ dayjs().startOf('day').subtract(30, 'days').format() }`)
       .should('contain', 'filter[state]=55555,66666,77777');
 
     cy

--- a/test/unit/utils/sorting.js
+++ b/test/unit/utils/sorting.js
@@ -7,7 +7,6 @@ import {
   alphaSort,
   intSortBy,
   numSortBy,
-  intSort,
   numSort,
 } from 'js/utils/sorting';
 
@@ -60,16 +59,6 @@ context('sorting', function() {
         const valA = modelA.get('alpha');
         const valB = modelB.get('alpha');
         return alphaSort(sortDir, valA, valB);
-      };
-    });
-  });
-
-  specify('intSort', function() {
-    testSort(sortDir => {
-      return function(modelA, modelB) {
-        const valA = modelA.get('int');
-        const valB = modelB.get('int');
-        return intSort(sortDir, valA, valB);
       };
     });
   });


### PR DESCRIPTION
Shortcut Story ID: [sc-32726] [sc-32720]

`intSort()` is exactly the same as `numSort()` and is not used in the application. So it was removed (along with its test).

`type` is a reserved word in JSON:Api, so we changed it to `sort_type` instead.

Also updated Cypress to test numerical sorting. Previously we were only testing alphabetical sorting, which caused a Coveralls coverage drop.