### PR TITLE
Feature/form get field

### DIFF
--- a/src/js/entities-service/entities/patient-fields.js
+++ b/src/js/entities-service/entities/patient-fields.js
@@ -1,4 +1,5 @@
 import { isObject, isEmpty, extend } from 'underscore';
+import { v5 as uuid } from 'uuid';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -21,6 +22,11 @@ const _Model = BaseModel.extend({
   },
   saveAll(attrs) {
     attrs = extend({}, this.attributes, attrs);
+
+    // NOTE: sets the id instead of attrs.id due to how backbone's save works
+    if (!attrs.id) {
+      this.set({ id: uuid(`resource:field:${ attrs.name.toLowerCase() }`, attrs._patient) });
+    }
 
     const relationships = {
       'patient': this.toRelation(attrs._patient, 'patients'),

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -44,12 +44,16 @@ function updateField(fieldName, value) {
   return router.updateField({ fieldName, value });
 }
 
+function getField(fieldName) {
+  return router.getField({ fieldName });
+}
+
 function getDirectory(directoryName, query) {
   return router.getDirectory({ directoryName, query });
 }
 
 function getContext(contextScripts) {
-  return getScriptContext(contextScripts, { getDirectory, updateField, Handlebars, TEMPLATES: {}, parsePhoneNumber });
+  return getScriptContext(contextScripts, { getDirectory, getField, updateField, Handlebars, TEMPLATES: {}, parsePhoneNumber });
 }
 
 let prevSubmission;
@@ -187,6 +191,7 @@ const Router = Backbone.Router.extend({
     this.requestResolves = {};
     this.on({
       'fetch:directory': this.onFetchDirectory,
+      'fetch:field': this.onFetchField,
       'update:field': this.onUpdateField,
     });
   },
@@ -221,6 +226,15 @@ const Router = Backbone.Router.extend({
     return this.requestValue({ args, message, requestId });
   },
   onFetchDirectory(args) {
+    this.resolveValue(args);
+  },
+  getField(args) {
+    const message = 'fetch:field';
+    const requestId = uniqueId('field');
+
+    return this.requestValue({ args, message, requestId });
+  },
+  onFetchField(args) {
     this.resolveValue(args);
   },
   updateField(args) {

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -27,6 +27,7 @@ export default App.extend({
     'update:storedSubmission': 'updateStoredSubmission',
     'get:storedSubmission': 'getStoredSubmission',
     'clear:storedSubmission': 'clearStoredSubmission',
+    'fetch:field': 'fetchField',
     'update:field': 'updateField',
     'version': 'checkVersion',
   },
@@ -66,6 +67,21 @@ export default App.extend({
   },
   clearStoredSubmission() {
     store.remove(this.getStoreId());
+  },
+  fetchField({ fieldName, requestId }) {
+    const channel = this.getChannel();
+    const field = Radio.request('entities', 'patientFields:model', {
+      name: fieldName,
+      _patient: this.patient.id,
+    });
+
+    return field.fetch()
+      .then(() => {
+        channel.request('send', 'fetch:field', { value: field.getValue(), requestId });
+      })
+      .catch(error => {
+        channel.request('send', 'fetch:field', { error, requestId });
+      });
   },
   updateField({ fieldName, value, requestId }) {
     const channel = this.getChannel();

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -89,6 +89,9 @@ export default App.extend({
     return Promise.resolve(Radio.request('entities', 'fetch:directories:model', directoryName, query))
       .then(directory => {
         channel.request('send', 'fetch:directory', { value: directory.get('value'), requestId });
+      })
+      .catch(error => {
+        channel.request('send', 'fetch:directory', { error, requestId });
       });
   },
   fetchForm() {

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { v5 as uuid } from 'uuid';
 
 context('Noncontext Form', function() {
   beforeEach(function() {
@@ -9,17 +10,13 @@ context('Noncontext Form', function() {
     cy
       .route({
         method: 'GET',
-        url: '/appconfig.json',
-        response: { versions: { frontend: 'foo' } },
-      })
-      .route({
-        method: 'GET',
         url: '/api/directory/foo*',
         response: { data: { attributes: { value: ['one', 'two'] } } },
       })
       .as('routeDirectoryFoo')
       .route({
         method: 'GET',
+        status: 400,
         url: '/api/directory/bar*',
         response: { data: { attributes: { value: ['bar', 'baz'] } } },
       })
@@ -55,7 +52,12 @@ context('Noncontext Form', function() {
               tableView: true,
               dataSrc: 'custom',
               data: {
-                custom: 'values = getDirectory(\'bar\', { filter: { foo: \'bar\' }})',
+                custom: `
+                  values = getDirectory(\'bar\', { filter: { foo: \'bar\' }})
+                    .catch(e => {
+                      return ['bar', 'error'];
+                    })
+                `,
               },
               template: '<span>{{ item }}</span>',
               refreshOn: 'data',
@@ -122,20 +124,39 @@ context('Noncontext Form', function() {
       .first()
       .should('contain', 'bar')
       .next()
-      .should('contain', 'baz');
+      .should('contain', 'error');
   });
 
   specify('update patient field', function() {
+    // NOTE: Needs an actual uuid for uuid v5 generation
+    const patientId = '368a7fcf-c877-41bf-aefe-2ea4341cf9b4';
     cy
+      .routePatient(fx => {
+        fx.data.id = patientId;
+        return fx;
+      })
+      .routePatientField(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.name = 'foo';
+        fx.data.attributes.value = [1, 2];
+        return fx;
+      }, 'foo')
+      .route({
+        method: 'GET',
+        url: `/api/patients/${ patientId }/fields/bar`,
+        status: 400,
+        response: { data: 'Error' },
+      })
+      .as('routePatientFieldbar')
       .route({
         method: 'PATCH',
-        url: '/api/patients/1/fields/foo',
+        url: `/api/patients/${ patientId }/fields/foo`,
         response: { data: { attributes: { name: 'foo', value: ['one', 'two'] } } },
       })
       .as('routePatchPatientFieldFoo')
       .route({
         method: 'PATCH',
-        url: '/api/patients/1/fields/bar',
+        url: `/api/patients/${ patientId }/fields/bar`,
         status: 400,
         response: { data: 'Error' },
       })
@@ -145,15 +166,64 @@ context('Noncontext Form', function() {
           display: 'form',
           components: [
             {
+              label: 'Test Get Field',
+              action: 'custom',
+              key: 'test1',
+              type: 'button',
+              input: true,
+              custom: `
+                getField('foo')
+                  .then(value => {
+                    data.opts = value;
+                  });
+              `,
+            },
+            {
+              label: 'Test Get Error',
+              action: 'custom',
+              key: 'test2',
+              type: 'button',
+              input: true,
+              custom: `
+                getField('bar')
+                  .catch(value => {
+                    data.opts = ['error'];
+                  });
+              `,
+            },
+            {
+              label: 'Test Update Field',
+              action: 'custom',
+              key: 'test3',
+              type: 'button',
+              input: true,
+              custom: `
+                updateField('foo', ['one', 'two'])
+                  .then(value => {
+                    data.opts = value;
+                  });
+              `,
+            },
+            {
+              label: 'Test Update Error',
+              action: 'custom',
+              key: 'test4',
+              type: 'button',
+              input: true,
+              custom: `
+                updateField('bar', ['one', 'two'])
+                  .catch(value => {
+                    data.opts = ['error1', 'error2'];
+                  });
+              `,
+            },
+            {
               label: 'Select Foo',
               widget: 'choicesjs',
               tableView: true,
               dataSrc: 'custom',
               data: {
-                custom: `
-                  if(instance.values) return instance.values;
-                  values = instance.values = updateField('foo', ['one', 'two'])
-                `,
+                custom: 'values = data.opts',
               },
               template: '<span>{{ item }}</span>',
               refreshOn: 'data',
@@ -161,80 +231,121 @@ context('Noncontext Form', function() {
               type: 'select',
               input: true,
             },
-            {
-              label: 'Select Bar',
-              widget: 'choicesjs',
-              tableView: true,
-              dataSrc: 'custom',
-              data: {
-                custom: `
-                  if(instance.values) return instance.values;
-                  values = instance.values = new Promise(resolve => {
-                    updateField('bar', ['bar', 'baz'])
-                    .then(v => { resolve(v); })
-                    .catch(e => { resolve([e]); })
-                  });
-                `,
-              },
-              template: '<span>{{ item }}</span>',
-              refreshOn: 'data',
-              key: 'select2',
-              type: 'select',
-              input: true,
-            },
           ],
         };
       })
-      .routePatient(fx => {
-        fx.data.id = '1';
-        return fx;
-      })
       .routeForm(_.identity, '11111')
       .routeFormFields()
-      .visit('/patient/1/form/11111')
+      .visit(`/patient/${ patientId }/form/11111`)
       .wait('@routePatient')
       .wait('@routeForm')
       .wait('@routeFormFields')
       .wait('@routeFormDefinition');
 
+    // NOTE: .wait(100) account for form.io data delays
+
     cy
+      .iframe()
+      .find('button')
+      .contains('Test Get Field')
+      .click()
+      .wait('@routePatientFieldfoo')
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('.formio-component-select .dropdown')
+      .click();
+
+    cy
+      .iframe()
+      .find('.choices__list--dropdown.is-active')
+      .find('.choices__item--selectable')
+      .should('contain', '1')
+      .should('contain', '2')
+      .first()
+      .click();
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Get Error')
+      .click()
+      .wait('@routePatientFieldbar')
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('.formio-component-select .dropdown')
+      .click();
+
+    cy
+      .iframe()
+      .find('.choices__list--dropdown.is-active')
+      .find('.choices__item--selectable')
+      .should('contain', 'error')
+      .first()
+      .click();
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Update Field')
+      .click()
       .wait('@routePatchPatientFieldFoo')
-      .wait('@routePatchPatientFieldBar')
-      .its('request.body.data.attributes')
-      .should('deep.equal', { name: 'bar', value: ['bar', 'baz'] });
+      .its('request.body.data')
+      .then(data => {
+        expect(data.id).to.equal('1');
+        expect(data.attributes.name).to.equal('foo');
+        expect(data.attributes.value).to.deep.equal(['one', 'two']);
+      })
+      .wait(100);
 
     cy
       .iframe()
       .find('.formio-component-select .dropdown')
-      .first()
       .click();
 
     cy
       .iframe()
       .find('.choices__list--dropdown.is-active')
       .find('.choices__item--selectable')
-      .first()
       .should('contain', 'one')
-      .next()
       .should('contain', 'two')
+      .first()
       .click();
 
     cy
       .iframe()
+      .find('button')
+      .contains('Test Update Error')
+      .click()
+      .wait('@routePatchPatientFieldBar')
+      .its('request.body.data.id')
+      .should('equal', uuid('resource:field:bar', patientId))
+      .wait(100);
+
+    cy
+      .iframe()
       .find('.formio-component-select .dropdown')
-      .last()
       .click();
 
     cy
       .iframe()
       .find('.choices__list--dropdown.is-active')
       .find('.choices__item--selectable')
+      .should('contain', 'error')
       .first()
-      .should('contain', 'Error: Bad Request');
+      .click();
   });
 
   specify('form scripts and reducers', { retries: 4 }, function() {
     cy
+      .route({
+        method: 'GET',
+        url: '/appconfig.json',
+        response: { versions: { frontend: 'foo' } },
+      })
       .routePatient(fx => {
         fx.data.id = '1';
         return fx;


### PR DESCRIPTION
Shortcut Story ID: [sc-35533]

I'd been looking into fixing [sc-35282] and then @zfixler, we had talked about adding a `getField`

In order to successfully test a patient field the form had loaded and a patient field the form hadn't loaded regarding patching it's `id` for coverage, the easiest way was to finish the `getField`

