### PR TITLE
Remove state colors from `Cypress.env`

### DIFF
--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress';
 import webpackProcessor from '@cypress/webpack-preprocessor';
 
-import hexToRgb from './test/plugins/hex-to-rgb.js';
 import coveragePlugin from './test/plugins/coverage.js';
 import fakerPlugin from './test/plugins/faker-generator.js';
 import webpackOptions from './test/webpack.config.js';
@@ -27,14 +26,6 @@ export default defineConfig({
   },
   env: {
     featureFlags: {},
-    stateColors: hexToRgb({
-      error: '#E45245',
-      info: '#0582DA',
-      success: '#00BF68',
-      warning: '#FFBE00',
-      highlighted: '#FFFDDE',
-      greyed: '#EDF0F2',
-    }),
   },
   retries: {
     runMode: 1,

--- a/test/helpers/state-colors.js
+++ b/test/helpers/state-colors.js
@@ -1,0 +1,10 @@
+import hexToRgb from '../plugins/hex-to-rgb.js';
+
+export default hexToRgb({
+  error: '#E45245',
+  info: '#0582DA',
+  success: '#00BF68',
+  warning: '#FFBE00',
+  highlighted: '#FFFDDE',
+  greyed: '#EDF0F2',
+});

--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -1,8 +1,7 @@
 import _ from 'underscore';
 
 import { getError } from 'helpers/json-api';
-
-const stateColors = Cypress.env('stateColors');
+import stateColors from 'helpers/state-colors';
 
 const workspaces = [
   {

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -3,8 +3,7 @@ import _ from 'underscore';
 import { getError, getRelationship } from 'helpers/json-api';
 
 import { testTs } from 'helpers/test-timestamp';
-
-const stateColors = Cypress.env('stateColors');
+import stateColors from 'helpers/state-colors';
 
 const workspaces = [
   {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -4,8 +4,7 @@ import dayjs from 'dayjs';
 import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
-
-const stateColors = Cypress.env('stateColors');
+import stateColors from 'helpers/state-colors';
 
 context('action sidebar', function() {
   specify('display new action sidebar', function() {

--- a/test/integration/programs/sidebar/program-sidebar.js
+++ b/test/integration/programs/sidebar/program-sidebar.js
@@ -4,8 +4,7 @@ import formatDate from 'helpers/format-date';
 
 import { getError } from 'helpers/json-api';
 import { testTs } from 'helpers/test-timestamp';
-
-const stateColors = Cypress.env('stateColors');
+import stateColors from 'helpers/state-colors';
 
 context('program sidebar', function() {
   specify('display new program sidebar', function() {

--- a/test/state-colors.json
+++ b/test/state-colors.json
@@ -1,8 +1,0 @@
-{
-  "error": "#E65140",
-  "info": "#0582DA",
-  "success": "#00BF68",
-  "warning": "#FFBE00",
-  "highlighted": "#FFF8E5",
-  "notspecified": "#CCCCCC"
-}


### PR DESCRIPTION
Shortcut Story ID: [sc-30278]

Export them from a `/test/helpers/state-colors.js` file instead.