### PR TITLE
Fix Datadog console error when the response object is empty

### DIFF
--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -53,7 +53,7 @@ function initRum({ isForm }) {
     beforeSend(event, context) {
       // Add header/response context to api errors
       if (event.type === 'resource' && event.resource.type === 'fetch') {
-        if (context.response.status && context.response.status >= 400) {
+        if (get(context, 'response.status') >= 400) {
           extend(event.context, { context });
         }
       }


### PR DESCRIPTION
Shortcut Story ID: [sc-37555]

Original attempt at fixing this: #1076. But we're still seeing that console error when an API request is cancelled.

When an API request is cancelled, the `context.response` object is empty. So instead of checking `context.response.status`, we need to verify that `context.response` exists before including the status.