### PR TITLE
Fetch form model to pass context to form modal

### DIFF
--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -223,6 +223,11 @@ const widgets = {
   formWidget: View.extend({
     className: 'button-primary widgets__form-widget',
     tagName: 'button',
+    attributes() {
+      return {
+        disabled: this.getOption('is_modal'),
+      };
+    },
     template: hbs`
       {{far "square-poll-horizontal"}}
       <span class="u-text--overflow">{{formName}}</span>
@@ -232,13 +237,21 @@ const widgets = {
         formName: this.getOption('form_name'),
       };
     },
+    initialize({ is_modal, form_id }) {
+      if (is_modal) {
+        const fetchForm = Radio.request('entities', 'fetch:forms:model', form_id);
+        fetchForm.then(form => {
+          this.form = form;
+          this.$el.prop('disabled', false);
+        });
+      }
+    },
     triggers: {
       'click': 'click',
     },
     onClick() {
       if (this.getOption('is_modal')) {
-        const form = Radio.request('entities', 'forms:model', this.getOption('form_id'));
-        Radio.request('modal', 'show:form', this.model, this.getOption('form_name'), form, this.getOption('modal_size'));
+        Radio.request('modal', 'show:form', this.model, this.getOption('form_name'), this.form, this.getOption('modal_size'));
         return;
       }
       Radio.trigger('event-router', 'form:patient', this.model.id, this.getOption('form_id'));

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -91,7 +91,7 @@ context('patient sidebar', function() {
       .routesForPatientDashboard()
       .routeFormDefinition()
       .routeFormFields()
-      .routeForm()
+      .routeForm(_.identity, '33333')
       .routeSettings(fx => {
         fx.data[0].attributes = {
           value: {
@@ -301,7 +301,7 @@ context('patient sidebar', function() {
             widget_type: 'formWidget',
             definition: {
               display_name: 'Modal Form',
-              form_id: '11111',
+              form_id: '33333',
               form_name: 'Test Modal Form',
               is_modal: true,
             },
@@ -514,6 +514,12 @@ context('patient sidebar', function() {
     });
 
     cy
+      .wait('@routeForm')
+      .itsUrl()
+      .its('pathname')
+      .should('contain', '33333');
+
+    cy
       .get('.patient-sidebar')
       .as('patientSidebar')
       .should('contain', 'First Last')
@@ -719,6 +725,7 @@ context('patient sidebar', function() {
     cy
       .get('@iframe')
       .find('textarea[name="data[storyTime]"]')
+      .should('contain', 'foo')
       .clear()
       .type('New typing');
 
@@ -786,7 +793,7 @@ context('patient sidebar', function() {
 
     cy
       .url()
-      .should('contain', 'patient/1/form/1');
+      .should('contain', 'patient/1/form/11111');
   });
 
   specify('patient workspaces', function() {


### PR DESCRIPTION
Previously form’s were preloaded at bootstrap, but the widget now needs to fetch the form for context.

Shortcut Story ID: [sc-34041]
