### PR TITLE
Form submit UI updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
       "screwdriver-wrench",
       "share-from-square",
       "shield",
+      "shield-check",
       "sliders",
       "square-poll-horizontal",
       "stopwatch",

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -63,7 +63,7 @@ export default App.extend({
       }
     });
   },
-  onBeforeStop() {
+  onStop() {
     invoke(this.routers, 'destroy');
     this.routers = [];
   },
@@ -89,6 +89,8 @@ export default App.extend({
     });
   },
   toggleNav(shouldShow) {
+    if (!this.isRunning()) return;
+
     this.getView().toggleNav(!!shouldShow);
   },
 });

--- a/src/js/base/dayjs.js
+++ b/src/js/base/dayjs.js
@@ -4,11 +4,13 @@ import utcPlugin from 'dayjs/plugin/utc';
 import localizedFormatPlugin from 'dayjs/plugin/localizedFormat';
 import weekdayPlugin from 'dayjs/plugin/weekday';
 import customParseFormatPlugin from 'dayjs/plugin/customParseFormat';
+import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(localizedFormatPlugin);
 dayjs.extend(utcPlugin);
 dayjs.extend(weekdayPlugin);
 dayjs.extend(customParseFormatPlugin);
+dayjs.extend(relativeTime);
 
 const formats = {
   // Jan 15
@@ -32,6 +34,13 @@ const formats = {
   TIME_OR_DAY(date) {
     if (date.isSame(dayjs(), 'day')) {
       return date.format(formats.TIME);
+    }
+
+    return formats.DATE(date);
+  },
+  AGO_OR_TODAY(date) {
+    if (date.isSame(dayjs(), 'day')) {
+      return date.fromNow();
     }
 
     return formats.DATE(date);

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -23,6 +23,9 @@ const _Model = BaseModel.extend({
   isReadOnly() {
     return get(this.get('options'), 'read_only');
   },
+  isSubmitHidden() {
+    return get(this.get('options'), 'submit_hidden');
+  },
   getReducers() {
     return get(this.get('options'), 'reducers', [defaultReducer]);
   },

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -107,27 +107,34 @@ careOptsFrontend:
           showActionSidebar: Show Action Sidebar
         historyView:
           currentVersionButton: Back to Current Version
+        lastUpdatedView:
+          storedWork: Your work is stored automatically.
+          updatedAt: Last edit was { updated }
         previewView:
           backBtn: Go Back
           title: Form Preview
         readOnlyView:
           buttonText: Read Only
         saveView:
-          droplistLabel: Your Save Button Preference
+          droplistLabel: Your Submit Button Preference
           save:
-            buttonText: Save
-            droplistItemText: Save Form
+            buttonText: Submit
+            droplistItemText: Submit Form
           saveAndGoBack:
-            buttonText: Save + Go Back
-            droplistItemText: Save Form + Go Back
+            buttonText: Submit + Go Back
+            droplistItemText: Submit Form + Go Back
         statusView:
-          label: Last saved { date }
-          notSaved: Your edits are not saved
+          label: Last submitted { date }
+          notSaved: Your edits are not submitted
         storedSubmissionView:
-          title: You have unsaved work on this form. Would you like to load your unsaved work?
-          submitButton: Load Form with Unsaved Work
-          cancelButton: Discard Unsaved Work
-          updated: Data stored on { updated }
+          cancelButton: Discard My Work...
+          discardModal:
+            bodyText: Discarding your unsubmitted work on this form will load the latest data for this patient, but you'll lose your unsubmitted work.
+            headingText: Are you sure?
+            submitText: Discard My Work
+          submitButton: Load Form with My Work
+          title: You have unsubmitted work on this form. Would you like to load your work?
+          updated: Last edit was { updated }
         updateView:
           buttonText: Update
   globals:

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -52,6 +52,7 @@ export default App.extend({
     const updated = dayjs().format();
     try {
       store.set(this.getStoreId(), { submission, updated });
+      this.trigger('update:submission', updated);
     } catch (e) /* istanbul ignore next: Tested locally, test runner borks on CI */ {
       store.each((value, key) => {
         if (String(key).startsWith('form-subm-')) store.remove(key);

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -39,7 +39,7 @@
 .form__title-icon {
   align-items: center;
   display: flex;
-  margin-right: 16px;
+  margin-right: 12px;
 
   .icon {
     font-size: 20px;
@@ -121,13 +121,8 @@
 .form__controls {
   display: flex;
   justify-content: flex-end;
-  margin-top: 12px;
-}
-
-.form__actions {
-  border-right: 1px solid $black-80;
-  display: flex;
-  margin-right: 20px;
+  line-height: 1.2;
+  padding: 16px 0 16px 16px;
 }
 
 .form__alert-text {
@@ -137,11 +132,15 @@
 
 .form__actions-icon {
   cursor: pointer;
-  margin-right: 20px;
+  margin-right: 16px;
 
   .icon {
     color: $black-60;
     font-size: 20px;
+  }
+
+  &:last-child {
+    margin-right: 0;
   }
 
   &:hover,
@@ -164,4 +163,34 @@
       color: $black-80;
     }
   }
+}
+
+.form__last-updated {
+  align-items: center;
+  border-left: 1px solid $black-80;
+  display: flex;
+  margin-left: 20px;
+  padding-left: 20px;
+}
+
+.form__last-updated-icon {
+  font-size: 20px;
+  margin-right: 12px;
+
+  .icon {
+    color: $black-60;
+    font-size: 20px;
+    vertical-align: -0.125em;
+  }
+}
+
+.form__last-updated-text {
+  font-size: 12px;
+}
+
+.form__form-action {
+  border-left: 1px solid $black-80;
+  display: flex;
+  margin-left: 20px;
+  padding-left: 20px;
 }

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -47,7 +47,7 @@ const ContextTrailView = View.extend({
 });
 
 const FormActionsView = View.extend({
-  className: 'form__actions',
+  className: 'flex',
   template: hbs`
     {{#if hasHistory}}<button class="js-history-button form__actions-icon{{#if shouldShowHistory}} is-selected{{/if}}">{{far "clock-rotate-left"}}</button>{{/if}}
     <button class="js-expand-button form__actions-icon">{{#if isExpanded}}{{far "down-left-and-up-right-to-center"}}{{else}}{{far "up-right-and-down-left-from-center"}}{{/if}}</button>
@@ -134,7 +134,8 @@ const LayoutView = View.extend({
           <div data-status-region>&nbsp;</div>
           <div class="form__controls">
             <div data-actions-region></div>
-            <div><div data-form-action-region></div></div>
+            <div data-form-updated-region></div>
+            <div data-form-action-region></div>
           </div>
         </div>
       </div>
@@ -148,7 +149,11 @@ const LayoutView = View.extend({
     actions: '[data-actions-region]',
     contextTrail: '[data-context-trail-region]',
     form: '[data-form-region]',
-    formAction: '[data-form-action-region]',
+    formUpdated: '[data-form-updated-region]',
+    formAction: {
+      el: '[data-form-action-region]',
+      replaceElement: true,
+    },
     sidebar: {
       el: '[data-sidebar-region]',
       replaceElement: false,
@@ -188,10 +193,10 @@ const StoredSubmissionView = View.extend({
       <div class="form__prompt-dialog">
         <div class="flex-shrink">
           <button class="button--blue button--large js-submit">{{ @intl.forms.form.formViews.storedSubmissionView.submitButton }}</button>
-          <div class="u-margin--t-16">{{formatHTMLMessage (intlGet "forms.form.formViews.storedSubmissionView.updated") updated=(formatDateTime updated "AT_TIME")}}</div>
+          <div class="u-margin--t-16">{{formatHTMLMessage (intlGet "forms.form.formViews.storedSubmissionView.updated") updated=(formatDateTime updated "AGO_OR_TODAY")}}</div>
         </div>
         <div class="flex-shrink">
-          <button class="button-secondary button--large form__discard-button js-cancel" style="color:red">{{ @intl.forms.form.formViews.storedSubmissionView.cancelButton }}</button>
+          <button class="button-secondary button--large form__discard-button js-discard" style="color:red">{{ @intl.forms.form.formViews.storedSubmissionView.cancelButton }}</button>
         </div>
       </div>
     </div>
@@ -203,7 +208,19 @@ const StoredSubmissionView = View.extend({
   },
   triggers: {
     'click .js-submit': 'submit',
-    'click .js-cancel': 'cancel',
+    'click .js-discard': 'discard',
+  },
+  onDiscard() {
+    const modal = Radio.request('modal', 'show:small', {
+      bodyText: i18n.storedSubmissionView.discardModal.bodyText,
+      headingText: i18n.storedSubmissionView.discardModal.headingText,
+      submitText: i18n.storedSubmissionView.discardModal.submitText,
+      buttonClass: 'button--red',
+      onSubmit: () => {
+        modal.destroy();
+        this.triggerMethod('discard:submission');
+      },
+    });
   },
 });
 
@@ -246,12 +263,10 @@ const StatusView = View.extend({
 });
 
 const ReadOnlyView = View.extend({
-  tagName: 'button',
-  className: 'button--grey',
-  attributes: {
-    disabled: true,
-  },
-  template: hbs`{{ @intl.forms.form.formViews.readOnlyView.buttonText }}`,
+  className: 'form__form-action',
+  template: hbs`
+    <button class="button--grey" disabled=true>{{ @intl.forms.form.formViews.readOnlyView.buttonText }}</button>
+  `,
 });
 
 const SaveButtonTypeDroplist = Droplist.extend({
@@ -284,8 +299,28 @@ const SaveButtonTypeDroplist = Droplist.extend({
   },
 });
 
+const LastUpdatedView = View.extend({
+  className: 'form__last-updated',
+  template: hbs`
+    <div class="form__last-updated-icon">
+      {{far "shield-check"}}
+    </div>
+    <div class="form__last-updated-text">
+      <div class="u-text--overflow">{{ @intl.forms.form.formViews.lastUpdatedView.storedWork }}</div>
+      {{#if updated}}
+        <div class="u-text--overflow">{{formatHTMLMessage (intlGet "forms.form.formViews.lastUpdatedView.updatedAt") updated=(formatDateTime updated "AGO_OR_TODAY")}}</div>
+      {{/if}}
+    </div>
+  `,
+  templateContext() {
+    return {
+      updated: this.getOption('updated'),
+    };
+  },
+});
+
 const SaveView = View.extend({
-  className: 'flex',
+  className: 'form__form-action',
   regions: {
     saveType: {
       el: '[data-save-type-region]',
@@ -335,9 +370,10 @@ const SaveView = View.extend({
 });
 
 const UpdateView = View.extend({
-  tagName: 'button',
-  className: 'button--green',
-  template: hbs`{{ @intl.forms.form.formViews.updateView.buttonText }}`,
+  className: 'form__form-action',
+  template: hbs`
+    <button class="button--green">{{ @intl.forms.form.formViews.updateView.buttonText }}</button>
+  `,
   triggers: {
     'click': 'click',
   },
@@ -392,4 +428,5 @@ export {
   ReadOnlyView,
   UpdateView,
   HistoryView,
+  LastUpdatedView,
 };


### PR DESCRIPTION
Shortcut Story ID: [sc-34162] [sc-34069]

Changes made in this PR (applied to both patient and patient action forms):

- Change the verbage on the form submit button from `Save`/`Save + Go Back` => `Submit`/`Submit + Go Back`.
    - Any other places where `Save` verbage existed was also changed to `Submit`.
- Allow for the form submit button to be optionally hidden. 
    - Based on `form.model.options.submit_hidden = BOOLEAN`.
    - Doesn't affect the `Read Only` or `Update` buttons.
- Add a section on the form page that shows the last time the form was updated.
    - Last edit date is based on the `updated: DATE` property stored by the latest submission in local storage ([screenshot](https://user-images.githubusercontent.com/35355575/223540109-f4fcf8e9-352b-4200-9e5d-e4f8e243c4c2.png)).
    - If there's no stored submission, the section is shown without the last edited date ([screenshot](https://user-images.githubusercontent.com/35355575/223540500-637ff1c5-1da1-494a-a0f9-8c8adb32d765.png)).
    - This section is hidden on read only forms or if the form has already been submitted (i.e. when the `Read Only` or `Update` buttons are shown).
    - The last edited date should be removed from the UI after a user discards their stored form submission.
- Show a confirmation modal when a user selects the `Discard My Work` button to remove their stored form submission.
    - [Screenshot](https://user-images.githubusercontent.com/35355575/223541364-1045fb8a-3fe5-40a1-b1a4-3bbc6384891b.png)
- Stop the nav menu from showing when the form page is hard refreshed.