### PR TITLE
Refactor worklists/schedule `CountView`s to use one shared view

### DIFF
--- a/src/js/apps/patients/schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced_schedule_app.js
@@ -4,7 +4,9 @@ import App from 'js/base/app';
 
 import SearchComponent from 'js/views/shared/components/list-search';
 
-import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView, CountView } from 'js/views/patients/schedule/schedule_views';
+import { CountView } from 'js/views/patients/shared/list_views';
+
+import { LayoutView, ScheduleTitleView, TableHeaderView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
 
 export default App.extend({
   onBeforeStop() {

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -58,9 +58,10 @@ export default App.extend({
       if (!isFiltersSidebarOpen) Radio.request('sidebar', 'close');
 
       this.showScheduleTitle();
-      this.showCountView();
       this.showDateFilter();
       this.getRegion('list').startPreloader();
+
+      this.getRegion('count').empty();
 
       return;
     }

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -14,7 +14,9 @@ import DateFilterComponent from 'js/views/patients/shared/components/date-filter
 import SearchComponent from 'js/views/shared/components/list-search';
 import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
-import { LayoutView, ScheduleTitleView, TableHeaderView, SelectAllView, ScheduleListView, CountView } from 'js/views/patients/schedule/schedule_views';
+import { CountView } from 'js/views/patients/shared/list_views';
+
+import { LayoutView, ScheduleTitleView, TableHeaderView, SelectAllView, ScheduleListView } from 'js/views/patients/schedule/schedule_views';
 import { BulkEditButtonView, BulkEditActionsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 
 export default App.extend({

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -13,10 +13,11 @@ import BulkEditFlowsApp from 'js/apps/patients/sidebar/bulk-edit-flows_app';
 import DateFilterComponent from 'js/views/patients/shared/components/date-filter';
 import SearchComponent from 'js/views/shared/components/list-search';
 import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
+import { CountView } from 'js/views/patients/shared/list_views';
 
 import { getSortOptions } from './worklist_sort';
 
-import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, NoOwnerToggleView, CountView } from 'js/views/patients/worklist/worklist_views';
+import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, NoOwnerToggleView } from 'js/views/patients/worklist/worklist_views';
 import { BulkEditButtonView, BulkEditFlowsSuccessTemplate, BulkEditActionsSuccessTemplate, BulkDeleteFlowsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 
 const i18n = intl.patients.worklist.filtersApp;

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -76,8 +76,9 @@ export default App.extend({
       this.showSortDroplist();
       this.showTableHeaders();
       this.showDateFilter();
-      this.showCountView();
       this.getRegion('list').startPreloader();
+
+      this.getRegion('count').empty();
 
       return;
     }

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -271,10 +271,6 @@ careOptsFrontend:
       scheduleViews:
         allFiltersButtonView:
           allFiltersButton: All Filters
-        countView:
-          actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
-          maximumListCount: Showing {maximumCount} of many Actions.
-          maximumListCountNarrowed: "Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}."
         dayItemView:
           noTime: No Time
         emptyFindInListView:
@@ -424,6 +420,14 @@ careOptsFrontend:
           bodyText: There are actions not set to a Done state on this flow. You must set all actions to a Done state before setting this flow to a Done state.
           headingText: Flow Actions Must Be Done
           submitText: OK
+      listViews:
+        countView:
+          actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
+          flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
+          maximumActionsCountNarrowed: Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}.
+          maximumFlowsCountNarrowed: Showing {itemCount, plural, one {# Flow} other {# Flows}} of {maximumCount}.
+          maximumListCount: Showing {maximumCount} of many {isFlowList, select, true {Flows} false {Actions}}.
+          narrowFilters: Try narrowing your filters.
     sidebar:
       action:
         actionDetailsTemplate:
@@ -602,13 +606,6 @@ careOptsFrontend:
       worklistViews:
         allFiltersButtonView:
           allFiltersButton: All Filters
-        countView:
-            actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
-            flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
-            maximumActionsCountNarrowed: "Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}."
-            maximumFlowsCountNarrowed: "Showing {itemCount, plural, one {# Flow} other {# Flows}} of {maximumCount}."
-            maximumListCount: "Showing {maximumCount} of many {isFlowList, select, true {Flows} false {Actions}}."
-            narrowFilters: Try narrowing your filters.
         emptyFindInListView:
           noResults: No results match your Find in List search
         listTitleView:

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -8,8 +8,6 @@ import { alphaSort } from 'js/utils/sorting';
 import intl from 'js/i18n';
 import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
-import { MAXIMUM_LIST_COUNT } from 'js/static';
-
 import 'scss/modules/buttons.scss';
 import 'scss/modules/list-pages.scss';
 import 'scss/modules/table-list.scss';
@@ -116,51 +114,6 @@ const SelectAllView = View.extend({
     if (this.getOption('isSelectNone') || this.getOption('isDisabled')) return hbs`{{fal "square"}}`;
 
     return hbs`{{fas "square-minus"}}`;
-  },
-});
-
-const ListCountTemplate = hbs`
-  <strong>
-    {{formatMessage (intlGet "patients.schedule.scheduleViews.countView.actionsCount") itemCount=count}}
-  </strong>
-`;
-
-const MaximumCountTemplate = hbs`
-  <div>{{formatMessage (intlGet "patients.schedule.scheduleViews.countView.maximumListCount") maximumCount=maximumCount}}</div>
-  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
-`;
-
-const MaximumCountNarrowedTemplate = hbs`
-  <div>{{formatMessage (intlGet "patients.schedule.scheduleViews.countView.maximumListCountNarrowed") itemCount=count maximumCount=maximumCount}}</div>
-  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
-`;
-
-const CountView = View.extend({
-  getTemplate() {
-    const filteredCollection = this.getOption('filteredCollection');
-
-    if (!this.collection || !filteredCollection.length) return hbs``;
-
-    const hasReachedMaximum = this.collection.length === MAXIMUM_LIST_COUNT;
-    const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
-
-    if (!hasReachedMaximum) {
-      return ListCountTemplate;
-    }
-
-    if (isFindInListApplied) {
-      return MaximumCountNarrowedTemplate;
-    }
-
-    return MaximumCountTemplate;
-  },
-  templateContext() {
-    const filteredCollection = this.getOption('filteredCollection');
-
-    return {
-      maximumCount: MAXIMUM_LIST_COUNT,
-      count: filteredCollection.length,
-    };
   },
 });
 
@@ -488,7 +441,6 @@ export {
   LayoutView,
   ScheduleTitleView,
   AllFiltersButtonView,
-  CountView,
   TableHeaderView,
   ScheduleListView,
   SelectAllView,

--- a/src/js/views/patients/shared/list_views.js
+++ b/src/js/views/patients/shared/list_views.js
@@ -1,0 +1,64 @@
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import { MAXIMUM_LIST_COUNT } from 'js/static';
+
+const ListCountTemplate = hbs`
+  <strong>
+    {{#if isFlowList}}
+      {{formatMessage (intlGet "patients.shared.listViews.countView.flowsCount") itemCount=count}}
+    {{else}}
+      {{formatMessage (intlGet "patients.shared.listViews.countView.actionsCount") itemCount=count}}
+    {{/if}}
+  </strong>
+`;
+
+const MaximumCountTemplate = hbs`
+  <div>{{formatMessage (intlGet "patients.shared.listViews.countView.maximumListCount") maximumCount=maximumCount isFlowList=isFlowList}}</div>
+  <div>{{ @intl.patients.shared.listViews.countView.narrowFilters }}</div>
+`;
+
+const MaximumCountNarrowedTemplate = hbs`
+  <div>
+    {{#if isFlowList}}
+      {{formatMessage (intlGet "patients.shared.listViews.countView.maximumFlowsCountNarrowed") itemCount=count maximumCount=maximumCount}}
+    {{else}}
+      {{formatMessage (intlGet "patients.shared.listViews.countView.maximumActionsCountNarrowed") itemCount=count maximumCount=maximumCount}}
+    {{/if}}
+  </div>
+  <div>{{ @intl.patients.shared.listViews.countView.narrowFilters }}</div>
+`;
+
+const CountView = View.extend({
+  getTemplate() {
+    const filteredCollection = this.getOption('filteredCollection');
+
+    if (!this.collection || !filteredCollection.length) return hbs``;
+
+    const hasReachedMaximum = this.collection.length === MAXIMUM_LIST_COUNT;
+    const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
+
+    if (!hasReachedMaximum) {
+      return ListCountTemplate;
+    }
+
+    if (isFindInListApplied) {
+      return MaximumCountNarrowedTemplate;
+    }
+
+    return MaximumCountTemplate;
+  },
+  templateContext() {
+    const filteredCollection = this.getOption('filteredCollection');
+
+    return {
+      maximumCount: MAXIMUM_LIST_COUNT,
+      count: filteredCollection.length,
+      isFlowList: !!this.getOption('isFlowList'),
+    };
+  },
+});
+
+export {
+  CountView,
+};

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -7,8 +7,6 @@ import intl, { renderTemplate } from 'js/i18n';
 import underscored from 'js/utils/formatting/underscored';
 import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
-import { MAXIMUM_LIST_COUNT } from 'js/static';
-
 import 'scss/modules/buttons.scss';
 import 'scss/modules/list-pages.scss';
 import 'scss/modules/table-list.scss';
@@ -225,62 +223,6 @@ const EmptyFindInListView = View.extend({
   `,
 });
 
-const ListCountTemplate = hbs`
-  <strong>
-    {{#if isFlowList}}
-      {{formatMessage (intlGet "patients.worklist.worklistViews.countView.flowsCount") itemCount=count}}
-    {{else}}
-      {{formatMessage (intlGet "patients.worklist.worklistViews.countView.actionsCount") itemCount=count}}
-    {{/if}}
-  </strong>
-`;
-
-const MaximumCountTemplate = hbs`
-  <div>{{formatMessage (intlGet "patients.worklist.worklistViews.countView.maximumListCount") maximumCount=maximumCount isFlowList=isFlowList}}</div>
-  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
-`;
-
-const MaximumCountNarrowedTemplate = hbs`
-  <div>
-    {{#if isFlowList}}
-      {{formatMessage (intlGet "patients.worklist.worklistViews.countView.maximumFlowsCountNarrowed") itemCount=count maximumCount=maximumCount}}
-    {{else}}
-      {{formatMessage (intlGet "patients.worklist.worklistViews.countView.maximumActionsCountNarrowed") itemCount=count maximumCount=maximumCount}}
-    {{/if}}
-  </div>
-  <div>{{ @intl.patients.worklist.worklistViews.countView.narrowFilters }}</div>
-`;
-
-const CountView = View.extend({
-  getTemplate() {
-    const filteredCollection = this.getOption('filteredCollection');
-
-    if (!this.collection || !filteredCollection.length) return hbs``;
-
-    const hasReachedMaximum = this.collection.length === MAXIMUM_LIST_COUNT;
-    const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
-
-    if (!hasReachedMaximum) {
-      return ListCountTemplate;
-    }
-
-    if (isFindInListApplied) {
-      return MaximumCountNarrowedTemplate;
-    }
-
-    return MaximumCountTemplate;
-  },
-  templateContext() {
-    const filteredCollection = this.getOption('filteredCollection');
-
-    return {
-      maximumCount: MAXIMUM_LIST_COUNT,
-      count: filteredCollection.length,
-      isFlowList: this.getOption('isFlowList'),
-    };
-  },
-});
-
 const ListView = CollectionView.extend({
   className: 'table-list',
   tagName: 'table',
@@ -381,5 +323,4 @@ export {
   TypeToggleView,
   i18n,
   NoOwnerToggleView,
-  CountView,
 };


### PR DESCRIPTION
Shortcut Story ID: [sc-35368]

In #1007, we added a separate `CountView` for both the worklist and schedule. But they are almost completely identical. The only difference being that the worklist version supports messaging for `Flows` via the `isFlowList` variable.

This PR creates a shared `CountView` in a `/js/views/patients/shared/list_views.js` file that is used by the worklist, schedule, and reduced schedule.
