### PR TITLE
Add a `Find in list...` specific test to the reduced schedule test file

### DIFF
--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1508,6 +1508,10 @@ context('schedule page', function() {
       });
 
     cy
+      .get('[data-count-region]')
+      .should('contain', '20 Actions');
+
+    cy
       .get('@listSearch')
       .should('have.attr', 'placeholder', 'Find in List...')
       .focus()

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3509,6 +3509,10 @@ context('worklist page', function() {
       });
 
     cy
+      .get('[data-count-region]')
+      .should('contain', '10 Flows');
+
+    cy
       .get('@listSearch')
       .should('have.attr', 'placeholder', 'Find in List...')
       .focus()


### PR DESCRIPTION
Shortcut Story ID: [sc-35924]

Currently the `Find in list...` functionality for the reduced schedule is tested in the `reduced schedule page => display schedule` test.

This PR creates a new `reduced schedule page => find in list` test in that same file.

Moving the `Find in list...` specific testing to it's own test will make it easier to understand and update those tests in the future.