### PR TITLE
On clinicians page, disable 'Find in list...' input until clinicians are loaded

### DIFF
--- a/src/js/apps/clinicians/clinicians-all_app.js
+++ b/src/js/apps/clinicians/clinicians-all_app.js
@@ -18,6 +18,9 @@ export default SubRouterApp.extend({
   viewEvents: {
     'click:addClinician': 'onClickAddClinician',
   },
+  onBeforeStop() {
+    this.clinicians = null;
+  },
   onBeforeStart() {
     this.showView(new LayoutView());
     this.getRegion('list').startPreloader();

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -13,8 +13,8 @@ context('clinicians list', function() {
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
         fx.data[0].attributes.last_active_at = testTs();
-        fx.data[0].relationships.role = { data: { id: '33333' } };
-        fx.data[0].relationships.team = { data: { id: '11111' } };
+        fx.data[0].relationships.role.data.id = '33333';
+        fx.data[0].relationships.team.data.id = '11111';
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
@@ -209,12 +209,12 @@ context('clinicians list', function() {
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
         fx.data[0].relationships.workspaces = { data: [{ type: 'workspaces', id: '11111' }] };
-        fx.data[0].relationships.role = { data: { id: '33333' } };
+        fx.data[0].relationships.role.data.id = '33333';
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
         fx.data[1].relationships.workspaces = { data: [{ type: 'workspaces', id: '22222' }] };
-        fx.data[1].relationships.role = { data: { id: '22222' } };
+        fx.data[1].relationships.role.data.id = '22222';
 
         return fx;
       })

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -202,6 +202,10 @@ context('clinicians list', function() {
 
   specify('find in list', function() {
     cy
+      .routeActions()
+      .visit();
+
+    cy
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 2);
 
@@ -218,7 +222,7 @@ context('clinicians list', function() {
 
         return fx;
       })
-      .visit('/clinicians');
+      .navigate('/clinicians');
 
     cy
       .get('.list-page__header')
@@ -293,12 +297,10 @@ context('clinicians list', function() {
       .should('contain', 'Employee');
 
     cy
-      .get('[data-nav-content-region]')
-      .find('[data-worklists-region]')
-      .find('.app-nav__link')
-      .first()
-      .click()
       .go('back');
+
+    cy
+      .navigate('/clinicians');
 
     cy
       .get('.list-page__header')

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -13,8 +13,8 @@ context('clinicians list', function() {
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
         fx.data[0].attributes.last_active_at = testTs();
-        fx.data[0].relationships.role.data.id = '33333';
-        fx.data[0].relationships.team.data.id = '11111';
+        fx.data[0].relationships.role = { data: { id: '33333' } };
+        fx.data[0].relationships.team = { data: { id: '11111' } };
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
@@ -191,6 +191,11 @@ context('clinicians list', function() {
       .wait('@routeClinicians');
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:disabled')
+      .should('have.attr', 'placeholder', 'Find in List...');
+
+    cy
       .get('.table-empty-list')
       .contains('No Clinicians');
   });
@@ -204,12 +209,12 @@ context('clinicians list', function() {
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
         fx.data[0].relationships.workspaces = { data: [{ type: 'workspaces', id: '11111' }] };
-        fx.data[0].relationships.role.data.id = '33333';
+        fx.data[0].relationships.role = { data: { id: '33333' } };
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
         fx.data[1].relationships.workspaces = { data: [{ type: 'workspaces', id: '22222' }] };
-        fx.data[1].relationships.role.data.id = '22222';
+        fx.data[1].relationships.role = { data: { id: '22222' } };
 
         return fx;
       })
@@ -286,5 +291,25 @@ context('clinicians list', function() {
       .should('have.length', 1)
       .first()
       .should('contain', 'Employee');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .first()
+      .click()
+      .go('back');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:disabled')
+      .should('have.attr', 'placeholder', 'Find in List...');
+
+    cy
+      .wait('@routeClinicians');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:not([disabled])');
   });
 });

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -54,9 +54,9 @@ Cypress.Commands.add('routeCurrentClinician', (mutator = _.identity) => {
 Cypress.Commands.add('routeClinicians', (mutator = _.identity) => {
   cy.route({
     url: '/api/clinicians',
-    delay: 100,
     response() {
-      const clinicians = getResource(fxClinicians, 'clinicians');
+      // Remove current clinician
+      const clinicians = getResource(_.rest(fxClinicians), 'clinicians');
 
       _.each(clinicians, clinician => {
         clinician.relationships = getClinicianRelationships(clinician);

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -54,6 +54,7 @@ Cypress.Commands.add('routeCurrentClinician', (mutator = _.identity) => {
 Cypress.Commands.add('routeClinicians', (mutator = _.identity) => {
   cy.route({
     url: '/api/clinicians',
+    delay: 100,
     response() {
       const clinicians = getResource(fxClinicians, 'clinicians');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-34469]

When the clinicians page is initially loaded, the `Find in list...` should be disabled until the clinicians data is done being retrieved and displayed in the list. And then it should be enabled so users can filter the list.

On the first page load, this works properly. But on subsequent visits, the `Find in list...` input is not disabled before the clinicians data is loaded.