### PR TITLE
Allow alwaysEnable on Button Components

### DIFF
--- a/src/js/formapp/components.js
+++ b/src/js/formapp/components.js
@@ -91,9 +91,26 @@ class DirectoryComponent extends SelectComponent {
   }
 }
 
+class CustomButtonComponent extends Formio.Components.components.button {
+  get shouldDisabled() {
+    if (this.component.alwaysEnable) return false;
+
+    return super.shouldDisabled;
+  }
+
+  set disabled(disabled) {
+    this._disabled = disabled;
+  }
+
+  get disabled() {
+    return !this.component.alwaysEnable && (this._disabled || this.parentDisabled);
+  }
+}
+
 Formio.use({
   components: {
     snippet: SnippetComponent,
     directory: DirectoryComponent,
+    button: CustomButtonComponent,
   },
 });


### PR DESCRIPTION
For use in `Read Only` forms where buttons are used for toggling show/hide conditionals.
Shortcut Story ID: [sc-35714]