### PR TITLE
Replace $.params with rwell specific GET param handling

### DIFF
--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -1,15 +1,47 @@
 //  Similar to https://github.com/akre54/Backbone.Fetch
-import $ from 'jquery';
-import { isObject, defaults, extend } from 'underscore';
+import { isObject, isArray, defaults, extend, map, flatten, reduce, first, rest } from 'underscore';
 import Radio from 'backbone.radio';
 
 import { getToken } from 'js/auth';
+
+function getValue(value) {
+  return encodeURIComponent(value ?? '');
+}
+
+function getKey(key) {
+  // Builds key[subkey] or key[subkey1][subkey2]
+  if (isArray(key)) {
+    const firstKey = encodeURIComponent(first(key));
+
+    return reduce(rest(key), (str, k) => `${ str }[${ encodeURIComponent(k) }]`, firstKey);
+  }
+
+  return encodeURIComponent(key);
+}
+
+function buildParams(value, key) {
+  if (isArray(value)) {
+    // Builds key=value1,value2,value3
+    return `${ getKey(key) }=${ value.map(getValue).join() }`;
+  }
+
+  if (isObject(value)) {
+    // Builds key[subkey]=value or key[subkey1][subkey2]=value
+    return flatten(map(value, (val, name) => buildParams(val, flatten([key, name])))).join('&');
+  }
+
+  return `${ getKey(key) }=${ getValue(value) }`;
+}
+
+function serializeParams(obj) {
+  return map(obj, buildParams).join('&');
+}
 
 // Makes data object into `/url?param1=value1&param2=value2` string
 function getUrl(url, data) {
   if (!isObject(data)) return url;
 
-  const params = $.param(data);
+  const params = serializeParams(data);
   if (!params) return url;
 
   return `${ url }?${ params }`;

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -63,7 +63,7 @@ export default async(url, opts) => {
 
   const options = extend({}, opts);
 
-  if (options.method === 'GET') {
+  if (!options.method || options.method === 'GET') {
     url = getUrl(url, options.data);
   } else if (options.data) {
     options.body = options.data;

--- a/src/js/entities-service/files.js
+++ b/src/js/entities-service/files.js
@@ -8,9 +8,10 @@ const Entity = BaseEntity.extend({
     'fetch:files:collection:byAction': 'fetchFilesByAction',
   },
   fetchFilesByAction(actionId) {
-    const url = `/api/actions/${ actionId }/relationships/files?urls=download,view`;
+    const url = `/api/actions/${ actionId }/relationships/files`;
+    const data = { urls: ['download', 'view'] };
 
-    return this.fetchCollection({ url });
+    return this.fetchCollection({ url, data });
   },
 });
 

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -16,13 +16,12 @@ const Entity = BaseEntity.extend({
     return fetcher(`/api/form-responses/${ responseId }/response`).then(handleJSON);
   },
   fetchLatestSubmission(patientId, filter) {
-    const searchParams = reduce(filter, (filters, value, key) => {
+    const data = reduce(filter, (filters, value, key) => {
       if (!value) return filters;
-      const param = `filter[${ key }]=${ encodeURIComponent(value) }`;
-      return filters + (filters ? '&' : '?') + param;
-    }, '');
-
-    return fetcher(`/api/patients/${ patientId }/form-responses/latest${ searchParams }`).then(handleJSON);
+      filters.filter[key] = value;
+      return filters;
+    }, { filter: {} });
+    return fetcher(`/api/patients/${ patientId }/form-responses/latest`, { data }).then(handleJSON);
   },
 });
 

--- a/src/js/entities-service/forms.js
+++ b/src/js/entities-service/forms.js
@@ -21,7 +21,9 @@ const Entity = BaseEntity.extend({
     if (actionId) {
       return fetcher(`/api/actions/${ actionId }/form/fields`).then(handleJSON);
     }
-    return fetcher(`/api/forms/${ formId }/fields?filter[patient]=${ patientId }`).then(handleJSON);
+
+    const data = { filter: { patient: patientId } };
+    return fetcher(`/api/forms/${ formId }/fields`, { data }).then(handleJSON);
   },
   fetchByAction(actionId) {
     return this.fetchBy(`/api/actions/${ actionId }/form`);

--- a/src/js/entities-service/program-actions.js
+++ b/src/js/entities-service/program-actions.js
@@ -1,4 +1,3 @@
-import { result } from 'underscore';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/program-actions';
 
@@ -22,9 +21,7 @@ const Entity = BaseEntity.extend({
   fetchProgramActions(behavior = PROGRAM_BEHAVIORS.STANDARD) {
     const collection = new this.Entity.Collection();
 
-    const url = `${ result(collection, 'url') }?filter[behavior]=${ behavior }`;
-
-    return collection.fetch({ url });
+    return collection.fetch({ data: { filter: { behavior } } });
   },
   fetchProgramActionsByFlow(flowId, options) {
     const collection = new Collection([], { flowId });

--- a/src/js/entities-service/program-flows.js
+++ b/src/js/entities-service/program-flows.js
@@ -1,4 +1,3 @@
-import { result } from 'underscore';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/program-flows';
 
@@ -21,9 +20,7 @@ const Entity = BaseEntity.extend({
   fetchProgramFlows(behavior = PROGRAM_BEHAVIORS.STANDARD) {
     const collection = new this.Entity.Collection();
 
-    const url = `${ result(collection, 'url') }?filter[behavior]=${ behavior }`;
-
-    return collection.fetch({ url });
+    return collection.fetch({ data: { filter: { behavior } } });
   },
 });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-32354]

This replaces the magic of `$.param` and reduces our dependency on jQuery but I am uncertain if it handles every edge case.  We may run into issues in the future where it isn't enough, but we'll be able to modify it as necessary.

This also allows for `fetcher(fooUrl, { data: { filter: { foo: 1 } }).then...` so we aren't building url params all over the place.

_However_ this doesn't handle everything like the file upload which is a `POST` to a url with params, but those seem like edge cases beyond the scope of this work.