### PR TITLE
Persist 'Find in list...' query on the worklist/schedule

### DIFF
--- a/src/js/apps/clinicians/clinicians-all_app.js
+++ b/src/js/apps/clinicians/clinicians-all_app.js
@@ -56,7 +56,6 @@ export default SubRouterApp.extend({
     const searchComponent = this.showChildView('search', new SearchComponent({
       state: {
         query: this.getState('searchQuery'),
-        isDisabled: !this.clinicians || !this.clinicians.length,
       },
     }));
 

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -101,7 +101,6 @@ export default App.extend({
     const searchComponent = this.showChildView('search', new SearchComponent({
       state: {
         query: this.getState('searchQuery'),
-        isDisabled: !this.collection || !this.collection.length,
       },
     }));
 

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
@@ -1,4 +1,4 @@
-import { clone, omit, each, filter, contains } from 'underscore';
+import { clone, each, filter, contains } from 'underscore';
 import store from 'store';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
@@ -31,7 +31,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey());
   },
   onChange() {
-    store.set(this.getStoreKey(), omit(this.attributes, 'searchQuery'));
+    store.set(this.getStoreKey(), this.attributes);
   },
   getFilters() {
     return clone(this.get('filters'));

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -200,7 +200,6 @@ export default App.extend({
     const searchComponent = this.showChildView('search', new SearchComponent({
       state: {
         query: this.getState('searchQuery'),
-        isDisabled: !this.collection || !this.collection.length,
       },
     }));
 
@@ -299,12 +298,5 @@ export default App.extend({
       searchQuery: searchQuery.length > 2 ? searchQuery : '',
       lastSelectedIndex: null,
     });
-  },
-  onStop() {
-    if (this.isRestarting()) {
-      this.setState('searchQuery', '');
-
-      this.showSearchView();
-    }
   },
 });

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -45,7 +45,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey());
   },
   onChange() {
-    store.set(this.getStoreKey(), omit(this.attributes, 'searchQuery', 'isFiltering', 'lastSelectedIndex'));
+    store.set(this.getStoreKey(), omit(this.attributes, 'isFiltering', 'lastSelectedIndex'));
   },
   getFilters() {
     return clone(this.get('filters'));

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -394,7 +394,6 @@ export default App.extend({
     const searchComponent = this.showChildView('search', new SearchComponent({
       state: {
         query: this.getState('searchQuery'),
-        isDisabled: !this.collection || !this.collection.length,
       },
     }));
 
@@ -416,12 +415,5 @@ export default App.extend({
       searchQuery: searchQuery.length > 2 ? searchQuery : '',
       lastSelectedIndex: null,
     });
-  },
-  onStop() {
-    if (this.isRestarting()) {
-      this.setState('searchQuery', '');
-
-      this.showSearchView();
-    }
   },
 });

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -59,7 +59,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey(id));
   },
   onChange() {
-    store.set(this.getStoreKey(this.id), omit(this.attributes, 'searchQuery', 'isFiltering', 'lastSelectedIndex'));
+    store.set(this.getStoreKey(this.id), omit(this.attributes, 'isFiltering', 'lastSelectedIndex'));
   },
   setDateFilters(filters) {
     return this.set(`${ this.getType() }DateFilters`, clone(filters));

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -295,6 +295,9 @@ const DayListView = CollectionView.extend({
 
     this.listenTo(state, 'change:searchQuery', this.searchList);
   },
+  onAttach() {
+    this.searchList(null, this.state.get('searchQuery'));
+  },
   childViewTriggers: {
     'render': 'listItem:render',
     'select': 'select',
@@ -359,7 +362,7 @@ const ScheduleListView = CollectionView.extend({
     'render:children': 'onChildFilter',
   },
   emptyView() {
-    if (this.state.get('searchQuery')) {
+    if (this.collection.length && this.state.get('searchQuery')) {
       return EmptyFindInListView;
     }
 
@@ -369,7 +372,7 @@ const ScheduleListView = CollectionView.extend({
     return alphaSort('asc', viewA.model.get('date'), viewB.model.get('date'));
   },
   viewFilter(view) {
-    if (this.state.get('searchQuery')) {
+    if (this.isAttached() && this.state.get('searchQuery')) {
       return !view.isEmpty();
     }
 

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -230,7 +230,7 @@ const ListView = CollectionView.extend({
     return this.isFlowList ? FlowItemView : ActionItemView;
   },
   emptyView() {
-    if (this.state.get('searchQuery')) {
+    if (this.collection.length && this.state.get('searchQuery')) {
       return EmptyFindInListView;
     }
 
@@ -257,6 +257,8 @@ const ListView = CollectionView.extend({
   },
   onAttach() {
     this.triggerMethod('update:listDom', this);
+
+    this.searchList(null, this.state.get('searchQuery'));
   },
   /* istanbul ignore next: future proof */
   onRenderChildren() {

--- a/src/js/views/shared/components/list-search/index.js
+++ b/src/js/views/shared/components/list-search/index.js
@@ -4,7 +4,6 @@ import Component from 'js/base/component';
 
 import { SearchView } from './list-search_views';
 
-
 const StateModel = Backbone.Model.extend({
   defaults: {
     query: '',

--- a/src/js/views/shared/components/list-search/list-search_views.js
+++ b/src/js/views/shared/components/list-search/list-search_views.js
@@ -9,8 +9,13 @@ import './list-search-component.scss';
 
 const InputTemplate = hbs`
   <span class="list-search__search-icon">{{far "magnifying-glass"}}</span>
-  <input class="list-search__input input-primary--small js-input w-100" type="text" {{#if isDisabled}}disabled{{/if}} placeholder="{{@intl.shared.components.listSearch.listSearchViews.placeholder}}"/>
-  <span class="list-search__clear-icon js-clear is-hidden">{{fas "circle-xmark"}}</span>
+  <input
+    class="list-search__input input-primary--small js-input w-100"
+    type="text"
+    placeholder="{{@intl.shared.components.listSearch.listSearchViews.placeholder}}"
+    value="{{query}}"
+  />
+  <span class="list-search__clear-icon js-clear {{#unless query}}is-hidden{{/unless}}">{{fas "circle-xmark"}}</span>
 `;
 
 const SearchView = View.extend({
@@ -21,7 +26,6 @@ const SearchView = View.extend({
   template: InputTemplate,
   templateContext() {
     return {
-      isDisabled: this.getOption('state').isDisabled,
       query: this.getOption('state').query,
     };
   },
@@ -38,9 +42,6 @@ const SearchView = View.extend({
   onClear() {
     this.ui.input.val('');
     this.ui.clear.addClass('is-hidden');
-  },
-  onRender() {
-    this.$el.toggleClass('is-disabled', this.getOption('state').isDisabled);
   },
 });
 

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -181,11 +181,6 @@ context('clinicians list', function() {
       .wait('@routeClinicians');
 
     cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:disabled')
-      .should('have.attr', 'placeholder', 'Find in List...');
-
-    cy
       .get('.table-empty-list')
       .contains('No Clinicians');
   });
@@ -193,9 +188,6 @@ context('clinicians list', function() {
   specify('find in list', function() {
     cy
       .routesForDefault()
-      .visit();
-
-    cy
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 2);
 
@@ -212,23 +204,14 @@ context('clinicians list', function() {
 
         return fx;
       })
-      .navigate('/clinicians');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:disabled')
-      .should('have.attr', 'placeholder', 'Find in List...');
-
-    cy
+      .visit('/clinicians')
       .wait('@routeClinicians');
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
+      .find('[data-search-region] .js-input')
       .as('listSearch')
-      .type('abc')
-      .next()
-      .should('have.class', 'js-clear');
+      .type('abc');
 
     cy
       .get('.list-page__list')
@@ -239,6 +222,7 @@ context('clinicians list', function() {
     cy
       .get('@listSearch')
       .next()
+      .should('have.class', 'js-clear')
       .click();
 
     cy
@@ -285,23 +269,5 @@ context('clinicians list', function() {
       .should('have.length', 1)
       .first()
       .should('contain', 'Employee');
-
-    cy
-      .go('back');
-
-    cy
-      .navigate('/clinicians');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:disabled')
-      .should('have.attr', 'placeholder', 'Find in List...');
-
-    cy
-      .wait('@routeClinicians');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])');
   });
 });

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -384,7 +384,7 @@ context('schedule page', function() {
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
+      .find('[data-search-region] .js-input')
       .as('listSearch')
       .type('First Action');
 
@@ -1383,6 +1383,18 @@ context('schedule page', function() {
   });
 
   specify('find in list', function() {
+    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+      clinicianId: '11111',
+      filters: {},
+      searchQuery: 'Action',
+      dateFilters: {
+        dateType: 'due_date',
+        selectedDate: null,
+        selectedMonth: null,
+        relativeDate: null,
+      },
+    }));
+
     cy
       .routeActions(fx => {
         fx.data[0].attributes = {
@@ -1470,28 +1482,43 @@ context('schedule page', function() {
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:disabled')
-      .should('have.attr', 'placeholder', 'Find in List...');
+      .find('[data-search-region] .js-input')
+      .as('listSearch')
+      .should('have.attr', 'value', 'Action');
 
     cy
       .get('[data-count-region]')
-      .should('not.contain', '20 Actions');
+      .should('not.contain', '4 Actions');
 
     cy
       .wait('@routeActions');
 
     cy
       .get('[data-count-region]')
-      .should('contain', '20 Actions');
+      .should('contain', '4 Actions');
 
     cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
-      .as('listSearch')
+      .get('@listSearch')
+      .next()
+      .click()
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+
+        expect(storage.searchQuery).to.equal('');
+      });
+
+    cy
+      .get('@listSearch')
+      .should('have.attr', 'placeholder', 'Find in List...')
       .focus()
       .type('abc')
       .next()
-      .should('have.class', 'js-clear');
+      .should('have.class', 'js-clear')
+      .then(() => {
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+
+        expect(storage.searchQuery).to.equal('abc');
+      });
 
     cy
       .get('[data-count-region] div')
@@ -1666,34 +1693,16 @@ context('schedule page', function() {
       .should('contain', 'Second Action');
 
     cy
-      .get('@listSearch')
-      .next()
-      .click();
-
-    cy
-      .get('@listSearch')
-      .type('abc');
-
-    cy
       .get('[data-date-filter-region]')
       .find('.js-prev')
       .click();
 
     cy
-      .get('@listSearch')
-      .should('have.attr', 'placeholder', 'Find in List...');
-
-    cy
       .wait('@routeActions');
 
     cy
-      .get('[data-count-region]')
-      .should('contain', '20 Actions');
-
-    cy
-      .get('@scheduleList')
-      .find('.schedule-list__day-list-row')
-      .should('have.length', 20);
+      .get('@listSearch')
+      .should('have.attr', 'value', 'In Progress');
 
     cy
       .get('[data-nav-content-region]')
@@ -1704,14 +1713,16 @@ context('schedule page', function() {
       .wait('@routeActions');
 
     cy
-      .navigate('/schedule');
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Schedule')
+      .click()
+      .wait('@routeActions');
 
     cy
-      .intercept('GET', '/api/action?*', { delay: 100, body: { data: [] } });
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input:disabled');
+      .get('@listSearch')
+      .should('have.attr', 'value', 'In Progress');
   });
 
   specify('click+shift multiselect', function() {
@@ -1873,13 +1884,13 @@ context('schedule page', function() {
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
+      .find('[data-search-region] .js-input')
       .focus()
       .type('abcd');
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
+      .find('[data-search-region] .js-input')
       .next()
       .click();
 


### PR DESCRIPTION
Shortcut Story ID: [sc-34500]

A user's `Find in list...` search query will now be stored in local storage. 

Which means it will persist when the worklist/schedule is restarted (i.e. due to a new date, clinician, etc. filter being selected) and on route changes.

These changes apply to the worklist, schedule, and reduced schedule.