### PR TITLE
Outreach: form header being hidden when scrolling to bottom on mobile

### DIFF
--- a/src/js/outreach/views/form.scss
+++ b/src/js/outreach/views/form.scss
@@ -1,4 +1,3 @@
-
 .form__header {
   align-items: center;
   background: #F2F9FD;
@@ -7,6 +6,9 @@
   font-weight: 600;
   line-height: 48px;
   padding: 10px 24px;
+  position: fixed;
+  top: 0;
+  width: 100%;
 }
 
 .form__title {
@@ -18,6 +20,7 @@
 .form__content {
   background-color: $white;
   height: calc(100vh - 68px);
+  padding-top: 68px;
 
   iframe {
     display: block;


### PR DESCRIPTION
Shortcut Story ID: [sc-39185]
