### PR TITLE
Prevent action editing on a worklist for actions on a done flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
       "calendar-days",
       "calendar-star",
       "circle-check",
+      "circle-dashed",
       "circle-exclamation",
       "circle-info",
       "circle-minus",

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -89,7 +89,7 @@ export default App.extend({
   },
   beforeStart() {
     const filter = this.getState().getEntityFilter();
-    return Radio.request('entities', 'fetch:actions:collection', { filter });
+    return Radio.request('entities', 'fetch:actions:collection', { data: { filter } });
   },
   onStart(options, collection) {
     this.collection = collection;

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -106,7 +106,8 @@ export default App.extend({
   },
   beforeStart() {
     const filter = this.getState().getEntityFilter();
-    return Radio.request('entities', 'fetch:actions:collection', { filter });
+    const fields = { flows: ['name', 'state'] };
+    return Radio.request('entities', 'fetch:actions:collection', { data: { filter, fields } });
   },
   onStart(options, collection) {
     this.collection = collection;

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -65,12 +65,8 @@ export default App.extend({
   viewEvents: {
     'close': 'stop',
   },
-  isFlowDone() {
-    const flow = this.action.getFlow();
-    return flow && flow.isDone();
-  },
   showAction() {
-    const canEdit = !this.isFlowDone() && this.action.canEdit();
+    const canEdit = !this.action.isFlowDone() && this.action.canEdit();
 
     if (canEdit === this.canEdit) return;
 

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -114,9 +114,11 @@ export default App.extend({
   },
   beforeStart() {
     return Radio.request('entities', `fetch:${ this.getState().getType() }:collection`, {
-      filter: this.getState().getEntityFilter(),
-      fields: { flows: ['name', 'state'] },
-      include: this.sortOptions.getInclude(),
+      data: {
+        filter: this.getState().getEntityFilter(),
+        fields: { flows: ['name', 'state'] },
+        include: this.sortOptions.getInclude(),
+      },
     });
   },
   onStart(options, collection) {

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -115,6 +115,7 @@ export default App.extend({
   beforeStart() {
     return Radio.request('entities', `fetch:${ this.getState().getType() }:collection`, {
       filter: this.getState().getEntityFilter(),
+      fields: { flows: ['name', 'state'] },
       include: this.sortOptions.getInclude(),
     });
   },

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -18,8 +18,8 @@ const Entity = BaseEntity.extend({
     ].join();
     return this.fetchModel(id, { data: { include } });
   },
-  fetchActions({ filter, include }) {
-    const data = { filter, include };
+  fetchActions({ filter, include, fields }) {
+    const data = { filter, include, fields };
 
     return this.fetchCollection({ data });
   },

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -7,7 +7,7 @@ const Entity = BaseEntity.extend({
     'actions:model': 'getModel',
     'actions:collection': 'getCollection',
     'fetch:actions:model': 'fetchAction',
-    'fetch:actions:collection': 'fetchActions',
+    'fetch:actions:collection': 'fetchCollection',
     'fetch:actions:collection:byPatient': 'fetchActionsByPatient',
     'fetch:actions:collection:byFlow': 'fetchActionsByFlow',
   },
@@ -17,11 +17,6 @@ const Entity = BaseEntity.extend({
       'flow.program-flow.program',
     ].join();
     return this.fetchModel(id, { data: { include } });
-  },
-  fetchActions({ filter, include, fields }) {
-    const data = { filter, include, fields };
-
-    return this.fetchCollection({ data });
   },
   fetchActionsByPatient({ patientId, filter }) {
     const data = { filter };

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -77,6 +77,10 @@ const _Model = BaseModel.extend({
     const state = this.getState();
     return state.isDone();
   },
+  isFlowDone() {
+    const flow = this.getFlow();
+    return flow && flow.isDone();
+  },
   isOverdue() {
     if (this.isDone()) return false;
 

--- a/src/js/entities-service/flows.js
+++ b/src/js/entities-service/flows.js
@@ -7,7 +7,7 @@ const Entity = BaseEntity.extend({
     'flows:model': 'getModel',
     'flows:collection': 'getCollection',
     'fetch:flows:model': 'fetchFlow',
-    'fetch:flows:collection': 'fetchFlows',
+    'fetch:flows:collection': 'fetchCollection',
     'fetch:flows:collection:byPatient': 'fetchFlowsByPatient',
   },
   fetchFlow(id) {
@@ -17,11 +17,6 @@ const Entity = BaseEntity.extend({
       'program-flow.program-actions',
     ].join();
     return this.fetchModel(id, { data: { include } });
-  },
-  fetchFlows({ filter, include }) {
-    const data = { filter, include };
-
-    return this.fetchCollection({ data });
   },
   fetchFlowsByPatient({ patientId, filter }) {
     const data = { filter };

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -245,7 +245,7 @@ const DayItemView = View.extend({
   },
   onRender() {
     const canEdit = this.canEdit;
-    this.canEdit = this.model.canEdit();
+    this.canEdit = !this.model.isFlowDone() && this.model.canEdit();
 
     this.showDetailsTooltip();
     this.showCheck();

--- a/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
@@ -99,12 +99,14 @@ const ReadOnlyActionView = View.extend({
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.readOnlyActionView.ownerLabel }}</h4><div class="flex-grow" data-owner-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.readOnlyActionView.dueDayLabel }}</h4><div class="flex flex-grow" data-due-datetime-region></div></div>
     <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.readOnlyActionView.durationLabel }}</h4><div class="flex-grow" data-duration-region></div></div>
+    {{#unless canEdit}}
     <div class="flex u-margin--t-8">
       <h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.readOnlyActionView.permissionLabel }}</h4>
       <div class="flex flex--grow action-sidebar__info">
         {{far "ban"}}<span class="u-margin--l-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.readOnlyActionView.permissionInfo }}</span>
       </div>
     </div>
+    {{/unless}}
   `,
   regions: {
     state: '[data-state-region]',
@@ -133,6 +135,11 @@ const ReadOnlyActionView = View.extend({
   showDuration() {
     const readOnlyDurationView = new ReadOnlyDurationView({ model: this.model });
     this.showChildView('duration', readOnlyDurationView);
+  },
+  templateContext() {
+    return {
+      canEdit: this.model.canEdit(),
+    };
   },
 });
 

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -83,7 +83,7 @@ const ActionItemView = View.extend({
     this.showDetailsTooltip();
 
     const canEdit = this.canEdit;
-    this.canEdit = this.model.canEdit();
+    this.canEdit = !this.model.isFlowDone() && this.model.canEdit();
 
     this.showCheck();
     this.showState();

--- a/test/fixtures/test/states.json
+++ b/test/fixtures/test/states.json
@@ -53,5 +53,16 @@
       "icon": "arrow-right-arrow-left",
       "color": "purple"
     }
+  },
+  {
+    "id": "88888",
+    "name": "Evernorth",
+    "sequence": 5,
+    "status": "done",
+    "options": {
+      "iconType": "far",
+      "icon": "circle-dashed",
+      "color": "purple"
+    }
   }
 ]

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -125,6 +125,38 @@ context('patient flow page', function() {
       .should('contain', 'Test Action');
   });
 
+  specify('done patient flow action sidebar', function() {
+    cy
+      .routesForPatientAction()
+      .routeFlow(fx => {
+        fx.data.id = '1';
+        fx.data.relationships.state = {
+          data: { id: '55555' },
+        };
+        return fx;
+      })
+      .routeFlowActions()
+      .routeAction(fx => {
+        fx.data.id = '1';
+        fx.data.attributes.name = 'Test Action';
+
+        fx.data.relationships.flow = { data: { id: '1' } };
+
+        return fx;
+      })
+      .routePatientByFlow()
+      .routeActionActivity()
+      .visit('/flow/1/action/1')
+      .wait('@routeFlow')
+      .wait('@routePatientByFlow')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .sidebar__label')
+      .should('not.contain', 'Permissions');
+  });
+
   specify('flow actions list', function() {
     cy
       .routesForPatientAction()

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1745,8 +1745,7 @@ context('action sidebar', function() {
     cy
       .get('[data-action-region]')
       .should('contain', 'No details')
-      .and('contain', 'No Duration')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'No Duration');
 
     cy
       .get('.sidebar')
@@ -1761,6 +1760,12 @@ context('action sidebar', function() {
       .find('[data-attachments-region]')
       .find('.js-add')
       .should('not.exist');
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region]')
+      .should('contain', 'Permissions')
+      .and('contain', 'You are not able to change settings on actions.');
   });
 
   specify('flow action without work:manage permission', function() {
@@ -1793,7 +1798,7 @@ context('action sidebar', function() {
             due_time: '07:15:00',
           },
           relationships: {
-            owner: { data: { id: '11111', type: 'clinicians' } },
+            owner: { data: { id: '22222', type: 'clinicians' } },
             state: { data: { id: '22222' } },
             form: { data: { id: '11111' } },
             flow: { data: { id: '1' } },
@@ -1840,5 +1845,10 @@ context('action sidebar', function() {
       .and('contain', formatDate(testDateSubtract(2), 'SHORT'))
       .and('contain', '7:15 AM')
       .and('contain', '5 mins');
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .sidebar__label')
+      .should('contain', 'Permissions');
   });
 });

--- a/test/integration/patients/sidebar/filter-sidebar.js
+++ b/test/integration/patients/sidebar/filter-sidebar.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import { NIL as NIL_UUID } from 'uuid';
 
 const STATE_VERSION = 'v6';
@@ -13,7 +14,24 @@ context('filter sidebar', function() {
       flowStates: ['22222', '33333'],
     }));
 
+    function hasTestState({ id }) {
+      return ['22222', '33333', '55555', '66666'].includes(id);
+    }
+
     cy
+      .routeWorkspaces(fx => {
+        _.each(fx.data, workspace => {
+          const states = workspace.relationships.states.data;
+
+          workspace.relationships.states.data = _.filter(states, hasTestState);
+        });
+
+        return fx;
+      })
+      .routeStates(fx => {
+        fx.data = _.filter(fx.data, hasTestState);
+        return fx;
+      })
       .routeActions()
       .routeFlows()
       .routeFlow()
@@ -238,7 +256,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square')
-      .should('have.length', 3);
+      .should('have.length', 2);
 
     cy
       .get('@filtersSidebar')
@@ -246,8 +264,7 @@ context('filter sidebar', function() {
       .should('contain', 'To Do')
       .should('contain', 'In Progress')
       .should('contain', 'Done')
-      .should('contain', 'Unable to Complete')
-      .should('contain', 'THMG Transfered');
+      .should('contain', 'Unable to Complete');
 
     cy
       .get('@filtersSidebar')
@@ -272,8 +289,7 @@ context('filter sidebar', function() {
       .should('contain', 'To Do')
       .should('contain', 'In Progress')
       .should('contain', 'Done')
-      .should('contain', 'Unable to Complete')
-      .should('contain', 'THMG Transfered');
+      .should('contain', 'Unable to Complete');
 
     cy
       .get('@filtersSidebar')
@@ -313,7 +329,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square')
-      .should('have.length', 4);
+      .should('have.length', 3);
 
     cy
       .get('@filtersSidebar')
@@ -352,7 +368,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square')
-      .should('have.length', 5);
+      .should('have.length', 4);
 
     cy
       .get('@filtersSidebar')
@@ -391,7 +407,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square')
-      .should('have.length', 4);
+      .should('have.length', 3);
 
     cy
       .get('@filtersSidebar')
@@ -428,7 +444,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square')
-      .should('have.length', 3);
+      .should('have.length', 2);
 
     cy
       .get('@filtersSidebar')
@@ -476,6 +492,12 @@ context('filter sidebar', function() {
 
   specify('worklist filtering - done states', function() {
     cy
+      .routeStates(fx => {
+        fx.data = _.filter(fx.data, state => {
+          return ['22222', '33333', '55555', '66666'].includes(state.id);
+        });
+        return fx;
+      })
       .routeActions()
       .routeFlow()
       .routeFlowActions()
@@ -485,7 +507,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=55555,66666,77777');
+      .should('contain', 'filter[state]=55555,66666');
 
     cy
       .get('.list-page__filters')
@@ -498,7 +520,7 @@ context('filter sidebar', function() {
       .as('filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square-check')
-      .should('have.length', 3);
+      .should('have.length', 2);
 
     cy
       .get('@filtersSidebar')
@@ -512,8 +534,7 @@ context('filter sidebar', function() {
       .should('not.contain', 'To Do')
       .should('not.contain', 'In Progress')
       .should('contain', 'Done')
-      .should('contain', 'Unable to Complete')
-      .should('contain', 'THMG Transfered');
+      .should('contain', 'Unable to Complete');
 
     cy
       .get('@filtersSidebar')
@@ -524,12 +545,12 @@ context('filter sidebar', function() {
       .then(() => {
         const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_11111-${ STATE_VERSION }`));
 
-        expect(storage.states).to.deep.equal(['66666', '77777']);
+        expect(storage.states).to.deep.equal(['66666']);
       })
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=66666,77777');
+      .should('contain', 'filter[state]=66666');
 
     cy
       .get('.list-page__filters')
@@ -546,7 +567,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square-check')
-      .should('have.length', 2);
+      .should('have.length', 1);
 
     cy
       .get('@filtersSidebar')
@@ -561,12 +582,12 @@ context('filter sidebar', function() {
       .then(() => {
         const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_11111-${ STATE_VERSION }`));
 
-        expect(storage.states).to.deep.equal(['55555', '66666', '77777']);
+        expect(storage.states).to.deep.equal(['55555', '66666']);
       })
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=55555,66666,77777');
+      .should('contain', 'filter[state]=55555,66666');
 
     cy
       .get('.list-page__filters')
@@ -583,7 +604,7 @@ context('filter sidebar', function() {
       .get('@filtersSidebar')
       .find('[data-states-filters-region]')
       .find('.fa-square-check')
-      .should('have.length', 3);
+      .should('have.length', 2);
 
     cy
       .get('@filtersSidebar')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1687,4 +1687,41 @@ context('schedule page', function() {
     cy
       .get('[data-select-all-region] button:disabled');
   });
+
+  specify('actions on a done-flow', function() {
+    cy
+      .routesForPatientAction()
+      .routeActions(fx => {
+        _.each(fx.data, action => {
+          action.relationships.flow = {
+            data: { id: '1' },
+          };
+        });
+
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend(_.sample(this.fxFlows), {
+            name: 'Done Test Flow',
+          }),
+          relationships: {
+            state: { data: { id: '55555' } },
+          },
+        });
+
+        return fx;
+      })
+      .visit('/schedule');
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'fields[flows]=name,state');
+
+    cy
+      .get('.app-frame__content')
+      .find('.schedule-list__list-row .js-select')
+      .should('not.exist');
+  });
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -888,7 +888,7 @@ context('worklist page', function() {
     cy.clock().invoke('restore');
   });
 
-  specify('action done flow list', function() {
+  specify('actions on a done-flow list', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
@@ -912,6 +912,12 @@ context('worklist page', function() {
         return fx;
       })
       .visit('/worklist/owned-by');
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'fields[flows]=name,state');
 
     cy
       .get('.worklist-list__meta')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -470,8 +470,10 @@ context('worklist page', function() {
           type: 'flows',
           attributes: _.extend(_.sample(this.fxFlows), {
             name: 'Test Flow',
-            id: '1',
           }),
+          relationships: {
+            state: { data: { id: '33333' } },
+          },
         };
 
         fx.data = actions;
@@ -884,6 +886,37 @@ context('worklist page', function() {
       .go('back');
 
     cy.clock().invoke('restore');
+  });
+
+  specify('action done flow list', function() {
+    cy
+      .routesForPatientAction()
+      .routeActions(fx => {
+        _.each(fx.data, action => {
+          action.relationships.flow = {
+            data: { id: '1' },
+          };
+        });
+
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend(_.sample(this.fxFlows), {
+            name: 'Test Flow',
+          }),
+          relationships: {
+            state: { data: { id: '55555' } },
+          },
+        });
+
+        return fx;
+      })
+      .visit('/worklist/owned-by');
+
+    cy
+      .get('.worklist-list__meta')
+      .find('button')
+      .should('not.exist');
   });
 
   specify('maximum list count reached', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-39759]
Shortcut Story ID: [sc-39757]

This PR includes 3 things.  It includes the fix for preventing the editing of flow actions for a done flow on a worklist.  This is the exact same logic we use on a flow, but now the worklist is no longer necessarily hiding these actions.  We needed to request the fields for the `action.relationships.flow.relationships.state` in order to account for this.

Additionally @wweaver4th requested an icon for Evernorth

And there was an unrelated but close to the issue bug where an action sidebar for an action on a done flow was showing the permissions info box, but this should only show if the user doesn't have the permissions.
