### PR TITLE
`istanbul ignore` branch for hiding nav menu on form page refresh

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -89,6 +89,8 @@ export default App.extend({
     });
   },
   toggleNav(shouldShow) {
+    // NOTE: stops the nav menu from showing when the form page is reloaded
+    /* istanbul ignore if: can't test reload */
     if (!this.isRunning()) return;
 
     this.getView().toggleNav(!!shouldShow);


### PR DESCRIPTION
Shortcut Story ID: [sc-34690]

In #953, we added a flag to the `app-frame_app.js` file to stop the nav menu from showing when the form page is refreshed ([this line of code](https://github.com/RoundingWell/care-ops-frontend/blob/develop/src/js/apps/globals/app-frame_app.js#L92)).

To test this, we'd need to do a `cy.reload()` in the tests, but that would clear the coverage.