### PR TITLE
Add an `All Time` date filter to the worklist & schedule

### DIFF
--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -100,6 +100,10 @@ export default Backbone.Model.extend({
       };
     }
 
+    if (relativeDate === 'alltime') {
+      return {};
+    }
+
     const { prev, unit } = relativeRanges.get(relativeDate || 'thismonth').pick('prev', 'unit');
     const relativeRange = dayjs().subtract(prev, unit);
 

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -110,6 +110,10 @@ export default Backbone.Model.extend({
       };
     }
 
+    if (relativeDate === 'alltime') {
+      return {};
+    }
+
     const { prev, unit } = relativeRanges.get(relativeDate || 'thismonth').pick('prev', 'unit');
     const relativeRange = dayjs().subtract(prev, unit);
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -381,6 +381,7 @@ careOptsFrontend:
             updateButton: Updated
           dateTypes: "{type, select, created_at {Added} due_date {Due} updated_at {Updated}}"
           relativeDate: "{relativeTo, select,
+              alltime {All Time}
               calendar {Select from calendar...}
               thismonth {This Month}
               lastmonth {Last Month}

--- a/src/js/views/patients/shared/components/date-filter/date-filter_views.js
+++ b/src/js/views/patients/shared/components/date-filter/date-filter_views.js
@@ -54,13 +54,17 @@ const DefaultTemplate = hbs`{{ @intl.patients.shared.components.dateFilterCompon
 
 const ControllerView = View.extend({
   template: hbs`
-    <button class="button-secondary--compact u-margin--r-8 js-prev">{{far "angle-left"}}</button>{{~ remove_whitespace ~}}
+    {{#unless hidePrevNextButtons}}
+      <button class="button-secondary--compact u-margin--r-8 js-prev">{{far "angle-left"}}</button>{{~ remove_whitespace ~}}
+    {{/unless}}
     <button class="button-filter js-date">
       {{far "calendar-days"}}{{~ remove_whitespace ~}}
       {{formatMessage (intlGet "patients.shared.components.dateFilterComponent.dateTypes") type=dateType }}{{~ remove_whitespace ~}}:
       <span data-date-picker-label-region></span>
     </button>{{~ remove_whitespace ~}}
-    <button class="button-secondary--compact u-margin--l-8 js-next">{{far "angle-right"}}</button>
+    {{#unless hidePrevNextButtons}}
+      <button class="button-secondary--compact u-margin--l-8 js-next">{{far "angle-right"}}</button>
+    {{/unless}}
   `,
   regions: {
     datepicker: {
@@ -98,7 +102,14 @@ const ControllerView = View.extend({
       },
     });
 
+    if (this.model.get('relativeDate') === 'alltime') return;
+
     this.getTooltips();
+  },
+  templateContext() {
+    return {
+      hidePrevNextButtons: this.model.get('relativeDate') === 'alltime',
+    };
   },
   getTooltips() {
     const tooltipMessages = this.getTooltipMessages();

--- a/src/js/views/patients/shared/components/date-filter/index.js
+++ b/src/js/views/patients/shared/components/date-filter/index.js
@@ -11,7 +11,7 @@ import StateModel from './date-filter_state';
 
 import { RELATIVE_DATE_RANGES } from 'js/static';
 
-const relativeRanges = new Backbone.Collection([...RELATIVE_DATE_RANGES, { id: 'calendar' }]);
+const relativeRanges = new Backbone.Collection([...RELATIVE_DATE_RANGES, { id: 'calendar' }, { id: 'alltime' }]);
 
 const dateTypes = ['create_at', 'updated_at', 'due_date'];
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -658,7 +658,40 @@ context('schedule page', function() {
     cy
       .get('[data-date-filter-region]')
       .should('contain', formatDate(dayjs(testDateSubtract(1, 'week')).startOf('week'), 'MM/DD/YYYY'))
-      .should('contain', formatDate(dayjs(testDateSubtract(1, 'week')).endOf('week'), 'MM/DD/YYYY'));
+      .should('contain', formatDate(dayjs(testDateSubtract(1, 'week')).endOf('week'), 'MM/DD/YYYY'))
+      .click();
+
+    cy
+      .get('.app-frame__pop-region')
+      .contains('All Time')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+
+        expect(storage.dateFilters.relativeDate).to.equal('alltime');
+        expect(storage.dateFilters.selectedDate).to.be.null;
+        expect(storage.dateFilters.selectedMonth).to.be.null;
+      });
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('not.contain', 'filter[due_date]');
+
+    cy
+      .get('[data-date-filter-region]')
+      .should('contain', 'All Time');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('.js-prev')
+      .should('not.exist');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('.js-next')
+      .should('not.exist');
 
     cy.clock().invoke('restore');
   });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1845,7 +1845,8 @@ context('worklist page', function() {
     cy
       .get('[data-date-filter-region]')
       .find('.js-next')
-      .click();
+      .click()
+      .wait('@routeActions');
 
     cy
       .get('[data-date-filter-region]')
@@ -1909,7 +1910,8 @@ context('worklist page', function() {
     cy
       .get('.datepicker')
       .find('.is-today')
-      .click();
+      .click()
+      .wait('@routeActions');
 
     cy
       .get('.datepicker')
@@ -1918,7 +1920,41 @@ context('worklist page', function() {
     cy
       .get('[data-date-filter-region]')
       .should('contain', 'Added:')
-      .should('contain', formatDate(testDate(), 'MM/DD/YYYY'));
+      .should('contain', formatDate(testDate(), 'MM/DD/YYYY'))
+      .click();
+
+    cy
+      .get('.app-frame__pop-region')
+      .contains('All Time')
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+
+        expect(storage.actionsDateFilters.relativeDate).to.equal('alltime');
+        expect(storage.actionsDateFilters.selectedDate).to.be.null;
+        expect(storage.actionsDateFilters.selectedMonth).to.be.null;
+        expect(storage.actionsDateFilters.dateType).to.equal('created_at');
+      });
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('not.contain', 'filter[created_at]');
+
+    cy
+      .get('[data-date-filter-region]')
+      .should('contain', 'All Time');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('.js-prev')
+      .should('not.exist');
+
+    cy
+      .get('[data-date-filter-region]')
+      .find('.js-next')
+      .should('not.exist');
 
     cy.clock().invoke('restore');
   });


### PR DESCRIPTION
Shortcut Story ID: [sc-35043]

When the `All Time` filter is selected, the API request will have the date filter removed entirely (i.e. `filter[created_at]`, `filter[update_at]`, or `filter[due_date]`).

In the UI, it looks like this:

<img width="301" alt="Clipboard 2023-04-04 at 2 25 58 PM" src="https://user-images.githubusercontent.com/35355575/233134565-27345f10-f2ba-45f7-8eed-df139c7b5198.png">

