### PR TITLE
Datadog session replay and heatmaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "CC-BY-4.0",
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.0.2",
-        "@datadog/browser-logs": "^4.3.0",
-        "@datadog/browser-rum": "^4.34.1",
+        "@datadog/browser-logs": "^4.39.0",
+        "@datadog/browser-rum": "^4.39.0",
         "@fortawesome/fontawesome-pro": "^6.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.0",
         "@fortawesome/pro-light-svg-icons": "^6.1.0",
@@ -1860,19 +1860,19 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.37.0.tgz",
-      "integrity": "sha512-UMsG+xaAbZMfBSo4PJmj8Y4uvo393RSO6Enq6op1j0rVupVLarPw0LGYZF85UywDROwixzPnFn4S6DWMpeiJkA=="
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.39.0.tgz",
+      "integrity": "sha512-jSwXfdSPaeU9xFLepour7d2jATk/VVcjab69/42gmWkh1MtzDloTd8RaKSVRo0Y7CsHroO6Mdzp+enEivI7NkA=="
     },
     "node_modules/@datadog/browser-logs": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.37.0.tgz",
-      "integrity": "sha512-t7qh2W7Ofp+JKMCnmFhamca9sEZSFyvgxd7yK6n0F1hHekIbL2LRcRwCISkwiyO5UZy01cn5QQdBaYkBiy8Cpw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.39.0.tgz",
+      "integrity": "sha512-MKnfIMek2uL4WzVrBoqQdAKMlgMdMZKNa8PxBiBD5/5J9uFxVFTnFnMeZMEGRMMK3U48+dGW/+xCuXToNPMZMw==",
       "dependencies": {
-        "@datadog/browser-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0"
       },
       "peerDependencies": {
-        "@datadog/browser-rum": "4.37.0"
+        "@datadog/browser-rum": "4.39.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-rum": {
@@ -1881,15 +1881,15 @@
       }
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.37.0.tgz",
-      "integrity": "sha512-KKpsGGA+6FirOEWCoavbsrTOVmUTq7qNYbHtXs0mLW/EawkAztk4eUm71pVwsxH1+NjH6drdyXnccptnmS5PjQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.39.0.tgz",
+      "integrity": "sha512-7owNySSTxWnNbwRjDCC+fHRU2ycWb3lPDGn+VvQE3US+o9MRlEbFesaLO5/3Nj0A+vJGq6Ao35d++eCHl5dw2Q==",
       "dependencies": {
-        "@datadog/browser-core": "4.37.0",
-        "@datadog/browser-rum-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0",
+        "@datadog/browser-rum-core": "4.39.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "4.37.0"
+        "@datadog/browser-logs": "4.39.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -1898,11 +1898,11 @@
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.37.0.tgz",
-      "integrity": "sha512-fjMBIk8bSv6mDyvo8FYeitn1KugPhL/gN7ODdnwhr/+1MPUkUvelxc/yOAuqrlhyTs9ZNUHcGJs92+wPo+IlbQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.39.0.tgz",
+      "integrity": "sha512-UhAEELzt7ZQlAbWSaMJ7Ubwfdxk+uig8xm39iktNyTNCcxN92aNHWsNhsz5FtWXe3Oci7xKSDZf3ccjFl7KABw==",
       "dependencies": {
-        "@datadog/browser-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -16523,33 +16523,33 @@
       }
     },
     "@datadog/browser-core": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.37.0.tgz",
-      "integrity": "sha512-UMsG+xaAbZMfBSo4PJmj8Y4uvo393RSO6Enq6op1j0rVupVLarPw0LGYZF85UywDROwixzPnFn4S6DWMpeiJkA=="
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.39.0.tgz",
+      "integrity": "sha512-jSwXfdSPaeU9xFLepour7d2jATk/VVcjab69/42gmWkh1MtzDloTd8RaKSVRo0Y7CsHroO6Mdzp+enEivI7NkA=="
     },
     "@datadog/browser-logs": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.37.0.tgz",
-      "integrity": "sha512-t7qh2W7Ofp+JKMCnmFhamca9sEZSFyvgxd7yK6n0F1hHekIbL2LRcRwCISkwiyO5UZy01cn5QQdBaYkBiy8Cpw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.39.0.tgz",
+      "integrity": "sha512-MKnfIMek2uL4WzVrBoqQdAKMlgMdMZKNa8PxBiBD5/5J9uFxVFTnFnMeZMEGRMMK3U48+dGW/+xCuXToNPMZMw==",
       "requires": {
-        "@datadog/browser-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0"
       }
     },
     "@datadog/browser-rum": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.37.0.tgz",
-      "integrity": "sha512-KKpsGGA+6FirOEWCoavbsrTOVmUTq7qNYbHtXs0mLW/EawkAztk4eUm71pVwsxH1+NjH6drdyXnccptnmS5PjQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.39.0.tgz",
+      "integrity": "sha512-7owNySSTxWnNbwRjDCC+fHRU2ycWb3lPDGn+VvQE3US+o9MRlEbFesaLO5/3Nj0A+vJGq6Ao35d++eCHl5dw2Q==",
       "requires": {
-        "@datadog/browser-core": "4.37.0",
-        "@datadog/browser-rum-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0",
+        "@datadog/browser-rum-core": "4.39.0"
       }
     },
     "@datadog/browser-rum-core": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.37.0.tgz",
-      "integrity": "sha512-fjMBIk8bSv6mDyvo8FYeitn1KugPhL/gN7ODdnwhr/+1MPUkUvelxc/yOAuqrlhyTs9ZNUHcGJs92+wPo+IlbQ==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.39.0.tgz",
+      "integrity": "sha512-UhAEELzt7ZQlAbWSaMJ7Ubwfdxk+uig8xm39iktNyTNCcxN92aNHWsNhsz5FtWXe3Oci7xKSDZf3ccjFl7KABw==",
       "requires": {
-        "@datadog/browser-core": "4.37.0"
+        "@datadog/browser-core": "4.39.0"
       }
     },
     "@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -200,8 +200,8 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.0.2",
-    "@datadog/browser-logs": "^4.3.0",
-    "@datadog/browser-rum": "^4.34.1",
+    "@datadog/browser-logs": "^4.39.0",
+    "@datadog/browser-rum": "^4.39.0",
     "@fortawesome/fontawesome-pro": "^6.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.0",
     "@fortawesome/pro-light-svg-icons": "^6.1.0",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,7 +4,7 @@ import 'js/i18n';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
-import { datadogRum } from '@datadog/browser-rum';
+import { addError } from 'js/datadog';
 
 import 'scss/provider-core.scss';
 import 'scss/app-root.scss';
@@ -132,9 +132,7 @@ const Application = App.extend({
   },
 
   onFail(options, response) {
-    datadogRum.addError(response);
-    // eslint-disable-next-line no-console
-    if (_DEVELOP_ && response.status !== 500) console.error(new Error(response));
+    addError(response);
     this.getRegion('preloader').show(new PreloaderView({ notSetup: true }));
   },
 

--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -10,6 +10,11 @@ function getEnv() {
   return `${ app.env }.${ app.stack_id }`;
 }
 
+function isPdfPrinter() {
+  const urlPaths = location.pathname.substring(1).split('/');
+  return (urlPaths[0] === 'formapp' && urlPaths[1] === 'pdf');
+}
+
 function initLogs({ isForm }) {
   datadogLogs.init({
     env: getEnv(),
@@ -27,6 +32,7 @@ function initLogs({ isForm }) {
 }
 
 function initRum({ isForm }) {
+  if (isPdfPrinter()) return;
   datadogRum.init({
     env: getEnv(),
     applicationId: config.app_id,

--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -1,4 +1,4 @@
-import { datadogRum } from '@datadog/browser-rum';
+import { setUser } from 'js/datadog';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/clinicians';
 
@@ -15,7 +15,7 @@ const Entity = BaseEntity.extend({
   fetchCurrentClinician() {
     return this.fetchBy('/api/clinicians/me')
       .then(currentUser => {
-        datadogRum.setUser(currentUser.pick('id', 'name', 'email'));
+        setUser(currentUser.pick('id', 'name', 'email'));
         return currentUser;
       });
   },

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -1,6 +1,6 @@
 /* global Formio, FormioUtils */
 import { extend, reduce } from 'underscore';
-import { datadogRum } from '@datadog/browser-rum';
+import { addError } from 'js/datadog';
 
 // Note: Allows for setting the submission at form instantiation
 // https://github.com/formio/formio.js/pull/4580
@@ -22,9 +22,7 @@ Formio.Evaluator.evaluator = function(func, ...params) {
   try {
     return evaluator(func, ...params);
   } catch (e) {
-    datadogRum.addError(e);
-    /* eslint-disable-next-line no-console */
-    if (_DEVELOP_) console.error(e);
+    addError(e);
   }
 };
 
@@ -34,9 +32,7 @@ Formio.Evaluator.evaluate = function(func, ...params) {
   try {
     return evaluate(func, ...params);
   } catch (e) {
-    datadogRum.addError(e);
-    /* eslint-disable-next-line no-console */
-    if (_DEVELOP_) console.error(e);
+    addError(e);
   }
 };
 


### PR DESCRIPTION
Turns out we can already record sessions.

I also put some of the datadog functions guarded by a check for cypress as it might be responsible for some of our 504 flake.  The 504 flake is also why we didn’t log 500+ errors in the onFail

Shortcut Story ID: [sc-35791]

