### PR TITLE
In Cypress, verify that empty widgets show the `::before` content (`-`)

### DIFF
--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -673,6 +673,15 @@ context('patient sidebar', function() {
       .should('contain', 'Patient Identifier With Empty Value')
       .should('contain', 'No Identifier Found');
 
+    // verifies that the ::before content ('-') is shown for empty widget values
+    cy
+      .get('@patientSidebar')
+      .find('.patient-sidebar__section')
+      .contains('Empty Nested Option Widget')
+      .next()
+      .find('.widgets-value')
+      .hasBeforeContent('–');
+
     cy
       .get('@patientSidebar')
       .find('.widgets__form-widget')


### PR DESCRIPTION
Shortcut Story ID: [sc-30516]

Any widget with an empty value should show a `-` symbol in the UI. Which is displayed by the `::before` CSS pseudo element.

This PR adds a test to Cypress that verifies that symbol is shown correctly using our `hasBeforeContent()` Cypress command.