### PR TITLE
Make form read-only on "done" actions 

### DIFF
--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -74,8 +74,8 @@ export default App.extend({
     this.patient = patient;
     this.action = action;
     this.responses = action.getFormResponses();
-    this.isReadOnly = this.form.isReadOnly();
-    this.isSubmitHidden = this.form.isSubmitHidden();
+    this.isReadOnly = action.isDone() || form.isReadOnly();
+    this.isSubmitHidden = form.isSubmitHidden();
 
     this.listenTo(action, 'destroy', function() {
       Radio.request('alert', 'show:success', intl.forms.form.formApp.deleteSuccess);

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -69,13 +69,14 @@ const updateSubmision = debounce(function(submission) {
   router.request('update:storedSubmission', submission);
 }, 2000);
 
-async function renderForm({ definition, storedSubmission, formData, formSubmission, reducers, changeReducers, contextScripts, beforeSubmit }) {
+async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, reducers, changeReducers, contextScripts, beforeSubmit }) {
   const evalContext = await getContext(contextScripts);
 
   const submission = storedSubmission || await getSubmission(formData, formSubmission, reducers, evalContext);
   prevSubmission = structuredClone(submission);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
+    readOnly: isReadOnly,
     evalContext,
     data: submission,
     onChange({ fromChangeReducers }, { instance }) {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -946,6 +946,7 @@ context('Patient Action Form', function() {
       .iframe()
       .find('[name="data[patient.fields.foo]"]')
       .should('have.value', 'bar')
+      .should('be.disabled');
   });
 
   specify('read only form', function() {
@@ -990,7 +991,8 @@ context('Patient Action Form', function() {
     cy
       .iframe()
       .find('[name="data[patient.fields.foo]"]')
-      .should('have.value', 'bar');
+      .should('have.value', 'bar')
+      .should('be.disabled');
   });
 
   specify('routing to form-response', function() {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -910,21 +910,50 @@ context('Patient Action Form', function() {
       .should('not.contain', 'patient-action/1/form/11111');
   });
 
-  specify('read only form', function() {
-    localStorage.setItem('form-subm-11111-1-22222-1', JSON.stringify({
-      updated: testTs(),
-      submission: {
-        patient: { fields: { foo: 'foo' } },
-      },
-    }));
+  specify('action done form', function() {
+    cy
+      .routesForPatientAction()
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.form.data = { id: '11111' };
+        fx.data.relationships.state.data = { id: '55555' };
+        fx.data.relationships['form-responses'].data = [];
+        return fx;
+      })
+      .routeFormByAction()
+      .routeFormDefinition()
+      .routeFormActionFields(fx => {
+        fx.data.attributes = { patient: { fields: { foo: 'bar' } } };
 
+        return fx;
+      })
+      .visit('/patient-action/1/form/22222')
+      .wait('@routeAction')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
+
+    cy
+      .get('[data-form-updated-region]')
+      .should('be.empty');
+
+    cy
+      .get('.form__controls')
+      .find('button')
+      .contains('Read Only')
+      .should('be.disabled');
+
+    cy
+      .iframe()
+      .find('[name="data[patient.fields.foo]"]')
+      .should('have.value', 'bar')
+  });
+
+  specify('read only form', function() {
     cy
       .routeAction(fx => {
         fx.data.id = '1';
         fx.data.relationships.form.data = { id: '22222' };
         fx.data.relationships['form-responses'].data = [];
-        fx.data.relationships['program-action'] = { data: { id: '11111' } };
-
         return fx;
       })
       .routePatient()

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -57,6 +57,7 @@ Cypress.Commands.add('routeAction', (mutator = _.identity) => {
     response() {
       const apiData = generateData.call(this);
       apiData.data = _.sample(apiData.data);
+      apiData.data.relationships.state.data.id = '33333';
       return mutator(apiData);
     },
   })


### PR DESCRIPTION
Shortcut Story ID: [sc-34969]

Not doing much here.  This is a policy and not a permission, so it just prompts the form how to render based on the status of the action at render time, but it is not enforced beyond that.