### PR TITLE
Move dashboards link to the left nav

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -139,13 +139,14 @@ careOptsFrontend:
       appNavViews:
         adminNav:
           clinicians: Clinicians
-          dashboards: Dashboards
           programs: Programs
         adminToolsDroplist:
           adminTools: Admin Tools
         appNavView:
           addPatient: Add Patient
           minimizeMenu: Minimize Menu
+        dashboardsNav:
+          dashboards: Dashboards
         mainNavDroplist:
           help: Help & Support
           organizationHeading: Your Organization

--- a/src/js/views/globals/app-nav/app-nav.scss
+++ b/src/js/views/globals/app-nav/app-nav.scss
@@ -3,13 +3,13 @@ $menu-hover-color: #375467;
 .app-nav {
   color: $black-90;
   height: 100%;
-  min-height: 608px;
+  min-height: 652px;
   position: relative;
   transition: width 250ms ease-in-out 0s;
   width: 200px;
 
   &.minimized {
-    min-height: 544px;
+    min-height: 588px;
     width: 56px;
   }
 }

--- a/src/js/views/globals/app-nav/app-nav_views.js
+++ b/src/js/views/globals/app-nav/app-nav_views.js
@@ -139,12 +139,17 @@ const AdminToolsDroplist = Droplist.extend({
 const BottomNavView = View.extend({
   className: 'app-nav__bottom',
   regions: {
+    dashboards: {
+      el: '[data-nav-dashboards-region]',
+      replaceElement: true,
+    },
     adminTools: {
       el: '[data-nav-admin-tools-region]',
       replaceElement: true,
     },
   },
   template: hbs`
+    <div data-nav-dashboards-region></div>
     {{#if canPatientCreate}}
       <div class="flex flex-align-center app-nav__bottom-button js-add-patient">
         {{fas "circle-plus"}}{{#unless isMinimized}}<span class="u-text--overflow">{{ @intl.globals.appNav.appNavViews.appNavView.addPatient }}</span>{{/unless}}
@@ -280,5 +285,6 @@ export {
   PatientsAppNav,
   AdminToolsDroplist,
   BottomNavView,
+  NavItemView,
   i18n,
 };


### PR DESCRIPTION
Shortcut Story ID: [sc-33794]

Before this link was in the admin tools droplist:

![Screenshot 2023-02-28 at 9 47 18 AM](https://user-images.githubusercontent.com/35355575/221905214-be972f50-fc61-4a58-b334-8c133291967a.png)

Now it will be in the nav:

![Screenshot 2023-02-28 at 9 46 31 AM](https://user-images.githubusercontent.com/35355575/221905178-099537fd-9d8c-4b33-ae9a-e4b4f2710fc2.png)

Still hidden if the user doesn't have the `dashboards:view` permission.