### PR TITLE
Outreach: Handle 404 Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
       "hand-wave",
       "octagon-exclamation",
       "thumbs-up",
+      "triangle-exclamation",
       "user-lock"
     ],
     "fas": [

--- a/src/js/outreach/apps/error_app.js
+++ b/src/js/outreach/apps/error_app.js
@@ -1,0 +1,35 @@
+import { bind } from 'underscore';
+
+import RouterApp from 'js/base/routerapp';
+
+import { DialogView } from 'js/outreach/views/dialog_views';
+
+import {
+  ErrorView,
+  Error404View,
+} from 'js/outreach/views/error_views';
+
+export default RouterApp.extend({
+  eventRoutes: {
+    'error': {
+      route: 'outreach/500',
+      action: 'show500',
+      root: true,
+    },
+  },
+  initialize() {
+    this.router.route('*unknown', 'show404', bind(this.show404, this));
+  },
+  show404() {
+    const dialogView = new DialogView();
+    this.showView(dialogView);
+
+    this.showChildView('content', new Error404View());
+  },
+  show500() {
+    const dialogView = new DialogView();
+    this.showView(dialogView);
+
+    this.showChildView('content', new ErrorView());
+  },
+});

--- a/src/js/outreach/apps/form_app.js
+++ b/src/js/outreach/apps/form_app.js
@@ -10,10 +10,8 @@ import {
   SaveView,
 } from 'js/outreach/views/form_views';
 
-import {
-  DialogView,
-  ErrorView,
-} from 'js/outreach/views/dialog_views';
+import { DialogView } from 'js/outreach/views/dialog_views';
+import { ErrorView } from 'js/outreach/views/error_views';
 
 export default App.extend({
   beforeStart({ actionId }) {

--- a/src/js/outreach/apps/opt-in_app.js
+++ b/src/js/outreach/apps/opt-in_app.js
@@ -9,9 +9,7 @@ import {
   ResponseErrorView,
 } from 'js/outreach/views/opt-in_views';
 
-import {
-  DialogView,
-} from 'js/outreach/views/dialog_views';
+import { DialogView } from 'js/outreach/views/dialog_views';
 
 const StateModel = Backbone.Model.extend({
   defaults: {

--- a/src/js/outreach/apps/verify_app.js
+++ b/src/js/outreach/apps/verify_app.js
@@ -11,10 +11,8 @@ import {
   NotAvailableView,
 } from 'js/outreach/views/verify_views';
 
-import {
-  DialogView,
-  ErrorView,
-} from 'js/outreach/views/dialog_views';
+import { DialogView } from 'js/outreach/views/dialog_views';
+import { ErrorView } from 'js/outreach/views/error_views';
 
 export default App.extend({
   beforeStart({ actionId }) {

--- a/src/js/outreach/index.js
+++ b/src/js/outreach/index.js
@@ -9,11 +9,7 @@ import RouterApp from 'js/base/routerapp';
 import VerifyApp from 'js/outreach/apps/verify_app';
 import FormApp from 'js/outreach/apps/form_app';
 import OptInApp from 'js/outreach/apps/opt-in_app';
-
-import {
-  DialogView,
-  ErrorView,
-} from 'js/outreach/views/dialog_views';
+import ErrorApp from 'js/outreach/apps/error_app';
 
 import 'scss/outreach-core.scss';
 import './outreach.scss';
@@ -26,20 +22,15 @@ const OutreachApp = RouterApp.extend({
   },
   routerAppName: 'PatientsApp',
   eventRoutes: {
-    'outreach': {
-      action: 'show',
+    'outreach:id': {
       route: 'outreach/:id',
+      action: 'show',
       root: true,
     },
     'outreach:opt:in': {
-      action: 'showOptIn',
       route: 'outreach/opt-in',
+      action: 'showOptIn',
       root: true,
-    },
-    'error': {
-      route: '500',
-      root: true,
-      action: 'show500',
     },
   },
   show(actionId) {
@@ -61,17 +52,12 @@ const OutreachApp = RouterApp.extend({
   showOptIn() {
     this.startCurrent('optIn');
   },
-  show500() {
-    const dialogView = new DialogView();
-    this.showView(dialogView);
-
-    this.showChildView('content', new ErrorView());
-  },
 });
 
 function startOutreachApp() {
   // Modify viewport for mobile devices at full width
   $('meta[name=viewport]').attr('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
+  new ErrorApp({ region: { el: document.getElementById('root') } });
   new OutreachApp({ region: { el: document.getElementById('root') } });
   Backbone.history.start({ pushState: true });
 }

--- a/src/js/outreach/views/dialog_views.js
+++ b/src/js/outreach/views/dialog_views.js
@@ -23,15 +23,6 @@ const DialogView = View.extend({
   },
 });
 
-const ErrorView = View.extend({
-  template: hbs`
-    <div class="dialog__icon dialog__icon--error">{{fat "octagon-exclamation"}}</div>
-    <div>Uh-oh, there was an error. Try reloading the page.</div>
-  `,
-});
-
 export {
   DialogView,
-  ErrorView,
 };
-

--- a/src/js/outreach/views/error.scss
+++ b/src/js/outreach/views/error.scss
@@ -1,0 +1,14 @@
+.dialog__icon--error {
+  color: $error-color;
+  margin: 0 auto 24px;
+}
+
+.dialog__error-header {
+  font-size: 20px;
+}
+
+.dialog__error-info {
+  font-size: 16px;
+  font-weight: 600;
+  margin-top: 24px;
+}

--- a/src/js/outreach/views/error_views.js
+++ b/src/js/outreach/views/error_views.js
@@ -1,0 +1,24 @@
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import './error.scss';
+
+const ErrorView = View.extend({
+  template: hbs`
+    <div class="dialog__icon dialog__icon--error">{{fat "octagon-exclamation"}}</div>
+    <div class="dialog__error-header">Uh-oh, there was an error. Try reloading the page.</div>
+  `,
+});
+
+const Error404View = View.extend({
+  template: hbs`
+    <div class="dialog__icon">{{fat "triangle-exclamation"}}</div>
+    <div class="dialog__error-header">Oops! The page you requested can’t be found.</div>
+    <div class="dialog__error-info">Return to the Outreach message and re-open the link.</div>
+  `,
+});
+
+export {
+  ErrorView,
+  Error404View,
+};

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -762,4 +762,27 @@ context('Outreach', function() {
       .get('body')
       .contains('Uh-oh, there was an error. Try reloading the page.');
   });
+
+  specify('404 error', function() {
+    cy
+      .visit('/outreach', { noWait: true, isRoot: true });
+
+    cy
+      .get('body')
+      .contains('Oops! The page you requested can\’t be found.');
+
+    cy
+      .visit('/outreach/', { noWait: true, isRoot: true });
+
+    cy
+      .get('body')
+      .contains('Oops! The page you requested can\’t be found.');
+
+    cy
+      .visit('/outreach/11111/22222', { noWait: true, isRoot: true });
+
+    cy
+      .get('body')
+      .contains('Oops! The page you requested can\’t be found.');
+  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-39558]

When a malformed URL is loaded by a user (.i.e. `/outreach`, `/outreach/`, `/outreach/asdf/asdf`), show a `404` error:

![Screenshot 2023-08-17 at 2 53 59 PM](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/2f32f5a8-7c19-44c1-9315-2e633733ba38)
