### PR TITLE
Remove `include=` from `/actions`, `/actions/{id}`, & `/flows` API requests

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -111,7 +111,6 @@ export default App.extend({
   beforeStart() {
     return Radio.request('entities', `fetch:${ this.getState().getType() }:collection`, {
       filter: this.getState().getEntityFilter(),
-      include: this.sortOptions.getInclude(),
     });
   },
   onStart(options, collection) {

--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -1,4 +1,4 @@
-import { get, union, map, uniq, compact } from 'underscore';
+import { get, union } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
@@ -48,13 +48,6 @@ const SortOptions = Backbone.Collection.extend({
     const filtered = this.filter(option => option.get('entities').includes(entityType));
     clone.reset(filtered);
     return clone;
-  },
-  getInclude() {
-    const fieldNames = compact(this.map('field_name'));
-
-    return map(uniq(fieldNames), fieldName => {
-      return `patient.patient-fields.${ fieldName }`;
-    }).join(',');
   },
 });
 

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -12,14 +12,10 @@ const Entity = BaseEntity.extend({
     'fetch:actions:collection:byFlow': 'fetchActionsByFlow',
   },
   fetchAction(id) {
-    const include = [
-      'program-action.program',
-      'flow.program-flow.program',
-    ].join();
-    return this.fetchModel(id, { data: { include } });
+    return this.fetchModel(id);
   },
-  fetchActions({ filter, include }) {
-    const data = { filter, include };
+  fetchActions({ filter }) {
+    const data = { filter };
 
     return this.fetchCollection({ data });
   },

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2682,10 +2682,7 @@ context('worklist page', function() {
         return fx;
       })
       .visit('/worklist/shared-by')
-      .wait('@routeFlows')
-      .itsUrl()
-      .its('search')
-      .should('contain', 'include=patient.patient-fields.foo');
+      .wait('@routeFlows');
 
     cy
       .get('.app-frame__content')
@@ -3427,10 +3424,7 @@ context('worklist page', function() {
       .get('[data-toggle-region]')
       .contains('Actions')
       .click()
-      .wait('@routeActions')
-      .itsUrl()
-      .its('search')
-      .should('contain', 'include=patient.patient-fields.foo');
+      .wait('@routeActions');
 
     cy
       .get('.worklist-list__filter-sort')


### PR DESCRIPTION
Shortcut Story ID: [sc-33614]

`include=` is deprecated by the backend in these API routes:

* GET `/actions`
* GET `/actions/{id}`
* GET `/flows`