### PR TITLE
Prevent form request from a breaking resolve after submission

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -215,6 +215,9 @@ const Router = Backbone.Router.extend({
     return request;
   },
   resolveValue({ value, error, requestId }) {
+    // Prevents an edge case where a request is resolved
+    // after the form is submitted and reloaded
+    if (!this.requestResolves[requestId]) return;
     const { resolve, reject } = this.requestResolves[requestId];
     delete this.requestResolves[requestId];
     error ? reject(error) : resolve(value);


### PR DESCRIPTION
Super edge-case.. if a user is mid-`getDirectory` and submits the form and the `getDirectory` then resolves to the newly rendered read-only submission, it fails with this error:

```
Cannot destructure property 'resolve' of 'this.requestResolves[o]' as it is undefined.
```

https://app.datadoghq.com/rum/explorer?query=%40session.id%3A0e307b45-6380-45e4-bc9e-2f8b3f338592%20%40type%3Aview&cols=&event=AgAAAYe42ckF22lMEwAAAAAAAAAYAAAAAEFZZTQyY2tGQUFBRVJzdk1BYm9YNnc3TQAAACQAAAAAMDE4N2I4ZjQtNWQxMi00N2Y2LTk2NGYtOTNhNDRiYTMyMGE1&p_tab=issues&tab=view&viz=stream&from_ts=1679841493253&to_ts=1682447893253&live=false

<img width="872" alt="Screenshot 2023-04-26 at 12 41 15 AM" src="https://user-images.githubusercontent.com/2028470/234332903-1f52cfa5-29d8-4590-b124-ee7742b7a857.png">
