### PR TITLE
Enable/disable uploading attachments per program action

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -1,5 +1,6 @@
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import { size } from 'underscore';
 import dayjs from 'dayjs';
 
 import App from 'js/base/app';
@@ -68,7 +69,7 @@ export default App.extend({
     });
   },
   showAttachments() {
-    const canUploadAttachments = !!Radio.request('bootstrap', 'setting', 'upload_attachments');
+    const canUploadAttachments = !!Radio.request('bootstrap', 'setting', 'upload_attachments') && !!size(this.action.get('allowed_uploads'));
 
     if (!canUploadAttachments && !this.attachments.length) return;
 

--- a/src/js/apps/programs/sidebar/action-sidebar_app.js
+++ b/src/js/apps/programs/sidebar/action-sidebar_app.js
@@ -1,10 +1,11 @@
 import Radio from 'backbone.radio';
+import { size } from 'underscore';
 
 import { ACTION_OUTREACH } from 'js/static';
 
 import App from 'js/base/app';
 
-import { LayoutView, FormSharingButtonView, FormSharingView } from 'js/views/programs/sidebar/action/action-sidebar_views';
+import { LayoutView, FormSharingButtonView, FormSharingView, UploadsEnabledView } from 'js/views/programs/sidebar/action/action-sidebar_views';
 
 export default App.extend({
   beforeStart() {
@@ -19,8 +20,28 @@ export default App.extend({
     }));
 
     this.showFormSharing();
-
     this.listenTo(this.action, 'change:_form change:outreach', this.showFormSharing);
+
+    this.showUploadsEnabled();
+    this.listenTo(this.action, 'change:allowed_uploads', this.showUploadsEnabled);
+  },
+  showUploadsEnabled() {
+    if (!Radio.request('bootstrap', 'setting', 'upload_attachments')) return;
+
+    const uploadsEnabledView = new UploadsEnabledView({
+      isUploadsEnabled: !!size(this.action.get('allowed_uploads')),
+      isButtonDisabled: this.action.isNew(),
+    });
+
+    this.listenTo(uploadsEnabledView, 'click:enable', () => {
+      this.action.enableAttachmentUploads();
+    });
+
+    this.listenTo(uploadsEnabledView, 'click:disable', () => {
+      this.action.disableAttachmentUploads();
+    });
+
+    this.showChildView('allowUploads', uploadsEnabledView);
   },
   showFormSharing() {
     if (!Radio.request('bootstrap', 'setting', 'care_team_outreach')) return;

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -57,6 +57,12 @@ const _Model = BaseModel.extend({
       _program_action: this.id,
     });
   },
+  enableAttachmentUploads() {
+    this.save({ allowed_uploads: ['pdf'] });
+  },
+  disableAttachmentUploads() {
+    this.save({ allowed_uploads: [] });
+  },
   getOwner() {
     const owner = this.get('_owner');
     if (!owner) return;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -766,6 +766,10 @@ careOptsFrontend:
           timestampsView:
             createdAt: Added
             updatedAt: Updated
+          uploadsEnabledView:
+            attachmentsHeadingText: Attachments
+            disableButtonText: Disable Uploads
+            enableButtonText: Enable Attachment Uploads
         layoutView:
           menuOptions:
             delete: Delete Program Action

--- a/src/js/views/programs/sidebar/action/action-sidebar.hbs
+++ b/src/js/views/programs/sidebar/action/action-sidebar.hbs
@@ -17,7 +17,8 @@
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.programs.sidebar.action.actionSidebarTemplate.ownerLabel }}</h4><div class="flex-grow" data-owner-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.programs.sidebar.action.actionSidebarTemplate.dueDayLabel }}</h4><div class="flex-grow" data-due-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.programs.sidebar.action.actionSidebarTemplate.formLabel }}</h4><div class="flex-grow" data-form-region></div></div>
-    <div class="flex u-margin--t-24" data-form-sharing-region></div>
+    <div class="u-margin--t-24" data-form-sharing-region></div>
+    <div class="u-margin--t-24" data-allow-uploads-region></div>
     {{#if canTag}}
     <div class="sidebar__section">
       <div><h3 class="sidebar__section-label">{{ @intl.programs.sidebar.action.actionSidebarTemplate.tagsLabel }}</h3></div>

--- a/src/js/views/programs/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/programs/sidebar/action/action-sidebar_views.js
@@ -113,7 +113,7 @@ const HeadingView = View.extend({
 
 const FormSharingButtonView = View.extend({
   tagName: 'button',
-  className: 'button--blue w-100 u-text-align--center',
+  className: 'button--blue w-100',
   attributes() {
     return {
       disabled: this.getOption('isDisabled'),
@@ -146,6 +146,33 @@ const FormSharingView = View.extend({
   `,
 });
 
+const UploadsEnabledView = View.extend({
+  template: hbs`
+    {{#if isUploadsEnabled}}
+      <div class="flex sidebar__attachments">
+        <h3 class="flex-grow sidebar__heading">
+          {{far "paperclip"}}<span class="u-margin--l-8">{{ @intl.programs.sidebar.action.actionSidebarViews.uploadsEnabledView.attachmentsHeadingText }}</span>
+        </h3>
+        <button class="button--link js-disable">{{ @intl.programs.sidebar.action.actionSidebarViews.uploadsEnabledView.disableButtonText }}</button>
+      </div>
+    {{else}}
+      <button {{#if isButtonDisabled}}disabled{{/if}} class="button--blue w-100 js-enable">
+        {{far "paperclip"}} {{ @intl.programs.sidebar.action.actionSidebarViews.uploadsEnabledView.enableButtonText }}
+      </button>
+    {{/if}}
+  `,
+  triggers: {
+    'click .js-enable': 'click:enable',
+    'click .js-disable': 'click:disable',
+  },
+  templateContext() {
+    return {
+      isUploadsEnabled: this.getOption('isUploadsEnabled'),
+      isButtonDisabled: this.getOption('isButtonDisabled'),
+    };
+  },
+});
+
 const LayoutView = View.extend({
   childViewTriggers: {
     'save': 'save',
@@ -162,6 +189,7 @@ const LayoutView = View.extend({
     due: '[data-due-region]',
     form: '[data-form-region]',
     formSharing: '[data-form-sharing-region]',
+    allowUploads: '[data-allow-uploads-region]',
     tags: '[data-tags-region]',
     save: '[data-save-region]',
     timestamps: '[data-timestamps-region]',
@@ -357,4 +385,5 @@ export {
   LayoutView,
   FormSharingButtonView,
   FormSharingView,
+  UploadsEnabledView,
 };

--- a/src/scss/modules/sidebar.scss
+++ b/src/scss/modules/sidebar.scss
@@ -53,7 +53,7 @@
 .sidebar__attachments {
   border-bottom: 1px solid $black-90;
   border-top: 1px solid $black-90;
-  padding: 16px 0 24px;
+  padding: 16px 0;
 }
 
 .sidebar__activity {


### PR DESCRIPTION
Shortcut Story ID: [sc-33784]

Adds a toggle on the program action sidebar between enabling ([screenshot](https://user-images.githubusercontent.com/35355575/236052819-54d12182-bc3b-40f8-aa22-6954a62b1dc7.png)) and disabling ([screenshot](https://user-images.githubusercontent.com/35355575/236052724-8915038b-6fc2-4ff2-a9f7-78699421d19e.png)) the ability to upload attachments on that specific action.

Enabling sets `action.attributes.uploads_allowed: ['pdf']` and disabling sets `action.attributes.uploads_allowed: []`.

If the `upload_attachments` org setting is `false` or `undefined`, the entire section will be hidden.

The patient action sidebar was also updated to not show the upload attachment button if uploads are not set to be allowed for the corresponding program action (i.e. equal to `uploads_allowed: []`).