### PR TITLE
Refactor how `currentOrg.directories` is retrieved for the filters sidebar app

### DIFF
--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -11,7 +11,7 @@ export default App.extend({
   onStart({ availableStates }) {
     const currentOrg = Radio.request('bootstrap', 'currentOrg');
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.directories = Radio.request('bootstrap', 'currentOrg:directories');
+    this.directories = currentOrg.getDirectories();
     this.states = currentOrg.getStates();
     this.availableStates = availableStates;
 

--- a/src/js/entities-service/entities/organizations.js
+++ b/src/js/entities-service/entities/organizations.js
@@ -25,6 +25,9 @@ const _Model = BaseModel.extend({
   getSetting(id) {
     return this.get('settings').get(id);
   },
+  getDirectories() {
+    return this.get('directories').clone();
+  },
   type: TYPE,
 });
 

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -25,7 +25,6 @@ export default App.extend({
     'currentOrg': 'getCurrentOrg',
     'currentOrg:setting': 'getOrgSetting',
     'currentOrg:roles': 'getOrgRoles',
-    'currentOrg:directories': 'getOrgDirectories',
     'sidebarWidgets': 'getSidebarWidgets',
     'sidebarWidgets:fields': 'getSidebarWidgetFields',
     'fetch': 'fetchBootstrap',
@@ -50,9 +49,6 @@ export default App.extend({
     activeRolesCache = Radio.request('entities', 'roles:collection', activeRoles);
 
     return activeRolesCache;
-  },
-  getOrgDirectories() {
-    return this.getCurrentOrg().get('directories');
   },
   getCurrentOrg() {
     return this.currentOrg;


### PR DESCRIPTION
Shortcut Story ID: [sc-32921]

To avoid modifying the cache, remove the `Radio.request('bootstrap', 'currentOrg:directories')` and do `currentOrg.getDirectories()` instead using a new `getDirectories()` function from the organizations service.

Originated here: https://github.com/RoundingWell/care-ops-frontend/pull/880#discussion_r1060597877