### PR TITLE
Reshow nav droplist on workspace change

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -173,6 +173,11 @@ export default RouterApp.extend({
   StateModel,
   startAfterInitialized: true,
   channelName: 'nav',
+  initialize() {
+    const bootstrapCh = Radio.channel('bootstrap');
+
+    this.listenTo(bootstrapCh, 'change:workspace', this.showMainNavDroplist);
+  },
   radioRequests: {
     'search': 'showSearch',
     'patient': 'showPatientModal',


### PR DESCRIPTION
Fixes [sc-34124]

Replaces https://github.com/RoundingWell/care-ops-frontend/pull/943

This reshowing needs to within the nav app.  As the nav app is now a router, it’d be best if it didn’t have to restart and rerender everything.  The app should be able to handle the change internally.
