### PR TITLE
Update circleci cypress docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome-and-firefox:
     docker:
-      - image: "cypress/browsers:node16.5.0-chrome94-ff93"
+      - image: "cypress/browsers:node16.18.0-chrome107-ff106-edge"
 
 commands:
   font_awesome:


### PR DESCRIPTION
Includes later versions of chrome and firefox

This isn't a "fix" but the error we're seeing, after @zfixler getting this error on a `getDirectory` error in the Brave browser it led me to think that the `catch` `postMessage` was failing attempting to serialize the `error` object.  However `Error`s [should be serializable](https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/error) and even though this is failing on firefox on CI consistently, I can never make it fail locally in firefox.

So I'm hoping this is an older-FF issue.

Shortcut Story ID: [sc-35282]
