### PR TITLE
Don't persist `Find in list...` query when a user's session ends

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -24,9 +24,15 @@ export default App.extend({
   },
   stateEvents: {
     'change:filters change:states': 'restart',
+    'change:searchQuery': 'onChangeSearchQuery',
+  },
+  onChangeSearchQuery(state) {
+    this.currentSearchQuery = state.get('searchQuery');
   },
   initListState() {
     const storedState = this.getState().getStore();
+
+    this.setState({ searchQuery: this.currentSearchQuery });
 
     if (storedState) {
       this.setState(storedState);

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
@@ -1,4 +1,4 @@
-import { clone, each, filter, contains } from 'underscore';
+import { clone, each, filter, contains, omit } from 'underscore';
 import store from 'store';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
@@ -31,7 +31,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey());
   },
   onChange() {
-    store.set(this.getStoreKey(), this.attributes);
+    store.set(this.getStoreKey(), omit(this.attributes, 'searchQuery'));
   },
   getFilters() {
     return clone(this.get('filters'));

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -33,9 +33,15 @@ export default App.extend({
   stateEvents: {
     'change:filters change:clinicianId change:dateFilters change:states': 'restart',
     'change:selectedActions': 'onChangeSelected',
+    'change:searchQuery': 'onChangeSearchQuery',
+  },
+  onChangeSearchQuery(state) {
+    this.currentSearchQuery = state.get('searchQuery');
   },
   initListState() {
     const storedState = this.getState().getStore();
+
+    this.setState({ searchQuery: this.currentSearchQuery });
 
     if (storedState) {
       this.setState(storedState);

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -45,7 +45,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey());
   },
   onChange() {
-    store.set(this.getStoreKey(), omit(this.attributes, 'isFiltering', 'lastSelectedIndex'));
+    store.set(this.getStoreKey(), omit(this.attributes, 'isFiltering', 'lastSelectedIndex', 'searchQuery'));
   },
   getFilters() {
     return clone(this.get('filters'));

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -41,6 +41,7 @@ export default App.extend({
     'change:flowsSortId': 'onChangeStateSort',
     'change:selectedFlows': 'onChangeSelected',
     'change:selectedActions': 'onChangeSelected',
+    'change:searchQuery': 'onChangeSearchQuery',
   },
   onChangeStateSort() {
     if (!this.isRunning()) return;
@@ -50,8 +51,13 @@ export default App.extend({
   onChangeSelected() {
     this.toggleBulkSelect();
   },
+  onChangeSearchQuery(state) {
+    this.currentSearchQuery = state.get('searchQuery');
+  },
   initListState() {
     const storedState = this.getState().getStore(this.worklistId);
+
+    this.setState({ searchQuery: this.currentSearchQuery });
 
     if (storedState) {
       this.setState(storedState);
@@ -61,6 +67,9 @@ export default App.extend({
     this.setState({ id: this.worklistId });
 
     this.getState().setDefaultFilterStates();
+  },
+  onBeforeStop() {
+    this.collection = null;
   },
   onBeforeStart({ worklistId }) {
     const isFiltersSidebarOpen = this.getState('isFiltering');

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -59,7 +59,7 @@ export default Backbone.Model.extend({
     return store.get(this.getStoreKey(id));
   },
   onChange() {
-    store.set(this.getStoreKey(this.id), omit(this.attributes, 'isFiltering', 'lastSelectedIndex'));
+    store.set(this.getStoreKey(this.id), omit(this.attributes, 'isFiltering', 'lastSelectedIndex', 'searchQuery'));
   },
   setDateFilters(filters) {
     return this.set(`${ this.getType() }DateFilters`, clone(filters));

--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -61,7 +61,8 @@
       "work:manage",
       "work:owned:manage",
       "app:schedule:reduced",
-      "work:own"
+      "work:own",
+      "dashboards:view"
     ]
   },
   {

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -710,12 +710,6 @@ context('reduced schedule page', function() {
   });
 
   specify('find in list', function() {
-    localStorage.setItem(`reduced-schedule_123456_11111-${ STATE_VERSION }`, JSON.stringify({
-      searchQuery: 'First Action',
-      filters: {},
-      states: ['22222', '33333'],
-    }));
-
     cy
       .routeCurrentClinician(fx => {
         fx.data.id = '123456';
@@ -748,62 +742,30 @@ context('reduced schedule page', function() {
         );
 
         return fx;
-      })
-      .visit('/');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input')
-      .as('listSearch')
-      .should('have.attr', 'value', 'First Action');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('have.class', 'is-applied');
+      }, 100)
+      .routeDashboards()
+      .visit('/schedule');
 
     cy
       .get('[data-count-region]')
-      .should('not.contain', '1 Action');
+      .should('not.contain', '20 Actions');
 
     cy
       .wait('@routeActions');
 
     cy
       .get('[data-count-region]')
-      .should('contain', '1 Action');
-
-    cy
-      .get('@listSearch')
-      .next()
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_123456_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('');
-      });
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('not.have.class', 'is-applied');
-
-    cy
-      .get('[data-count-region]')
       .should('contain', '20 Actions');
 
     cy
-      .get('@listSearch')
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input')
+      .as('listSearch')
       .should('have.attr', 'placeholder', 'Find in List...')
       .focus()
       .type('abc')
       .next()
-      .should('have.class', 'js-clear')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_123456_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('abc');
-      });
+      .should('have.class', 'js-clear');
 
     cy
       .get('.list-page__header')
@@ -824,6 +786,11 @@ context('reduced schedule page', function() {
       .get('@listSearch')
       .next()
       .click();
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
 
     cy
       .get('[data-count-region]')
@@ -871,5 +838,29 @@ context('reduced schedule page', function() {
     cy
       .get('@listSearch')
       .should('have.attr', 'value', 'Test');
+
+    cy
+      .get('.app-nav')
+      .find('.app-nav__bottom')
+      .contains('Dashboards')
+      .click()
+      .wait('@routeDashboards');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Schedule')
+      .click()
+      .wait('@routeActions');
+
+    cy
+      .get('@listSearch')
+      .should('have.attr', 'value', 'Test');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
   });
 });

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1383,18 +1383,6 @@ context('schedule page', function() {
   });
 
   specify('find in list', function() {
-    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
-      clinicianId: '11111',
-      filters: {},
-      searchQuery: 'Action',
-      dateFilters: {
-        dateType: 'due_date',
-        selectedDate: null,
-        selectedMonth: null,
-        relativeDate: null,
-      },
-    }));
-
     cy
       .routeActions(fx => {
         fx.data[0].attributes = {
@@ -1481,58 +1469,25 @@ context('schedule page', function() {
       .visit('/schedule');
 
     cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input')
-      .as('listSearch')
-      .should('have.attr', 'value', 'Action');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('have.class', 'is-applied');
-
-    cy
       .get('[data-count-region]')
-      .should('not.contain', '4 Actions');
+      .should('not.contain', '20 Actions');
 
     cy
       .wait('@routeActions');
 
     cy
       .get('[data-count-region]')
-      .should('contain', '4 Actions');
-
-    cy
-      .get('@listSearch')
-      .next()
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('');
-      });
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('not.have.class', 'is-applied');
-
-    cy
-      .get('[data-count-region]')
       .should('contain', '20 Actions');
 
     cy
-      .get('@listSearch')
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input')
+      .as('listSearch')
       .should('have.attr', 'placeholder', 'Find in List...')
       .focus()
       .type('abc')
       .next()
-      .should('have.class', 'js-clear')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('abc');
-      });
+      .should('have.class', 'js-clear');
 
     cy
       .get('.list-page__header')
@@ -1553,6 +1508,11 @@ context('schedule page', function() {
       .get('@listSearch')
       .next()
       .click();
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
 
     cy
       .get('[data-count-region]')
@@ -1742,6 +1702,11 @@ context('schedule page', function() {
     cy
       .get('@listSearch')
       .should('have.attr', 'value', 'In Progress');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
   });
 
   specify('click+shift multiselect', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3413,7 +3413,6 @@ context('worklist page', function() {
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',
       clinicianId: '11111',
-      searchQuery: 'Test',
       filters: {},
       flowsDateFilters: {
         selectedMonth: `${ currentYear }-01-01`,
@@ -3482,58 +3481,25 @@ context('worklist page', function() {
       .visit('/worklist/owned-by');
 
     cy
-      .get('.list-page__header')
-      .find('[data-search-region] .js-input')
-      .as('listSearch')
-      .should('have.attr', 'value', 'Test');
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('have.class', 'is-applied');
-
-    cy
       .get('[data-count-region]')
-      .should('not.contain', '3 Flows');
+      .should('not.contain', '10 Flows');
 
     cy
       .wait('@routeFlows');
 
     cy
       .get('[data-count-region]')
-      .should('contain', '3 Flows');
-
-    cy
-      .get('@listSearch')
-      .next()
-      .click()
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('');
-      });
-
-    cy
-      .get('.list-page__header')
-      .find('[data-search-region] .list-search__container')
-      .should('not.have.class', 'is-applied');
-
-    cy
-      .get('[data-count-region]')
       .should('contain', '10 Flows');
 
     cy
-      .get('@listSearch')
+      .get('.list-page__header')
+      .find('[data-search-region] .js-input')
+      .as('listSearch')
       .should('have.attr', 'placeholder', 'Find in List...')
       .focus()
       .type('abcd')
       .next()
-      .should('have.class', 'js-clear')
-      .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
-
-        expect(storage.searchQuery).to.equal('abcd');
-      });
+      .should('have.class', 'js-clear');
 
     cy
       .get('.list-page__header')
@@ -3554,6 +3520,11 @@ context('worklist page', function() {
       .get('@listSearch')
       .next()
       .click();
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('not.have.class', 'is-applied');
 
     cy
       .get('[data-count-region]')
@@ -3778,6 +3749,11 @@ context('worklist page', function() {
     cy
       .get('@listSearch')
       .should('have.attr', 'value', 'Nurse');
+
+    cy
+      .get('.list-page__header')
+      .find('[data-search-region] .list-search__container')
+      .should('have.class', 'is-applied');
   });
 
   specify('click+shift multiselect', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-36060]

A user's `Find in list...` query should only persist during a specific browser session. If the user closes the app, the `Find in list...` query should be cleared.
