### PR TITLE
Remove `provider-core.scss` & `/modules/buttons.scss` imports from `prelogin_views.js`

### DIFF
--- a/src/js/views/globals/prelogin/prelogin.scss
+++ b/src/js/views/globals/prelogin/prelogin.scss
@@ -1,3 +1,34 @@
+// NOTE: Not using sass to prevent overriding form.io with base sass reset :-/
+
+@font-face {
+  font-family: ProximaSoft;
+  font-style: normal;
+  font-weight: normal;
+  src:
+    url('/fonts/ProximaSoft/3955CC_4_0.woff2') format('woff2'),
+    url('/fonts/ProximaSoft/3955CC_4_0.woff') format('woff'),
+    url('/fonts/ProximaSoft/3955CC_4_0.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: ProximaSoft;
+  font-style: normal;
+  font-weight: bold;
+  src:
+    url('/fonts/ProximaSoft/3955CC_1_0.woff2') format('woff2'),
+    url('/fonts/ProximaSoft/3955CC_1_0.woff') format('woff'),
+    url('/fonts/ProximaSoft/3955CC_1_0.ttf') format('truetype');
+}
+
+body {
+  margin: 0;
+}
+
+.prelogin * {
+  border: 0;
+  box-sizing: border-box;
+}
+
 @keyframes reveal-preloader {
   0% {
     opacity: 0;
@@ -11,11 +42,18 @@
 .prelogin {
   align-items: center;
   animation: 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) 0.5s reveal-preloader forwards;
+  box-sizing: border-box;
+  color: $black-20;
   display: flex;
   flex-direction: column;
+  font-family: ProximaSoft, 'Droid Sans', 'helvetica neue', arial, sans-serif;
+  font-size: 14px;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   height: 100vh;
   justify-content: top;
   line-height: 20px;
+  margin: 0;
   opacity: 0;
   vertical-align: baseline;
   width: 100%;
@@ -28,6 +66,7 @@
 .prelogin__content {
   background-color: $white;
   border-radius: 4px;
+  color: $black-20;
   line-height: 2.6em;
   min-height: 380px;
   padding: 48px 0;
@@ -48,9 +87,35 @@
 }
 
 .prelogin__continue-button {
+  background-color: color(green);
+  border: 1px solid color(green);
+  border-radius: 4px;
+  color: $white;
+  cursor: pointer;
+  display: inline-block;
+  font-family: ProximaSoft, 'Droid Sans', 'helvetica neue', arial, sans-serif;
   font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
   margin-top: 48px;
+  overflow: hidden;
   padding: 8px 48px;
+  position: relative;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  transition: background-color 0.15s;
+  transition-timing-function: linear;
+  vertical-align: middle;
+  white-space: nowrap;
+
+  &:hover:enabled {
+    background-color: color(green, light);
+  }
+
+  &:active:enabled,
+  &:focus {
+    background-color: color(green, dark);
+  }
 
   .fa-right-to-bracket {
     display: inline-block;
@@ -67,6 +132,7 @@
 
   a {
     color: color(blue);
+    text-decoration: none;
   }
 }
 
@@ -80,7 +146,9 @@
 }
 
 .prelogin__message {
+  color: $black-20;
   font-size: 28px;
   line-height: 40px;
   padding: 16px 80px;
+  text-align: center;
 }

--- a/src/js/views/globals/prelogin/prelogin_views.js
+++ b/src/js/views/globals/prelogin/prelogin_views.js
@@ -2,10 +2,7 @@ import { View } from 'marionette';
 
 import PreloadRegion from 'js/regions/preload_region';
 
-import 'scss/provider-core.scss';
-
 import 'scss/modules/fill-window.scss';
-import 'scss/modules/buttons.scss';
 
 import PreloginTemplate from './prelogin.hbs';
 import LoginPromptTemplate from './login-prompt.hbs';


### PR DESCRIPTION
Shortcut Story ID: [sc-33773]

Those imports cause a bug where all core styles are applied twice in the app. Which results in all sorts of cascading issues.

Originally presented itself as the alignment on a button icon being off. Discovered by Sofia in QA.
