### PR TITLE
Enhance datadog error logging

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -139,8 +139,6 @@ const Application = App.extend({
   },
 
   onStart(options, currentUser, { default: AppFrameApp }) {
-    datadogRum.setUser(currentUser.pick('id', 'name', 'email'));
-
     if (!currentUser.hasTeam() || !currentUser.get('enabled')) {
       this.getRegion('preloader').show(new PreloaderView({ notSetup: true }));
       return;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -132,8 +132,9 @@ const Application = App.extend({
   },
 
   onFail(options, response) {
+    datadogRum.addError(response);
     // eslint-disable-next-line no-console
-    if (response.status !== 500) console.error(new Error(response));
+    if (_DEVELOP_ && response.status !== 500) console.error(new Error(response));
     this.getRegion('preloader').show(new PreloaderView({ notSetup: true }));
   },
 

--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -4,9 +4,13 @@ import { datadogLogs } from '@datadog/browser-logs';
 
 import { datadogConfig as config, versions, appConfig as app } from './config';
 
+function getEnv() {
+  return `${ app.env }.${ app.stack_id }`;
+}
+
 function initLogs({ isForm }) {
   datadogLogs.init({
-    env: `${ app.env }.${ app.stack_id }`,
+    env: getEnv(),
     clientToken: config.client_token,
     site: 'datadoghq.com',
     service: isForm ? 'care-ops-forms' : 'care-ops-frontend',
@@ -22,7 +26,7 @@ function initLogs({ isForm }) {
 
 function initRum({ isForm }) {
   datadogRum.init({
-    env: app.env,
+    env: getEnv(),
     applicationId: config.app_id,
     clientToken: config.client_token,
     site: 'datadoghq.com',

--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -1,3 +1,4 @@
+import { datadogRum } from '@datadog/browser-rum';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/clinicians';
 
@@ -12,7 +13,11 @@ const Entity = BaseEntity.extend({
     'fetch:clinicians:byWorkspace': 'fetchByWorkspace',
   },
   fetchCurrentClinician() {
-    return this.fetchBy('/api/clinicians/me');
+    return this.fetchBy('/api/clinicians/me')
+      .then(currentUser => {
+        datadogRum.setUser(currentUser.pick('id', 'name', 'email'));
+        return currentUser;
+      });
   },
   fetchByWorkspace(workspaceId) {
     const url = `/api/workspaces/${ workspaceId }/relationships/clinicians`;

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -1,5 +1,6 @@
 /* global Formio, FormioUtils */
 import { extend, reduce } from 'underscore';
+import { datadogRum } from '@datadog/browser-rum';
 
 // Note: Allows for setting the submission at form instantiation
 // https://github.com/formio/formio.js/pull/4580
@@ -21,8 +22,9 @@ Formio.Evaluator.evaluator = function(func, ...params) {
   try {
     return evaluator(func, ...params);
   } catch (e) {
+    datadogRum.addError(e);
     /* eslint-disable-next-line no-console */
-    console.error(e);
+    if (_DEVELOP_) console.error(e);
   }
 };
 
@@ -32,8 +34,9 @@ Formio.Evaluator.evaluate = function(func, ...params) {
   try {
     return evaluate(func, ...params);
   } catch (e) {
+    datadogRum.addError(e);
     /* eslint-disable-next-line no-console */
-    console.error(e);
+    if (_DEVELOP_) console.error(e);
   }
 };
 


### PR DESCRIPTION
Shortcut Story ID: [sc-###]

Need to add a card

This does 3 things
- makes the RUM env match the log env.. which should have been done before.
- moves the `setUser` to immediately after the user is fetched so any error after that has the user data.
- send errors we were `console.error`ing directly to datadog as the `console.error` might be breaking the stack.. hoping to get more insights this way.. we'll see.