### PR TITLE
Disable the `Find in list...` input when the worklist/schedule list is loading

### DIFF
--- a/src/js/apps/patients/schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced_schedule_app.js
@@ -7,6 +7,9 @@ import SearchComponent from 'js/views/shared/components/list-search';
 import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
 
 export default App.extend({
+  onBeforeStop() {
+    this.collection = null;
+  },
   onBeforeStart() {
     this.setState({ isReduced: true });
 

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -46,6 +46,9 @@ export default App.extend({
 
     this.getState().setDefaultFilterStates();
   },
+  onBeforeStop() {
+    this.collection = null;
+  },
   onBeforeStart() {
     if (this.isRestarting()) {
       const isFiltersSidebarOpen = this.getState('isFiltering');

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -61,6 +61,9 @@ export default App.extend({
 
     this.getState().setDefaultFilterStates();
   },
+  onBeforeStop() {
+    this.collection = null;
+  },
   onBeforeStart({ worklistId }) {
     const isFiltersSidebarOpen = this.getState('isFiltering');
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1177,6 +1177,20 @@ context('schedule page', function() {
       .get('.sidebar')
       .find('[data-name-region] .action-sidebar__name')
       .should('contain', 'Test Action');
+
+    cy
+      .navigate('/schedule');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:disabled');
+
+    cy
+      .wait('@routeActions');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:not([disabled])');
   });
 
   specify('bulk edit', function() {
@@ -1742,6 +1756,24 @@ context('schedule page', function() {
       .get('@scheduleList')
       .find('.schedule-list__day-list-row')
       .should('have.length', 20);
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Owned By')
+      .click()
+      .wait('@routeActions');
+
+    cy
+      .navigate('/schedule');
+
+    cy
+      .intercept('GET', '/api/action?*', { delay: 100, body: { data: [] } });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:disabled');
   });
 
   specify('click+shift multiselect', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3221,6 +3221,7 @@ context('worklist page', function() {
         return fx;
       })
       .routePatientByAction()
+      .routeActions()
       .visit('/worklist/owned-by');
 
     cy
@@ -3441,6 +3442,24 @@ context('worklist page', function() {
       .get('@flowList')
       .find('.work-list__item')
       .should('have.length', 10);
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Shared By')
+      .click()
+      .wait('@routeActions');
+
+    cy
+      .navigate('/worklist/owned-by');
+
+    cy
+      .intercept('GET', '/api/flows?*', { delay: 100, body: { data: [] } });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input:disabled');
   });
 
   specify('click+shift multiselect', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-34746]

This was only happening on the initial page load. It should now be properly disabled on subsequent page loads or when filters are applied to the list (which causes just the list of actions/flows to reload).

Applies to the worklists, schedule, and reduced schedule.
