### PR TITLE
Add org setting to show/hide file attachments upload functionality

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -68,7 +68,14 @@ export default App.extend({
     });
   },
   showAttachments() {
-    const attachmentsView = new AttachmentsView({ collection: this.attachments });
+    const canUploadAttachments = !!Radio.request('bootstrap', 'currentOrg:setting', 'upload_attachments');
+
+    if (!canUploadAttachments && !this.attachments.length) return;
+
+    const attachmentsView = new AttachmentsView({
+      collection: this.attachments,
+      canUploadAttachments,
+    });
 
     this.listenTo(attachmentsView, {
       'add:attachment': this.onAddAttachment,

--- a/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
@@ -93,12 +93,19 @@ const AttachmentsView = CollectionView.extend({
         {{far "paperclip"}}<span class="u-margin--l-8">{{ @intl.patients.sidebar.action.actionSidebarAttachmentsViews.attachmentsViews.attachmentsHeadingText }}</span>
       </h3>
       <div data-attachments-files-region></div>
-      <form>
-        <input type="file" id="upload-attachment" accept=".pdf" class="action-sidebar__attachment-file js-file">
-        <label for="upload-attachment" class="button-primary u-margin--t-16 js-add">{{far "paperclip"}}<span>{{ @intl.patients.sidebar.action.actionSidebarAttachmentsViews.attachmentsViews.addAttachment }}</span></label>
-      </form>
+      {{#if canUploadAttachments}}
+        <form>
+          <input type="file" id="upload-attachment" accept=".pdf" class="action-sidebar__attachment-file js-file">
+          <label for="upload-attachment" class="button-primary u-margin--t-16 js-add">{{far "paperclip"}}<span>{{ @intl.patients.sidebar.action.actionSidebarAttachmentsViews.attachmentsViews.addAttachment }}</span></label>
+        </form>
+      {{/if}}
     </div>
   `,
+  templateContext() {
+    return {
+      canUploadAttachments: this.getOption('canUploadAttachments'),
+    };
+  },
   childViewContainer: '[data-attachments-files-region]',
   childView: AttachmentView,
   emptyView: EmptyView,


### PR DESCRIPTION
Shortcut Story ID: [sc-33283]

Show/hide the upload file attachments functionality based on a new `upload_attachments` org setting. 

As a result, the attachments section of the action sidebar will only be shown if the org can upload attachments and/or the action has attachments.

Below are the 4 different scenarios in the UI:

1. If `orgSettings.upload_attachments = true` and the action has file attachments:

![Screenshot 2023-01-30 at 12 02 38 PM](https://user-images.githubusercontent.com/35355575/215559597-eee52937-50e4-47ff-874c-2ce456f77506.png)

2. If `orgSettings.upload_attachments = false` (or `undefined`) and the action has file attachments:

![Screenshot 2023-01-30 at 11 58 35 AM](https://user-images.githubusercontent.com/35355575/215559940-aa03ec60-d90b-47dd-935f-176ca0276b96.png)

3. If `orgSettings.upload_attachments = true` and the action doesn't have file attachments:

![Screenshot 2023-01-30 at 12 03 05 PM](https://user-images.githubusercontent.com/35355575/215560191-4ecf46c5-e648-4c9d-ac34-c0d57711913e.png)

4. If both `orgSettings.upload_attachments = false` (or `undefined`) and the action doesn't have file attachments, the entire attachments section in the action sidebar is hidden.

