### PR TITLE
Add tests for forms with a hidden submit button

### DIFF
--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -55,5 +55,12 @@
       "prefill_form_id": "11111",
       "prefill_action_tag": "foo-tag"
     }
+  },
+  {
+    "id": "88888",
+    "name": "Submit Hidden Form",
+    "options": {
+      "submit_hidden": true
+    }
   }
 ]

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1597,6 +1597,72 @@ context('Patient Action Form', function() {
       .find('.alert')
       .contains('Insufficient permissions');
   });
+
+  specify('hidden submit button', function() {
+    cy
+      .routeAction()
+      .routeFormByAction(_.identity, '88888')
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routePatientByAction()
+      .visit('/patient-action/1/form/88888')
+      .wait('@routeAction')
+      .wait('@routeFormByAction')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition');
+
+    cy
+      .iframe();
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Submit')
+      .should('not.exist');
+  });
+
+  specify('hidden submit button - update form', function() {
+    cy
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships['form-responses'].data = [
+          { id: '1', meta: { created_at: testTs() } },
+        ];
+
+        return fx;
+      })
+      .routeFormByAction(_.identity, '88888')
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routeFormResponse(fx => {
+        fx.data = {};
+
+        return fx;
+      })
+      .routeActionActivity()
+      .routePatientByAction()
+      .visit('/patient-action/1/form/88888')
+      .wait('@routeFormByAction')
+      .wait('@routeAction')
+      .wait('@routePatientByAction')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormResponse');
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Update')
+      .click();
+
+    cy
+      .iframe();
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Submit')
+      .should('not.exist');
+  });
 });
 
 context('Patient Form', function() {
@@ -2302,6 +2368,29 @@ context('Patient Form', function() {
       .get('@iframe')
       .find('.alert')
       .contains('Insufficient permissions');
+  });
+
+  specify('hidden submit button', function() {
+    cy
+      .routeForm(_.identity, '88888')
+      .routeFormDefinition()
+      .routeFormFields()
+      .routeFormResponse()
+      .routePatient()
+      .visit('/patient/1/form/88888')
+      .wait('@routePatient')
+      .wait('@routeForm')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
+
+    cy
+      .iframe();
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Submit')
+      .should('not.exist');
   });
 });
 

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -314,6 +314,8 @@ context('program action sidebar', function() {
       .routePrograms()
       .routeProgramByProgramFlow()
       .routeForms(fx => {
+        fx.data = _.first(fx.data, 6);
+
         fx.data[5].attributes.name = 'A Form';
         fx.data[5].attributes.published_at = testTs();
         fx.data[4].attributes.name = 'B Form';
@@ -324,6 +326,12 @@ context('program action sidebar', function() {
         fx.data[2].attributes.published_at = testTs();
         fx.data[3].attributes.name = 'E Form';
         fx.data[3].attributes.published_at = testTs();
+
+        return fx;
+      })
+      .routeWorkspaces(fx => {
+        fx.data[0].relationships.forms.data = _.first(fx.data[0].relationships.forms.data, 6);
+
         return fx;
       })
       .visit('/program-flow/1')


### PR DESCRIPTION
Shortcut Story ID: [sc-34330]

This feature was added in https://github.com/RoundingWell/care-ops-frontend/pull/953. But due to time constraints, tests weren't added at the time.
