### PR TITLE
Clear program-action form component cache per workspace

### DIFF
--- a/src/js/views/programs/shared/components/form_component.js
+++ b/src/js/views/programs/shared/components/form_component.js
@@ -22,12 +22,12 @@ const NoFormTemplate = hbs`
   </button>
 `;
 
+let currentWorkspaceCache;
 let formsCollection;
 
-function getForms() {
+function getForms(workspace) {
   if (formsCollection) return formsCollection;
-  const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-  formsCollection = currentWorkspace.getForms();
+  formsCollection = workspace.getForms();
   const formModels = formsCollection.reject({ published_at: null });
   formsCollection.reset(formModels);
   return formsCollection;
@@ -74,7 +74,14 @@ export default Droplist.extend({
     attr: 'name',
   },
   initialize({ form }) {
-    this.collection = getForms();
+    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+
+    if (currentWorkspaceCache !== currentWorkspace.id) {
+      formsCollection = null;
+      currentWorkspaceCache = currentWorkspace.id;
+    }
+
+    this.collection = getForms(currentWorkspace);
 
     this.setState({ selected: form });
   },

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -332,7 +332,7 @@ context('program action sidebar', function() {
       })
       .routeWorkspaces(fx => {
         fx.data[0].relationships.forms.data = _.first(fx.data[0].relationships.forms.data, 6);
-
+        fx.data[1].relationships.forms.data = [];
         return fx;
       })
       .visit('/program-flow/1')
@@ -543,16 +543,15 @@ context('program action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-form-region]')
-      .contains('Add Form...')
-      .click();
-
-
-    cy
-      .get('.sidebar')
       .find('[data-form-sharing-region]')
       .contains('Enable Form Sharing')
       .should('be.disabled');
+
+    cy
+      .get('.sidebar')
+      .find('[data-form-region]')
+      .contains('Add Form...')
+      .click();
 
     cy
       .get('.picklist')
@@ -665,6 +664,25 @@ context('program action sidebar', function() {
 
     cy
       .go('back');
+
+    cy
+      .navigate('/program-flow/1', 'two')
+      .wait('@routeProgramFlowActions')
+      .wait('@routeProgramFlow');
+
+    cy
+      .get('.program-flow__list')
+      .contains('Name')
+      .click();
+
+    cy
+      .get('.sidebar')
+      .find('[data-form-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .should('contain', 'No Available Forms');
   });
 
   specify('display action sidebar with no workspace forms', function() {


### PR DESCRIPTION
[sc-35285]

This follows the same pattern of the owner component on worklists.  FWIW I don't know that we were really testing that this pattern worked when switching workspaces even though we're hitting coverage.
