### PR TITLE
Restart the nav app when 'change:workspace' is triggered

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -20,9 +20,10 @@ export default App.extend({
     this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
     this.getRegion('content').empty();
 
+    new NavApp({ region: this.getRegion('nav') });
+
     if (this.isRestarting()) return;
 
-    new NavApp({ region: this.getRegion('nav') });
     new SidebarService({ region: this.getRegion('sidebar') });
 
     this.listenTo(Radio.channel('bootstrap'), 'change:workspace', this.restart);


### PR DESCRIPTION
Shortcut Story ID: [sc-34124]

Fixes an issue where the incorrect workspace was being shown in the top nav menu button. The nav app wasn't restarting when the `change:workspace` was triggered, which means it didn't have the correct `currentWorkspace` when a user changes between workspaces.

