### PR TITLE
Implement canEdit check for actions and flows

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -225,6 +225,22 @@ export default App.extend({
       },
     });
   },
+  showDeleteSuccess(itemCount) {
+    if (this.getState().isFlowType()) {
+      Radio.request('alert', 'show:success', renderTemplate(BulkDeleteFlowsSuccessTemplate, { itemCount }));
+      return;
+    }
+
+    Radio.request('alert', 'show:success', renderTemplate(BulkDeleteActionsSuccessTemplate, { itemCount }));
+  },
+  showUpdateSuccess(itemCount) {
+    if (this.getState().isFlowType()) {
+      Radio.request('alert', 'show:success', renderTemplate(BulkEditFlowsSuccessTemplate, { itemCount }));
+      return;
+    }
+
+    Radio.request('alert', 'show:success', renderTemplate(BulkEditActionsSuccessTemplate, { itemCount }));
+  },
   showDisabledSelectAll() {
     this.showChildView('selectAll', new SelectAllView({ isDisabled: true }));
   },
@@ -266,22 +282,6 @@ export default App.extend({
   getComparator() {
     const sortId = this.getState().getSort();
     return this.getSortOption(sortId).getComparator();
-  },
-  showDeleteSuccess(itemCount) {
-    if (this.getState().isFlowType()) {
-      Radio.request('alert', 'show:success', renderTemplate(BulkDeleteFlowsSuccessTemplate, { itemCount }));
-      return;
-    }
-
-    Radio.request('alert', 'show:success', renderTemplate(BulkDeleteActionsSuccessTemplate, { itemCount }));
-  },
-  showUpdateSuccess(itemCount) {
-    if (this.getState().isFlowType()) {
-      Radio.request('alert', 'show:success', renderTemplate(BulkEditFlowsSuccessTemplate, { itemCount }));
-      return;
-    }
-
-    Radio.request('alert', 'show:success', renderTemplate(BulkEditActionsSuccessTemplate, { itemCount }));
   },
   showCountView() {
     const countView = new CountView({

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -123,6 +123,7 @@ export default App.extend({
   showList() {
     const collectionView = new ListView({
       collection: this.collection,
+      editableCollection: this.editableCollection,
       state: this.getState(),
       viewComparator: this.getComparator(),
     });

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -1,4 +1,3 @@
-import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import intl, { renderTemplate } from 'js/i18n';
@@ -13,15 +12,12 @@ import BulkEditFlowsApp from 'js/apps/patients/sidebar/bulk-edit-flows_app';
 
 import DateFilterComponent from 'js/views/patients/shared/components/date-filter';
 import SearchComponent from 'js/views/shared/components/list-search';
-import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 import { CountView } from 'js/views/patients/shared/list_views';
 
 import { getSortOptions } from './worklist_sort';
 
-import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView, NoOwnerToggleView } from 'js/views/patients/worklist/worklist_views';
+import { ListView, SelectAllView, LayoutView, ListTitleView, TableHeaderView, SortDroplist, TypeToggleView } from 'js/views/patients/worklist/worklist_views';
 import { BulkEditButtonView, BulkEditFlowsSuccessTemplate, BulkEditActionsSuccessTemplate, BulkDeleteFlowsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
-
-const i18n = intl.patients.worklist.filtersApp;
 
 export default App.extend({
   StateModel,
@@ -38,10 +34,8 @@ export default App.extend({
   stateEvents: {
     'change:listType change:clinicianId change:teamId change:noOwner change:filters change:states': 'restart',
     'change:actionsDateFilters change:flowsDateFilters': 'restart',
-    'change:actionsSortId': 'onChangeStateSort',
-    'change:flowsSortId': 'onChangeStateSort',
-    'change:selectedFlows': 'onChangeSelected',
-    'change:selectedActions': 'onChangeSelected',
+    'change:actionsSortId change:flowsSortId': 'onChangeStateSort',
+    'change:actionsSelected change:flowsSelected': 'onChangeSelected',
     'change:searchQuery': 'onChangeSearchQuery',
   },
   onChangeStateSort() {
@@ -58,7 +52,7 @@ export default App.extend({
   initListState() {
     const storedState = this.getState().getStore(this.worklistId);
 
-    this.setState({ searchQuery: this.currentSearchQuery });
+    this.getState().setSearchQuery(this.currentSearchQuery);
 
     if (storedState) {
       this.setState(storedState);
@@ -73,19 +67,14 @@ export default App.extend({
     this.collection = null;
   },
   onBeforeStart({ worklistId }) {
-    const isFiltersSidebarOpen = this.getState('isFiltering');
-
     if (this.isRestarting()) {
+      const isFiltersSidebarOpen = this.getState('isFiltering');
       if (!isFiltersSidebarOpen) Radio.request('sidebar', 'close');
 
-      this.showListTitle();
-      this.showTypeToggleView();
-      this.showSortDroplist();
-      this.showTableHeaders();
-      this.showDateFilter();
-      this.getRegion('list').startPreloader();
-
       this.getRegion('count').empty();
+
+      this.showTypeViews();
+      this.getRegion('list').startPreloader();
 
       return;
     }
@@ -93,25 +82,16 @@ export default App.extend({
     this.worklistId = worklistId;
     this.initListState();
 
-    const currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.shouldShowClinician = this.getState().id !== 'shared-by';
-    this.shouldShowTeam = this.getState().id !== 'owned-by';
-    this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
+    this.setView(new LayoutView());
 
-    this.showView(new LayoutView({
-      worklistId: this.worklistId,
-      state: this.getState(),
-    }));
-
-    this.getRegion('list').startPreloader();
     this.showDisabledSelectAll();
-    this.showSortDroplist();
-    this.showTableHeaders();
-    this.showListTitle();
-    this.showTypeToggleView();
     this.showSearchView();
-    this.showDateFilter();
     this.startFiltersApp();
+
+    this.showTypeViews();
+    this.getRegion('list').startPreloader();
+
+    this.showView();
   },
   beforeStart() {
     return Radio.request('entities', `fetch:${ this.getState().getType() }:collection`, {
@@ -122,7 +102,22 @@ export default App.extend({
   onStart(options, collection) {
     this.collection = collection;
     this.filteredCollection = collection.clone();
+    this.editableCollection = collection.clone();
 
+    this.showCountView();
+    this.toggleBulkSelect();
+
+    this.showList();
+  },
+  // NOTE: Shows views dependent on getState().getType()
+  showTypeViews() {
+    this.showListTitle();
+    this.showTypeToggleView();
+    this.showDateFilter();
+    this.showSortDroplist();
+    this.showTableHeaders();
+  },
+  showList() {
     const collectionView = new ListView({
       collection: this.collection,
       state: this.getState(),
@@ -131,8 +126,9 @@ export default App.extend({
 
     this.listenTo(collectionView, 'filtered', filtered => {
       this.filteredCollection.reset(filtered);
-      this.toggleBulkSelect();
+      this.editableCollection.reset(this._getListEditable(collectionView));
       this.showCountView();
+      this.toggleBulkSelect();
     });
 
     this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
@@ -141,16 +137,17 @@ export default App.extend({
     });
 
     this.showChildView('list', collectionView);
-
-    this.showSearchView();
-    this.toggleBulkSelect();
-    this.showCountView();
+  },
+  _getListEditable(list) {
+    return list.children.reduce((models, { canEdit, model }) => {
+      if (canEdit) models.push(model);
+      return models;
+    }, []);
   },
   startFiltersApp() {
-    const state = this.getState();
     const filtersApp = this.startChildApp('filters', {
-      state: state.getFiltersState(),
-      availableStates: state.getAvailableStates(),
+      state: this.getState().getFiltersState(),
+      availableStates: this.getState().getAvailableStates(),
     });
 
     const filtersState = filtersApp.getState();
@@ -163,7 +160,7 @@ export default App.extend({
     });
   },
   toggleBulkSelect() {
-    this.selected = this.getState().getSelected(this.filteredCollection);
+    this.selected = this.getState().getSelected(this.editableCollection);
 
     this.showSelectAll();
 
@@ -174,6 +171,17 @@ export default App.extend({
     }
 
     this.startFiltersApp();
+  },
+  showBulkEditButtonView() {
+    const bulkEditButtonView = this.showChildView('filters', new BulkEditButtonView({
+      isFlowType: this.getState().isFlowType(),
+      collection: this.selected,
+    }));
+
+    this.listenTo(bulkEditButtonView, {
+      'click:cancel': this.onClickBulkCancel,
+      'click:edit': this.onClickBulkEdit,
+    });
   },
   onClickBulkCancel() {
     this.getState().clearSelected();
@@ -204,12 +212,12 @@ export default App.extend({
       },
       'delete'() {
         const itemCount = this.selected.length;
-
-        this.selected.destroy().then(() => {
-          this.showDeleteSuccess(itemCount);
-          app.stop();
-          this.getState().clearSelected();
-        });
+        this.selected.destroy()
+          .then(() => {
+            this.showDeleteSuccess(itemCount);
+            app.stop();
+            this.getState().clearSelected();
+          });
       },
     });
   },
@@ -217,15 +225,14 @@ export default App.extend({
     this.showChildView('selectAll', new SelectAllView({ isDisabled: true }));
   },
   showSelectAll() {
-    if (!this.filteredCollection.length) {
+    if (!this.editableCollection.length) {
       this.showDisabledSelectAll();
       return;
     }
-    const isSelectAll = this.selected.length === this.filteredCollection.length;
-    const isSelectNone = !this.selected.length;
+
     const selectAllView = new SelectAllView({
-      isSelectAll,
-      isSelectNone,
+      isSelectAll: this.selected.length === this.editableCollection.length,
+      isSelectNone: !this.selected.length,
     });
 
     this.listenTo(selectAllView, 'click', this.onClickBulkSelect);
@@ -233,19 +240,19 @@ export default App.extend({
     this.showChildView('selectAll', selectAllView);
   },
   onClickBulkSelect() {
-    if (this.selected.length === this.filteredCollection.length) {
+    if (this.selected.length === this.editableCollection.length) {
       this.getState().clearSelected();
       return;
     }
 
-    this.getState().selectMultiple(this.filteredCollection.map('id'));
+    this.getState().selectMultiple(this.editableCollection.map('id'));
   },
   getSortOption(sortId) {
     const opt = this.sortOptions.get(sortId);
 
     if (!opt) {
-      const state = this.getState();
-      const defaultSortId = state.defaults()[`${ state.getType() }SortId`];
+      const stateDefaults = this.getState().defaults();
+      const defaultSortId = stateDefaults[`${ this.getState().getType() }SortId`];
 
       return this.sortOptions.get(defaultSortId);
     }
@@ -273,37 +280,29 @@ export default App.extend({
     Radio.request('alert', 'show:success', renderTemplate(BulkEditActionsSuccessTemplate, { itemCount }));
   },
   showCountView() {
-    const listType = this.getState().getType();
-    const totalInDb = get(this.collection.getMeta(listType), 'total');
-
     const countView = new CountView({
       isFlowList: this.getState().isFlowType(),
       collection: this.collection,
       filteredCollection: this.filteredCollection,
-      totalInDb,
     });
 
     this.showChildView('count', countView);
   },
   showDateFilter() {
-    if (this.getState().id !== 'shared-by' && this.getState().id !== 'owned-by') return;
+    if (this.getState().getStaticDateFilter()) return;
 
-    const state = this.getState();
-    const dateTypes = state.isFlowType() ? ['created_at', 'updated_at'] : ['created_at', 'updated_at', 'due_date'];
+    const dateTypes = this.getState().isFlowType() ? ['created_at', 'updated_at'] : ['created_at', 'updated_at', 'due_date'];
 
     const dateFilterComponent = new DateFilterComponent({
       dateTypes,
-      state: state.getDateFilters(),
-      region: this.getRegion('dateFilter'),
+      state: this.getState().getDateFilters(),
     });
 
-    this.listenTo(dateFilterComponent.getState(), {
-      'change'({ attributes }) {
-        state.setDateFilters(attributes);
-      },
+    this.listenTo(dateFilterComponent.getState(), 'change', ({ attributes }) => {
+      this.getState().setDateFilters(attributes);
     });
 
-    dateFilterComponent.show();
+    this.showChildView('dateFilter', dateFilterComponent);
   },
   showSortDroplist() {
     this.sortOptions = getSortOptions(this.getState().getType());
@@ -327,27 +326,9 @@ export default App.extend({
     this.showChildView('table', tableHeadersView);
   },
   showListTitle() {
-    const owner = Radio.request('entities', 'clinicians:model', this.getState('clinicianId'));
-    const team = Radio.request('entities', 'teams:model', this.getState('teamId'));
+    const listTitleView = new ListTitleView({ model: this.getState() });
 
-    const showOwnerDroplist = (this.shouldShowClinician && this.canViewAssignedActions) || this.shouldShowTeam;
-    const shouldShowOwnerToggle = this.getState().id === 'shared-by' && this.canViewAssignedActions;
-
-    const listTitleView = this.showChildView('title', new ListTitleView({
-      owner,
-      team,
-      worklistId: this.worklistId,
-      isFlowList: this.getState().isFlowType(),
-      showOwnerDroplist,
-    }));
-
-    if (showOwnerDroplist) this.showOwnerDroplist(listTitleView, owner, team);
-    if (shouldShowOwnerToggle) this.showOwnerToggle(listTitleView);
-  },
-  showOwnerDroplist(listTitleView, owner, team) {
-    const ownerDroplistView = new OwnerDroplist(this.getOwnerFilterOptions(owner, team));
-
-    this.listenTo(ownerDroplistView, {
+    this.listenTo(listTitleView, {
       'change:owner'({ id, type }) {
         if (type === 'teams') {
           this.setState({ teamId: id, clinicianId: null });
@@ -355,76 +336,35 @@ export default App.extend({
           this.setState({ clinicianId: id, teamId: null });
         }
       },
+      'toggle:noOwner'() {
+        this.toggleState('noOwner');
+      },
     });
 
-    listTitleView.showChildView('owner', ownerDroplistView);
-  },
-  showOwnerToggle(listTitleView) {
-    const ownerToggleView = new NoOwnerToggleView({
-      model: this.getState(),
-    });
-
-    this.listenTo(ownerToggleView, 'click', () => {
-      this.toggleState('noOwner');
-    });
-
-    listTitleView.showChildView('ownerToggle', ownerToggleView);
-  },
-  getOwnerFilterOptions(owner, team) {
-    const clinicianId = this.getState('clinicianId');
-
-    const options = {
-      owner: this.shouldShowClinician && clinicianId ? owner : team,
-      hasClinicians: this.shouldShowClinician && this.canViewAssignedActions,
-      isTitleFilter: true,
-      headingText: this.shouldShowClinician ? i18n.ownerFilterHeadingText : i18n.teamsFilterHeadingText,
-      hasTeams: this.shouldShowTeam,
-      hasCurrentClinician: this.shouldShowClinician,
-      align: 'right',
-    };
-
-    if (!this.shouldShowClinician) options.placeholderText = i18n.teamsFilterPlaceholderText;
-
-    return options;
+    this.showChildView('title', listTitleView);
   },
   showTypeToggleView() {
     const typeToggleView = new TypeToggleView({
-      isFlowList: this.getState('listType') === 'flows',
+      isFlowList: this.getState().isFlowType(),
     });
 
     this.listenTo(typeToggleView, 'toggle:listType', listType => {
-      this.setState({
-        listType: listType,
-        lastSelectedIndex: null,
-      });
+      this.getState().setType(listType);
     });
 
     this.showChildView('toggle', typeToggleView);
   },
   showSearchView() {
-    const searchComponent = this.showChildView('search', new SearchComponent({
+    const searchComponent = new SearchComponent({
       state: {
         query: this.getState('searchQuery'),
       },
-    }));
-
-    this.listenTo(searchComponent.getState(), 'change:query', this.setSearchState);
-  },
-  showBulkEditButtonView() {
-    const bulkEditButtonView = this.showChildView('filters', new BulkEditButtonView({
-      isFlowType: this.getState().isFlowType(),
-      collection: this.selected,
-    }));
-
-    this.listenTo(bulkEditButtonView, {
-      'click:cancel': this.onClickBulkCancel,
-      'click:edit': this.onClickBulkEdit,
     });
-  },
-  setSearchState(state, searchQuery) {
-    this.setState({
-      searchQuery: searchQuery.length > 2 ? searchQuery : '',
-      lastSelectedIndex: null,
+
+    this.listenTo(searchComponent.getState(), 'change:query', (state, searchQuery) => {
+      this.getState().setSearchQuery(searchQuery);
     });
+
+    this.showChildView('search', searchComponent);
   },
 });

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -104,7 +104,10 @@ export default App.extend({
     this.filteredCollection = collection.clone();
     this.editableCollection = collection.clone();
 
+    this.listenTo(this.filteredCollection, 'reset', this.showCountView);
     this.showCountView();
+
+    this.listenTo(this.editableCollection, 'reset', this.toggleBulkSelect);
     this.toggleBulkSelect();
 
     this.showList();
@@ -124,16 +127,17 @@ export default App.extend({
       viewComparator: this.getComparator(),
     });
 
-    this.listenTo(collectionView, 'filtered', filtered => {
-      this.filteredCollection.reset(filtered);
-      this.editableCollection.reset(this._getListEditable(collectionView));
-      this.showCountView();
-      this.toggleBulkSelect();
-    });
-
-    this.listenTo(collectionView, 'click:patientSidebarButton', ({ model }) => {
-      const patient = model.getPatient();
-      Radio.request('sidebar', 'start', 'patient', { patient });
+    this.listenTo(collectionView, {
+      'filtered'(filtered) {
+        this.filteredCollection.reset(filtered);
+        this.editableCollection.reset(this._getListEditable(collectionView));
+      },
+      'change:canEdit'() {
+        this.editableCollection.reset(this._getListEditable(collectionView));
+      },
+      'click:patientSidebarButton'({ model }) {
+        Radio.request('sidebar', 'start', 'patient', { patient: model.getPatient() });
+      },
     });
 
     this.showChildView('list', collectionView);

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -1,4 +1,4 @@
-import { clone, extend, keys, omit, reduce, intersection, sortBy } from 'underscore';
+import { clone, extend, keys, omit, reduce, intersection } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
@@ -109,7 +109,7 @@ export default Backbone.Model.extend({
     const { done, notDone } = this.states.groupByDone();
 
     const states = this.isDoneOnly() ? done : notDone;
-    return sortBy(states.map('id'));
+    return states.map('id');
   },
   setDefaultFilterStates() {
     this.set({ filters: {}, states: this.getDefaultSelectedStates() });

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -171,17 +171,22 @@ export default Backbone.Model.extend({
 
     return { state: selectedAvailableStates.join() || NIL_UUID };
   },
+  isOwnerTeam() {
+    const clinician = this.get('clinicianId');
+
+    return this.id === 'shared-by' || !clinician;
+  },
   getOwner() {
     const clinician = this.get('clinicianId');
 
-    if (clinician) return Radio.request('entities', 'clinicians:model', clinician);
+    if (this.isOwnerTeam()) return Radio.request('entities', 'teams:model', this.get('teamId'));
 
-    return Radio.request('entities', 'teams:model', this.get('teamId'));
+    return Radio.request('entities', 'clinicians:model', clinician);
   },
   getEntityOwnerFilter() {
     const clinician = this.get('clinicianId');
 
-    if (this.id === 'shared-by' || !clinician) {
+    if (this.isOwnerTeam()) {
       const team = this.get('teamId');
       const noOwner = this.get('noOwner');
       const canFilterClinicians = this.currentClinician.can('app:worklist:clinician_filter');

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -1,4 +1,4 @@
-import { clone, extend, keys, omit, reduce, filter, contains, sortBy } from 'underscore';
+import { clone, extend, keys, omit, reduce, intersection, sortBy } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
@@ -8,9 +8,9 @@ import Radio from 'backbone.radio';
 
 import { RELATIVE_DATE_RANGES } from 'js/static';
 
-const STATE_VERSION = 'v5';
-
 const relativeRanges = new Backbone.Collection(RELATIVE_DATE_RANGES);
+
+const STATE_VERSION = 'v5';
 
 export default Backbone.Model.extend({
   defaults() {
@@ -167,8 +167,9 @@ export default Backbone.Model.extend({
   getEntityStatesFilter() {
     const availableStateFilterIds = this.getAvailableStates().map('id');
     const selectedStates = this.getStatesFilters();
+    const selectedAvailableStates = intersection(selectedStates, availableStateFilterIds);
 
-    return { state: filter(selectedStates, id => contains(availableStateFilterIds, id)).join() || NIL_UUID };
+    return { state: selectedAvailableStates.join() || NIL_UUID };
   },
   getOwner() {
     const clinician = this.get('clinicianId');

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -1,4 +1,4 @@
-import { clone, extend, keys, omit, reduce, each, filter, contains, sortBy } from 'underscore';
+import { clone, extend, keys, omit, reduce, filter, contains, sortBy } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
@@ -8,7 +8,7 @@ import Radio from 'backbone.radio';
 
 import { RELATIVE_DATE_RANGES } from 'js/static';
 
-const STATE_VERSION = 'v4';
+const STATE_VERSION = 'v5';
 
 const relativeRanges = new Backbone.Collection(RELATIVE_DATE_RANGES);
 
@@ -38,8 +38,8 @@ export default Backbone.Model.extend({
       teamId: this.currentClinician.getTeam().id,
       noOwner: false,
       lastSelectedIndex: null,
-      selectedActions: {},
-      selectedFlows: {},
+      actionsSelected: {},
+      flowsSelected: {},
       searchQuery: '',
       listType: 'actions',
     };
@@ -73,8 +73,20 @@ export default Backbone.Model.extend({
   getStatesFilters() {
     return clone(this.get('states'));
   },
+  setSearchQuery(searchQuery = '') {
+    return this.set({
+      searchQuery: searchQuery.length > 2 ? searchQuery : '',
+      lastSelectedIndex: null,
+    });
+  },
   getType() {
     return this.get('listType');
+  },
+  setType(listType) {
+    return this.set({
+      listType,
+      lastSelectedIndex: null,
+    });
   },
   isFlowType() {
     return this.getType() === 'flows';
@@ -84,42 +96,6 @@ export default Backbone.Model.extend({
   },
   setSort(sortId) {
     this.set(`${ this.getType() }SortId`, sortId);
-  },
-  formatDateRange(date, rangeType, dateFormat) {
-    return `${ dayjs(date).startOf(rangeType).format(dateFormat) },${ dayjs(date).endOf(rangeType).format(dateFormat) }`;
-  },
-  getEntityDateFilter() {
-    const { dateType, selectedDate, selectedMonth, selectedWeek, relativeDate } = this.getDateFilters();
-    const dateFormat = (dateType === 'due_date') ? 'YYYY-MM-DD' : '';
-
-    if (selectedDate) {
-      return {
-        [dateType]: this.formatDateRange(selectedDate, 'day', dateFormat),
-      };
-    }
-
-    if (selectedMonth) {
-      return {
-        [dateType]: this.formatDateRange(selectedMonth, 'month', dateFormat),
-      };
-    }
-
-    if (selectedWeek) {
-      return {
-        [dateType]: this.formatDateRange(selectedWeek, 'week', dateFormat),
-      };
-    }
-
-    if (relativeDate === 'alltime') {
-      return {};
-    }
-
-    const { prev, unit } = relativeRanges.get(relativeDate || 'thismonth').pick('prev', 'unit');
-    const relativeRange = dayjs().subtract(prev, unit);
-
-    return {
-      [dateType]: this.formatDateRange(relativeRange, unit, dateFormat),
-    };
   },
   isDoneOnly() {
     return this.id === 'done-last-thirty-days';
@@ -138,12 +114,6 @@ export default Backbone.Model.extend({
   setDefaultFilterStates() {
     this.set({ filters: {}, states: this.getDefaultSelectedStates() });
   },
-  getSelectedStates() {
-    const availableStateFilterIds = this.getAvailableStates().map('id');
-    const selectedStates = this.getStatesFilters();
-
-    return filter(selectedStates, id => contains(availableStateFilterIds, id)).join() || NIL_UUID;
-  },
   getFiltersState() {
     return {
       filters: this.getFilters(),
@@ -151,17 +121,25 @@ export default Backbone.Model.extend({
       defaultStates: this.getDefaultSelectedStates(),
     };
   },
-  getEntityFilter() {
-    const filtersState = this.getFilters();
-    const clinicianId = this.get('clinicianId');
-    const teamId = this.get('teamId');
-    const noOwner = this.get('noOwner');
-    const selectedStates = this.getSelectedStates();
-    const dateFilter = this.getEntityDateFilter();
+  formatDateRange(dateType, date, rangeType) {
+    const dateFormat = (dateType === 'due_date') ? 'YYYY-MM-DD' : '';
+    return `${ dayjs(date).startOf(rangeType).format(dateFormat) },${ dayjs(date).endOf(rangeType).format(dateFormat) }`;
+  },
+  getDateRange({ dateType, selectedDate, selectedMonth, selectedWeek, relativeDate }) {
+    if (selectedDate) return this.formatDateRange(dateType, selectedDate, 'day');
 
-    const filters = {
-      'owned-by': dateFilter,
-      'shared-by': dateFilter,
+    if (selectedMonth) return this.formatDateRange(dateType, selectedMonth, 'month');
+
+    if (selectedWeek) return this.formatDateRange(dateType, selectedWeek, 'week');
+
+    relativeDate = relativeDate || 'thismonth';
+    const { prev, unit } = relativeRanges.get(relativeDate).pick('prev', 'unit');
+    const relativeRange = dayjs().subtract(prev, unit);
+
+    return this.formatDateRange(dateType, relativeRange, unit);
+  },
+  getStaticDateFilter() {
+    const staticDateFilters = {
       'new-past-day': {
         created_at: dayjs().subtract(24, 'hours').format(),
       },
@@ -173,56 +151,92 @@ export default Backbone.Model.extend({
       },
     };
 
-    filters[this.id].state = selectedStates;
+    return staticDateFilters[this.id];
+  },
+  getEntityDateFilter() {
+    const staticDateFilter = this.getStaticDateFilter();
+    if (staticDateFilter) return staticDateFilter;
 
-    if (this.id === 'shared-by' || !clinicianId) {
-      const currentClinician = Radio.request('bootstrap', 'currentUser');
-      const canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
-      filters[this.id].team = teamId;
+    const dateFilters = this.getDateFilters();
+    if (dateFilters.relativeDate === 'alltime') return {};
 
-      if (noOwner || !canViewAssignedActions) {
-        filters[this.id].clinician = NIL_UUID;
-      }
-    } else {
-      filters[this.id].clinician = clinicianId;
+    return {
+      [dateFilters.dateType]: this.getDateRange(dateFilters),
+    };
+  },
+  getEntityStatesFilter() {
+    const availableStateFilterIds = this.getAvailableStates().map('id');
+    const selectedStates = this.getStatesFilters();
+
+    return { state: filter(selectedStates, id => contains(availableStateFilterIds, id)).join() || NIL_UUID };
+  },
+  getOwner() {
+    const clinician = this.get('clinicianId');
+
+    if (clinician) return Radio.request('entities', 'clinicians:model', clinician);
+
+    return Radio.request('entities', 'teams:model', this.get('teamId'));
+  },
+  getEntityOwnerFilter() {
+    const clinician = this.get('clinicianId');
+
+    if (this.id === 'shared-by' || !clinician) {
+      const team = this.get('teamId');
+      const noOwner = this.get('noOwner');
+      const canFilterClinicians = this.currentClinician.can('app:worklist:clinician_filter');
+
+      if (noOwner || !canFilterClinicians) return { team, clinician: NIL_UUID };
+
+      return { team };
     }
 
-    each(filtersState, (selected, slug) => {
-      if (selected === null) return;
+    return { clinician };
+  },
+  getEntityCustomFilter() {
+    const filtersState = this.getFilters();
+    return reduce(filtersState, (filters, selected, slug) => {
+      if (selected !== null) filters[`@${ slug }`] = selected;
 
-      filters[this.id][`@${ slug }`] = selected;
+      return filters;
+    }, {});
+  },
+  getEntityFilter() {
+    const filters = {};
+
+    extend(filters, this.getEntityDateFilter());
+    extend(filters, this.getEntityStatesFilter());
+    extend(filters, this.getEntityOwnerFilter());
+    extend(filters, this.getEntityCustomFilter());
+
+    return filters;
+  },
+  setSelectedList(list, lastSelectedIndex) {
+    return this.set({
+      [`${ this.getType() }Selected`]: list,
+      lastSelectedIndex,
     });
-
-    return filters[this.id];
   },
   getSelectedList() {
-    return this.isFlowType() ? this.get('selectedFlows') : this.get('selectedActions');
+    return clone(this.get(`${ this.getType() }Selected`));
   },
   toggleSelected(model, isSelected, selectedIndex) {
-    const listName = this.isFlowType() ? 'selectedFlows' : 'selectedActions';
-    const currentList = clone(this.get(listName));
+    const selectedList = this.getSelectedList();
 
-    const newList = extend(currentList, {
-      [model.id]: isSelected,
-    });
+    selectedList[model.id] = isSelected;
 
-    this.set({
-      [listName]: newList,
-      lastSelectedIndex: isSelected ? selectedIndex : null,
-    });
+    this.setSelectedList(selectedList, isSelected ? selectedIndex : null);
   },
   isSelected(model) {
-    const list = this.getSelectedList();
+    const selectedList = this.getSelectedList();
 
-    return !!list[model.id];
+    return !!selectedList[model.id];
   },
   getSelected(collection) {
-    const list = this.getSelectedList();
-    const collectionSelected = reduce(keys(list), (selected, item) => {
-      if (list[item] && collection.get(item)) {
-        selected.push({
-          id: item,
-        });
+    const selectedList = this.getSelectedList();
+
+    const collectionSelected = reduce(keys(selectedList), (selected, id) => {
+      if (selectedList[id] && collection.get(id)) {
+        selected.push({ id });
       }
 
       return selected;
@@ -231,29 +245,19 @@ export default Backbone.Model.extend({
     return Radio.request('entities', `${ this.getType() }:collection`, collectionSelected);
   },
   clearSelected() {
-    const listName = this.isFlowType() ? 'selectedFlows' : 'selectedActions';
-
-    this.set({
-      [listName]: {},
-      lastSelectedIndex: null,
-    });
+    this.setSelectedList({}, null);
 
     this.trigger('select:none');
   },
   selectMultiple(selectedIds, newLastSelectedIndex = null) {
-    const listName = this.isFlowType() ? 'selectedFlows' : 'selectedActions';
-
-    const currentSelectedList = this.get(listName);
+    const selectedList = this.getSelectedList();
 
     const newSelectedList = selectedIds.reduce((selected, id) => {
       selected[id] = true;
       return selected;
-    }, clone(currentSelectedList));
+    }, selectedList);
 
-    this.set({
-      [listName]: newSelectedList,
-      lastSelectedIndex: newLastSelectedIndex,
-    });
+    this.setSelectedList(newSelectedList, newLastSelectedIndex);
 
     this.trigger('select:multiple');
   },

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -89,6 +89,15 @@ const _Model = BaseModel.extend({
   hasOutreach() {
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;
   },
+  canEdit() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+
+    if (currentUser.can('work:manage')) return true;
+
+    if (currentUser.can('work:owned:manage') && this.getOwner() === currentUser) return true;
+
+    return false;
+  },
   saveDueDate(date) {
     if (!date) {
       return this.save({ due_date: null, due_time: null });

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -43,6 +43,15 @@ const _Model = BaseModel.extend({
     const { complete, total } = this.get('_progress');
     return complete === total;
   },
+  canEdit() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+
+    if (currentUser.can('work:manage')) return true;
+
+    if (currentUser.can('work:owned:manage') && this.getOwner() === currentUser) return true;
+
+    return false;
+  },
   saveState(state) {
     return this.save({ _state: state.id }, {
       relationships: {

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -575,10 +575,6 @@ careOptsFrontend:
             updated_past_three_days {Actions updated in the last 3 days. States include To Do and In Progress.}
             done_last_thirty_days {Actions completed in the last 30 days.}
           }
-      filtersApp:
-        ownerFilterHeadingText: Filter by Owner
-        teamsFilterHeadingText: Filter by Team
-        teamsFilterPlaceholderText: Team...
       flowViews:
         flowEmptyView: No Flows
         flowListTooltips: |
@@ -620,7 +616,7 @@ careOptsFrontend:
           listTitles: |
             {title, select,
               owned_by {Owned By { owner }}
-              shared_by {Shared By { team } Team}
+              shared_by {Shared By { owner } Team}
               new_past_day {New < 24 hrs: { owner }}
               updated_past_three_days {Updated < 3 Days: {owner}}
               done_last_thirty_days {Done < 30 Days: {owner}}
@@ -641,6 +637,11 @@ careOptsFrontend:
         sortUpdateOptions:
           asc: 'Updated: Oldest - Newest'
           desc: 'Updated: Newest - Oldest'
+        titleOwnerDroplist:
+          ownerFilterHeadingText: Filter by Owner
+          ownerFilterPlaceholderText: Owner...
+          teamsFilterHeadingText: Filter by Team
+          teamsFilterPlaceholderText: Team...
         typeToggleView:
           actionsButton: Actions
           flowsButton: Flows

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -604,7 +604,7 @@ careOptsFrontend:
           allFiltersButton: All Filters
         emptyFindInListView:
           noResults: No results match your Find in List search
-        listTitleView:
+        listTitleLabelView:
           listLabels: |
             {title, select,
               owned_by {Owned By}

--- a/src/js/views/patients/shared/components/date-filter/index.js
+++ b/src/js/views/patients/shared/components/date-filter/index.js
@@ -49,7 +49,7 @@ export default Component.extend({
   dateTypes,
   StateModel,
   stateEvents: {
-    'change': 'foo',
+    'change': 'show',
   },
   ViewClass: ControllerView,
   viewOptions() {

--- a/src/js/views/patients/shared/list_views.js
+++ b/src/js/views/patients/shared/list_views.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'marionette';
 
@@ -24,13 +25,16 @@ const MaximumCountNarrowedTemplate = hbs`
 `;
 
 const CountView = View.extend({
+  initialize() {
+    const listType = this.getOption('isFlowList') ? 'flows' : 'actions';
+    this.totalInDb = get(this.collection.getMeta(listType), 'total');
+  },
   getTemplate() {
     const filteredCollection = this.getOption('filteredCollection');
-    const totalInDb = this.getOption('totalInDb');
 
     if (!this.collection || !filteredCollection.length) return hbs``;
 
-    const hasReachedMaximum = this.collection.length < totalInDb;
+    const hasReachedMaximum = this.collection.length < this.totalInDb;
     const isFindInListApplied = hasReachedMaximum && filteredCollection.length < this.collection.length;
 
     if (!hasReachedMaximum) {
@@ -50,7 +54,7 @@ const CountView = View.extend({
       maximumCount: this.collection.length,
       count: filteredCollection.length,
       isFlowList: !!this.getOption('isFlowList'),
-      totalInDb: this.getOption('totalInDb'),
+      totalInDb: this.totalInDb,
     };
   },
 });

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -74,18 +74,24 @@ const ActionItemView = View.extend({
     Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
   },
   onRender() {
-    this.showCheck();
-    this.showState();
-    this.showOwner();
-    this.showDueDate();
-    this.showDueTime();
     this.showForm();
     this.showDetailsTooltip();
+
+    this.canEdit = this.model.canEdit();
+
+    if (this.canEdit) {
+      this.showCheck();
+      this.showState();
+      this.showOwner();
+      this.showDueDate();
+      this.showDueTime();
+    }
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);
   },
   showCheck() {
+    if (!this.canEdit) return;
     const isSelected = this.state.isSelected(this.model);
     this.toggleSelected(isSelected);
     const checkComponent = new CheckComponent({ state: { isSelected } });

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -10,7 +10,7 @@ import ActionItemTemplate from './action-item.hbs';
 
 import './worklist-list.scss';
 
-const ActionTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.actionViews.actionListTooltips") title=worklistId team=team}}`;
+const ActionTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.actionViews.actionListTooltips") title=worklistId team=owner}}`;
 
 const ActionEmptyView = View.extend({
   tagName: 'tr',
@@ -35,11 +35,15 @@ const ActionItemView = View.extend({
     details: '[data-details-region]',
   },
   templateContext() {
+    const state = this.model.getState();
+
     return {
+      isOverdue: this.model.isOverdue(),
+      state: state.get('name'),
+      stateOptions: state.get('options'),
       flowName: this.flow && this.flow.get('name'),
       patient: this.model.getPatient().attributes,
       owner: this.model.getOwner().get('name'),
-      state: this.model.getState().get('name'),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
       hasAttachments: this.model.hasAttachments(),
     };

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -91,7 +91,10 @@ const ActionItemView = View.extend({
       this.showDueDate();
       this.showDueTime();
     }
-    if (canEdit !== this.canEdit) this.triggerMethod('change:canEdit');
+    if (canEdit !== this.canEdit) {
+      if (!this.canEdit) this.toggleSelected(false);
+      this.triggerMethod('change:canEdit');
+    }
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -81,6 +81,7 @@ const ActionItemView = View.extend({
     this.showForm();
     this.showDetailsTooltip();
 
+    const canEdit = this.canEdit;
     this.canEdit = this.model.canEdit();
 
     if (this.canEdit) {
@@ -90,6 +91,7 @@ const ActionItemView = View.extend({
       this.showDueDate();
       this.showDueTime();
     }
+    if (canEdit !== this.canEdit) this.triggerMethod('change:canEdit');
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -91,6 +91,7 @@ const ActionItemView = View.extend({
       this.showDueDate();
       this.showDueTime();
     }
+
     if (canEdit !== this.canEdit) {
       if (!this.canEdit) this.toggleSelected(false);
       this.triggerMethod('change:canEdit');

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -83,7 +83,10 @@ const FlowItemView = View.extend({
       this.showCheck();
       this.showOwner();
     }
-    if (canEdit !== this.canEdit) this.triggerMethod('change:canEdit');
+    if (canEdit !== this.canEdit) {
+      if (!this.canEdit) this.toggleSelected(false);
+      this.triggerMethod('change:canEdit');
+    }
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -12,7 +12,7 @@ import FlowItemTemplate from './flow-item.hbs';
 import 'scss/domain/action-state.scss';
 import './worklist-list.scss';
 
-const FlowTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.flowViews.flowListTooltips") title=worklistId team=team}}`;
+const FlowTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.flowViews.flowListTooltips") title=worklistId team=owner}}`;
 
 const FlowEmptyView = View.extend({
   tagName: 'tr',

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -78,11 +78,14 @@ const FlowItemView = View.extend({
   onRender() {
     const canEdit = this.canEdit;
     this.canEdit = this.model.canEdit();
+
     this.showState();
+
     if (this.canEdit) {
       this.showCheck();
       this.showOwner();
     }
+
     if (canEdit !== this.canEdit) {
       if (!this.canEdit) this.toggleSelected(false);
       this.triggerMethod('change:canEdit');

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -76,12 +76,14 @@ const FlowItemView = View.extend({
     Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
   },
   onRender() {
+    const canEdit = this.canEdit;
     this.canEdit = this.model.canEdit();
     this.showState();
     if (this.canEdit) {
       this.showCheck();
       this.showOwner();
     }
+    if (canEdit !== this.canEdit) this.triggerMethod('change:canEdit');
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -76,9 +76,12 @@ const FlowItemView = View.extend({
     Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
   },
   onRender() {
-    this.showCheck();
+    this.canEdit = this.model.canEdit();
     this.showState();
-    this.showOwner();
+    if (this.canEdit) {
+      this.showCheck();
+      this.showOwner();
+    }
   },
   toggleSelected(isSelected) {
     this.$el.toggleClass('is-selected', isSelected);
@@ -98,7 +101,7 @@ const FlowItemView = View.extend({
     this.showChildView('check', checkComponent);
   },
   showState() {
-    if (!this.model.isDone()) {
+    if (!this.model.isDone() || !this.canEdit) {
       const readOnlyStateView = new ReadOnlyFlowStateView({ model: this.model });
       this.showChildView('state', readOnlyStateView);
       return;

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -102,7 +102,6 @@
 
 .worklist-list__toggle {
   margin-left: auto;
-  margin-right: 16px;
   white-space: nowrap;
 }
 

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -218,13 +218,15 @@ const ListTitleView = View.extend({
   showOwnerDroplist() {
     if (!this.shouldShowDroplist) return;
 
+    const ownerI18n = i18n.titleOwnerDroplist;
+
     const ownerDroplistView = new TitleOwnerDroplist({
       owner: this.owner,
       hasClinicians: this.shouldShowClinician && this.canViewAssignedActions,
       hasTeams: this.shouldShowTeam,
       hasCurrentClinician: this.shouldShowClinician,
-      headingText: this.shouldShowClinician ? i18n.ownerFilterHeadingText : i18n.teamsFilterHeadingText,
-      placeholderText: this.shouldShowClinician ? i18n.ownerFilterPlaceholderText : i18n.teamsFilterPlaceholderText,
+      headingText: this.shouldShowClinician ? ownerI18n.ownerFilterHeadingText : ownerI18n.teamsFilterHeadingText,
+      placeholderText: this.shouldShowClinician ? ownerI18n.ownerFilterPlaceholderText : ownerI18n.teamsFilterPlaceholderText,
     });
 
     this.listenTo(ownerDroplistView, 'change:owner', owner => {

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -1,4 +1,4 @@
-import { every, rest, reduce } from 'underscore';
+import { every, rest, reduce, debounce } from 'underscore';
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
@@ -304,15 +304,22 @@ const ListView = CollectionView.extend({
   },
   childViewTriggers: {
     'render': 'listItem:render',
+    'change:canEdit': 'listItem:canEdit',
     'click:patientSidebarButton': 'click:patientSidebarButton',
     'select': 'select',
   },
   onListItemRender(view) {
     view.searchString = view.$el.text();
   },
+  onListItemCanEdit() {
+    // NOTE: debounced in initialize
+    this.triggerMethod('change:canEdit');
+  },
   initialize({ state }) {
     this.state = state;
     this.isFlowList = state.isFlowType();
+
+    this.onListItemCanEdit = debounce(this.onListItemCanEdit, 60);
 
     this.listenTo(state, 'change:searchQuery', this.searchList);
   },

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -1,4 +1,4 @@
-import { every, rest, reduce, debounce } from 'underscore';
+import { every, debounce } from 'underscore';
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
@@ -315,8 +315,9 @@ const ListView = CollectionView.extend({
     // NOTE: debounced in initialize
     this.triggerMethod('change:canEdit');
   },
-  initialize({ state }) {
+  initialize({ state, editableCollection }) {
     this.state = state;
+    this.editableCollection = editableCollection;
     this.isFlowList = state.isFlowType();
 
     this.onListItemCanEdit = debounce(this.onListItemCanEdit, 60);
@@ -350,12 +351,7 @@ const ListView = CollectionView.extend({
     const minIndex = Math.min(selectedIndex, lastSelectedIndex);
     const maxIndex = Math.max(selectedIndex, lastSelectedIndex);
 
-    const viewRange = rest(this.children.first(maxIndex + 1), minIndex);
-
-    const selectedIds = reduce(viewRange, (memo, view) => {
-      if (view.canEdit) memo.push(view.model.id);
-      return memo;
-    }, []);
+    const selectedIds = this.editableCollection.map('id').slice(minIndex, maxIndex + 1);
 
     this.state.selectMultiple(selectedIds, selectedIndex);
   },

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -1,4 +1,4 @@
-import { every } from 'underscore';
+import { every, rest, reduce } from 'underscore';
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
@@ -15,6 +15,7 @@ import PreloadRegion from 'js/regions/preload_region';
 
 import Droplist from 'js/components/droplist';
 import Tooltip from 'js/components/tooltip';
+import OwnerDroplist from 'js/views/patients/shared/components/owner_component';
 
 import { ActionTooltipTemplate, ActionEmptyView, ActionItemView } from './action_views';
 import { FlowTooltipTemplate, FlowEmptyView, FlowItemView } from './flow_views';
@@ -117,14 +118,12 @@ const TypeToggleView = View.extend({
 });
 
 const NoOwnerToggleView = View.extend({
+  className: 'u-margin--l-24 u-margin--r-16',
   template: hbs`
     <button class="button-filter-toggle {{#if noOwner}}button--blue{{/if}}">
       {{ @intl.patients.worklist.worklistViews.noOwnerToggleView.noOwner }}{{#if noOwner}}{{far "xmark"}}{{/if}}
     </button>
   `,
-  modelEvents: {
-    'change:noOwner': 'render',
-  },
   triggers: {
     click: 'click',
   },
@@ -138,8 +137,30 @@ const worklistIcons = {
   'done-last-thirty-days': ['3', '0'],
 };
 
+const TitleLabelView = View.extend({
+  className: 'u-text--nowrap',
+  getTemplate() {
+    if (this.getOption('owner')) {
+      return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId owner=owner}}`;
+    }
+    return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listLabels") title=worklistId}}`;
+  },
+  templateContext() {
+    return {
+      owner: this.getOption('owner'),
+      worklistId: underscored(this.getOption('worklistId')),
+    };
+  },
+});
+
+const TitleOwnerDroplist = OwnerDroplist.extend({
+  align: 'right',
+  isTitleFilter: true,
+});
+
 const ListTitleView = View.extend({
   regions: {
+    label: '[data-label-region]',
     owner: '[data-owner-filter-region]',
     ownerToggle: '[data-owner-toggle-region]',
   },
@@ -150,40 +171,80 @@ const ListTitleView = View.extend({
         {{far this}}
       {{/each}}
     </span>
-    {{#if showOwnerDroplist}}
-      <div class="u-text--nowrap">
-        {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listLabels") title=worklistId}}
-      </div>
-      <div data-owner-filter-region></div>
-    {{else}}
-      {{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId team=team owner=owner}}
-    {{/if}}
+    <div data-label-region></div>
+    <div data-owner-filter-region></div>
     <span class="list-page__header-icon js-title-info">{{far "circle-info"}}</span>
-    <div class="u-margin--l-24" data-owner-toggle-region></div>
+    <div data-owner-toggle-region></div>
   `,
   ui: {
     tooltip: '.js-title-info',
   },
   templateContext() {
-    const worklistId = this.getOption('worklistId');
-
     return {
-      team: this.getOption('team').get('name'),
-      owner: this.getOption('owner').get('name'),
-      worklistId: underscored(worklistId),
-      isFlowList: this.getOption('isFlowList'),
-      showOwnerDroplist: this.getOption('showOwnerDroplist'),
-      icons: worklistIcons[worklistId],
+      owner: this.owner.get('name'),
+      worklistId: underscored(this.model.id),
+      icons: worklistIcons[this.model.id],
     };
   },
+  initialize() {
+    const currentClinician = Radio.request('bootstrap', 'currentUser');
+    this.canViewAssignedActions = currentClinician.can('app:worklist:clinician_filter');
+    this.shouldShowTeam = this.model.id !== 'owned-by';
+    this.shouldShowClinician = this.model.id !== 'shared-by';
+    this.shouldShowDroplist = (this.shouldShowClinician && this.canViewAssignedActions) || this.shouldShowTeam;
+    this.owner = this.model.getOwner();
+  },
   onRender() {
-    const tooltipTemplate = this.getOption('isFlowList') ? FlowTooltipTemplate : ActionTooltipTemplate;
+    this.showLabel();
+    this.showOwnerDroplist();
+    this.showOwnerToggle();
+
+    const tooltipTemplate = this.model.isFlowType() ? FlowTooltipTemplate : ActionTooltipTemplate;
     new Tooltip({
       message: renderTemplate(tooltipTemplate, this.templateContext()),
       uiView: this,
       ui: this.ui.tooltip,
       orientation: 'vertical',
     });
+  },
+  showLabel() {
+    const titleLabelView = new TitleLabelView({
+      owner: this.shouldShowDroplist ? null : this.owner.get('name'),
+      worklistId: this.model.id,
+    });
+
+    this.showChildView('label', titleLabelView);
+  },
+  showOwnerDroplist() {
+    if (!this.shouldShowDroplist) return;
+
+    const ownerDroplistView = new TitleOwnerDroplist({
+      owner: this.owner,
+      hasClinicians: this.shouldShowClinician && this.canViewAssignedActions,
+      hasTeams: this.shouldShowTeam,
+      hasCurrentClinician: this.shouldShowClinician,
+      headingText: this.shouldShowClinician ? i18n.ownerFilterHeadingText : i18n.teamsFilterHeadingText,
+      placeholderText: this.shouldShowClinician ? i18n.ownerFilterPlaceholderText : i18n.teamsFilterPlaceholderText,
+    });
+
+    this.listenTo(ownerDroplistView, 'change:owner', owner => {
+      this.triggerMethod('change:owner', owner);
+    });
+
+    this.showChildView('owner', ownerDroplistView);
+  },
+  showOwnerToggle() {
+    if (this.shouldShowClinician || !this.canViewAssignedActions) return;
+
+    const ownerToggleView = new NoOwnerToggleView({
+      model: this.model,
+    });
+
+    this.listenTo(ownerToggleView, 'click', () => {
+      this.triggerMethod('toggle:noOwner');
+    });
+
+    this.showChildView('ownerToggle', ownerToggleView);
   },
 });
 
@@ -282,7 +343,12 @@ const ListView = CollectionView.extend({
     const minIndex = Math.min(selectedIndex, lastSelectedIndex);
     const maxIndex = Math.max(selectedIndex, lastSelectedIndex);
 
-    const selectedIds = this.children.map(view => view.model.id).slice(minIndex, maxIndex + 1);
+    const viewRange = rest(this.children.first(maxIndex + 1), minIndex);
+
+    const selectedIds = reduce(viewRange, (memo, view) => {
+      if (view.canEdit) memo.push(view.model.id);
+      return memo;
+    }, []);
 
     this.state.selectMultiple(selectedIds, selectedIndex);
   },

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -141,9 +141,9 @@ const TitleLabelView = View.extend({
   className: 'u-text--nowrap',
   getTemplate() {
     if (this.getOption('owner')) {
-      return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listTitles") title=worklistId owner=owner}}`;
+      return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleLabelView.listTitles") title=worklistId owner=owner}}`;
     }
-    return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleView.listLabels") title=worklistId}}`;
+    return hbs`{{formatMessage (intlGet "patients.worklist.worklistViews.listTitleLabelView.listLabels") title=worklistId}}`;
   },
   templateContext() {
     return {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1341,6 +1341,17 @@ context('worklist page', function() {
       .wait('@routeActions');
 
     cy
+      .get('[data-owner-filter-region]')
+      .should('contain', 'Nurse')
+      .find('button')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__heading')
+      .should('contain', 'Filter by Team');
+
+    cy
       .get('[data-owner-toggle-region]')
       .contains('No Owner')
       .should('not.have.class', 'button--blue')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -7,7 +7,7 @@ import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getResource } from 'helpers/json-api';
 
-const STATE_VERSION = 'v4';
+const STATE_VERSION = 'v5';
 
 context('worklist page', function() {
   specify('flow list', function() {
@@ -17,8 +17,8 @@ context('worklist page', function() {
       flowsSortId: 'sortUpdateDesc',
       clinicianId: '11111',
       filters: {},
-      selectedActions: {},
-      selectedFlows: {
+      actionsSelected: {},
+      flowsSelected: {
         '1': true,
       },
     }));
@@ -382,10 +382,10 @@ context('worklist page', function() {
       flowsSortId: 'sortUpdateDesc',
       clinicianId: '11111',
       filters: {},
-      selectedActions: {
+      actionsSelected: {
         '1': true,
       },
-      selectedFlows: {},
+      flowsSelected: {},
     }));
 
     const actions = [
@@ -1239,6 +1239,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-owner-filter-region]')
+      .find('button')
       .click();
 
     cy
@@ -1380,10 +1381,10 @@ context('worklist page', function() {
         selectedDate: filterDate,
         dateType: 'created_at',
       },
-      selectedActions: {
+      actionsSelected: {
         '1': true,
       },
-      selectedFlows: {},
+      flowsSelected: {},
       listType: 'flows',
     }));
 
@@ -2536,7 +2537,7 @@ context('worklist page', function() {
 
     cy
       .get('[data-owner-filter-region]')
-      .should('not.exist');
+      .should('be.empty');
   });
 
   specify('restricted employee -  shared by', function() {
@@ -2987,8 +2988,8 @@ context('worklist page', function() {
         selectedDate: testDate(),
         dateType: 'created_at',
       },
-      selectedActions: {},
-      selectedFlows: {},
+      actionsSelected: {},
+      flowsSelected: {},
       listType: 'actions',
     }));
 
@@ -3430,8 +3431,8 @@ context('worklist page', function() {
         selectedMonth: `${ currentYear }-01-01`,
         dateType: 'created_at',
       },
-      selectedActions: {},
-      selectedFlows: {},
+      actionsSelected: {},
+      flowsSelected: {},
       listType: 'flows',
     }));
 
@@ -3740,7 +3741,8 @@ context('worklist page', function() {
 
     cy
       .get('@listSearch')
-      .should('have.attr', 'value', 'Nurse');
+      .invoke('val')
+      .should('equal', 'Nurse');
 
     cy
       .get('[data-nav-content-region]')


### PR DESCRIPTION
Shortcut Story ID: [sc-35582]

This includes a pattern for dealing with actions/flows that can and can't be edited regarding how they're displayed and selected via multi-select.

The read-only row item is only a POC

This is only for the worklist.. and these patterns would be applied to schedule and patient dashboard/flow