### PR TITLE
Fix coverage for when submitting the edit patient modal

### DIFF
--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -888,6 +888,33 @@ context('patient sidebar', function() {
       .get('.modal')
       .as('patientModal')
       .contains('Patient Account');
+
+    cy
+      .get('@patientModal')
+      .find('.js-input')
+      .first()
+      .clear()
+      .type('New Test');
+
+    cy
+      .route({
+        status: 200,
+        method: 'PATCH',
+        url: '/api/patients/1',
+        response: {
+          data: {
+            type: 'patients',
+            id: '1',
+          },
+        },
+      })
+      .as('routePatchPatient');
+
+    cy
+      .get('@patientModal')
+      .find('.js-submit')
+      .click()
+      .wait('@routePatchPatient');
   });
 
   specify('view patient modal', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-37583]

Now that creating a new patient uses a `PUT` request, we need to test the `PATCH` endpoint when the edit patient modal is submitted.

The coverage drop we're trying to fix for this PR is this [line of code](https://github.com/RoundingWell/care-ops-frontend/blob/develop/src/js/entities-service/entities/patients.js#LL56C4-L56C41).