### PR TITLE
Temporarily hide file attachment functionality in the UI

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -41,7 +41,7 @@ export default App.extend({
 
     this.showActivity();
     this.showNewCommentForm();
-    this.showAttachments();
+    // this.showAttachments();
   },
   showActivity() {
     this.showChildView('activity', new ActivitiesView({

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -81,7 +81,8 @@ const ActionItemView = View.extend({
   templateContext() {
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
-      hasAttachments: this.model.hasAttachments(),
+      // hasAttachments: this.model.hasAttachments(),
+      hasAttachments: false,
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -88,7 +88,8 @@ const ActionItemView = View.extend({
   templateContext() {
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
-      hasAttachments: this.model.hasAttachments(),
+      // hasAttachments: this.model.hasAttachments(),
+      hasAttachments: false,
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -142,7 +142,8 @@ const ActionItemView = View.extend({
     return {
       hasForm: this.model.getForm(),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
-      hasAttachments: this.model.hasAttachments(),
+      // hasAttachments: this.model.hasAttachments(),
+      hasAttachments: false,
     };
   },
   tagName: 'tr',

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -41,7 +41,8 @@ const ActionItemView = View.extend({
       owner: this.model.getOwner().get('name'),
       state: this.model.getState().get('name'),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
-      hasAttachments: this.model.hasAttachments(),
+      // hasAttachments: this.model.hasAttachments(),
+      hasAttachments: false,
     };
   },
   initialize({ state }) {

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -309,11 +309,13 @@ context('patient archive page', function() {
       .find('[data-form-region]')
       .should('be.empty');
 
+    /*
     cy
       .get('.table-list__item')
       .first()
       .find('.fa-paperclip')
       .should('exist');
+    */
 
     cy
       .get('.table-list__item')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -369,11 +369,13 @@ context('patient dashboard page', function() {
       .contains('Clear')
       .click();
 
+    /*
     cy
       .get('.table-list__item')
       .first()
       .find('.fa-paperclip')
       .should('exist');
+    */
 
     cy
       .routeForm()

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -210,7 +210,7 @@ context('patient flow page', function() {
         expect($action.find('[data-owner-region]')).to.contain('NUR');
         expect($action.find('[data-due-day-region] .is-overdue')).to.exist;
         expect($action.find('[data-form-region]')).not.to.be.empty;
-        expect($action.find('.fa-paperclip')).to.exist;
+        // expect($action.find('.fa-paperclip')).to.exist;
       });
 
     cy

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -719,10 +719,12 @@ context('action sidebar', function() {
       .next()
       .should('contain', formatDate(testTs(), 'AT_TIME'));
 
+    /*
     cy
       .get('.sidebar')
       .find('[data-attachments-region]')
       .contains('No Attachments');
+    */
 
     cy
       .get('[data-activity-region]')
@@ -748,7 +750,7 @@ context('action sidebar', function() {
     cy.clock().invoke('restore');
   });
 
-  specify('action attachments', function() {
+  specify.skip('action attachments', function() {
     const actionData = {
       id: '1',
       attributes: {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -821,10 +821,12 @@ context('worklist page', function() {
       .find('[data-due-time-region] button')
       .should('be.disabled');
 
+    /*
     cy
       .get('@firstRow')
       .find('.fa-paperclip')
       .should('exist');
+    */
 
     cy
       .get('@secondRow')


### PR DESCRIPTION
Shortcut Story ID: [sc-33229]

Areas the UI where this needs to be hidden:

- Attachments section of the action sidebar.
- Paperclip icon added to any action list item that has an attachment (worklists, archive, patient dashboard, flow pages).