### PR TITLE
On worklist/schedule, display total actions/flows count in the capped results message

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
@@ -130,6 +131,7 @@ export default App.extend({
     const countView = new CountView({
       collection: this.collection,
       filteredCollection: this.filteredCollection,
+      totalInDb: get(this.collection.getMeta('actions'), 'total'),
     });
 
     this.showChildView('count', countView);

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -1,4 +1,4 @@
-import { clone } from 'underscore';
+import { clone, get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
@@ -228,6 +228,7 @@ export default App.extend({
     const countView = new CountView({
       collection: this.collection,
       filteredCollection: this.filteredCollection,
+      totalInDb: get(this.collection.getMeta('actions'), 'total'),
     });
 
     this.showChildView('count', countView);

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import intl, { renderTemplate } from 'js/i18n';
@@ -272,10 +273,14 @@ export default App.extend({
     Radio.request('alert', 'show:success', renderTemplate(BulkEditActionsSuccessTemplate, { itemCount }));
   },
   showCountView() {
+    const listType = this.getState().getType();
+    const totalInDb = get(this.collection.getMeta(listType), 'total');
+
     const countView = new CountView({
       isFlowList: this.getState().isFlowType(),
       collection: this.collection,
       filteredCollection: this.filteredCollection,
+      totalInDb,
     });
 
     this.showChildView('count', countView);

--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -1,4 +1,4 @@
-import { clone, invoke, extend, map, result } from 'underscore';
+import { clone, invoke, extend, map, result, get } from 'underscore';
 import Backbone from 'backbone';
 
 import { getActiveFetcher, registerFetcher } from './control';
@@ -27,7 +27,12 @@ export default Backbone.Collection.extend(extend({
 
     this.cacheIncluded(response.included);
 
+    this.meta = response.meta;
+
     return map(response.data, this.parseModel, this);
+  },
+  getMeta(key) {
+    return get(this.meta, key);
   },
   destroy(options) {
     const models = clone(this.models);

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -425,7 +425,7 @@ careOptsFrontend:
         countView:
           actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
           flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
-          maximumListCount: Showing {maximumCount} of many {isFlowList, select, true {Flows} false {Actions}}.
+          maximumListCount: Showing {maximumCount} of {totalInDb, number} {isFlowList, select, true {Flows} false {Actions}}.
           maximumListCountNarrowed: Showing {itemCount} of {maximumCount} {isFlowList, select, true {Flows} false {Actions}}.
           narrowFilters: Try narrowing your filters.
     sidebar:

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -1,5 +1,3 @@
-const MAXIMUM_LIST_COUNT = /* istanbul ignore next */ _TEST_ ? 50 : 500;
-
 const ACTION_OUTREACH = {
   DISABLED: 'disabled',
   PATIENT: 'patient',
@@ -62,7 +60,6 @@ const STATE_STATUS = {
 };
 
 export {
-  MAXIMUM_LIST_COUNT,
   ACTION_OUTREACH,
   ACTION_SHARING,
   PROGRAM_BEHAVIORS,

--- a/src/js/views/patients/shared/list_views.js
+++ b/src/js/views/patients/shared/list_views.js
@@ -1,8 +1,6 @@
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'marionette';
 
-import { MAXIMUM_LIST_COUNT } from 'js/static';
-
 const ListCountTemplate = hbs`
   <strong>
     {{#if isFlowList}}
@@ -14,7 +12,7 @@ const ListCountTemplate = hbs`
 `;
 
 const MaximumCountTemplate = hbs`
-  <div>{{formatMessage (intlGet "patients.shared.listViews.countView.maximumListCount") maximumCount=maximumCount isFlowList=isFlowList}}</div>
+  <div>{{formatMessage (intlGet "patients.shared.listViews.countView.maximumListCount") maximumCount=maximumCount totalInDb=totalInDb isFlowList=isFlowList}}</div>
   <div>{{ @intl.patients.shared.listViews.countView.narrowFilters }}</div>
 `;
 
@@ -28,10 +26,11 @@ const MaximumCountNarrowedTemplate = hbs`
 const CountView = View.extend({
   getTemplate() {
     const filteredCollection = this.getOption('filteredCollection');
+    const totalInDb = this.getOption('totalInDb');
 
     if (!this.collection || !filteredCollection.length) return hbs``;
 
-    const hasReachedMaximum = this.collection.length === MAXIMUM_LIST_COUNT;
+    const hasReachedMaximum = this.collection.length < totalInDb;
     const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
 
     if (!hasReachedMaximum) {
@@ -48,9 +47,10 @@ const CountView = View.extend({
     const filteredCollection = this.getOption('filteredCollection');
 
     return {
-      maximumCount: MAXIMUM_LIST_COUNT,
+      maximumCount: this.collection.length,
       count: filteredCollection.length,
       isFlowList: !!this.getOption('isFlowList'),
+      totalInDb: this.getOption('totalInDb'),
     };
   },
 });

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -299,6 +299,12 @@ context('reduced schedule page', function() {
           },
         ];
 
+        fx.meta = {
+          actions: {
+            total: 1000,
+          },
+        };
+
         return fx;
       })
       .visit('/')
@@ -306,7 +312,7 @@ context('reduced schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -341,7 +347,7 @@ context('reduced schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -372,6 +372,12 @@ context('schedule page', function() {
           },
         ];
 
+        fx.meta = {
+          actions: {
+            total: 1000,
+          },
+        };
+
         return fx;
       })
       .visit('/schedule')
@@ -379,7 +385,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -414,7 +420,7 @@ context('schedule page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
   });
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -951,6 +951,12 @@ context('worklist page', function() {
           },
         ];
 
+        fx.meta = {
+          actions: {
+            total: 1000,
+          },
+        };
+
         return fx;
       })
       .routeFlows(fx => {
@@ -1006,6 +1012,12 @@ context('worklist page', function() {
           },
         ];
 
+        fx.meta = {
+          flows: {
+            total: 1000,
+          },
+        };
+
         return fx;
       })
       .visit('/worklist/owned-by')
@@ -1013,7 +1025,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1048,7 +1060,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Actions.')
+      .should('contain', 'Showing 50 of 1,000 Actions.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1064,7 +1076,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Flows.')
+      .should('contain', 'Showing 50 of 1,000 Flows.')
       .should('contain', 'Try narrowing your filters.');
 
     cy
@@ -1099,7 +1111,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', 'Showing 50 of many Flows.')
+      .should('contain', 'Showing 50 of 1,000 Flows.')
       .should('contain', 'Try narrowing your filters.');
   });
 

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -112,7 +112,11 @@ Cypress.Commands.add('routeActions', (mutator = _.identity) => {
   cy.route({
     url: '/api/actions?*',
     response() {
-      return mutator(generateData.call(this, _.sample(this.fxPatients, 5)));
+      const apiData = mutator(generateData.call(this, _.sample(this.fxPatients, 5)));
+
+      if (!apiData.meta) apiData.meta = { actions: { total: apiData.data.length } };
+
+      return apiData;
     },
   })
     .as('routeActions');

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -101,7 +101,11 @@ Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
   cy.route({
     url: '/api/flows?*',
     response() {
-      return mutator(generateData.call(this));
+      const apiData = mutator(generateData.call(this));
+
+      if (!apiData.meta) apiData.meta = { flows: { total: apiData.data.length } };
+
+      return apiData;
     },
   })
     .as('routeFlows');


### PR DESCRIPTION
Shortcut Story ID: [sc-36700]

For example, display `Showing 500 of 600 actions.` instead of `Showing 500 of many actions.`, where `600` represents the total number of actions/flows stored in the database.

That total data is found via `actions.meta.total`/`flows.meta.total`. Added by backend here: https://github.com/RoundingWell/care-ops-backend/pull/5539
