### PR TITLE
Ensure form link with form sharing on action sidebar

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -26,6 +26,7 @@ export default App.extend({
     if (flow) this.listenTo(flow, 'change:_state', this.showAction);
     this.listenTo(action, 'change:_owner', this.showAction);
     this.showAction();
+    this.showForm();
 
     if (!this.action.isNew()) this.getRegion('activity').startPreloader();
 
@@ -48,8 +49,6 @@ export default App.extend({
   },
   onStart(options, activity, comments, attachments) {
     if (this.action.isNew()) return;
-
-    this.showForm();
 
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);
     this.attachments = attachments;
@@ -91,6 +90,8 @@ export default App.extend({
     });
   },
   showForm() {
+    if (!this.action.getForm() && !this.action.hasSharing()) return;
+
     const formView = this.showChildView('form', new FormLayoutView({
       model: this.action,
       isShowingForm: this.isShowingForm,

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -92,6 +92,9 @@ const _Model = BaseModel.extend({
   hasOutreach() {
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;
   },
+  hasSharing() {
+    return this.get('sharing') !== ACTION_SHARING.DISABLED;
+  },
   canEdit() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
 

--- a/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
@@ -97,27 +97,24 @@ const FormLayoutView = View.extend({
     'click:cancelShare': 'click:cancelShare',
     'click:undoCancelShare': 'click:undoCancelShare',
   },
-  isSharing() {
-    const sharing = this.model.get('sharing');
-
-    return sharing !== ACTION_SHARING.DISABLED;
-  },
-  className() {
-    return this.isSharing() ? 'flex u-margin--t-24' : 'flex u-margin--t-8';
-  },
-  getTemplate() {
-    if (this.isSharing() || !this.model.getForm()) {
-      return hbs`<div class="flex-grow" data-form-region></div>`;
-    }
-
-    return this.template;
-  },
   template: hbs`
-    <h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarFormsViews.formLayoutView.formLabel }}</h4>
-    <div class="flex-grow" data-form-region></div>
+    <div class="flex{{#if hasForm}} u-margin--t-8{{/if}}">
+      {{#if hasForm}}<h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarFormsViews.formLayoutView.formLabel }}</h4>{{/if}}
+      <div class="flex-grow" data-form-region></div>
+    </div>
+    <div class="flex{{#if hasSharing}} u-margin--t-24{{/if}}">
+      <div class="flex-grow" data-form-sharing-region></div>
+    </div>
   `,
+  templateContext() {
+    return {
+      hasSharing: this.model.hasSharing(),
+      hasForm: !!this.model.getForm(),
+    };
+  },
   regions: {
     form: '[data-form-region]',
+    formSharing: '[data-form-sharing-region]',
   },
   onChangeSharing() {
     this.showFormSharing();
@@ -131,7 +128,7 @@ const FormLayoutView = View.extend({
   },
   showForm() {
     const form = this.model.getForm();
-    if (!form || this.model.isNew()) return;
+    if (!form) return;
 
     const formView = new FormView({
       model: form,
@@ -145,7 +142,7 @@ const FormLayoutView = View.extend({
     this.showChildView('form', formView);
   },
   showFormSharing() {
-    if (!this.isSharing()) return;
+    if (!this.model.hasSharing()) return;
 
     const formSharingView = new FormSharingView({ model: this.model });
 
@@ -153,7 +150,7 @@ const FormLayoutView = View.extend({
       this.triggerMethod('click:form', this.model.getForm());
     });
 
-    this.showChildView('form', formSharingView);
+    this.showChildView('formSharing', formSharingView);
   },
 });
 

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -675,7 +675,7 @@ context('action sidebar', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-form-region]')
+      .find('[data-form-sharing-region]')
       .should('contain', 'Share Form');
 
     cy
@@ -1534,6 +1534,11 @@ context('action sidebar', function() {
         response: {},
       })
       .as('routePatchAction');
+
+    cy
+      .get('.sidebar')
+      .find('[data-form-region]')
+      .contains('Test Form');
 
     cy
       .get('.sidebar')


### PR DESCRIPTION
Shortcut Story ID: [sc-37939]

This adds the form component back when sharing is active and just adds an element for the regions when not in use.

In particular it separates the form and sharing as it was prior, but removes the need for neither at the app layer.