### PR TITLE
Handle workspace specific settings

### DIFF
--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -78,8 +78,12 @@ export default App.extend({
   },
   getSetting(settingName) {
     const workspaceSettings = this.currentWorkspace.get('settings');
-    const setting = get(workspaceSettings, settingName) || this.settings.get(settingName);
+    const workspaceSetting = get(workspaceSettings, settingName);
+    if (workspaceSetting) return workspaceSetting;
+
+    const setting = this.settings.get(settingName);
     if (!setting) return;
+
     return setting.get('value');
   },
   // Returns roles that the current user can manage

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -821,6 +821,34 @@ context('patient sidebar', function() {
       .should('not.contain', 'Workspace Two');
   });
 
+  specify('workspace specific widgets setting', function() {
+    cy
+      .routesForPatientDashboard()
+      .routeWorkspaces(fx => {
+        fx.data[0].attributes.settings = {
+          widgets_patient_sidebar: {
+            widgets: [
+              'divider',
+            ],
+          },
+        };
+
+        return fx;
+      });
+
+    cy
+      .visit('/patient/dashboard/1')
+      .wait('@routePatient');
+
+    cy
+      .get('.patient-sidebar')
+      .as('patientSidebar')
+      .find('.patient-sidebar__section')
+      .should('have.length', 1)
+      .first()
+      .find('.widgets__divider');
+  });
+
   specify('edit patient modal', function() {
     cy
       .routesForPatientDashboard()


### PR DESCRIPTION
Shortcut Story ID: [sc-35002]

Initial use case was adding patient sidebar widgets that are specific to a workspace. And that take precedent over that org setting.