### PR TITLE
Add extra error handling to surface better information

### DIFF
--- a/src/js/base/app.js
+++ b/src/js/base/app.js
@@ -1,4 +1,4 @@
-import { bind, isArray, noop, uniqueId } from 'underscore';
+import { bind, isArray, noop, uniqueId, isError } from 'underscore';
 import { App } from 'marionette.toolkit';
 
 export default App.extend({
@@ -33,7 +33,8 @@ export default App.extend({
     this.triggerMethod('fail', options, ...args);
   },
   onFail(options, error) {
-    throw error;
+    if (isError(error)) throw error;
+    throw new Error(JSON.stringify(error));
   },
   isRunning() {
     return this._isRunning && !this.isLoading();


### PR DESCRIPTION
In some cases if the response is not in an expected format FE will handle it at a generic error, but that can end up as a `Uncaught "[Response]”`

Shortcut Story ID: [sc-39329]
