### PR TITLE
Stop `watchKeyUp()` throttle from resolving if it's view is destroyed

### DIFF
--- a/src/js/behaviors/input-watcher.js
+++ b/src/js/behaviors/input-watcher.js
@@ -44,6 +44,9 @@ export default Behavior.extend({
   // contenteditable doesn't have oninput for contenteditable for IE9+
   watchKeyUp: throttle(function(evt) {
     /* istanbul ignore next */
+    if (!this.view.isRendered()) return;
+
+    /* istanbul ignore next */
     if (evt.which === ENTER_KEY) {
       evt.preventDefault();
       return;


### PR DESCRIPTION
Shortcut Story ID: [sc-36522]
