### PR TITLE
Show ellipsis overflow on the form title

### DIFF
--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -32,7 +32,7 @@
 .form__title {
   display: flex;
   font-size: 24px;
-  line-height: 1.2;
+  line-height: 1.4;
   padding: 16px 16px 16px 0;
 }
 
@@ -137,6 +137,7 @@
   .icon {
     color: $black-60;
     font-size: 20px;
+    vertical-align: middle;
   }
 
   &:last-child {

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -128,7 +128,10 @@ const LayoutView = View.extend({
       <div class="flex">
         <div class="overflow--hidden flex-grow">
           <div data-context-trail-region></div>
-          <div class="form__title u-text--overflow"><span class="form__title-icon">{{far "square-poll-horizontal"}}</span>{{patient.first_name}} {{patient.last_name}} — {{ name }}</div>
+          <div class="form__title">
+            <span class="form__title-icon">{{far "square-poll-horizontal"}}</span>
+            <span class="u-text--overflow">{{patient.first_name}} {{patient.last_name}} — {{ name }}</span>
+          </div>
         </div>
         <div class="flex-grow">
           <div data-status-region>&nbsp;</div>


### PR DESCRIPTION
Shortcut Story ID: [sc-34474]

Was added a while ago, but stopped working after a recent, unrelated code change.

This PR also includes some small UI CSS alignment fixes for the form title and form action elements.