### PR TITLE
Persist `Find in list...` query on the clinicians page

### DIFF
--- a/src/js/apps/clinicians/clinicians-all_app.js
+++ b/src/js/apps/clinicians/clinicians-all_app.js
@@ -18,9 +18,17 @@ export default SubRouterApp.extend({
   viewEvents: {
     'click:addClinician': 'onClickAddClinician',
   },
+  stateEvents: {
+    'change:searchQuery': 'onChangSearchQuery',
+  },
+  onChangSearchQuery(state) {
+    this.currentSearchQuery = state.get('searchQuery');
+  },
   onBeforeStart() {
     this.showView(new LayoutView());
     this.getRegion('list').startPreloader();
+
+    this.setState({ searchQuery: this.currentSearchQuery });
 
     this.showSearchView();
   },

--- a/src/js/views/clinicians/clinicians-all_views.js
+++ b/src/js/views/clinicians/clinicians-all_views.js
@@ -166,7 +166,7 @@ const ListView = CollectionView.extend({
   tagName: 'table',
   childView: ItemView,
   emptyView() {
-    if (this.state.get('searchQuery')) {
+    if (this.collection.length && this.state.get('searchQuery')) {
       return EmptyFindInListView;
     }
 
@@ -185,6 +185,9 @@ const ListView = CollectionView.extend({
     this.state = state;
 
     this.listenTo(state, 'change:searchQuery', this.searchList);
+  },
+  onAttach() {
+    this.searchList(null, this.state.get('searchQuery'));
   },
   onListItemRender(view) {
     view.searchString = view.$el.text();

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -204,6 +204,7 @@ context('clinicians list', function() {
 
         return fx;
       })
+      .routeActions()
       .visit('/clinicians')
       .wait('@routeClinicians');
 
@@ -279,5 +280,21 @@ context('clinicians list', function() {
       .should('have.length', 1)
       .first()
       .should('contain', 'Employee');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Owned By')
+      .click()
+      .wait('@routeActions');
+
+    cy
+      .go('back')
+      .wait('@routeClinicians');
+
+    cy
+      .get('@listSearch')
+      .should('have.attr', 'value', 'Employee');
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-36164]

Add the same functionality as we did for the worklist/schedule in #1028.

It should only persist it per user session. In other words, it should be cleared when the user closes the app.