### PR TITLE
Update program action/flow sidebar tests to not check for the default state droplist element

### DIFF
--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -39,12 +39,6 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-state-region]')
-      .find('.is-disabled')
-      .contains('To Do');
-
-    cy
-      .get('.sidebar')
       .find('[data-owner-region]')
       .contains('Select Team...')
       .should('be.disabled');
@@ -460,21 +454,6 @@ context('program action sidebar', function() {
       .should(({ data }) => {
         expect(data.attributes.status).to.equal('conditional');
       });
-
-    cy
-      .get('.sidebar')
-      .find('[data-state-region]')
-      .contains('To Do')
-      .as('stateButton')
-      .trigger('pointerover');
-
-    cy
-      .get('.tooltip')
-      .contains('set to To Do by default');
-
-    cy
-      .get('@stateButton')
-      .trigger('mouseout');
 
     cy
       .get('.sidebar')

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -41,12 +41,6 @@ context('flow sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-state-region]')
-      .find('.is-disabled')
-      .contains('To Do');
-
-    cy
-      .get('.sidebar')
       .find('[data-owner-region]')
       .contains('Select Team')
       .should('be.disabled');
@@ -312,14 +306,6 @@ context('flow sidebar', function() {
       .get('@flowHeader')
       .find('[data-owner-region]')
       .contains('NUR');
-
-    cy
-      .get('[data-state-region]')
-      .trigger('pointerover');
-
-    cy
-      .get('.tooltip')
-      .contains('Program Flows are set to To Do by default.');
 
     cy
       .get('.sidebar__footer')


### PR DESCRIPTION
Shortcut Story ID: [sc-34374]

These tests are failing because we're checking for the default state droplist element. But those were removed in #949 ([shortcut story](https://app.shortcut.com/roundingwell/story/34154/design-qa-state-on-program-action-and-flow-is-not-correct)).

Due to time constraints, those tests weren't updated at the time.
