### PR TITLE
Change form expand buttons from `far` (regular) to `fas` (solid)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "circle-info",
       "circle-plus",
       "circle-xmark",
+      "down-left-and-up-right-to-center",
       "ellipsis",
       "folder",
       "folder-open",
@@ -66,6 +67,7 @@
       "square-check",
       "square-minus",
       "toggle-on",
+      "up-right-and-down-left-from-center",
       "xmark"
     ],
     "far": [
@@ -92,7 +94,6 @@
       "circle-xmark",
       "clock",
       "clock-rotate-left",
-      "down-left-and-up-right-to-center",
       "download",
       "ellipsis",
       "file-lines",
@@ -121,7 +122,6 @@
       "toggle-off",
       "traffic-cone",
       "trash-can",
-      "up-right-and-down-left-from-center",
       "user",
       "user-plus",
       "users",

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -50,7 +50,7 @@ const FormStateActionsView = View.extend({
   className: 'flex',
   template: hbs`
     {{#if hasHistory}}<button class="js-history-button form__actions-icon{{#if shouldShowHistory}} is-selected{{/if}}">{{far "clock-rotate-left"}}</button>{{/if}}
-    <button class="js-expand-button form__actions-icon">{{#if isExpanded}}{{far "down-left-and-up-right-to-center"}}{{else}}{{far "up-right-and-down-left-from-center"}}{{/if}}</button>
+    <button class="js-expand-button form__actions-icon">{{#if isExpanded}}{{fas "down-left-and-up-right-to-center"}}{{else}}{{fas "up-right-and-down-left-from-center"}}{{/if}}</button>
     {{#if hasAction}}<button class="js-sidebar-button form__actions-icon{{#if isActionShown}} is-selected{{/if}}">{{far "file-lines"}}</button>{{/if}}
   `,
   templateContext() {

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -223,7 +223,7 @@ const widgets = {
   formWidget: View.extend({
     className: 'button-primary widgets__form-widget',
     tagName: 'button',
-    template: hbs`{{far "square-poll-horizontal"}} {{formName}} {{far "up-right-and-down-left-from-center"}}`,
+    template: hbs`{{far "square-poll-horizontal"}} {{formName}} {{fas "up-right-and-down-left-from-center"}}`,
     templateContext() {
       return {
         formName: this.getOption('form_name'),

--- a/src/js/views/programs/shared/components/form_component.js
+++ b/src/js/views/programs/shared/components/form_component.js
@@ -14,7 +14,7 @@ const i18n = intl.programs.shared.components.formComponent;
 const FormTemplate = hbs`
   <button class="js-button button-secondary button__group flex-grow" {{#if isDisabled}}disabled{{/if}}>
     {{far "square-poll-horizontal"}}<span>{{ name }}</span>
-  </button><button class="js-click-form button button__group form-component__form-button" {{#if isDisabled}}disabled{{/if}}>{{far "up-right-and-down-left-from-center"}}</button>
+  </button><button class="js-click-form button button__group form-component__form-button" {{#if isDisabled}}disabled{{/if}}>{{fas "up-right-and-down-left-from-center"}}</button>
 `;
 const NoFormTemplate = hbs`
   <button class="js-button button-secondary w-100" {{#if isDisabled}}disabled{{/if}}>


### PR DESCRIPTION
Shortcut Story ID: [sc-35392]

Currently using this icon (regular version):

<img width="57" alt="Screenshot 2023-04-12 at 10 57 51 AM" src="https://user-images.githubusercontent.com/35355575/231514706-bc56eb37-425e-4598-b58e-a00cb83e6b66.png">

This PR switches to using this icon (solid version):

<img width="56" alt="Screenshot 2023-04-12 at 10 54 01 AM" src="https://user-images.githubusercontent.com/35355575/231513645-b73e960a-90f5-433f-9224-e74979f3681d.png">

Changed in these places:

* Form page action buttons section (used to expand/collapse sidebar).
* Form component in the program action sidebar.
* Form widget.