### PR TITLE
Update worklist icons to match new navigation icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,15 @@
       "xmark"
     ],
     "far": [
+      "0",
+      "1",
+      "3",
       "address-card",
       "angle-down",
       "angle-left",
       "angle-right",
       "arrow-down-arrow-up",
+      "arrow-right-arrow-left",
       "arrow-up-right-from-square",
       "calendar-days",
       "calendar-star",

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -598,7 +598,7 @@ careOptsFrontend:
             {title, select,
               owned_by {Owned By}
               shared_by {Shared By}
-              new_past_day {New < 24 hrs: }
+              new_past_day {New < 1 Day: }
               updated_past_three_days {Updated < 3 Days: }
               done_last_thirty_days {Done < 30 Days: }
             }

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -129,6 +129,14 @@ const NoOwnerToggleView = View.extend({
   },
 });
 
+const worklistIcons = {
+  'owned-by': ['list'],
+  'shared-by': ['arrow-right-arrow-left'],
+  'new-past-day': ['angle-left', '1'],
+  'updated-past-three-days': ['angle-left', '3'],
+  'done-last-thirty-days': ['3', '0'],
+};
+
 const ListTitleView = View.extend({
   regions: {
     owner: '[data-owner-filter-region]',
@@ -136,7 +144,11 @@ const ListTitleView = View.extend({
   },
   className: 'flex list-page__title-filter',
   template: hbs`
-    <span class="list-page__title-icon">{{far "list"}}</span>
+    <span class="list-page__title-icon">
+      {{#each icons}}
+        {{far this}}
+      {{/each}}
+    </span>
     {{#if showOwnerDroplist}}
       <div class="u-text--nowrap">
         {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listLabels") title=worklistId}}
@@ -147,17 +159,20 @@ const ListTitleView = View.extend({
     {{/if}}
     <span class="list-page__header-icon js-title-info">{{far "circle-info"}}</span>
     <div class="u-margin--l-24" data-owner-toggle-region></div>
-    `,
+  `,
   ui: {
     tooltip: '.js-title-info',
   },
   templateContext() {
+    const worklistId = this.getOption('worklistId');
+
     return {
       team: this.getOption('team').get('name'),
       owner: this.getOption('owner').get('name'),
-      worklistId: underscored(this.getOption('worklistId')),
+      worklistId: underscored(worklistId),
       isFlowList: this.getOption('isFlowList'),
       showOwnerDroplist: this.getOption('showOwnerDroplist'),
+      icons: worklistIcons[worklistId],
     };
   },
   onRender() {

--- a/src/scss/modules/list-pages.scss
+++ b/src/scss/modules/list-pages.scss
@@ -28,11 +28,31 @@
 }
 
 .list-page__title-icon {
+  align-items: center;
+  display: flex;
   margin-right: 16px;
 
   .icon {
     font-size: 20px;
     vertical-align: middle;
+    width: 1em;
+  }
+
+  .icon.fa-angle-left {
+    margin-right: 2px;
+    width: 8px;
+  }
+
+  .icon.fa-0 {
+    width: 16px;
+  }
+
+  .icon.fa-1 {
+    width: 14px;
+  }
+
+  .icon.fa-3 {
+    width: 12px;
   }
 }
 


### PR DESCRIPTION
Shortcut Story ID: [sc-33239]

New navigation icons were added in PR: https://github.com/RoundingWell/care-ops-frontend/pull/897.

This PR updates the icons used in the worklist title to match what's in the new navigation. Which we forgot to do in the original PR.