### PR TITLE
Replace `cy.route()` with `cy.intercept()` in cypress integration files

### DIFF
--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -48,11 +48,9 @@ context('clinicians modal', function() {
       .click();
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/clinicians',
-        response: {
+      .intercept('POST', '/api/clinicians', {
+        statusCode: 201,
+        body: {
           data: {
             enabled: true,
             last_active_at: '2021-10-18T04:25:22.961Z',
@@ -168,12 +166,10 @@ context('clinicians modal', function() {
     const errors = _.map({ name: 'name error', email: 'email error' }, getError);
 
     cy
-      .route({
-        status: 400,
+      .intercept('POST', '/api/clinicians', {
+        statusCode: 400,
         delay: 100,
-        method: 'POST',
-        url: '/api/clinicians',
-        response: { errors },
+        body: { errors },
       })
       .as('routePostClinicianError');
 

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -55,29 +55,23 @@ context('clinician sidebar', function() {
       .should('be.empty');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/clinicians/1',
-        response: {},
+      .intercept('PATCH', '/api/clinicians/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchClinician');
 
     cy
-      .route({
-        status: 204,
-        method: 'POST',
-        url: '/api/workspaces/11111/relationships/clinicians',
-        response: {},
+      .intercept('POST', '/api/workspaces/11111/relationships/clinicians', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeAddWorkspaceClinician');
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/workspaces/11111/relationships/clinicians',
-        response: {},
+      .intercept('DELETE', '/api/workspaces/11111/relationships/clinicians', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteWorkspaceClinician');
 
@@ -365,11 +359,9 @@ context('clinician sidebar', function() {
       .type('Edited Clinician Name');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/clinicians/1',
-        response: {},
+      .intercept('PATCH', '/api/clinicians/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchClinician');
 
@@ -399,12 +391,10 @@ context('clinician sidebar', function() {
     const errors = _.map({ name: 'name error', email: 'email error' }, getError);
 
     cy
-      .route({
-        status: 400,
+      .intercept('PATCH', '/api/clinicians/1', {
+        statusCode: 400,
         delay: 100,
-        method: 'PATCH',
-        url: '/api/clinicians/1',
-        response: { errors },
+        body: { errors },
       })
       .as('routePatchClinicianError');
 

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -75,11 +75,9 @@ context('clinicians list', function() {
       .contains('Never');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/clinicians/*',
-        response: {},
+      .intercept('PATCH', '/api/clinicians/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchClinician');
 

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -36,10 +36,9 @@ context('dashboard', function() {
   specify('dashboard does not exist', function() {
     cy
       .routeDashboards()
-      .route({
-        url: '/api/dashboards/1',
-        status: 404,
-        response: {
+      .intercept('GET', '/api/dashboards/1', {
+        statusCode: 404,
+        body: {
           errors: [{
             id: '1',
             status: '404',

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -13,10 +13,9 @@ context('Patient Action Form', function() {
 
   specify('deleted action', function() {
     cy
-      .route({
-        url: '/api/actions/1*',
-        status: 404,
-        response: {
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 404,
+        body: {
           errors: [{
             id: '1',
             status: '404',
@@ -766,12 +765,10 @@ context('Patient Action Form', function() {
       .type('New typing');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
         delay: 100,
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
+        body: { data: { id: '12345' } },
       })
       .as('routePostResponse');
 
@@ -890,11 +887,9 @@ context('Patient Action Form', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('DELETE', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteAction');
 
@@ -1310,12 +1305,10 @@ context('Patient Action Form', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
         delay: 100,
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
+        body: { data: { id: '12345' } },
       })
       .as('routePostResponse');
 
@@ -1454,12 +1447,10 @@ context('Patient Action Form', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 403,
         delay: 100,
-        url: '/api/form-responses',
-        response: {
+        body: {
           errors: [
             {
               id: '1',
@@ -1531,12 +1522,10 @@ context('Patient Action Form', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 403,
         delay: 100,
-        url: '/api/form-responses',
-        response: {
+        body: {
           errors: [
             {
               id: '1',

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -8,17 +8,13 @@ context('Noncontext Form', function() {
 
   specify('directory', function() {
     cy
-      .route({
-        method: 'GET',
-        url: '/api/directory/foo*',
-        response: { data: { attributes: { value: ['one', 'two'] } } },
+      .intercept('GET', '/api/directory/foo*', {
+        body: { data: { attributes: { value: ['one', 'two'] } } },
       })
       .as('routeDirectoryFoo')
-      .route({
-        method: 'GET',
-        status: 400,
-        url: '/api/directory/bar*',
-        response: { data: { attributes: { value: ['bar', 'baz'] } } },
+      .intercept('GET', '/api/directory/bar*', {
+        statusCode: 400,
+        body: { data: { attributes: { value: ['bar', 'baz'] } } },
       })
       .as('routeDirectoryBar')
       .routeAction(fx => {
@@ -141,24 +137,18 @@ context('Noncontext Form', function() {
         fx.data.attributes.value = [1, 2];
         return fx;
       }, 'foo')
-      .route({
-        method: 'GET',
-        url: `/api/patients/${ patientId }/fields/bar`,
-        status: 400,
-        response: { data: 'Error' },
+      .intercept('GET', `/api/patients/${ patientId }/fields/bar`, {
+        statusCode: 400,
+        body: { data: 'Error' },
       })
       .as('routePatientFieldbar')
-      .route({
-        method: 'PATCH',
-        url: `/api/patients/${ patientId }/fields/foo`,
-        response: { data: { attributes: { name: 'foo', value: ['one', 'two'] } } },
+      .intercept('PATCH', `/api/patients/${ patientId }/fields/foo`, {
+        body: { data: { attributes: { name: 'foo', value: ['one', 'two'] } } },
       })
       .as('routePatchPatientFieldFoo')
-      .route({
-        method: 'PATCH',
-        url: `/api/patients/${ patientId }/fields/bar`,
-        status: 400,
-        response: { data: 'Error' },
+      .intercept('PATCH', `/api/patients/${ patientId }/fields/bar`, {
+        statusCode: 400,
+        body: { data: 'Error' },
       })
       .as('routePatchPatientFieldBar')
       .routeFormDefinition(fx => {
@@ -341,10 +331,8 @@ context('Noncontext Form', function() {
 
   specify('form scripts and reducers', { retries: 4 }, function() {
     cy
-      .route({
-        method: 'GET',
-        url: '/appconfig.json',
-        response: { versions: { frontend: 'foo' } },
+      .intercept('GET', '/appconfig.json', {
+        body: { versions: { frontend: 'foo' } },
       })
       .routePatient(fx => {
         fx.data.id = '1';

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -85,12 +85,10 @@ context('Patient Form', function() {
       .should('have.value', 'Once upon a time...');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
         delay: 100,
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
+        body: { data: { id: '12345' } },
       })
       .as('routePostResponse');
 
@@ -484,12 +482,10 @@ context('Patient Form', function() {
       .type('Here is some typing');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
         delay: 100,
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
+        body: { data: { id: '12345' } },
       })
       .as('routePostResponse');
 
@@ -600,12 +596,10 @@ context('Patient Form', function() {
       .wait('@routePatient');
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 403,
         delay: 100,
-        url: '/api/form-responses',
-        response: {
+        body: {
           errors: [
             {
               id: '1',
@@ -675,12 +669,10 @@ context('Patient Form', function() {
       .wait('@routePatient');
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 403,
         delay: 100,
-        url: '/api/form-responses',
-        response: {
+        body: {
           errors: [
             {
               id: '1',

--- a/test/integration/forms/preview.js
+++ b/test/integration/forms/preview.js
@@ -2,16 +2,14 @@ import _ from 'underscore';
 
 import { testDate } from 'helpers/test-date';
 
+import fxTestFormKitchenSink from 'fixtures/test/form-kitchen-sink';
+
 context('Preview Form', function() {
   specify('routing to form', function() {
     cy
-      .fixture('test/form-kitchen-sink.json').as('fxTestFormKitchenSink')
       .routeForm(_.identity, '11111')
-      .route({
-        url: '/api/forms/*/definition',
-        response() {
-          return this.fxTestFormKitchenSink;
-        },
+      .intercept('GET', '/api/forms/*/definition', {
+        body: fxTestFormKitchenSink,
       })
       .as('routeFormKitchenSink')
       .visit('/form/11111/preview')

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -61,38 +61,30 @@ context('Formservice', function() {
 
   specify('formservice iframe makes correct api requests', function() {
     cy
-      .route({
-        status: 200,
-        method: 'GET',
-        url: '/api/forms/1',
-        response: {},
+      .intercept('GET', '/api/forms/1', {
+        statusCode: 200,
+        body: {},
       })
       .as('routeFormModel');
 
     cy
-      .route({
-        status: 200,
-        method: 'GET',
-        url: '/api/forms/1/definition',
-        response: {},
+      .intercept('GET', '/api/forms/1/definition', {
+        statusCode: 200,
+        body: {},
       })
       .as('routeFormDefinition');
 
     cy
-      .route({
-        status: 200,
-        method: 'GET',
-        url: '/api/forms/1/fields?filter[patient]=1',
-        response: { data: {} },
+      .intercept('GET', '/api/forms/1/fields?filter[patient]=1', {
+        statusCode: 200,
+        body: { data: {} },
       })
       .as('routeFormPatientFields');
 
     cy
-      .route({
-        status: 200,
-        method: 'GET',
-        url: '/api/form-responses/1/response',
-        response: {},
+      .intercept('GET', '/api/form-responses/1/response', {
+        statusCode: 200,
+        body: {},
       })
       .as('routeFormResponse');
 

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -687,11 +687,9 @@ context('App Nav', function() {
       .click();
 
     cy
-      .route({
-        status: 201,
-        method: 'PUT',
-        url: '/api/patients',
-        response: {
+      .intercept('PUT', '/api/patients', {
+        statusCode: 201,
+        body: {
           data: {
             id: '1',
             first_name: 'First',
@@ -888,16 +886,16 @@ context('App Nav', function() {
       .should('not.have.class', 'has-error');
 
     cy
-      .route({
-        status: 400,
-        method: 'PUT',
-        url: '/api/patients',
-        response: {
-          errors: [{
-            status: '400',
-            title: 'Bad Request',
-            detail: 'Similar patient exists',
-          }],
+      .intercept('PUT', '/api/patients', {
+        statusCode: 400,
+        body: {
+          errors: [
+            {
+              status: '400',
+              title: 'Bad Request',
+              detail: 'Similar patient exists',
+            },
+          ],
         },
       })
       .as('routeSimilarPatientError');

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -92,10 +92,9 @@ context('patient page', function() {
 
   specify('current clinician has been disabled', function() {
     cy
-      .route({
-        url: '/api/clinicians/me',
-        status: 401,
-        response: {},
+      .intercept('GET', '/api/clinicians/me', {
+        statusCode: 401,
+        body: {},
       })
       .as('routeClinicianDisabled')
       .visit('/', { noWait: true })

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -58,10 +58,9 @@ context('Global Error Page', function() {
 
   specify('500 error', function() {
     cy
-      .route({
-        url: '/api/clinicians/me',
-        status: 500,
-        response: {},
+      .intercept('GET', '/api/clinicians/me', {
+        statusCode: 500,
+        body: {},
       })
       .as('routeCurrentClinician')
       .visit('/', { noWait: true });

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -8,11 +8,9 @@ context('Outreach', function() {
       .visit('/outreach/opt-in', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        method: 'POST',
-        url: '/api/outreach/opt-in',
+      .intercept('POST', '/api/outreach/opt-in', {
         delay: 100,
-        response: {
+        body: {
           data: {
             first_name: 'Test',
             last_name: 'Patient',
@@ -90,13 +88,9 @@ context('Outreach', function() {
       .visit('/outreach/opt-in', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
-        url: '/api/outreach/opt-in',
-        response: {
-          data: {},
-        },
+      .intercept('POST', '/api/outreach/opt-in', {
+        statusCode: 403,
+        body: { data: {} },
       })
       .as('routeOptInRequest')
       .visit('/outreach/opt-in', { noWait: true, isRoot: true });
@@ -142,10 +136,8 @@ context('Outreach', function() {
 
   specify('Form', function() {
     cy
-      .route({
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        body: {
           data: {
             id: '1',
             type: 'patient-tokens',
@@ -156,9 +148,8 @@ context('Outreach', function() {
         },
       })
       .as('routePatientToken')
-      .route({
-        url: '/api/actions/1/form',
-        response: {
+      .intercept('GET', '/api/actions/1/form', {
+        body: {
           data: {
             id: '1',
             type: 'forms',
@@ -192,12 +183,10 @@ context('Outreach', function() {
       .contains('Form Name');
 
     cy
-      .route({
-        url: '/api/actions/1/relationships/form-responses',
-        method: 'POST',
-        status: 400,
+      .intercept('POST', '/api/actions/1/relationships/form-responses', {
+        statusCode: 400,
         delay: 100,
-        response: {
+        body: {
           errors: [
             {
               id: '1',
@@ -238,11 +227,9 @@ context('Outreach', function() {
       .contains('This is a form error');
 
     cy
-      .route({
-        url: '/api/actions/1/relationships/form-responses',
-        method: 'POST',
+      .intercept('POST', '/api/actions/1/relationships/form-responses', {
         delay: 100,
-        response: { data: {} },
+        body: { data: {} },
       })
       .as('postFormResponse');
 
@@ -259,10 +246,8 @@ context('Outreach', function() {
 
   specify('Read-only Form', function() {
     cy
-      .route({
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        body: {
           data: {
             id: '1',
             type: 'patient-tokens',
@@ -272,9 +257,8 @@ context('Outreach', function() {
           },
         },
       })
-      .route({
-        url: '/api/actions/1/form',
-        response: {
+      .intercept('GET', '/api/actions/1/form', {
+        body: {
           data: {
             id: '1',
             type: 'forms',
@@ -329,11 +313,9 @@ context('Outreach', function() {
       .visit('/outreach/1', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 400,
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        statusCode: 400,
+        body: {
           errors: [
             {
               id: '1',
@@ -377,10 +359,8 @@ context('Outreach', function() {
       .should('not.exist');
 
     cy
-      .route({
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        body: {
           data: {
             id: '1',
             type: 'patient-tokens',
@@ -393,10 +373,9 @@ context('Outreach', function() {
       .as('postFormToken');
 
     cy
-      .route({
-        status: 500,
-        url: '/api/actions/1/form',
-        response: {
+      .intercept('GET', '/api/actions/1/form', {
+        statusCode: 500,
+        body: {
           errors: [
             {
               id: '1',
@@ -426,11 +405,9 @@ context('Outreach', function() {
       .visit('/outreach/1', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 500,
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        statusCode: 500,
+        body: {
           errors: [
             {
               id: '1',
@@ -469,11 +446,9 @@ context('Outreach', function() {
       .visit('/outreach/1', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 409,
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        statusCode: 409,
+        body: {
           errors: [
             {
               id: '1',
@@ -512,11 +487,9 @@ context('Outreach', function() {
       .visit('/outreach/1', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -555,11 +528,9 @@ context('Outreach', function() {
       .visit('/outreach/1', { noWait: true, isRoot: true });
 
     cy
-      .route({
-        status: 404,
-        method: 'POST',
-        url: '/api/patient-tokens',
-        response: {
+      .intercept('POST', '/api/patient-tokens', {
+        statusCode: 404,
+        body: {
           errors: [
             {
               id: '1',

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -106,20 +106,16 @@ context('patient archive page', function() {
       .should('have.lengthOf', 4);
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/2',
-        response: {},
+      .intercept('PATCH', '/api/flows/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -6,22 +6,18 @@ import { testDate, testDateSubtract } from 'helpers/test-date';
 
 function createActionPostRoute(id) {
   cy
-    .route({
-      status: 201,
-      method: 'POST',
-      url: '/api/patients/1/relationships/actions*',
-      response() {
-        return {
-          data: {
-            id,
-            attributes: {
-              updated_at: testTs(),
-              outreach: 'disabled',
-              sharing: 'disabled',
-              due_time: null,
-            },
+    .intercept('POST', '/api/patients/1/relationships/actions*', {
+      statusCode: 201,
+      body: {
+        data: {
+          id,
+          attributes: {
+            updated_at: testTs(),
+            outreach: 'disabled',
+            sharing: 'disabled',
+            due_time: null,
           },
-        };
+        },
       },
     })
     .as('routePostAction');
@@ -128,20 +124,16 @@ context('patient dashboard page', function() {
       .should('have.lengthOf', 4);
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/2',
-        response: {},
+      .intercept('PATCH', '/api/flows/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -653,11 +645,10 @@ context('patient dashboard page', function() {
       });
 
     cy
-      .route({
-        method: 'GET',
-        url: '/api/actions/test-1*',
-        response: {},
-      }).as('routeTestAction1');
+      .intercept('GET', '/api/actions/test-1*', {
+        body: {},
+      })
+      .as('routeTestAction1');
 
     cy
       .get('.picklist')
@@ -709,11 +700,10 @@ context('patient dashboard page', function() {
       });
 
     cy
-      .route({
-        method: 'GET',
-        url: '/api/actions/test-2*',
-        response: {},
-      }).as('routeTestAction2');
+      .intercept('GET', '/api/actions/test-2*', {
+        body: {},
+      })
+      .as('routeTestAction2');
 
     cy
       .get('.picklist')
@@ -765,11 +755,10 @@ context('patient dashboard page', function() {
       });
 
     cy
-      .route({
-        method: 'GET',
-        url: '/api/actions/test-3*',
-        response: {},
-      }).as('routeTestAction3');
+      .intercept('GET', '/api/actions/test-3*', {
+        body: {},
+      })
+      .as('routeTestAction3');
 
     cy
       .get('.picklist')
@@ -800,17 +789,13 @@ context('patient dashboard page', function() {
       .should('contain', 'Two of Two');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/patients/1/relationships/flows*',
-        response() {
-          return {
-            data: {
-              id: '1',
-              attributes: { updated_at: testTs() },
-            },
-          };
+      .intercept('POST', '/api/patients/1/relationships/flows*', {
+        statusCode: 201,
+        body: {
+          data: {
+            id: '1',
+            attributes: { updated_at: testTs() },
+          },
         },
       })
       .as('routePostFlow');

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -195,11 +195,9 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/2',
-        response: {},
+      .intercept('PATCH', '/api/actions/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction')
       .routeActionActivity()
@@ -340,11 +338,9 @@ context('patient flow page', function() {
       .should('contain', '11:15 AM');
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/actions/2',
-        response: {
+      .intercept('DELETE', '/api/actions/2', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -375,11 +371,9 @@ context('patient flow page', function() {
 
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/2',
-        response: {},
+      .intercept('DELETE', '/api/actions/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteFlowAction');
 
@@ -472,20 +466,16 @@ context('patient flow page', function() {
       .wait('@routeFlowActions');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/flows/**/relationships/actions',
-        response() {
-          return {
-            data: {
-              id: 'test-1',
-              attributes: {
-                updated_at: testTs(),
-                due_time: null,
-              },
+      .intercept('POST', '/api/flows/**/relationships/actions', {
+        statusCode: 201,
+        body: {
+          data: {
+            id: 'test-1',
+            attributes: {
+              updated_at: testTs(),
+              due_time: null,
             },
-          };
+          },
         },
       })
       .as('routePostAction');
@@ -544,9 +534,8 @@ context('patient flow page', function() {
     cy
       .routePatientByFlow()
       .routeFlowActions()
-      .route({
-        status: 404,
-        url: '/api/flows/1**',
+      .intercept('GET', '/api/flows/1**', {
+        statusCode: 404,
       })
       .visit('/flow/1');
 
@@ -651,11 +640,9 @@ context('patient flow page', function() {
         return fx;
       })
       .routeActionActivity()
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow')
       .visit('/flow/1')
@@ -861,18 +848,14 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction')
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('DELETE', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteAction')
       .routeAction(fx => {
@@ -1072,18 +1055,14 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/*',
-        response: {},
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
       })
       .routeActionActivity()
       .routePatientField()
@@ -1283,25 +1262,19 @@ context('patient flow page', function() {
       .should('contain', 'Multiple Durations...');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction1')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/2',
-        response: {},
+      .intercept('PATCH', '/api/actions/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction2')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/3',
-        response: {},
+      .intercept('PATCH', '/api/actions/3', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction3');
 
@@ -1463,11 +1436,9 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('DELETE', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       });
 
     cy
@@ -1523,11 +1494,9 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .route({
-        status: 404,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 404,
+        body: {},
       })
       .as('failedPatchAction');
 
@@ -1726,12 +1695,11 @@ context('patient flow page', function() {
       .wait('@routeFlowActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
-      }).as('patchAction');
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchAction');
 
     cy
       .get('.app-frame__content')

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -694,12 +694,10 @@ context('patient sidebar', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .route({
-        status: 403,
-        method: 'POST',
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 403,
         delay: 300,
-        url: '/api/form-responses',
-        response: {
+        body: {
           errors: [
             {
               id: '1',
@@ -742,11 +740,9 @@ context('patient sidebar', function() {
       .wait('@postFormResponse');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/form-responses',
-        response: { data: { id: '12345' } },
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
+        body: { data: { id: '12345' } },
       })
       .as('postFormResponse');
 
@@ -897,11 +893,9 @@ context('patient sidebar', function() {
       .type('New Test');
 
     cy
-      .route({
-        status: 200,
-        method: 'PATCH',
-        url: '/api/patients/1',
-        response: {
+      .intercept('PATCH', '/api/patients/1', {
+        statusCode: 200,
+        body: {
           data: {
             type: 'patients',
             id: '1',

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -137,11 +137,9 @@ context('action sidebar', function() {
       .type('Test{enter} Name');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/patients/1/relationships/actions*',
-        response: {
+      .intercept('POST', '/api/patients/1/relationships/actions*', {
+        statusCode: 201,
+        body: {
           data: {
             id: '1',
             attributes: {
@@ -202,11 +200,9 @@ context('action sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/actions/1*',
-        response: {
+      .intercept('DELETE', '/api/actions/1*', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -242,11 +238,9 @@ context('action sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/1*',
-        response: {},
+      .intercept('DELETE', '/api/actions/1*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteAction');
 
@@ -400,11 +394,9 @@ context('action sidebar', function() {
       .clear();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -846,11 +838,9 @@ context('action sidebar', function() {
       .contains('HRA v2.pdf');
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/files/*',
-        response: {},
+      .intercept('DELETE', '/api/files/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteFile');
 
@@ -1242,11 +1232,9 @@ context('action sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/comments/*',
-        response: {},
+      .intercept('PATCH', '/api/comments/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchComment');
 
@@ -1274,11 +1262,9 @@ context('action sidebar', function() {
       .find('.comment__edited');
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/comments/*',
-        response: {},
+      .intercept('DELETE', '/api/comments/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteComment');
 
@@ -1345,11 +1331,9 @@ context('action sidebar', function() {
       .type('more comment');
 
     cy
-      .route({
-        status: 204,
-        method: 'POST',
-        url: '/api/actions/*/relationships/comments',
-        response: {},
+      .intercept('POST', '/api/actions/*/relationships/comments', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePostComment');
 
@@ -1474,10 +1458,9 @@ context('action sidebar', function() {
   specify('deleted action', function() {
     cy
       .routesForPatientDashboard()
-      .route({
-        url: '/api/actions/1*',
-        status: 404,
-        response: {
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 404,
+        body: {
           errors: [{
             id: '1',
             status: '404',
@@ -1527,11 +1510,9 @@ context('action sidebar', function() {
       .wait('@routeAction');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/12345',
-        response: {},
+      .intercept('PATCH', '/api/actions/12345', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -1589,11 +1570,9 @@ context('action sidebar', function() {
       .wait('@routeAction');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/12345',
-        response: {},
+      .intercept('PATCH', '/api/actions/12345', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -1678,11 +1657,9 @@ context('action sidebar', function() {
       .wait('@routeAction');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -1777,20 +1754,16 @@ context('action sidebar', function() {
       .wait('@routeFlow');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -92,11 +92,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -303,11 +301,9 @@ context('flow sidebar', function() {
       .should('not.have.class', 'is-selected');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -363,11 +359,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/flows/1',
-        response: {
+      .intercept('DELETE', '/api/flows/1', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -404,11 +398,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('DELETE', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteFlow');
 
@@ -583,11 +575,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -314,12 +314,11 @@ context('Worklist bulk editing', function() {
       .should('contain', 'Edit 3 Flows');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/*',
-        response: {},
-      }).as('patchFlow');
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlow');
 
     cy
       .get('@bulkEditSidebar')
@@ -407,48 +406,36 @@ context('Worklist bulk editing', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchFlow1')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/2',
-        response: {},
+      .intercept('PATCH', '/api/flows/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchFlow2')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/3',
-        response: {},
+      .intercept('PATCH', '/api/flows/3', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchFlow3');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1/relationships/actions',
-        response: {},
+      .intercept('PATCH', '/api/flows/1/relationships/actions', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchOwner1')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/2/relationships/actions',
-        response: {},
+      .intercept('PATCH', '/api/flows/2/relationships/actions', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchOwner2')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/3/relationships/actions',
-        response: {},
+      .intercept('PATCH', '/api/flows/3/relationships/actions', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchOwner3');
 
@@ -555,23 +542,17 @@ context('Worklist bulk editing', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('DELETE', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/flows/2',
-        response: {},
+      .intercept('DELETE', '/api/flows/2', {
+        statusCode: 204,
+        body: {},
       })
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/flows/3',
-        response: {},
+      .intercept('DELETE', '/api/flows/3', {
+        statusCode: 204,
+        body: {},
       });
 
     cy
@@ -704,11 +685,9 @@ context('Worklist bulk editing', function() {
       .wait('@routeActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction');
 
@@ -781,32 +760,24 @@ context('Worklist bulk editing', function() {
       .should('contain', 'Multiple Durations...');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction1')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/2',
-        response: {},
+      .intercept('PATCH', '/api/actions/2', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction2')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/3',
-        response: {},
+      .intercept('PATCH', '/api/actions/3', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction3')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/4',
-        response: {},
+      .intercept('PATCH', '/api/actions/4', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction4');
 
@@ -984,11 +955,9 @@ context('Worklist bulk editing', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('DELETE', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       });
 
     cy
@@ -1042,11 +1011,9 @@ context('Worklist bulk editing', function() {
       .click();
 
     cy
-      .route({
-        status: 404,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 404,
+        body: {},
       })
       .as('failedPatchAction');
 
@@ -1290,12 +1257,11 @@ context('Worklist bulk editing', function() {
       .wait('@routeActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/*',
-        response: {},
-      }).as('patchFlow');
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlow');
 
     cy
       .get('.worklist-list__toggle')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1211,11 +1211,9 @@ context('schedule page', function() {
       .should('contain', 'Edit 20 Actions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('patchAction');
 
@@ -1303,11 +1301,9 @@ context('schedule page', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('DELETE', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
       });
 
     cy
@@ -1340,11 +1336,9 @@ context('schedule page', function() {
       .should('have.length', 15);
 
     cy
-      .route({
-        status: 401,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 401,
+        body: {},
       })
       .as('patchActionFail');
 
@@ -1980,12 +1974,11 @@ context('schedule page', function() {
       .visit('/schedule');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/*',
-        response: {},
-      }).as('patchAction');
+      .intercept('PATCH', '/api/actions/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchAction');
 
     cy
       .get('.schedule-list__table')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -211,11 +211,9 @@ context('worklist page', function() {
       .should('contain', 'State, Owner');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/1',
-        response: {},
+      .intercept('PATCH', '/api/flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -342,11 +340,9 @@ context('worklist page', function() {
       .should('contain', 'filter[state]=55555,66666,77777');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/*',
-        response: {},
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -658,11 +654,9 @@ context('worklist page', function() {
       .wait('@routeActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/actions/1',
-        response: {},
+      .intercept('PATCH', '/api/actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -4417,12 +4411,11 @@ context('worklist page', function() {
       .wait('@routeActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/flows/*',
-        response: {},
-      }).as('patchFlow');
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlow');
 
     cy
       .get('.worklist-list__toggle')

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -77,11 +77,9 @@ context('program flow page', function() {
         return fx;
       })
       .routeProgram()
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/programs/1',
-        response: {},
+      .intercept('PATCH', '/api/programs/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchProgram')
       .visit('/program-flow/1')
@@ -157,32 +155,24 @@ context('program flow page', function() {
         return fx;
       })
       .routeProgramByProgramFlow()
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-flows/1',
-        response: {},
+      .intercept('PATCH', '/api/program-flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow')
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-actions/*',
-        response: {},
+      .intercept('PATCH', '/api/program-actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction')
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/program-actions/*',
-        response: {},
+      .intercept('DELETE', '/api/program-actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteAction')
-      .route({
-        status: 204,
-        method: 'GET',
-        url: '/api/program-actions/*',
-        response: {},
+      .intercept('GET', '/api/program-actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeProgramAction')
       .visit('/program-flow/1')
@@ -392,10 +382,9 @@ context('program flow page', function() {
     cy
       .routeProgramByProgramFlow()
       .routeProgramFlowActions()
-      .route({
-        url: '/api/program-flows/1',
-        status: 404,
-        response: {
+      .intercept('GET', '/api/program-flows/1', {
+        statusCode: 404,
+        body: {
           errors: [{
             id: '1',
             status: '404',
@@ -467,11 +456,9 @@ context('program flow page', function() {
       })
       .routePrograms()
       .routeProgramByProgramFlow()
-      .route({
-        status: 204,
-        method: 'GET',
-        url: '/api/program-actions/*',
-        response: {},
+      .intercept('GET', '/api/program-actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeProgramAction')
       .visit('/program-flow/1')
@@ -480,14 +467,11 @@ context('program flow page', function() {
       .wait('@routeProgramByProgramFlow');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: 'api/program-flows/1/actions',
-        response: {},
+      .intercept('PATCH', 'api/program-flows/1/actions', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeUpdateActionSequences');
-
 
     cy
       .get('.program-flow__list')
@@ -527,20 +511,16 @@ context('program flow page', function() {
       });
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-actions/1',
-        response: {},
+      .intercept('PATCH', '/api/program-actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/program-actions',
-        response: {
+      .intercept('POST', '/api/program-actions', {
+        statusCode: 201,
+        body: {
           data: {
             id: '98765',
             attributes: {
@@ -557,20 +537,16 @@ context('program flow page', function() {
       .as('routePostAction');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/program-flows/1/actions',
-        response: {},
+      .intercept('POST', '/api/program-flows/1/actions', {
+        statusCode: 201,
+        body: {},
       })
       .as('routePostFlowAction');
 
     cy
-      .route({
-        status: 201,
-        method: 'PATCH',
-        url: '/api/program-flows/1/actions',
-        response: {},
+      .intercept('PATCH', '/api/program-flows/1/actions', {
+        statusCode: 201,
+        body: {},
       });
 
     cy
@@ -770,11 +746,9 @@ context('program flow page', function() {
       .go('back');
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/program-actions/*',
-        response: {
+      .intercept('DELETE', '/api/program-actions/*', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -810,11 +784,9 @@ context('program flow page', function() {
       .should('contain', 'Insufficient permissions to delete action');
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/program-actions/*',
-        response: {},
+      .intercept('DELETE', '/api/program-actions/*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteFlowAction');
 

--- a/test/integration/programs/program/program.js
+++ b/test/integration/programs/program/program.js
@@ -58,11 +58,9 @@ context('program page', function() {
       .visit('/program/1');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/programs/1',
-        response: {},
+      .intercept('PATCH', '/api/programs/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchProgram');
 

--- a/test/integration/programs/program/workflows.js
+++ b/test/integration/programs/program/workflows.js
@@ -68,11 +68,9 @@ context('program workflows page', function() {
       .wait('@routeProgramFlows');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-actions/1',
-        response: {},
+      .intercept('PATCH', '/api/program-actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -240,11 +238,9 @@ context('program workflows page', function() {
       .as('flowItem');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-flows/1',
-        response: {},
+      .intercept('PATCH', '/api/program-flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -420,18 +416,16 @@ context('program workflows page', function() {
       .type('Test Flow');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/programs/1/relationships/flows',
-        response() {
-          return {
+      .intercept('POST', '/api/programs/1/relationships/flows', {
+        statusCode: 201,
+        body: {
+          data: {
             id: '1',
             attributes: {
               updated_at: testTs(),
               name: 'Test Flow',
             },
-          };
+          },
         },
       })
       .as('routePostFlow');

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -127,11 +127,9 @@ context('program action sidebar', function() {
       .type('Test{enter} Name');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/program-actions',
-        response: {
+      .intercept('POST', '/api/program-actions', {
+        statusCode: 201,
+        body: {
           data: {
             id: '1',
             attributes: {
@@ -197,11 +195,9 @@ context('program action sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/program-actions/1*',
-        response: {
+      .intercept('DELETE', '/api/program-actions/1*', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -232,11 +228,9 @@ context('program action sidebar', function() {
       .contains('Test Name');
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/program-actions/1*',
-        response: {},
+      .intercept('DELETE', '/api/program-actions/1*', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteActionSucceed');
 
@@ -395,11 +389,9 @@ context('program action sidebar', function() {
       .clear();
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-actions/1',
-        response: {},
+      .intercept('PATCH', '/api/program-actions/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchAction');
 
@@ -760,10 +752,9 @@ context('program action sidebar', function() {
       .routeProgram()
       .routeProgramActions(_.identity, '1')
       .routeProgramFlows(() => [])
-      .route({
-        url: '/api/program-actions/1',
-        status: 404,
-        response: {
+      .intercept('GET', '/api/program-actions/1', {
+        statusCode: 404,
+        body: {
           errors: [{
             id: '1',
             status: '404',

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -107,11 +107,9 @@ context('flow sidebar', function() {
       .type('Test{enter} Details');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/programs/1/relationships/flows*',
-        response: {
+      .intercept('POST', '/api/programs/1/relationships/flows*', {
+        statusCode: 201,
+        body: {
           data: {
             id: '1',
             attributes: {
@@ -186,11 +184,9 @@ context('flow sidebar', function() {
       .wait('@routeProgramFlowActions');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/program-flows/1',
-        response: {},
+      .intercept('PATCH', '/api/program-flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchFlow');
 
@@ -349,11 +345,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 403,
-        method: 'DELETE',
-        url: '/api/program-flows/1',
-        response: {
+      .intercept('DELETE', '/api/program-flows/1', {
+        statusCode: 403,
+        body: {
           errors: [
             {
               id: '1',
@@ -391,11 +385,9 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .route({
-        status: 204,
-        method: 'DELETE',
-        url: '/api/program-flows/1',
-        response: {},
+      .intercept('DELETE', '/api/program-flows/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routeDeleteFlow');
 

--- a/test/integration/programs/sidebar/program-sidebar.js
+++ b/test/integration/programs/sidebar/program-sidebar.js
@@ -70,13 +70,12 @@ context('program sidebar', function() {
     const errors = _.map({ name: 'name error' }, getError);
 
     cy
-      .route({
-        method: 'POST',
-        url: '/api/programs',
-        response: { errors },
+      .intercept('POST', '/api/programs', {
+        statusCode: 400,
         delay: 100,
-        status: 400,
-      }).as('routePostProgramError');
+        body: { errors },
+      })
+      .as('routePostProgramError');
 
     cy
       .get('.sidebar')
@@ -112,11 +111,9 @@ context('program sidebar', function() {
       .type('Test{enter} Details');
 
     cy
-      .route({
-        status: 201,
-        method: 'POST',
-        url: '/api/programs',
-        response: {
+      .intercept('POST', '/api/programs', {
+        statusCode: 201,
+        body: {
           data: {
             id: '1',
             attributes: {
@@ -185,11 +182,9 @@ context('program sidebar', function() {
       .wait('@routeProgram');
 
     cy
-      .route({
-        status: 204,
-        method: 'PATCH',
-        url: '/api/programs/1',
-        response: {},
+      .intercept('PATCH', '/api/programs/1', {
+        statusCode: 204,
+        body: {},
       })
       .as('routePatchProgram');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-30276]

This refactors all instances of `cy.route()` to `cy.intercept()` that are used in `test/integration/...` files.

The `test/support/api` files still use `cy.route()`. I figured we could tackle that in a separate PR since it gets a little more complicated.