### PR TITLE
Fix broken shift+click multiselect tests

### DIFF
--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1752,12 +1752,7 @@ context('schedule page', function() {
       .first()
       .as('firstActionRow')
       .find('.js-select')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(0);
-      });
+      .click();
 
     cy
       .get('@scheduleList')
@@ -1765,13 +1760,9 @@ context('schedule page', function() {
       .eq(2)
       .find('.schedule-list__day-list-row')
       .first()
+      .as('sixthActionRow')
       .find('.js-select')
-      .click({ shiftKey: true })
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(5);
-      });
+      .click({ shiftKey: true });
 
     cy
       .get('@scheduleList')
@@ -1790,11 +1781,43 @@ context('schedule page', function() {
       .click();
 
     cy
+      .get('@sixthActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
       .get('@scheduleList')
-      .find('.schedule-list__list-row')
-      .eq(2)
-      .find('.schedule-list__day-list-row')
-      .first()
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 6);
+
+    cy
+      .get('[data-filters-region]')
+      .as('filterRegion')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 6 Actions');
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@sixthActionRow')
       .find('.js-select')
       .click({ shiftKey: true });
 
@@ -1804,60 +1827,34 @@ context('schedule page', function() {
       .should('have.length', 1);
 
     cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
       .get('@firstActionRow')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@sixthActionRow')
       .find('.js-select')
       .click({ shiftKey: true });
 
     cy
       .get('@scheduleList')
       .find('.schedule-list__day-list-row.is-selected')
-      .should('have.length', 6);
-
-    cy
-      .get('[data-filters-region]')
-      .as('filterRegion')
-      .find('.js-bulk-edit')
-      .should('contain', 'Edit 6 Actions');
+      .should('have.length', 1);
 
     cy
       .get('[data-filters-region]')
       .find('.js-cancel')
       .click();
-
-    cy
-      .get('@firstActionRow')
-      .find('.js-select')
-      .click();
-
-    cy
-      .get('[data-select-all-region]')
-      .find('.fa-square-minus')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-cancel')
-      .click();
-
-    cy
-      .get('@firstActionRow')
-      .find('.js-select')
-      .click();
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-cancel')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
 
     cy
       .get('@firstActionRow')
@@ -1868,18 +1865,27 @@ context('schedule page', function() {
       .get('.list-page__header')
       .find('[data-search-region] .js-input:not([disabled])')
       .focus()
-      .type('abcd')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+      .type('abcd');
 
     cy
       .get('.list-page__header')
       .find('[data-search-region] .js-input:not([disabled])')
       .next()
       .click();
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .first()
+      .find('.schedule-list__day-list-row')
+      .eq(2)
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 2);
 
     cy
       .get('[data-filters-region]')
@@ -1895,11 +1901,20 @@ context('schedule page', function() {
       .navigate('/worklist');
 
     cy
-      .go('back')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+      .go('back');
 
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .first()
+      .find('.schedule-list__day-list-row')
+      .eq(2)
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__day-list-row.is-selected')
+      .should('have.length', 2);
   });
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3345,68 +3345,30 @@ context('worklist page', function() {
 
   specify('click+shift multiselect', function() {
     cy
-      .routeFlows(fx => {
+      .routeActions(fx => {
         fx.data = _.sample(fx.data, 3);
 
         return fx;
       })
-      .routeActions()
       .routeFlow()
       .routeFlowActions()
       .routePatientByFlow()
       .visit('/worklist/owned-by')
-      .wait('@routeFlows');
+      .wait('@routeActions');
 
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
+      .as('firstTableListItem')
       .find('.js-select')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(0);
-      });
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .last()
-      .find('.js-select')
-      .click({ shiftKey: true })
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(2);
-      });
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item.is-selected')
-      .should('have.length', 3);
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-bulk-edit')
-      .should('contain', 'Edit 3 Flows');
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-cancel')
       .click();
 
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
       .last()
-      .find('.js-select')
-      .click();
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .as('lastTableListItem')
       .find('.js-select')
       .click({ shiftKey: true });
 
@@ -3418,19 +3380,7 @@ context('worklist page', function() {
     cy
       .get('[data-filters-region]')
       .find('.js-bulk-edit')
-      .should('contain', 'Edit 3 Flows');
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
-      .find('.js-select')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+      .should('contain', 'Edit 3 Actions');
 
     cy
       .get('[data-filters-region]')
@@ -3438,21 +3388,24 @@ context('worklist page', function() {
       .click();
 
     cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .get('@lastTableListItem')
       .find('.js-select')
       .click();
 
     cy
-      .get('[data-select-all-region]')
-      .find('.fa-square-minus')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+      .get('@firstTableListItem')
+      .find('.js-select')
+      .click({ shiftKey: true });
 
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 3);
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-bulk-edit')
+      .should('contain', 'Edit 3 Actions');
 
     cy
       .get('[data-filters-region]')
@@ -3460,26 +3413,57 @@ context('worklist page', function() {
       .click();
 
     cy
+      .get('@firstTableListItem')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@firstTableListItem')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('@lastTableListItem')
+      .find('.js-select')
+      .click({ shiftKey: true });
+
+    cy
       .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .find('.table-list__item.is-selected')
+      .should('have.length', 1);
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstTableListItem')
       .find('.js-select')
       .click();
 
     cy
       .get('[data-filters-region]')
       .find('.js-cancel')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+      .click();
 
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+    cy
+      .get('@lastTableListItem')
+      .find('.js-select')
+      .click({ shiftKey: true });
 
     cy
       .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .find('.table-list__item.is-selected')
+      .should('have.length', 1);
+
+    cy
+      .get('[data-filters-region]')
+      .find('.js-cancel')
+      .click();
+
+    cy
+      .get('@firstTableListItem')
       .find('.js-select')
       .click();
 
@@ -3488,12 +3472,7 @@ context('worklist page', function() {
       .find('[data-search-region] .js-input:not([disabled])')
       .as('listSearch')
       .focus()
-      .type('abcd')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+      .type('abcd');
 
     cy
       .get('@listSearch')
@@ -3501,26 +3480,24 @@ context('worklist page', function() {
       .click();
 
     cy
+      .get('@lastTableListItem')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 2);
+
+    cy
       .get('[data-filters-region]')
       .find('.js-cancel')
       .click();
 
     cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .get('@firstTableListItem')
       .find('.js-select')
       .click();
-
-    cy
-      .get('.worklist-list__toggle')
-      .contains('Actions')
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
 
     cy
       .get('.worklist-list__toggle')
@@ -3528,14 +3505,27 @@ context('worklist page', function() {
       .click();
 
     cy
+      .get('.worklist-list__toggle')
+      .contains('Actions')
+      .click();
+
+    cy
+      .get('@lastTableListItem')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 2);
+
+    cy
       .get('[data-filters-region]')
       .find('.js-cancel')
       .click();
 
     cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .first()
+      .get('@firstTableListItem')
       .find('.js-select')
       .click();
 
@@ -3543,12 +3533,17 @@ context('worklist page', function() {
       .navigate('/schedule');
 
     cy
-      .go('back')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+      .go('back');
 
-        expect(storage.lastSelectedIndex).to.equal(null);
-      });
+    cy
+      .get('@lastTableListItem')
+      .find('.js-select')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 2);
   });
 
   specify('patient sidebar', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-34350]

We're no longer storing the `lastSelectedIndex` value in local storage (changed in https://github.com/RoundingWell/care-ops-frontend/commit/1bad202df027bff6434657f5dde126417d8784ab). So tests that checked for that value broke as a result.
