### PR TITLE
Remove collection clearing in the `onBeforeStart()` of the worklist, schedule, & clinician apps

### DIFF
--- a/src/js/apps/clinicians/clinicians-all_app.js
+++ b/src/js/apps/clinicians/clinicians-all_app.js
@@ -18,9 +18,6 @@ export default SubRouterApp.extend({
   viewEvents: {
     'click:addClinician': 'onClickAddClinician',
   },
-  onBeforeStop() {
-    this.clinicians = null;
-  },
   onBeforeStart() {
     this.showView(new LayoutView());
     this.getRegion('list').startPreloader();

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -39,9 +39,6 @@ export default App.extend({
 
     this.getState().setDefaultFilterStates();
   },
-  onBeforeStop() {
-    this.collection = null;
-  },
   onBeforeStart() {
     if (this.isRestarting()) {
       this.getRegion('list').startPreloader();

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -48,9 +48,6 @@ export default App.extend({
 
     this.getState().setDefaultFilterStates();
   },
-  onBeforeStop() {
-    this.collection = null;
-  },
   onBeforeStart() {
     if (this.isRestarting()) {
       const isFiltersSidebarOpen = this.getState('isFiltering');

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -62,9 +62,6 @@ export default App.extend({
 
     this.getState().setDefaultFilterStates();
   },
-  onBeforeStop() {
-    this.collection = null;
-  },
   onBeforeStart({ worklistId }) {
     const isFiltersSidebarOpen = this.getState('isFiltering');
 

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -187,20 +187,19 @@ context('clinicians list', function() {
 
   specify('find in list', function() {
     cy
-      .routesForDefault()
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
-        fx.data[0].relationships.workspaces = { data: [{ type: 'workspaces', id: '11111' }] };
+        fx.data[0].attributes.last_active_at = testTs();
         fx.data[0].relationships.role.data.id = '33333';
+        fx.data[0].relationships.team.data.id = '11111';
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
-        fx.data[1].relationships.workspaces = { data: [{ type: 'workspaces', id: '22222' }] };
-        fx.data[1].relationships.role.data.id = '22222';
+        fx.data[1].attributes.last_active_at = null;
 
         return fx;
       })
@@ -209,7 +208,7 @@ context('clinicians list', function() {
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input')
+      .find('[data-search-region] .js-input:not([disabled])')
       .as('listSearch')
       .type('abc');
 
@@ -245,29 +244,5 @@ context('clinicians list', function() {
       .should('have.length', 1)
       .first()
       .should('contain', 'Aaron Aaronson');
-
-    cy
-      .get('@listSearch')
-      .clear()
-      .type('Workspace One');
-
-    cy
-      .get('@cliniciansList')
-      .find('.table-list__item')
-      .should('have.length', 1)
-      .first()
-      .should('contain', 'Workspace One');
-
-    cy
-      .get('@listSearch')
-      .clear()
-      .type('Employee');
-
-    cy
-      .get('@cliniciansList')
-      .find('.table-list__item')
-      .should('have.length', 1)
-      .first()
-      .should('contain', 'Employee');
   });
 });

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -187,19 +187,20 @@ context('clinicians list', function() {
 
   specify('find in list', function() {
     cy
+      .routesForDefault()
       .routeClinicians(fx => {
         fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
         fx.data[0].attributes.name = 'Aaron Aaronson';
         fx.data[0].attributes.enabled = true;
-        fx.data[0].attributes.last_active_at = testTs();
+        fx.data[0].relationships.workspaces = { data: [{ type: 'workspaces', id: '11111' }] };
         fx.data[0].relationships.role.data.id = '33333';
-        fx.data[0].relationships.team.data.id = '11111';
 
         fx.data[1].attributes.name = 'Baron Baronson';
         fx.data[1].attributes.enabled = true;
-        fx.data[1].attributes.last_active_at = null;
+        fx.data[1].relationships.workspaces = { data: [{ type: 'workspaces', id: '22222' }] };
+        fx.data[1].relationships.role.data.id = '22222';
 
         return fx;
       })
@@ -208,7 +209,7 @@ context('clinicians list', function() {
 
     cy
       .get('.list-page__header')
-      .find('[data-search-region] .js-input:not([disabled])')
+      .find('[data-search-region] .js-input')
       .as('listSearch')
       .type('abc');
 
@@ -244,5 +245,29 @@ context('clinicians list', function() {
       .should('have.length', 1)
       .first()
       .should('contain', 'Aaron Aaronson');
+
+    cy
+      .get('@listSearch')
+      .clear()
+      .type('Workspace One');
+
+    cy
+      .get('@cliniciansList')
+      .find('.table-list__item')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'Workspace One');
+
+    cy
+      .get('@listSearch')
+      .clear()
+      .type('Employee');
+
+    cy
+      .get('@cliniciansList')
+      .find('.table-list__item')
+      .should('have.length', 1)
+      .first()
+      .should('contain', 'Employee');
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-36004]

In PR #980 and #999, we added these to the worklist, schedule, and clinicians apps:

```js
onBeforeStop() {
   this.collection = null;
},
```

These were originally added to ensure the FIL input element was disabled properly when the list is loading.

After #1028, the FIL element is no longer being disabled and is now always in an enabled state. Therefore, we no longer need to clear the collection when these apps are stopped.
