### PR TITLE
Replace clinician saveTeam PUT with typical PATCH

### DIFF
--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -72,22 +72,17 @@ const _Model = BaseModel.extend({
     return includes(permissions, prop);
   },
   saveRole(role) {
-    const saveOpts = { _role: role.id };
-
-    return this.save(saveOpts, {
+    return this.save({ _role: role.id }, {
       relationships: {
         role: this.toRelation(role),
       },
     });
   },
   saveTeam(team) {
-    const url = `/api/clinicians/${ this.id }/relationships/team`;
-
-    this.set({ _team: team.id });
-
-    this.sync('update', this, {
-      url,
-      data: JSON.stringify(this.toRelation(team)),
+    return this.save({ _team: team.id }, {
+      relationships: {
+        team: this.toRelation(team),
+      },
     });
   },
   saveAll(attrs) {

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -66,15 +66,6 @@ context('clinician sidebar', function() {
     cy
       .route({
         status: 204,
-        method: 'PUT',
-        url: '/api/clinicians/1/relationships/team',
-        response: {},
-      })
-      .as('routePutTeam');
-
-    cy
-      .route({
-        status: 204,
         method: 'POST',
         url: '/api/workspaces/11111/relationships/clinicians',
         response: {},
@@ -171,11 +162,10 @@ context('clinician sidebar', function() {
       .click();
 
     cy
-      .wait('@routePutTeam')
+      .wait('@routePatchClinician')
       .its('request.body')
       .should(({ data }) => {
-        expect(data.id).to.equal('22222');
-        expect(data.type).to.equal('teams');
+        expect(data.relationships.team.data.id).to.equal('22222');
       });
 
     cy

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -77,15 +77,6 @@ context('clinicians list', function() {
     cy
       .route({
         status: 204,
-        method: 'PUT',
-        url: '/api/clinicians/1/relationships/team',
-        response: {},
-      })
-      .as('routePutTeam');
-
-    cy
-      .route({
-        status: 204,
         method: 'PATCH',
         url: '/api/clinicians/*',
         response: {},
@@ -118,11 +109,10 @@ context('clinicians list', function() {
       .click();
 
     cy
-      .wait('@routePutTeam')
+      .wait('@routePatchClinician')
       .its('request.body')
       .should(({ data }) => {
-        expect(data.id).to.equal('22222');
-        expect(data.type).to.equal('teams');
+        expect(data.relationships.team.data.id).to.equal('22222');
       });
 
     cy


### PR DESCRIPTION
This used an older semi-unique endpoint for updating the relationship http://localhost:8888/#tag/Clinician/paths/~1clinicians~1%7BclinicianId%7D~1relationships~1team/put

Shortcut Story ID: [sc-34979]
