### PR TITLE
Add guard to prevent extra requests in form test definition

### DIFF
--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -150,7 +150,10 @@ context('Noncontext Form', function() {
               tableView: true,
               dataSrc: 'custom',
               data: {
-                custom: 'values = updateField(\'foo\', [\'one\', \'two\'])',
+                custom: `
+                  if(instance.values) return instance.values;
+                  values = instance.values = updateField('foo', ['one', 'two'])
+                `,
               },
               template: '<span>{{ item }}</span>',
               refreshOn: 'data',
@@ -164,7 +167,14 @@ context('Noncontext Form', function() {
               tableView: true,
               dataSrc: 'custom',
               data: {
-                custom: 'values = new Promise(resolve => { updateField(\'bar\', [\'bar\', \'baz\']).then(v => { resolve(v); }).catch(e => { resolve([e]); }) });',
+                custom: `
+                  if(instance.values) return instance.values;
+                  values = instance.values = new Promise(resolve => {
+                    updateField('bar', ['bar', 'baz'])
+                    .then(v => { resolve(v); })
+                    .catch(e => { resolve([e]); })
+                  });
+                `,
               },
               template: '<span>{{ item }}</span>',
               refreshOn: 'data',


### PR DESCRIPTION
On firefox these tests were failing due to `postMessage` not being able to serialize the submission.

https://cloud.cypress.io/projects/ep9zr6/runs/4e2c7d3d-74fe-4daf-a42e-7818d1088058/test-results/b45a527c-68fe-4f4d-b59f-ee588d331bf6/screenshots

I don’t really know what is going on, but I do know that form.io hammers these end points.  This keeps it to a single request which I think will prevent the firefox failure.

Notably I could not get this to fail in Firefox locally.
