### PR TITLE
Update capped list + find in list filtered messaging

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -424,9 +424,8 @@ careOptsFrontend:
         countView:
           actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
           flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
-          maximumActionsCountNarrowed: Showing {itemCount, plural, one {# Action} other {# Actions}} of {maximumCount}.
-          maximumFlowsCountNarrowed: Showing {itemCount, plural, one {# Flow} other {# Flows}} of {maximumCount}.
           maximumListCount: Showing {maximumCount} of many {isFlowList, select, true {Flows} false {Actions}}.
+          maximumListCountNarrowed: Showing {itemCount} of {maximumCount} {isFlowList, select, true {Flows} false {Actions}}.
           narrowFilters: Try narrowing your filters.
     sidebar:
       action:

--- a/src/js/views/patients/shared/list_views.js
+++ b/src/js/views/patients/shared/list_views.js
@@ -20,11 +20,7 @@ const MaximumCountTemplate = hbs`
 
 const MaximumCountNarrowedTemplate = hbs`
   <div>
-    {{#if isFlowList}}
-      {{formatMessage (intlGet "patients.shared.listViews.countView.maximumFlowsCountNarrowed") itemCount=count maximumCount=maximumCount}}
-    {{else}}
-      {{formatMessage (intlGet "patients.shared.listViews.countView.maximumActionsCountNarrowed") itemCount=count maximumCount=maximumCount}}
-    {{/if}}
+    {{formatMessage (intlGet "patients.shared.listViews.countView.maximumListCountNarrowed") itemCount=count maximumCount=maximumCount isFlowList=isFlowList}}
   </div>
   <div>{{ @intl.patients.shared.listViews.countView.narrowFilters }}</div>
 `;

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -390,7 +390,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 1 Action of 50.')
+      .should('contain', 'Showing 1 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -402,7 +402,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 25 Actions of 50.')
+      .should('contain', 'Showing 25 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1402,7 +1402,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 1 Action of 50.')
+      .should('contain', 'Showing 1 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1414,7 +1414,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 25 Actions of 50.')
+      .should('contain', 'Showing 25 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1024,7 +1024,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 1 Action of 50.')
+      .should('contain', 'Showing 1 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1036,7 +1036,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 25 Actions of 50.')
+      .should('contain', 'Showing 25 of 50 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1070,7 +1070,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 1 Flow of 50.')
+      .should('contain', 'Showing 1 of 50 Flows.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1082,7 +1082,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 25 Flows of 50.')
+      .should('contain', 'Showing 25 of 50 Flows.')
       .should('contain', 'Try narrowing your filters.');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-35407]

This version of the messaging is shown when the list has reached its maximum length and then the user further filters the list via the `Find in list...` input.

Current messaging:

```
Showing 167 Actions of 500.
Try narrowing your filters.
```

New messaging:

```
Showing 167 of 500 Actions.
Try narrowing your filters.
```
