### PR TITLE
Don't include `fields[flows]=name,state` in `/flows` api request

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -113,13 +113,18 @@ export default App.extend({
     this.showView();
   },
   beforeStart() {
-    return Radio.request('entities', `fetch:${ this.getState().getType() }:collection`, {
-      data: {
-        filter: this.getState().getEntityFilter(),
-        fields: { flows: ['name', 'state'] },
-        include: this.sortOptions.getInclude(),
-      },
-    });
+    const listType = this.getState().getType();
+
+    const data = {
+      filter: this.getState().getEntityFilter(),
+      include: this.sortOptions.getInclude(),
+    };
+
+    if (listType === 'actions') {
+      data.fields = { flows: ['name', 'state'] };
+    }
+
+    return Radio.request('entities', `fetch:${ listType }:collection`, { data });
   },
   onStart(options, collection) {
     this.collection = collection;

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -119,7 +119,10 @@ context('worklist page', function() {
       .get('.worklist-list__toggle')
       .contains('Flows')
       .click()
-      .wait('@routeFlows');
+      .wait('@routeFlows')
+      .itsUrl()
+      .its('search')
+      .should('not.contain', 'fields[flows]=name,state');
 
     cy
       .get('[data-filters-region]')


### PR DESCRIPTION
Shortcut Story ID: [sc-39819]

Bug introduced by this commit: https://github.com/RoundingWell/care-ops-frontend/pull/1116/commits/216b733b87d41cad56341a9a719feec0c9a7fdde.

If `fields[flows]=name,state` is included in the `/flows` api request, it throws this error on the flows version of the worklist:

![Screenshot 2023-08-22 at 3 19 59 PM (1) (1)](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/45824142-4d17-4fe6-ad5b-fa37f1a6ab22)

Removing `fields[flows]=name,state` fixes the error. But it's still not clear why that causes the error in the first place.