### PR TITLE
Fix datadog console error when a response status is empty (i.e. cancelled API request)

### DIFF
--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -53,7 +53,7 @@ function initRum({ isForm }) {
     beforeSend(event, context) {
       // Add header/response context to api errors
       if (event.type === 'resource' && event.resource.type === 'fetch') {
-        if (context.response.status >= 400) {
+        if (context.response.status && context.response.status >= 400) {
           extend(event.context, { context });
         }
       }


### PR DESCRIPTION
Shortcut Story ID: [sc-37555]

This was discovered on QA when an API request is cancelled when typing a query into the patient search modal.