### PR TITLE
Change `filter[action.tag]` => `filter[action.tags]` in patient form response API request

### DIFF
--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -122,7 +122,7 @@ export default App.extend({
 
     if (prefillActionTag) {
       return {
-        'action.tag': prefillActionTag,
+        'action.tags': prefillActionTag,
         'flow': flowId,
       };
     }

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -478,7 +478,7 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormResponseByPatient')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[action.tag]=foo-tag')
+      .should('contain', 'filter[action.tags]=foo-tag')
       .should('not.contain', 'filter[flow]')
       .should('not.contain', 'filter[form]');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-35176]

Feature for requesting a form response by a `prefill_action_tag` was added in #972.

But the `filter[action.tag]` should have been `filter[action.tags]`.