### PR TITLE
Add capped results messaging & action/flow counts to lists

### DIFF
--- a/src/js/apps/patients/schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced_schedule_app.js
@@ -4,14 +4,14 @@ import App from 'js/base/app';
 
 import SearchComponent from 'js/views/shared/components/list-search';
 
-import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
+import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView, CountView } from 'js/views/patients/schedule/schedule_views';
 
 export default App.extend({
   onBeforeStop() {
     this.collection = null;
   },
   onBeforeStart() {
-    this.setState({ isReduced: true });
+    this.setState({ isReduced: true, searchQuery: '' });
 
     this.showView(new LayoutView({
       state: this.getState(),
@@ -38,14 +38,21 @@ export default App.extend({
   },
   onStart(options, collection) {
     this.collection = collection;
+    this.filteredCollection = collection.clone();
 
     this.showScheduleList();
     this.showSearchView();
+    this.showCountView();
   },
   showScheduleList() {
     const collectionView = new ScheduleListView({
       collection: this.collection.groupByDate(),
       state: this.getState(),
+    });
+
+    this.listenTo(collectionView, 'filtered', filtered => {
+      this.filteredCollection.reset(filtered);
+      this.showCountView();
     });
 
     this.showChildView('list', collectionView);
@@ -72,6 +79,14 @@ export default App.extend({
     const tableHeadersView = new TableHeaderView();
 
     this.showChildView('table', tableHeadersView);
+  },
+  showCountView() {
+    const countView = new CountView({
+      collection: this.collection,
+      filteredCollection: this.filteredCollection,
+    });
+
+    this.showChildView('count', countView);
   },
   setSearchState(state, searchQuery) {
     this.setState({

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -14,7 +14,7 @@ import DateFilterComponent from 'js/views/patients/shared/components/date-filter
 import SearchComponent from 'js/views/shared/components/list-search';
 import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
-import { LayoutView, ScheduleTitleView, TableHeaderView, SelectAllView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
+import { LayoutView, ScheduleTitleView, TableHeaderView, SelectAllView, ScheduleListView, CountView } from 'js/views/patients/schedule/schedule_views';
 import { BulkEditButtonView, BulkEditActionsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 
 export default App.extend({
@@ -54,9 +54,12 @@ export default App.extend({
       const isFiltersSidebarOpen = this.getState('isFiltering');
 
       if (!isFiltersSidebarOpen) Radio.request('sidebar', 'close');
+
       this.showScheduleTitle();
+      this.showCountView();
       this.showDateFilter();
       this.getRegion('list').startPreloader();
+
       return;
     }
 
@@ -89,6 +92,7 @@ export default App.extend({
     this.showScheduleList();
     this.showSearchView();
     this.toggleBulkSelect();
+    this.showCountView();
   },
   onChangeSelected() {
     this.toggleBulkSelect();
@@ -151,6 +155,7 @@ export default App.extend({
     this.listenTo(collectionView, 'filtered', filtered => {
       this.filteredCollection.reset(filtered);
       this.toggleBulkSelect();
+      this.showCountView();
     });
 
     this.showChildView('list', collectionView);
@@ -213,6 +218,14 @@ export default App.extend({
     this.listenTo(filtersApp, 'toggle:filtersSidebar', isSidebarOpen => {
       this.setState('isFiltering', isSidebarOpen);
     });
+  },
+  showCountView() {
+    const countView = new CountView({
+      collection: this.collection,
+      filteredCollection: this.filteredCollection,
+    });
+
+    this.showChildView('count', countView);
   },
   showDateFilter() {
     const dateTypes = ['due_date'];

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -16,7 +16,7 @@ import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
 import { getSortOptions } from './worklist_sort';
 
-import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, NoOwnerToggleView } from 'js/views/patients/worklist/worklist_views';
+import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, NoOwnerToggleView, CountView } from 'js/views/patients/worklist/worklist_views';
 import { BulkEditButtonView, BulkEditFlowsSuccessTemplate, BulkEditActionsSuccessTemplate, BulkDeleteFlowsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 
 const i18n = intl.patients.worklist.filtersApp;
@@ -69,12 +69,15 @@ export default App.extend({
 
     if (this.isRestarting()) {
       if (!isFiltersSidebarOpen) Radio.request('sidebar', 'close');
+
       this.showListTitle();
       this.showTypeToggleView();
       this.showSortDroplist();
       this.showTableHeaders();
       this.showDateFilter();
+      this.showCountView();
       this.getRegion('list').startPreloader();
+
       return;
     }
 
@@ -120,6 +123,7 @@ export default App.extend({
     this.listenTo(collectionView, 'filtered', filtered => {
       this.filteredCollection.reset(filtered);
       this.toggleBulkSelect();
+      this.showCountView();
     });
 
     this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
@@ -131,6 +135,7 @@ export default App.extend({
 
     this.showSearchView();
     this.toggleBulkSelect();
+    this.showCountView();
   },
   startFiltersApp() {
     const state = this.getState();
@@ -257,6 +262,15 @@ export default App.extend({
     }
 
     Radio.request('alert', 'show:success', renderTemplate(BulkEditActionsSuccessTemplate, { itemCount }));
+  },
+  showCountView() {
+    const countView = new CountView({
+      isFlowList: this.getState().isFlowType(),
+      collection: this.collection,
+      filteredCollection: this.filteredCollection,
+    });
+
+    this.showChildView('count', countView);
   },
   showDateFilter() {
     if (this.getState().id !== 'shared-by' && this.getState().id !== 'owned-by') return;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -271,6 +271,10 @@ careOptsFrontend:
       scheduleViews:
         allFiltersButtonView:
           allFiltersButton: All Filters
+        countView:
+          actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
+          maximumListCount: Showing {maximumCount} of many Actions.
+          maximumListCountNarrowed: "Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}."
         dayItemView:
           noTime: No Time
         emptyFindInListView:
@@ -598,6 +602,13 @@ careOptsFrontend:
       worklistViews:
         allFiltersButtonView:
           allFiltersButton: All Filters
+        countView:
+            actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
+            flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
+            maximumActionsCountNarrowed: "Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}."
+            maximumFlowsCountNarrowed: "Showing {itemCount, plural, one {# Flow} other {# Flows}} of {maximumCount}."
+            maximumListCount: "Showing {maximumCount} of many {isFlowList, select, true {Flows} false {Actions}}."
+            narrowFilters: Try narrowing your filters.
         emptyFindInListView:
           noResults: No results match your Find in List search
         listTitleView:

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -1,3 +1,5 @@
+const MAXIMUM_LIST_COUNT = /* istanbul ignore next */ _TEST_ ? 50 : 500;
+
 const ACTION_OUTREACH = {
   DISABLED: 'disabled',
   PATIENT: 'patient',
@@ -60,6 +62,7 @@ const STATE_STATUS = {
 };
 
 export {
+  MAXIMUM_LIST_COUNT,
   ACTION_OUTREACH,
   ACTION_SHARING,
   PUBLISH_STATE_STATUS,

--- a/src/js/views/patients/schedule/layout.hbs
+++ b/src/js/views/patients/schedule/layout.hbs
@@ -6,6 +6,7 @@
   <div class="list-page__filters flex">
     <div class="flex u-margin--r-24" data-select-all-region></div>
     <div class="flex flex-align-center w-100" data-filters-region></div>
+    <div class="schedule__count{{#if isReduced}} is-reduced{{/if}}" data-count-region></div>
     <div class="flex u-text--nowrap" data-date-filter-region></div>
   </div>
   <table class="w-100" data-table-region></table>

--- a/src/js/views/patients/schedule/schedule-list.scss
+++ b/src/js/views/patients/schedule/schedule-list.scss
@@ -2,6 +2,20 @@
   margin-left: auto;
 }
 
+.schedule__count {
+  align-items: center;
+  color: $black-60;
+  display: flex;
+  font-size: 12px;
+  line-height: 1.2;
+  margin-right: 24px;
+  white-space: nowrap;
+
+  &.is-reduced {
+    min-height: 36px;
+  }
+}
+
 .schedule-list__header {
   border-bottom: 1px solid $black-90;
   color: $black-60;

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -8,6 +8,8 @@ import { alphaSort } from 'js/utils/sorting';
 import intl from 'js/i18n';
 import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
+import { MAXIMUM_LIST_COUNT } from 'js/static';
+
 import 'scss/modules/buttons.scss';
 import 'scss/modules/list-pages.scss';
 import 'scss/modules/table-list.scss';
@@ -39,6 +41,12 @@ const LayoutView = View.extend({
     },
     dateFilter: '[data-date-filter-region]',
     search: '[data-search-region]',
+    count: '[data-count-region]',
+  },
+  templateContext() {
+    return {
+      isReduced: this.getOption('state').get('isReduced'),
+    };
   },
 });
 
@@ -108,6 +116,51 @@ const SelectAllView = View.extend({
     if (this.getOption('isSelectNone') || this.getOption('isDisabled')) return hbs`{{fal "square"}}`;
 
     return hbs`{{fas "square-minus"}}`;
+  },
+});
+
+const ListCountTemplate = hbs`
+  <strong>
+    {{formatMessage (intlGet "patients.schedule.scheduleViews.countView.actionsCount") itemCount=count}}
+  </strong>
+`;
+
+const MaximumCountTemplate = hbs`
+  <div>{{formatMessage (intlGet "patients.schedule.scheduleViews.countView.maximumListCount") maximumCount=maximumCount}}</div>
+  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
+`;
+
+const MaximumCountNarrowedTemplate = hbs`
+  <div>{{formatMessage (intlGet "patients.schedule.scheduleViews.countView.maximumListCountNarrowed") itemCount=count maximumCount=maximumCount}}</div>
+  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
+`;
+
+const CountView = View.extend({
+  getTemplate() {
+    const filteredCollection = this.getOption('filteredCollection');
+
+    if (!this.collection || !filteredCollection.length) return hbs``;
+
+    const hasReachedMaximum = this.collection.length === MAXIMUM_LIST_COUNT;
+    const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
+
+    if (!hasReachedMaximum) {
+      return ListCountTemplate;
+    }
+
+    if (isFindInListApplied) {
+      return MaximumCountNarrowedTemplate;
+    }
+
+    return MaximumCountTemplate;
+  },
+  templateContext() {
+    const filteredCollection = this.getOption('filteredCollection');
+
+    return {
+      maximumCount: MAXIMUM_LIST_COUNT,
+      count: filteredCollection.length,
+    };
   },
 });
 
@@ -435,6 +488,7 @@ export {
   LayoutView,
   ScheduleTitleView,
   AllFiltersButtonView,
+  CountView,
   TableHeaderView,
   ScheduleListView,
   SelectAllView,

--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -8,6 +8,7 @@
     <div class="flex u-margin--r-24" data-select-all-region></div>
     <div class="flex flex-align-center w-100" data-filters-region></div>
     <div class="flex">
+      <span class="worklist-list__count" data-count-region></span>
       <span class="u-margin--r-16 u-text--nowrap" data-date-filter-region></span>
       <span class="worklist-list__filter-sort" data-sort-region></span>
     </div>

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -86,6 +86,16 @@
   width: 43%;
 }
 
+.worklist-list__count {
+  align-items: center;
+  color: $black-60;
+  display: flex;
+  font-size: 12px;
+  line-height: 1.2;
+  margin-right: 24px;
+  white-space: nowrap;
+}
+
 .worklist-list__filter-sort .fa-arrow-down-arrow-up {
   margin-right: 8px;
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-34741]

The backend recently capped list results to a maximum of 500 flows/actons. This PR is for adding messaging to lists on the frontend that indicates when a user's results are being capped.

The list count messaging can be in 4 different states:

1. The list count is below the capped maximum. ([screenshot](https://user-images.githubusercontent.com/35355575/230633166-9bc679b5-4dd3-4a38-bb72-aaf0149cdfff.png))
2. The capped maximum has been reached. ([screenshot](https://user-images.githubusercontent.com/35355575/230633296-faa7687b-80d0-4087-9e29-9a48074ef567.png))
3. The capped maximum has been reached, and the user narrows the list via the `Find in list...` input. ([screenshot](https://user-images.githubusercontent.com/35355575/230633351-df6688ad-a4eb-43df-a1b5-3337a25e712c.png))
4. The action/flow list is empty, so no count messaging is shown. ([screenshot](https://user-images.githubusercontent.com/35355575/230633239-20c180bb-1710-4c04-add8-b574856bc56d.png))

These changes apply to the worklists, schedule, and reduced schedule.
