### PR TITLE
Request form response by `prefill_action_tag`

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -63,6 +63,9 @@ const _Model = BaseModel.extend({
 
     return prefillFormId;
   },
+  getPrefillActionTag() {
+    return get(this.get('options'), 'prefill_action_tag');
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -1,3 +1,4 @@
+import { reduce } from 'underscore';
 import BaseEntity from 'js/base/entity-service';
 import fetcher, { handleJSON } from 'js/base/fetch';
 import { _Model, Model, Collection } from './entities/form-responses';
@@ -14,12 +15,14 @@ const Entity = BaseEntity.extend({
     if (!responseId) return [{}];
     return fetcher(`/api/form-responses/${ responseId }/response`).then(handleJSON);
   },
-  fetchLatestSubmission(patientId, formId, flowId) {
-    if (flowId) {
-      return fetcher(`/api/patients/${ patientId }/form-responses/latest?filter[form]=${ formId }&filter[flow]=${ flowId }`).then(handleJSON);
-    }
+  fetchLatestSubmission(patientId, filter) {
+    const searchParams = reduce(filter, (filters, value, key) => {
+      if (!value) return filters;
+      const param = `filter[${ key }]=${ encodeURIComponent(value) }`;
+      return filters + (filters ? '&' : '?') + param;
+    }, '');
 
-    return fetcher(`/api/patients/${ patientId }/form-responses/latest?filter[form]=${ formId }`).then(handleJSON);
+    return fetcher(`/api/patients/${ patientId }/form-responses/latest${ searchParams }`).then(handleJSON);
   },
 });
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -97,15 +97,30 @@ export default App.extend({
       });
     });
   },
+  _getPrefillFilters(flowId, form) {
+    const prefillActionTag = form.getPrefillActionTag();
+
+    if (prefillActionTag) {
+      return {
+        'action.tag': prefillActionTag,
+        'flow': flowId,
+      };
+    }
+
+    return {
+      form: form.getPrefillFormId(),
+      flow: flowId,
+    };
+  },
   fetchLatestFormSubmission(flowId) {
     const channel = this.getChannel();
 
-    const prefillFormId = this.form.getPrefillFormId();
+    const filter = this._getPrefillFilters(flowId, this.form);
 
     return Promise.all([
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:forms:fields', get(this.action, 'id'), this.patient.id, this.form.id),
-      Radio.request('entities', 'fetch:formResponses:latestSubmission', this.patient.id, prefillFormId, flowId),
+      Radio.request('entities', 'fetch:formResponses:latestSubmission', this.patient.id, filter),
     ]).then(([definition, fields, response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -47,5 +47,13 @@
     "options": {
       "prefill_form_id": "11111"
     }
+  },
+  {
+    "id": "77777",
+    "name": "Test Prefill Action Tag",
+    "options": {
+      "prefill_form_id": "11111",
+      "prefill_action_tag": "foo-tag"
+    }
   }
 ]


### PR DESCRIPTION
[sc-33956]

Since both form options can be set, `prefill_action_tag` is preferred.

We might be over testing that the form renders the response in these various tag tests, as past the correct api request, it’s all already tested elsewhere, but for consistency I made it the same for now.

`'fetch:formResponses:latestSubmission’` is now less specific to allow for various future combinations, but the form service `_getPrefillFilters` may need to be rethought if we start introducing other varieties.

