### PR TITLE
Fix go back history on forms

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -71,39 +71,46 @@ export default App.extend({
       form: this.form,
     });
 
-    this.listenTo(formService, {
-      'submit'() {
-        const saveButtonType = this.getState('saveButtonType');
+    this.bindEvents(formService, this.serviceEvents);
+  },
+  serviceEvents: {
+    'submit': 'onFormServiceSubmit',
+    'success': 'onFormServiceSuccess',
+    'ready': 'onFormServiceReady',
+    'error': 'onFormServiceError',
+  },
+  onFormServiceSubmit() {
+    const saveButtonType = this.getState('saveButtonType');
 
-        if (saveButtonType !== 'saveAndGoBack') return;
+    if (saveButtonType !== 'saveAndGoBack') return;
 
-        this.loadingModal = Radio.request('modal', 'show:loading');
-      },
-      'success'(response) {
-        const saveButtonType = this.getState('saveButtonType');
+    this.loadingModal = Radio.request('modal', 'show:loading');
+  },
+  onFormServiceSuccess(response) {
+    const saveButtonType = this.getState('saveButtonType');
 
-        if (saveButtonType === 'saveAndGoBack') {
-          this.listenTo(this.loadingModal, 'destroy', () => {
-            Radio.request('history', 'go:back');
-          });
+    if (saveButtonType === 'saveAndGoBack') {
+      this.listenTo(this.loadingModal, 'destroy', () => {
+        Radio.request('history', 'go:back', () => {
+          Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
+        });
+      });
 
-          return;
-        }
+      return;
+    }
 
-        response.set({ _created_at: dayjs().format() });
+    response.set({ _created_at: dayjs().format() });
 
-        this.showForm(response.id);
-        this.showFormStatus(response);
-      },
-      'ready'() {
-        this.showFormSave();
-      },
-      'error'() {
-        if (this.loadingModal) this.loadingModal.destroy();
+    this.showForm(response.id);
+    this.showFormStatus(response);
+  },
+  onFormServiceReady() {
+    this.showFormSave();
+  },
+  onFormServiceError() {
+    if (this.loadingModal) this.loadingModal.destroy();
 
-        this.showFormSave();
-      },
-    });
+    this.showFormSave();
   },
   stateEvents: {
     'change': 'onChangeState',

--- a/src/js/services/history.js
+++ b/src/js/services/history.js
@@ -48,7 +48,16 @@ export default App.extend({
   triggerChange() {
     this.getChannel().trigger('change:route', this._prevHistory[0]);
   },
-  goBack() {
+  goBack(handleEmptyHistory) {
+    if (handleEmptyHistory && this._prevHistory.length < 2) {
+      handleEmptyHistory();
+      return;
+    }
+
+    // Remove the current route from the stack
+    this._prevHistory.shift();
+
+    // Navigate to the previous route
     Backbone.history.navigate(this._prevHistory.shift(), { trigger: true });
   },
 });

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -34,9 +34,14 @@ const ContextTrailView = View.extend({
     'click .js-dashboard': 'click:dashboard',
   },
   onClickBack() {
-    Radio.request('history', 'go:back');
+    Radio.request('history', 'go:back', () => {
+      this.routeToPatient();
+    });
   },
   onClickDashboard() {
+    this.routeToPatient();
+  },
+  routeToPatient() {
     Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
   },
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-34125]

So this latest history service is working far far better than the previous one, but 🤦 I wasn't removing the current route before going back in this release, so it was going to the current route.

In any case I snuck in an empty history handler which defaults forms to go to the patient's dashboard if there was no previous history recorded @shadowhand   seems to work.