### PR TITLE
Give the `Find in list...` element a blue/white CSS color scheme when applied to lists

### DIFF
--- a/src/js/views/shared/components/list-search/list-search-component.scss
+++ b/src/js/views/shared/components/list-search/list-search-component.scss
@@ -1,9 +1,9 @@
 .list-search__container {
   position: relative;
 
-  &.is-disabled {
+  &.is-applied {
     .icon {
-      opacity: 0.5;
+      color: $white;
     }
   }
 }
@@ -31,8 +31,10 @@
   line-height: 24px;
   padding: 4px 32px 4px 40px;
 
-  &[disabled]:hover {
-    border: 1px solid $black-90;
+  .is-applied & {
+    background-color: color(blue);
+    border: 1px solid color(blue);
+    color: $white;
   }
 
   &::placeholder {

--- a/src/js/views/shared/components/list-search/list-search_views.js
+++ b/src/js/views/shared/components/list-search/list-search_views.js
@@ -22,7 +22,13 @@ const SearchView = View.extend({
   behaviors: {
     InputWatcherBehavior,
   },
-  className: 'list-search__container',
+  className() {
+    const query = this.getOption('state').query;
+
+    if (query.length > 2) return 'list-search__container is-applied';
+
+    return 'list-search__container';
+  },
   template: InputTemplate,
   templateContext() {
     return {
@@ -38,10 +44,12 @@ const SearchView = View.extend({
   },
   onWatchChange(text) {
     this.ui.clear.toggleClass('is-hidden', !text.length);
+    this.$el.toggleClass('is-applied', text.length > 2);
   },
   onClear() {
     this.ui.input.val('');
     this.ui.clear.addClass('is-hidden');
+    this.$el.removeClass('is-applied');
   },
 });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-34500]

To give the user a better visual indication that a FIL search query is being applied.

What the UI change looks like:

<img width="166" alt="Clipboard 2023-26-04 at 4 48 03 PM (1)" src="https://user-images.githubusercontent.com/35355575/234910224-2c342552-5dae-4628-9869-e18659ab4e00.png">
