### PR TITLE
Have form.ios submit event respect the ready:form event

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -117,9 +117,13 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
 
   form.on('error', () => {
     router.request('ready:form');
+    form._isReady = true;
   });
 
   form.on('submit', response => {
+    // Prevents submission after a success
+    if (!form._isReady) return;
+    form._isReady = false;
     // Always run one last change event on submit
     onChangeDebounce.cancel();
     onChange(form, changeReducers);
@@ -135,6 +139,7 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
   });
 
   router.request('ready:form');
+  form._isReady = true;
 }
 
 async function renderPreview({ definition, contextScripts }) {


### PR DESCRIPTION
We use the `ready:form` to tell the app when to enable the button prior to the form’s first render and after an error.  This same logic can prevent an extra submission between a successful submission and a form redirect.

Shortcut Story ID: [sc-35898]
