### PR TITLE
User current workspace for owner component

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -17,7 +17,7 @@ import ProgramsMainApp from 'js/apps/programs/programs-main_app';
 export default App.extend({
   routers: [],
   onBeforeStart() {
-    // TODO: Preloader content area
+    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
     this.getRegion('content').empty();
 
     if (this.isRestarting()) return;
@@ -28,14 +28,15 @@ export default App.extend({
     this.listenTo(Radio.channel('bootstrap'), 'change:workspace', this.restart);
   },
   beforeStart() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
     return [
+      Radio.request('entities', 'fetch:clinicians:byWorkspace', this.currentWorkspace.id),
       Radio.request('entities', 'fetch:states:collection'),
       Radio.request('entities', 'fetch:forms:collection'),
-      Radio.request('entities', 'fetch:clinicians:byWorkspace', currentWorkspace.id),
     ];
   },
-  onStart() {
+  onStart(options, clinicians) {
+    this.currentWorkspace.updateClinicians(clinicians);
+
     const currentUser = Radio.request('bootstrap', 'currentUser');
 
     this.startPatientsMain(currentUser);

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -67,7 +67,6 @@ export default App.extend({
 
     const currentClinician = Radio.request('bootstrap', 'currentUser');
     this.canViewAssignedActions = currentClinician.can('app:schedule:clinician_filter');
-    this.workspaces = currentClinician.getWorkspaces();
 
     this.showView(new LayoutView({
       state: this.getState(),
@@ -183,8 +182,7 @@ export default App.extend({
   },
   getOwnerFilterOptions(owner) {
     const options = {
-      owner: owner,
-      workspaces: this.workspaces,
+      owner,
       isTitleFilter: true,
       headingText: intl.patients.schedule.filtersApp.ownerFilterHeadingText,
       hasTeams: false,

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -1,12 +1,11 @@
-import { clone, extend } from 'underscore';
+import { clone } from 'underscore';
 import Radio from 'backbone.radio';
-import store from 'store';
 
 import App from 'js/base/app';
 
 import intl, { renderTemplate } from 'js/i18n';
 
-import StateModel, { STATE_VERSION } from './schedule_state';
+import StateModel from './schedule_state';
 
 import FiltersApp from './filters_app';
 import BulkEditActionsApp from 'js/apps/patients/sidebar/bulk-edit-actions_app';
@@ -34,21 +33,16 @@ export default App.extend({
     'change:selectedActions': 'onChangeSelected',
   },
   initListState() {
-    const currentUser = Radio.request('bootstrap', 'currentUser');
-    const storedState = store.get(`schedule_${ currentUser.id }-${ STATE_VERSION }`);
-
-    this.setState({ id: `schedule_${ currentUser.id }` });
+    const storedState = this.getState().getStore();
 
     if (storedState) {
-      const filters = this.getState().getFilters();
-      // NOTE: Allows for new defaults to get added to stored filters
-      storedState.filters = extend({}, filters, storedState.filters);
-      storedState.lastSelectedIndex = null;
-
       this.setState(storedState);
 
       return;
     }
+
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    this.setState({ id: `schedule_${ currentUser.id }` });
 
     this.getState().setDefaultFilterStates();
   },

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -9,7 +9,7 @@ import { RELATIVE_DATE_RANGES } from 'js/static';
 
 const relativeRanges = new Backbone.Collection(RELATIVE_DATE_RANGES);
 
-export const STATE_VERSION = 'v4';
+const STATE_VERSION = 'v4';
 
 export default Backbone.Model.extend({
   defaults() {
@@ -31,16 +31,21 @@ export default Backbone.Model.extend({
     };
   },
   preinitialize() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-    this.states = currentWorkspace.getStates();
-
+    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    this.states = this.currentWorkspace.getStates();
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
   },
   initialize() {
     this.on('change', this.onChange);
   },
+  getStoreKey() {
+    return `schedule_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
+  },
+  getStore() {
+    return store.get(this.getStoreKey());
+  },
   onChange() {
-    store.set(`schedule_${ this.currentClinician.id }-${ STATE_VERSION }`, omit(this.attributes, 'searchQuery', 'isFiltering'));
+    store.set(this.getStoreKey(), omit(this.attributes, 'searchQuery', 'isFiltering', 'lastSelectedIndex'));
   },
   getFilters() {
     return clone(this.get('filters'));

--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -35,6 +35,16 @@ export default App.extend({
   showCustomFiltersView() {
     const collection = this.directories.clone();
 
+    const customFilters = Radio.request('bootstrap', 'setting', 'custom_filters');
+
+    if (customFilters && customFilters.length) {
+      const filteredDirectories = collection.filter(directory => {
+        return customFilters.includes(directory.get('slug'));
+      });
+
+      collection.reset(filteredDirectories);
+    }
+
     const customFiltersView = new CustomFiltersView({
       collection,
       state: this.getState(),

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -1,14 +1,10 @@
-import { extend } from 'underscore';
-
-import store from 'store';
-
 import Radio from 'backbone.radio';
 
 import intl, { renderTemplate } from 'js/i18n';
 
 import App from 'js/base/app';
 
-import StateModel, { STATE_VERSION } from './worklist_state';
+import StateModel from './worklist_state';
 
 import FiltersApp from './filters_app';
 import BulkEditActionsApp from 'js/apps/patients/sidebar/bulk-edit-actions_app';
@@ -52,21 +48,14 @@ export default App.extend({
     this.toggleBulkSelect();
   },
   initListState() {
-    const currentUser = Radio.request('bootstrap', 'currentUser');
-    const storedState = store.get(`${ this.worklistId }_${ currentUser.id }-${ STATE_VERSION }`);
-
-    this.setState({ id: this.worklistId });
+    const storedState = this.getState().getStore(this.worklistId);
 
     if (storedState) {
-      const filters = this.getState().getFilters();
-      // NOTE: Allows for new defaults to get added to stored filters
-      storedState.filters = extend({}, filters, storedState.filters);
-      storedState.lastSelectedIndex = null;
-
       this.setState(storedState);
-
       return;
     }
+
+    this.setState({ id: this.worklistId });
 
     this.getState().setDefaultFilterStates();
   },

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -91,7 +91,6 @@ export default App.extend({
     this.shouldShowClinician = this.getState().id !== 'shared-by';
     this.shouldShowTeam = this.getState().id !== 'owned-by';
     this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
-    this.workspaces = currentClinician.getWorkspaces();
 
     this.showView(new LayoutView({
       worklistId: this.worklistId,
@@ -343,7 +342,7 @@ export default App.extend({
 
     const options = {
       owner: this.shouldShowClinician && clinicianId ? owner : team,
-      workspaces: this.shouldShowClinician && this.canViewAssignedActions ? this.workspaces : null,
+      hasClinicians: this.shouldShowClinician && this.canViewAssignedActions,
       isTitleFilter: true,
       headingText: this.shouldShowClinician ? i18n.ownerFilterHeadingText : i18n.teamsFilterHeadingText,
       hasTeams: this.shouldShowTeam,

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -41,7 +41,7 @@ export default Backbone.Model.extend({
       selectedActions: {},
       selectedFlows: {},
       searchQuery: '',
-      listType: 'flows',
+      listType: 'actions',
     };
   },
   preinitialize() {

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -8,7 +8,7 @@ import Radio from 'backbone.radio';
 
 import { RELATIVE_DATE_RANGES } from 'js/static';
 
-export const STATE_VERSION = 'v4';
+const STATE_VERSION = 'v4';
 
 const relativeRanges = new Backbone.Collection(RELATIVE_DATE_RANGES);
 
@@ -45,15 +45,21 @@ export default Backbone.Model.extend({
     };
   },
   preinitialize() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-    this.states = currentWorkspace.getStates();
+    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    this.states = this.currentWorkspace.getStates();
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
   },
   initialize() {
     this.on('change', this.onChange);
   },
+  getStoreKey(id) {
+    return `${ id }_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
+  },
+  getStore(id) {
+    return store.get(this.getStoreKey(id));
+  },
   onChange() {
-    store.set(`${ this.id }_${ this.currentClinician.id }-${ STATE_VERSION }`, omit(this.attributes, 'searchQuery', 'isFiltering'));
+    store.set(this.getStoreKey(this.id), omit(this.attributes, 'searchQuery', 'isFiltering', 'lastSelectedIndex'));
   },
   setDateFilters(filters) {
     return this.set(`${ this.getType() }DateFilters`, clone(filters));

--- a/src/js/entities-service/entities/teams.js
+++ b/src/js/entities-service/entities/teams.js
@@ -7,10 +7,6 @@ const TYPE = 'teams';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/teams',
-  hasClinicians() {
-    const clinicians = this.get('_clinicians');
-    return clinicians && clinicians.length;
-  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/entities/workspaces.js
+++ b/src/js/entities-service/entities/workspaces.js
@@ -1,4 +1,4 @@
-import { reject, union } from 'underscore';
+import { reject, union, pick } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -25,6 +25,9 @@ const _Model = BaseModel.extend({
     clinicians.reset(assignableClinicians);
 
     return clinicians;
+  },
+  updateClinicians(clinicians) {
+    this.set('_clinicians', clinicians.map(m => pick(m, 'id', 'type')));
   },
   addClinician(clinician) {
     const url = `/api/workspaces/${ this.id }/relationships/clinicians`;
@@ -69,6 +72,7 @@ const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/workspaces',
   model: Model,
+  comparator: 'name',
 });
 
 export {

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -75,7 +75,8 @@ export default App.extend({
     return this.directories;
   },
   getSetting(settingName) {
-    const setting = this.settings.get(settingName);
+    const workspaceSettings = this.currentWorkspace.get('settings');
+    const setting = get(workspaceSettings, settingName) || this.settings.get(settingName);
     if (!setting) return;
     return setting.get('value');
   },

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -32,7 +32,6 @@ export default App.extend({
     'setting': 'getSetting',
     'roles:active': 'getActiveRoles',
     'teams': 'getTeams',
-    'teams:active': 'getActiveTeams',
     'sidebarWidgets': 'getSidebarWidgets',
     'sidebarWidgets:fields': 'getSidebarWidgetFields',
     'fetch': 'fetchBootstrap',
@@ -93,16 +92,6 @@ export default App.extend({
   },
   getTeams() {
     return this.teams.clone();
-  },
-  // Returns teams with clinicians
-  getActiveTeams() { //
-    const teams = this.getTeams();
-
-    teams.reset(teams.filter(team => {
-      return team.hasClinicians();
-    }));
-
-    return teams;
   },
   getSidebarWidgets() {
     const sidebarWidgets = get(this.getSetting('widgets_patient_sidebar'), 'widgets');

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -109,7 +109,6 @@ const ActionItemView = View.extend({
   showOwner() {
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled: true },
     });
@@ -174,7 +173,6 @@ const FlowItemView = View.extend({
   showOwner() {
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled: true },
     });

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -118,7 +118,6 @@ const ActionItemView = View.extend({
     const isDisabled = this.model.isNew();
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });
@@ -192,7 +191,6 @@ const FlowItemView = View.extend({
     const isDisabled = this.model.isNew();
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -91,7 +91,6 @@ const HeaderView = View.extend({
     const isDisabled = this.model.isDone();
     const ownerComponent = new FlowOwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });
@@ -211,7 +210,6 @@ const ActionItemView = View.extend({
     const isDisabled = this.model.isDone() || this.flow.isDone();
     this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });

--- a/src/js/views/patients/shared/components/owner_component.js
+++ b/src/js/views/patients/shared/components/owner_component.js
@@ -15,21 +15,21 @@ const i18n = intl.patients.shared.components.ownerComponent;
 const OwnerItemTemplate = hbs`<div>{{matchText name query}} <span class="owner-component__team">{{matchText abbr query}}</span></div>`;
 const TitleOwnerFilterTemplate = hbs`<div><span class="owner-component__title-filter-name">{{ name }}</span>{{far "angle-down"}}</div>`;
 
+let currentWorkspaceCache;
 let teamsCollection;
+let cliniciansCache;
 
-function getTeams() {
+function getTeams(workspace) {
   if (teamsCollection) return teamsCollection;
-  teamsCollection = Radio.request('bootstrap', 'teams:active');
+  const clinicians = getClinicians(workspace);
+  teamsCollection = Radio.request('entities', 'teams:collection', clinicians.invoke('getTeam'));
   return teamsCollection;
 }
 
-// Caching for single renders
-let workspaceCache = {};
-
-function getWorkspaceClinicians(workspace) {
-  if (workspaceCache[workspace.id]) return workspaceCache[workspace.id];
-  workspaceCache[workspace.id] = workspace.getAssignableClinicians();
-  return workspaceCache[workspace.id];
+function getClinicians(workspace) {
+  if (cliniciansCache) return cliniciansCache;
+  cliniciansCache = workspace.getAssignableClinicians();
+  return cliniciansCache;
 }
 
 export default Droplist.extend({
@@ -37,6 +37,7 @@ export default Droplist.extend({
   headingText: i18n.headingText,
   placeholderText: i18n.placeholderText,
   hasTeams: true,
+  hasClinicians: true,
   hasCurrentClinician: true,
   popWidth() {
     const isCompact = this.getOption('isCompact');
@@ -93,37 +94,40 @@ export default Droplist.extend({
     };
   },
 
-  initialize({ owner, workspaces }) {
+  initialize({ owner }) {
     this.lists = [];
+    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
 
-    if (this.getOption('hasCurrentClinician')) {
-      const currentUser = Radio.request('bootstrap', 'currentUser');
+    if (currentWorkspaceCache !== currentWorkspace.id) {
+      teamsCollection = null;
+      cliniciansCache = null;
+      currentWorkspaceCache = currentWorkspace.id;
+    }
+
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const clinicians = getClinicians(currentWorkspace);
+
+    if (this.getOption('hasCurrentClinician') && clinicians.get(currentUser)) {
       this.lists.push({
         collection: new Backbone.Collection([currentUser]),
       });
     }
 
-    if (workspaces) {
-      this.lists.push(...workspaces.map(workspace => {
-        return {
-          collection: getWorkspaceClinicians(workspace),
-          headingText: workspace.get('name'),
-        };
-      }));
+    if (this.getOption('hasClinicians') && clinicians.length) {
+      this.lists.push({
+        collection: clinicians,
+        headingText: currentWorkspace.get('name'),
+      });
     }
 
     if (this.getOption('hasTeams')) {
       this.lists.push({
-        collection: getTeams(),
+        collection: getTeams(currentWorkspace),
         headingText: this.lists.length ? i18n.teamsHeadingText : null,
       });
     }
 
     this.setState({ selected: owner });
-  },
-  onDestroy() {
-    // NOTE: overzealously clearing the cache
-    workspaceCache = {};
   },
   onChangeSelected(selected) {
     this.triggerMethod('change:owner', selected);

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -333,7 +333,6 @@ const LayoutView = View.extend({
     const isDisabled = this.action.isNew() || this.action.isDone() || this.isFlowDone();
     const ownerComponent = new OwnerComponent({
       owner: this.action.getOwner(),
-      workspaces: this.action.getPatient().getWorkspaces(),
       state: { isDisabled },
     });
 

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -100,7 +100,6 @@ const LayoutView = View.extend({
     const isDisabled = this.model.isDone();
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       state: { isDisabled },
     });
 

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -112,7 +112,6 @@ const ActionItemView = View.extend({
     const isDisabled = this.model.isDone();
     this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -119,7 +119,6 @@ const FlowItemView = View.extend({
     const isDisabled = this.model.isDone();
     this.ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
-      workspaces: this.model.getPatient().getWorkspaces(),
       isCompact: true,
       state: { isDisabled },
     });

--- a/src/js/views/shared/components/team/index.js
+++ b/src/js/views/shared/components/team/index.js
@@ -14,14 +14,6 @@ const i18n = intl.shared.components.teamComponent;
 
 const TeamItemTemplate = hbs`<div>{{matchText name query}} <span class="team-component__team">{{matchText abbr query}}</span></div>`;
 
-let teamsCollection;
-
-function getTeams() {
-  if (teamsCollection) return teamsCollection;
-  teamsCollection = Radio.request('bootstrap', 'teams');
-  return teamsCollection;
-}
-
 export default Droplist.extend({
   TeamItemTemplate,
   isCompact: false,
@@ -70,7 +62,7 @@ export default Droplist.extend({
     };
   },
   initialize({ team }) {
-    this.collection = getTeams();
+    this.collection = Radio.request('bootstrap', 'teams');
 
     this.setState({ selected: this.collection.get(team) });
   },


### PR DESCRIPTION
Shortcut Story ID: [sc-33869]

We must load the clinicians every time we change workspaces, but workspace only bootstrap at the beginning.  Because they are fetched at different times there's a chance they get outdated so this updates the clinician relations on the workspace to prevent errors.

Then it moves all the workspace/team caching for the owner component into the component and clears the cache when the current workspace changes.

The clinician owner component was following a similar caching strategy, but with no clearing, and there's really no point in doing so