### PR TITLE
Remove reduced schedule default handler

### DIFF
--- a/src/js/apps/patients/reduced-patients-main_app.js
+++ b/src/js/apps/patients/reduced-patients-main_app.js
@@ -1,7 +1,3 @@
-import { defer } from 'underscore';
-
-import Radio from 'backbone.radio';
-
 import RouterApp from 'js/base/routerapp';
 
 import FlowApp from 'js/apps/patients/patient/flow/flow_app';
@@ -17,54 +13,37 @@ export default RouterApp.extend({
       schedule: ReducedScheduleApp,
     };
   },
-  defaultRoute() {
-    const defaultRoute = 'schedule';
 
-    this.routeAction(defaultRoute, () => {
-      defer(()=> {
-        this.navigateRoute(defaultRoute);
-        Radio.request('nav', 'select', this.routerAppName, defaultRoute);
-        this.setLatestList(defaultRoute);
-        this.showSchedule();
-      });
-    });
-  },
-  eventRoutes() {
-    return {
-      'default': {
-        action: 'defaultRoute',
-        route: '',
-      },
-      'schedule': {
-        action: 'showSchedule',
-        route: 'schedule',
-        isList: true,
-      },
-      'patient:dashboard': {
-        action: 'showPatient',
-        route: 'patient/dashboard/:id',
-      },
-      'patient:archive': {
-        action: 'showPatient',
-        route: 'patient/archive/:id',
-      },
-      'patient:action': {
-        action: 'showPatient',
-        route: 'patient/:id/action/:id',
-      },
-      'patient:action:new': {
-        action: 'showPatient',
-        route: 'patient/:id/action',
-      },
-      'flow': {
-        action: 'showFlow',
-        route: 'flow/:id',
-      },
-      'flow:action': {
-        action: 'showFlow',
-        route: 'flow/:id/action/:id',
-      },
-    };
+  eventRoutes: {
+    'schedule': {
+      action: 'showSchedule',
+      route: 'schedule',
+      isList: true,
+    },
+    'patient:dashboard': {
+      action: 'showPatient',
+      route: 'patient/dashboard/:id',
+    },
+    'patient:archive': {
+      action: 'showPatient',
+      route: 'patient/archive/:id',
+    },
+    'patient:action': {
+      action: 'showPatient',
+      route: 'patient/:id/action/:id',
+    },
+    'patient:action:new': {
+      action: 'showPatient',
+      route: 'patient/:id/action',
+    },
+    'flow': {
+      action: 'showFlow',
+      route: 'flow/:id',
+    },
+    'flow:action': {
+      action: 'showFlow',
+      route: 'flow/:id/action/:id',
+    },
   },
   showPatient(patientId) {
     this.startRoute('patient', { patientId });


### PR DESCRIPTION
Shortcut Story ID: [sc-34139]

Missed removing this when the same was done for the default patient app.

The default route is now handled in the `nav_app`