### PR TITLE
When a new action is created, set its initial state to the first state with `status: queued`

### DIFF
--- a/src/js/apps/patients/patient/action/action_app.js
+++ b/src/js/apps/patients/patient/action/action_app.js
@@ -1,3 +1,4 @@
+import { first } from 'underscore';
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 
@@ -14,9 +15,11 @@ export default App.extend({
       const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
       const states = currentWorkspace.getStates();
 
+      const defaultInitialState = first(states.filter({ status: 'queued' }));
+
       return Radio.request('entities', 'actions:model', {
         _patient: patientId,
-        _state: states.at(0).id,
+        _state: defaultInitialState.id,
         _owner: {
           type: 'clinicians',
           id: currentUser.id,

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -40,14 +40,11 @@ const _Model = BaseModel.extend({
   },
   getAction({ patientId, flowId }) {
     const currentUser = Radio.request('bootstrap', 'currentUser');
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-    const states = currentWorkspace.getStates();
 
     return Radio.request('entities', 'actions:model', {
       name: this.get('name'),
       _flow: flowId,
       _patient: patientId,
-      _state: states.at(0).id,
       _owner: this.get('_owner') || {
         id: currentUser.id,
         type: 'clinicians',

--- a/src/js/entities-service/entities/program-flows.js
+++ b/src/js/entities-service/entities/program-flows.js
@@ -46,13 +46,9 @@ const _Model = BaseModel.extend({
     return Radio.request('entities', 'teams:model', owner.id);
   },
   getFlow(patientId) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-    const states = currentWorkspace.getStates();
-
     const flow = Radio.request('entities', 'flows:model', {
       _patient: patientId,
       _program_flow: this.get('id'),
-      _state: states.at(0).id,
     });
 
     return flow;


### PR DESCRIPTION
Shortcut Story ID: [sc-34207]

We currently set `states[0]` to be the initial state when creating a new action. This causes issues if the states data is ordered in a way we don't expect, where `states[0]` is not a state with `status: queued` (e.g. an initial action state is `status: done`).

So we should do this instead: `_state: first(states.filter({ status: 'queued' })).id`.