### PR TITLE
In Cypress, verify the `.is-applied` class is added/removed properly for the `Find in list...` input

### DIFF
--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -214,6 +214,11 @@ context('clinicians list', function() {
       .type('abc');
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
+
+    cy
       .get('.list-page__list')
       .as('cliniciansList')
       .find('.table-empty-list')
@@ -224,6 +229,11 @@ context('clinicians list', function() {
       .next()
       .should('have.class', 'js-clear')
       .click();
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
 
     cy
       .get('@cliniciansList')

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -758,6 +758,11 @@ context('reduced schedule page', function() {
       .should('have.attr', 'value', 'First Action');
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('not.contain', '1 Action');
 
@@ -779,6 +784,11 @@ context('reduced schedule page', function() {
       });
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('contain', '20 Actions');
 
@@ -794,6 +804,11 @@ context('reduced schedule page', function() {
 
         expect(storage.searchQuery).to.equal('abc');
       });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
 
     cy
       .get('[data-count-region] div')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1487,6 +1487,11 @@ context('schedule page', function() {
       .should('have.attr', 'value', 'Action');
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('not.contain', '4 Actions');
 
@@ -1508,6 +1513,11 @@ context('schedule page', function() {
       });
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('contain', '20 Actions');
 
@@ -1523,6 +1533,11 @@ context('schedule page', function() {
 
         expect(storage.searchQuery).to.equal('abc');
       });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
 
     cy
       .get('[data-count-region] div')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3488,6 +3488,11 @@ context('worklist page', function() {
       .should('have.attr', 'value', 'Test');
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('not.contain', '3 Flows');
 
@@ -3509,6 +3514,11 @@ context('worklist page', function() {
       });
 
     cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
+
+    cy
       .get('[data-count-region]')
       .should('contain', '10 Flows');
 
@@ -3524,6 +3534,11 @@ context('worklist page', function() {
 
         expect(storage.searchQuery).to.equal('abcd');
       });
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
 
     cy
       .get('[data-count-region] div')


### PR DESCRIPTION
Shortcut Story ID: [sc-36059]

Need to verify the following:

* `.is-applied` is added when the search query is applied to the list (character length greater than 2). Including when the page initially loads.
* `.is-applied` is removed when the search query is cleared or has a length less than 2.

Feature was added in #1036, but tests weren't added at the time.