### PR TITLE
Outreach: Handle API Request 500 Errors

### DIFF
--- a/src/js/outreach/apps/verify_app.js
+++ b/src/js/outreach/apps/verify_app.js
@@ -21,6 +21,8 @@ export default App.extend({
     return getPatientInfo({ actionId });
   },
   onFail(options, response) {
+    if (response.status >= 500) return;
+
     const dialogView = new DialogView();
     this.showView(dialogView);
 

--- a/src/js/outreach/index.js
+++ b/src/js/outreach/index.js
@@ -10,6 +10,11 @@ import VerifyApp from 'js/outreach/apps/verify_app';
 import FormApp from 'js/outreach/apps/form_app';
 import OptInApp from 'js/outreach/apps/opt-in_app';
 
+import {
+  DialogView,
+  ErrorView,
+} from 'js/outreach/views/dialog_views';
+
 import 'scss/outreach-core.scss';
 import './outreach.scss';
 
@@ -31,6 +36,11 @@ const OutreachApp = RouterApp.extend({
       route: 'outreach/opt-in',
       root: true,
     },
+    'error': {
+      route: '500',
+      root: true,
+      action: 'show500',
+    },
   },
   show(actionId) {
     this.actionId = actionId;
@@ -50,6 +60,12 @@ const OutreachApp = RouterApp.extend({
   },
   showOptIn() {
     this.startCurrent('optIn');
+  },
+  show500() {
+    const dialogView = new DialogView();
+    this.showView(dialogView);
+
+    this.showChildView('content', new ErrorView());
   },
 });
 

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -747,4 +747,19 @@ context('Outreach', function() {
       .find('textarea[name="data[storyTime]"]')
       .should('have.value', 'Once upon a time...');
   });
+
+  specify('500 error', function() {
+    cy
+      .intercept('GET', '/api/outreach?filter[action]=11111', req => {
+        req.reply({
+          statusCode: 500,
+          body: {},
+        });
+      })
+      .visit('/outreach/11111', { noWait: true, isRoot: true });
+
+    cy
+      .get('body')
+      .contains('Uh-oh, there was an error. Try reloading the page.');
+  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-39316]

When the `/api/outreach?filter[action]=11111` API request returns a `500` error, a blank page was displayed ([screenshot](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/af616430-0d3c-4e9a-8c90-912f70addf2f)). 

Instead, this needs to show the `Uh-Oh...` error message we use in the main app ([screenshot](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/02938724-851d-4f78-9c40-8b14841fc0db)).