### PR TITLE
Implement `work:team:manage` permission

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -109,6 +109,14 @@ const _Model = BaseModel.extend({
 
     if (currentUser.can('work:owned:manage') && this.getOwner() === currentUser) return true;
 
+    if (currentUser.can('work:team:manage')) {
+      const owner = this.getOwner();
+      const currentUsersTeam = currentUser.getTeam();
+      const ownersTeam = owner.type === 'teams' ? owner : owner.getTeam();
+
+      if (currentUsersTeam === ownersTeam) return true;
+    }
+
     return false;
   },
   saveDueDate(date) {

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -120,6 +120,14 @@ const Collection = BaseCollection.extend({
   url: '/api/clinicians',
   model: Model,
   comparator: 'name',
+  filterAssignable() {
+    const assignable = this.filter(clinician => {
+      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
+    });
+
+    this.reset(assignable);
+    return this;
+  },
 });
 
 export {

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -121,12 +121,15 @@ const Collection = BaseCollection.extend({
   model: Model,
   comparator: 'name',
   filterAssignable() {
+    const clone = this.clone();
+
     const assignable = this.filter(clinician => {
       return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
     });
 
-    this.reset(assignable);
-    return this;
+    clone.reset(assignable);
+
+    return clone;
   },
 });
 

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -50,6 +50,14 @@ const _Model = BaseModel.extend({
 
     if (currentUser.can('work:owned:manage') && this.getOwner() === currentUser) return true;
 
+    if (currentUser.can('work:team:manage')) {
+      const owner = this.getOwner();
+      const currentUsersTeam = currentUser.getTeam();
+      const ownersTeam = owner.type === 'teams' ? owner : owner.getTeam();
+
+      if (currentUsersTeam === ownersTeam) return true;
+    }
+
     return false;
   },
   saveState(state) {

--- a/src/js/entities-service/entities/teams.js
+++ b/src/js/entities-service/entities/teams.js
@@ -11,9 +11,7 @@ const _Model = BaseModel.extend({
   getAssignableClinicians() {
     const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
 
-    clinicians.filterAssignable();
-
-    return clinicians;
+    return clinicians.filterAssignable();
   },
 });
 

--- a/src/js/entities-service/entities/teams.js
+++ b/src/js/entities-service/entities/teams.js
@@ -11,11 +11,7 @@ const _Model = BaseModel.extend({
   getAssignableClinicians() {
     const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
 
-    const assignableClinicians = clinicians.filter(clinician => {
-      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
-    });
-
-    clinicians.reset(assignableClinicians);
+    clinicians.filterAssignable();
 
     return clinicians;
   },

--- a/src/js/entities-service/entities/teams.js
+++ b/src/js/entities-service/entities/teams.js
@@ -1,3 +1,4 @@
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -7,6 +8,17 @@ const TYPE = 'teams';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/teams',
+  getAssignableClinicians() {
+    const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
+
+    const assignableClinicians = clinicians.filter(clinician => {
+      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
+    });
+
+    clinicians.reset(assignableClinicians);
+
+    return clinicians;
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/entities/workspaces.js
+++ b/src/js/entities-service/entities/workspaces.js
@@ -18,11 +18,7 @@ const _Model = BaseModel.extend({
   getAssignableClinicians() {
     const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
 
-    const assignableClinicians = clinicians.filter(clinician => {
-      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
-    });
-
-    clinicians.reset(assignableClinicians);
+    clinicians.filterAssignable();
 
     return clinicians;
   },

--- a/src/js/entities-service/entities/workspaces.js
+++ b/src/js/entities-service/entities/workspaces.js
@@ -18,9 +18,7 @@ const _Model = BaseModel.extend({
   getAssignableClinicians() {
     const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
 
-    clinicians.filterAssignable();
-
-    return clinicians;
+    return clinicians.filterAssignable();
   },
   updateClinicians(clinicians) {
     this.set('_clinicians', clinicians.map(m => pick(m, 'id', 'type')));

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -457,7 +457,7 @@ careOptsFrontend:
             noDetails: No details
             ownerLabel: Owner
             permissionLabel: Permissions
-            permissionInfo: You are not able to change settings on actions.
+            permissionInfo: You are not able to change settings on this action.
             stateLabel: State
           saveView:
             cancelBtn: Cancel
@@ -566,7 +566,7 @@ careOptsFrontend:
             headingText: Flow Menu
           permissionView:
             label: Permissions
-            info: You are not able to change settings on flows.
+            info: You are not able to change settings on this flow.
           timestampsView:
             createdAt: Added
             updatedAt: Updated

--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -82,5 +82,17 @@
       "work:owned:manage",
       "work:own"
     ]
+  },
+  {
+    "id": "77777",
+    "name": "liason_employee",
+    "label": "Liason Employee",
+    "description": "Can only manage work owned by their team or team members.",
+    "permissions": [
+      "app:schedule:clinician_filter",
+      "app:worklist:clinician_filter",
+      "work:team:manage",
+      "work:own"
+    ]
   }
 ]

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -318,7 +318,7 @@ context('patient archive page', function() {
     cy.clock().invoke('restore');
   });
 
-  specify('work with only work:owned:manage permission', function() {
+  specify('work with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -421,8 +421,9 @@ context('patient archive page', function() {
       .should('not.exist');
   });
 
-  specify('work with only work:team:manage permission', function() {
+  specify('work with work:team:manage permission', function() {
     cy
+      .routesForPatientAction()
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
         fx.data.relationships.team = { data: { id: '11111', type: 'teams' } };
@@ -430,19 +431,14 @@ context('patient archive page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
         return fx;
       })
-      .routesForPatientAction()
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.relationships.workspaces.data = [
@@ -457,30 +453,20 @@ context('patient archive page', function() {
       .routePatientActions(fx => {
         fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '55555' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '55555' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
       .routePatientFlows(fx => {
-        fx.data = _.sample(fx.data, 2);
-
-        fx.data[0].attributes.name = 'Owned by team member';
-        fx.data[0].attributes.updated_at = testTsSubtract(3);
-        fx.data[0].relationships.state = { data: { id: '55555' } };
-        fx.data[0].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[1].attributes.name = 'Owned by non team member';
-        fx.data[1].attributes.updated_at = testTsSubtract(4);
-        fx.data[1].relationships.state = { data: { id: '55555' } };
-        fx.data[1].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data = [];
 
         return fx;
       })
@@ -495,24 +481,12 @@ context('patient archive page', function() {
       .as('listItems')
       .first()
       .find('[data-state-region]')
-      .find('button');
-
-    cy
-      .get('@listItems')
-      .eq(1)
-      .find('[data-state-region]')
       .find('button')
       .should('not.exist');
 
     cy
       .get('@listItems')
-      .eq(2)
-      .find('[data-state-region]')
-      .find('button');
-
-    cy
-      .get('@listItems')
-      .eq(3)
+      .last()
       .find('[data-state-region]')
       .find('button')
       .should('not.exist');

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -849,7 +849,7 @@ context('patient dashboard page', function() {
       .should('be.empty');
   });
 
-  specify('work with only work:owned:manage permission', function() {
+  specify('work with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -940,7 +940,7 @@ context('patient dashboard page', function() {
       .should('not.exist');
   });
 
-  specify('work with only work:team:manage permission', function() {
+  specify('work with work:team:manage permission', function() {
     cy
       .routesForPatientDashboard()
       .routeCurrentClinician(fx => {
@@ -950,13 +950,9 @@ context('patient dashboard page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
@@ -965,30 +961,21 @@ context('patient dashboard page', function() {
       .routePatientActions(fx => {
         fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
+
 
         return fx;
       })
       .routePatientFlows(fx => {
-        fx.data = _.sample(fx.data, 2);
-
-        fx.data[0].attributes.name = 'Owned by team member';
-        fx.data[0].attributes.updated_at = testTsSubtract(3);
-        fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[1].attributes.name = 'Owned by non team member';
-        fx.data[1].attributes.updated_at = testTsSubtract(4);
-        fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data = [];
 
         return fx;
       })
@@ -1003,24 +990,12 @@ context('patient dashboard page', function() {
       .as('listItems')
       .first()
       .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('@listItems')
-      .eq(1)
-      .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
 
     cy
       .get('@listItems')
-      .eq(2)
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('@listItems')
-      .eq(3)
+      .last()
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -848,7 +848,7 @@ context('patient dashboard page', function() {
       .should('be.empty');
   });
 
-  specify('work without work:manage permission', function() {
+  specify('work with only work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -930,6 +930,92 @@ context('patient dashboard page', function() {
       .eq(2)
       .find('button')
       .should('not.exist');
+
+    cy
+      .get('@listItems')
+      .eq(3)
+      .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+  });
+
+  specify('work with only work:team:manage permission', function() {
+    cy
+      .routesForPatientDashboard()
+      .routeCurrentClinician(fx => {
+        fx.data.relationships.role = { data: { id: '77777' } };
+        fx.data.relationships.team = { data: { id: '11111', type: 'teams' } };
+
+        return fx;
+      })
+      .routeWorkspaceClinicians(fx => {
+        fx.data = _.first(fx.data, 3);
+
+        const teamMemberClinician = _.find(fx.data, { id: '22222' });
+        teamMemberClinician.attributes.name = 'Team Member';
+        teamMemberClinician.relationships.team.data.id = '11111';
+
+        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        nonTeamMemberClinician.attributes.name = 'Non Team Member';
+        nonTeamMemberClinician.relationships.team.data.id = '22222';
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = _.sample(fx.data, 2);
+
+        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.updated_at = testTsSubtract(1);
+        fx.data[0].relationships.state = { data: { id: '33333' } };
+        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+
+        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.updated_at = testTsSubtract(2);
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = _.sample(fx.data, 2);
+
+        fx.data[0].attributes.name = 'Owned by team member';
+        fx.data[0].attributes.updated_at = testTsSubtract(3);
+        fx.data[0].relationships.state = { data: { id: '33333' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
+
+        fx.data[1].attributes.name = 'Owned by non team member';
+        fx.data[1].attributes.updated_at = testTsSubtract(4);
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+
+        return fx;
+      })
+      .visit('/patient/dashboard/1')
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item')
+      .as('listItems')
+      .first()
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('@listItems')
+      .eq(1)
+      .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+
+    cy
+      .get('@listItems')
+      .eq(2)
+      .find('[data-owner-region]')
+      .find('button');
 
     cy
       .get('@listItems')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -808,7 +808,7 @@ context('patient flow page', function() {
       .should('contain', 'NUR');
   });
 
-  specify('flow with only work:owned:manage permission', function() {
+  specify('flow with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -847,7 +847,7 @@ context('patient flow page', function() {
       .should('not.exist');
   });
 
-  specify('flow with only work:team:manage permission', function() {
+  specify('flow with work:team:manage permission', function() {
     cy
       .routesForPatientDashboard()
       .routeCurrentClinician(fx => {
@@ -857,13 +857,9 @@ context('patient flow page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
@@ -875,31 +871,19 @@ context('patient flow page', function() {
         return fx;
       })
       .routePatientFlows(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
         fx.data[1].id = '2';
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].id = '3';
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.updated_at = testTsSubtract(3);
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].id = '4';
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.updated_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
@@ -914,8 +898,10 @@ context('patient flow page', function() {
     cy
       .routeFlow(fx => {
         fx.data.id = '1';
+        fx.data.attributes.name = 'Owned by another team';
         fx.data.relationships.state.data.id = '33333';
-        fx.data.relationships.owner.data = { id: '11111', type: 'teams' };
+        fx.data.relationships.owner.data = { id: '22222', type: 'teams' };
+
         return fx;
       });
 
@@ -933,31 +919,6 @@ context('patient flow page', function() {
     cy
       .get('[data-header-region]')
       .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .go('back');
-
-    cy
-      .routeFlow(fx => {
-        fx.data.id = '2';
-        fx.data.relationships.state.data.id = '33333';
-        fx.data.relationships.owner.data = { id: '22222', type: 'teams' };
-        return fx;
-      });
-
-    cy
-      .get('@listItems')
-      .eq(1)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
-
-    cy
-      .get('[data-header-region]')
-      .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
 
@@ -966,34 +927,11 @@ context('patient flow page', function() {
 
     cy
       .routeFlow(fx => {
-        fx.data.id = '3';
+        fx.data.id = '2';
+        fx.data.attributes.name = 'Owned by non team member';
         fx.data.relationships.state.data.id = '33333';
         fx.data.relationships.owner.data = { id: '22222', type: 'clinicians' };
-        return fx;
-      });
 
-    cy
-      .get('@listItems')
-      .eq(2)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
-
-    cy
-      .get('[data-header-region]')
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .go('back');
-
-    cy
-      .routeFlow(fx => {
-        fx.data.id = '4';
-        fx.data.relationships.state.data.id = '33333';
-        fx.data.relationships.owner.data = { id: '33333', type: 'clinicians' };
         return fx;
       });
 
@@ -1823,7 +1761,7 @@ context('patient flow page', function() {
       .should('contain', 'Edit 3 Actions');
   });
 
-  specify('actions with only work:owned:manage permission', function() {
+  specify('actions with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -1980,7 +1918,7 @@ context('patient flow page', function() {
       .find('.button--checkbox:disabled');
   });
 
-  specify('actions with only work:team:manage permission', function() {
+  specify('actions with work:team:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
@@ -1989,45 +1927,28 @@ context('patient flow page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
         return fx;
       })
       .routeFlowActions(fx => {
-        fx.data = _.sample(fx.data, 4);
-
+        fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
         fx.data[0].attributes.sequence = 0;
 
         fx.data[1].id = '2';
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
         fx.data[1].attributes.sequence = 1;
-
-        fx.data[2].id = '3';
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-        fx.data[2].attributes.sequence = 2;
-
-        fx.data[3].id = '4';
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
-        fx.data[3].attributes.sequence = 3;
 
         return fx;
       })
@@ -2045,43 +1966,17 @@ context('patient flow page', function() {
       .wait('@routeFlowActions');
 
     cy
-      .get('.patient-flow__actions')
-      .find('.button--checkbox')
-      .click();
-
-    cy
-      .get('.patient-flow__actions')
-      .find('.js-bulk-edit')
-      .should('contain', 'Edit 2 Actions');
-
-    cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .as('tableListItems')
+      .as('listItems')
       .first()
-      .should('have.class', 'is-selected')
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('@tableListItems')
-      .eq(1)
-      .should('not.have.class', 'is-selected')
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
 
     cy
-      .get('@tableListItems')
-      .eq(2)
-      .should('have.class', 'is-selected')
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('@tableListItems')
+      .get('@listItems')
       .last()
-      .should('not.have.class', 'is-selected')
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1765,7 +1765,7 @@ context('action sidebar', function() {
       .get('.sidebar')
       .find('[data-action-region]')
       .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'You are not able to change settings on this action.');
   });
 
   specify('action with only work:team:manage permission', function() {
@@ -1925,7 +1925,7 @@ context('action sidebar', function() {
     cy
       .get('[data-action-region]')
       .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'You are not able to change settings on this action.');
 
     cy
       .get('[data-attachments-files-region]')
@@ -2007,7 +2007,7 @@ context('action sidebar', function() {
     cy
       .get('[data-action-region]')
       .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'You are not able to change settings on this action.');
 
     cy
       .get('[data-attachments-files-region]')
@@ -2225,7 +2225,7 @@ context('action sidebar', function() {
     cy
       .get('[data-action-region]')
       .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'You are not able to change settings on this action.');
 
     cy
       .routeAction(fx => {
@@ -2298,6 +2298,6 @@ context('action sidebar', function() {
     cy
       .get('[data-action-region]')
       .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on actions.');
+      .and('contain', 'You are not able to change settings on this action.');
   });
 });

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1647,7 +1647,7 @@ context('action sidebar', function() {
       .go('back');
   });
 
-  specify('action with only work:owned:manage permission', function() {
+  specify('action with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -1772,7 +1772,7 @@ context('action sidebar', function() {
       .and('contain', 'You are not able to change settings on this action.');
   });
 
-  specify('action with only work:team:manage permission', function() {
+  specify('action with work:team:manage permission', function() {
     cy
       .routesForPatientAction()
       .routeSettings(fx => {
@@ -1787,13 +1787,9 @@ context('action sidebar', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
@@ -1808,43 +1804,30 @@ context('action sidebar', function() {
         fx.data = {
           id: '1',
           attributes: {
-            name: 'Owned by current clinician’s team',
+            name: 'Owned by another team',
           },
           relationships: {
-            owner: { data: { id: '11111', type: 'teams' } },
+            owner: { data: { id: '22222', type: 'teams' } },
             state: { data: { id: '33333' } },
-            files: { data: [{ id: '1' }] },
           },
         };
 
         return fx;
       })
       .routePatientActions(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
         fx.data[1].id = '2';
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].id = '3';
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.updated_at = testTsSubtract(3);
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].id = '4';
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.updated_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
@@ -1853,23 +1836,7 @@ context('action sidebar', function() {
 
         return fx;
       })
-      .routeActionFiles(fx => {
-        fx.data = [
-          {
-            id: '1',
-            attributes: {
-              path: 'patients/1/HRA.pdf',
-              created_at: '2019-08-24T14:15:22Z',
-            },
-            meta: {
-              view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
-              download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
-            },
-          },
-        ];
-
-        return fx;
-      })
+      .routeActionFiles()
       .visit('/patient/1/action/1')
       .wait('@routeAction')
       .wait('@routePatient')
@@ -1878,29 +1845,19 @@ context('action sidebar', function() {
 
     cy
       .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 2);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 5);
-
-    cy
-      .get('[data-attachments-files-region]')
-      .find('.js-remove');
+      .should('contain', 'Permissions')
+      .and('contain', 'You are not able to change settings on this action.');
 
     cy
       .routeAction(fx => {
         fx.data = {
           id: '2',
           attributes: {
-            name: 'Owned by another team',
+            name: 'Owned by non team member',
           },
           relationships: {
-            owner: { data: { id: '22222', type: 'teams' } },
+            owner: { data: { id: '22222', type: 'clinicians' } },
             state: { data: { id: '33333' } },
-            files: { data: [{ id: '1' }] },
           },
         };
 
@@ -1910,89 +1867,6 @@ context('action sidebar', function() {
     cy
       .get('.patient__list')
       .find('.table-list__item')
-      .as('listItems')
-      .eq(1)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
-      .should('contain', 'Permissions')
-      .and('contain', 'You are not able to change settings on this action.');
-
-    cy
-      .get('[data-attachments-files-region]')
-      .find('.js-remove')
-      .should('not.exist');
-
-    cy
-      .routeAction(fx => {
-        fx.data = {
-          id: '3',
-          attributes: {
-            name: 'Owned by team member',
-          },
-          relationships: {
-            owner: { data: { id: '22222', type: 'clinicians' } },
-            state: { data: { id: '33333' } },
-            files: { data: [{ id: '1' }] },
-          },
-        };
-
-        return fx;
-      });
-
-    cy
-      .get('@listItems')
-      .eq(2)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 2);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 5);
-
-    cy
-      .get('[data-attachments-files-region]')
-      .find('.js-remove');
-
-    cy
-      .routeAction(fx => {
-        fx.data = {
-          id: '4',
-          attributes: {
-            name: 'Owned by non team member',
-          },
-          relationships: {
-            owner: { data: { id: '33333', type: 'clinicians' } },
-            state: { data: { id: '33333' } },
-            files: { data: [{ id: '1' }] },
-          },
-        };
-
-        return fx;
-      });
-
-    cy
-      .get('@listItems')
       .last()
       .find('.patient__action-name')
       .click()
@@ -2000,26 +1874,11 @@ context('action sidebar', function() {
 
     cy
       .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
       .should('contain', 'Permissions')
       .and('contain', 'You are not able to change settings on this action.');
-
-    cy
-      .get('[data-attachments-files-region]')
-      .find('.js-remove')
-      .should('not.exist');
   });
 
-  specify('flow action with only work:owned:manage permission', function() {
+  specify('flow action with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -2103,7 +1962,7 @@ context('action sidebar', function() {
       .should('contain', 'Permissions');
   });
 
-  specify('flow action with only work:team:manage permission', function() {
+  specify('flow action with work:team:manage permission', function() {
     cy
       .routesForPatientAction()
       .routeCurrentClinician(fx => {
@@ -2113,13 +1972,9 @@ context('action sidebar', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
@@ -2135,66 +1990,6 @@ context('action sidebar', function() {
         fx.data = {
           id: '1',
           attributes: {
-            name: 'Owned by current clinician’s team',
-          },
-          relationships: {
-            owner: { data: { id: '11111', type: 'teams' } },
-            state: { data: { id: '33333' } },
-            flow: { data: { id: '1' } },
-          },
-        };
-
-        return fx;
-      })
-      .routeFlowActions(fx => {
-        fx.data = _.sample(fx.data, 4);
-
-        fx.data[0].id = '1';
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
-        fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
-        fx.data[0].attributes.sequence = 0;
-
-        fx.data[1].id = '2';
-        fx.data[1].attributes.name = 'Owned by another team';
-        fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-        fx.data[1].attributes.sequence = 1;
-
-        fx.data[2].id = '3';
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-        fx.data[2].attributes.sequence = 2;
-
-        fx.data[3].id = '4';
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
-        fx.data[3].attributes.sequence = 3;
-
-        return fx;
-      })
-      .routePatientByFlow()
-      .visit('/flow/1/action/1')
-      .wait('@routeFlow')
-      .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 1);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 5);
-
-    cy
-      .routeAction(fx => {
-        fx.data = {
-          id: '2',
-          attributes: {
             name: 'Owned by another team',
           },
           relationships: {
@@ -2205,26 +2000,28 @@ context('action sidebar', function() {
         };
 
         return fx;
-      });
+      })
+      .routeFlowActions(fx => {
+        fx.data = _.sample(fx.data, 2);
 
-    cy
-      .get('.patient-flow__list')
-      .find('.table-list__item')
-      .as('listItems')
-      .eq(1)
-      .find('.patient__action-name')
-      .click()
+        fx.data[0].id = '1';
+        fx.data[0].attributes.name = 'Owned by another team';
+        fx.data[0].relationships.state = { data: { id: '33333' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
+        fx.data[0].attributes.sequence = 0;
+
+        fx.data[1].id = '2';
+        fx.data[1].attributes.name = 'Owned by non team member';
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
+        fx.data[1].attributes.sequence = 1;
+
+        return fx;
+      })
+      .routePatientByFlow()
+      .visit('/flow/1/action/1')
+      .wait('@routeFlow')
       .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 0);
 
     cy
       .get('[data-action-region]')
@@ -2234,9 +2031,9 @@ context('action sidebar', function() {
     cy
       .routeAction(fx => {
         fx.data = {
-          id: '3',
+          id: '4',
           attributes: {
-            name: 'Owned by team member',
+            name: 'Owned by non team member',
           },
           relationships: {
             owner: { data: { id: '22222', type: 'clinicians' } },
@@ -2249,55 +2046,12 @@ context('action sidebar', function() {
       });
 
     cy
-      .get('@listItems')
-      .eq(2)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 1);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 5);
-
-    cy
-      .routeAction(fx => {
-        fx.data = {
-          id: '4',
-          attributes: {
-            name: 'Owned by non team member',
-          },
-          relationships: {
-            owner: { data: { id: '33333', type: 'clinicians' } },
-            state: { data: { id: '33333' } },
-            flow: { data: { id: '1' } },
-          },
-        };
-
-        return fx;
-      });
-
-    cy
-      .get('@listItems')
+      .get('.patient-flow__list')
+      .find('.table-list__item')
       .last()
       .find('.patient__action-name')
       .click()
       .wait('@routeAction');
-
-    cy
-      .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 0);
-
-    cy
-      .get('[data-action-region]')
-      .find('button')
-      .should('have.length', 0);
 
     cy
       .get('[data-action-region]')

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -615,7 +615,7 @@ context('flow sidebar', function() {
 
     cy
       .get('[data-permission-region]')
-      .should('contain', 'You are not able to change settings on flows.');
+      .should('contain', 'You are not able to change settings on this flow.');
   });
 
   specify('flow with only work:team:manage permission', function() {
@@ -776,7 +776,7 @@ context('flow sidebar', function() {
 
     cy
       .get('[data-permission-region]')
-      .should('contain', 'You are not able to change settings on flows.');
+      .should('contain', 'You are not able to change settings on this flow.');
 
     cy
       .get('.patient-flow__context-trail .js-patient')
@@ -884,6 +884,6 @@ context('flow sidebar', function() {
 
     cy
       .get('[data-permission-region]')
-      .should('contain', 'You are not able to change settings on flows.');
+      .should('contain', 'You are not able to change settings on this flow.');
   });
 });

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -511,7 +511,7 @@ context('flow sidebar', function() {
       .click();
   });
 
-  specify('flow with only work:owned:manage permission', function() {
+  specify('flow with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -618,7 +618,7 @@ context('flow sidebar', function() {
       .should('contain', 'You are not able to change settings on this flow.');
   });
 
-  specify('flow with only work:team:manage permission', function() {
+  specify('flow with work:team:manage permission', function() {
     cy
       .routesForPatientDashboard()
       .routeCurrentClinician(fx => {
@@ -628,13 +628,9 @@ context('flow sidebar', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        fx.data = _.first(fx.data, 3);
+        fx.data = _.first(fx.data, 2);
 
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
-
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
@@ -642,9 +638,9 @@ context('flow sidebar', function() {
       })
       .routeFlow(fx => {
         fx.data.id = '1';
-        fx.data.attributes.name = 'Owned by current clinician’s team';
+        fx.data.attributes.name = 'Owned by another team';
         fx.data.relationships.state = { data: { id: '33333', type: 'states' } };
-        fx.data.relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data.relationships.owner = { data: { id: '22222', type: 'teams' } };
         fx.data.relationships.patient.data.id = '1';
 
         fx.included.push({
@@ -659,31 +655,19 @@ context('flow sidebar', function() {
         return fx;
       })
       .routePatientFlows(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
         fx.data[0].id = '1';
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.updated_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
         fx.data[1].id = '2';
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.updated_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].id = '3';
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.updated_at = testTsSubtract(3);
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].id = '4';
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.updated_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
@@ -710,71 +694,6 @@ context('flow sidebar', function() {
       .click();
 
     cy
-      .get('.app-frame__sidebar')
-      .find('[data-state-region]')
-      .find('button');
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('.patient-flow__context-trail .js-patient')
-      .click()
-      .wait('@routePatient')
-      .wait('@routePatientActions')
-      .wait('@routePatientFlows');
-
-    cy
-      .routeFlow(fx => {
-        fx.data.id = '2';
-        fx.data.attributes.name = 'Owned by another team';
-        fx.data.relationships.state = { data: { id: '33333', type: 'states' } };
-        fx.data.relationships.owner = { data: { id: '22222', type: 'teams' } };
-        fx.data.relationships.patient.data.id = '1';
-
-        fx.included.push({
-          id: '1',
-          attributes: {
-            first_name: 'Test',
-            last_name: 'Patient',
-          },
-          type: 'patients',
-        });
-
-        return fx;
-      });
-
-    cy
-      .get('.patient__list')
-      .find('.table-list__item')
-      .as('listItems')
-      .eq(1)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
-
-    cy
-      .get('.patient-flow__header')
-      .find('.patient-flow__name')
-      .click();
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-state-region]')
-      .find('button')
-      .should('not.exist');
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-owner-region]')
-      .find('button')
-      .should('not.exist');
-
-    cy
       .get('[data-permission-region]')
       .should('contain', 'You are not able to change settings on this flow.');
 
@@ -787,8 +706,8 @@ context('flow sidebar', function() {
 
     cy
       .routeFlow(fx => {
-        fx.data.id = '3';
-        fx.data.attributes.name = 'Owned by team member';
+        fx.data.id = '1';
+        fx.data.attributes.name = 'Owned by non team member';
         fx.data.relationships.state = { data: { id: '33333', type: 'states' } };
         fx.data.relationships.owner = { data: { id: '22222', type: 'clinicians' } };
         fx.data.relationships.patient.data.id = '1';
@@ -806,58 +725,8 @@ context('flow sidebar', function() {
       });
 
     cy
-      .get('@listItems')
-      .eq(2)
-      .find('.patient__action-name')
-      .click()
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
-
-    cy
-      .get('.patient-flow__header')
-      .find('.patient-flow__name')
-      .click();
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-state-region]')
-      .find('button');
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('.patient-flow__context-trail .js-patient')
-      .click()
-      .wait('@routePatient')
-      .wait('@routePatientActions')
-      .wait('@routePatientFlows');
-
-    cy
-      .routeFlow(fx => {
-        fx.data.id = '4';
-        fx.data.attributes.name = 'Owned by non team member';
-        fx.data.relationships.state = { data: { id: '33333', type: 'states' } };
-        fx.data.relationships.owner = { data: { id: '33333', type: 'clinicians' } };
-        fx.data.relationships.patient.data.id = '1';
-
-        fx.included.push({
-          id: '1',
-          attributes: {
-            first_name: 'Test',
-            last_name: 'Patient',
-          },
-          type: 'patients',
-        });
-
-        return fx;
-      });
-
-    cy
-      .get('@listItems')
+      .get('.patient__list')
+      .find('.table-list__item')
       .last()
       .find('.patient__action-name')
       .click()
@@ -869,18 +738,6 @@ context('flow sidebar', function() {
       .get('.patient-flow__header')
       .find('.patient-flow__name')
       .click();
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-state-region]')
-      .find('button')
-      .should('not.exist');
-
-    cy
-      .get('.app-frame__sidebar')
-      .find('[data-owner-region]')
-      .find('button')
-      .should('not.exist');
 
     cy
       .get('[data-permission-region]')

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -1205,7 +1205,7 @@ context('Worklist bulk editing', function() {
       .should('be.disabled');
   });
 
-  specify('bulk editing with only work:owned:manage permission', function() {
+  specify('bulk editing with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -1370,7 +1370,7 @@ context('Worklist bulk editing', function() {
       .get('[data-select-all-region] button:disabled');
   });
 
-  specify('bulk editing with only work:team:manage permission', function() {
+  specify('bulk editing with work:team:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
@@ -1379,38 +1379,26 @@ context('Worklist bulk editing', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
+        fx.data = _.first(fx.data, 2);
 
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
         return fx;
       })
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.created_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.created_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.created_at = testTsSubtract(3);
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.created_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
@@ -1420,13 +1408,6 @@ context('Worklist bulk editing', function() {
       .routePatientByFlow()
       .visit('/worklist/owned-by')
       .wait('@routeActions');
-
-    cy
-      .intercept('PATCH', '/api/flows/*', {
-        statusCode: 204,
-        body: {},
-      })
-      .as('patchFlow');
 
     cy
       .get('.worklist-list__toggle')
@@ -1440,40 +1421,12 @@ context('Worklist bulk editing', function() {
       .as('listItems')
       .first()
       .find('.js-select')
-      .click();
-
-    cy
-      .get('@listItems')
-      .eq(1)
-      .find('.js-select')
       .should('not.exist');
-
-    cy
-      .get('@listItems')
-      .eq(2)
-      .find('.js-select')
-      .click();
 
     cy
       .get('@listItems')
       .last()
       .find('.js-select')
       .should('not.exist');
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-bulk-edit')
-      .should('contain', 'Edit 2 Flows')
-      .click();
-
-    cy
-      .get('.modal--sidebar')
-      .find('.js-submit')
-      .click()
-      .wait(['@patchFlow', '@patchFlow']);
-
-    cy
-      .get('.alert-box')
-      .should('contain', '2 Flows have been updated');
   });
 });

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1552,7 +1552,7 @@ context('schedule page', function() {
       .should('have.length', 2);
   });
 
-  specify('bulk editing with only work:owned:manage permission', function() {
+  specify('bulk editing with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -1690,7 +1690,7 @@ context('schedule page', function() {
       .get('[data-select-all-region] button:disabled');
   });
 
-  specify('bulk editing with only work:team:manage permission', function() {
+  specify('bulk editing with work:team:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
@@ -1710,42 +1710,23 @@ context('schedule page', function() {
         return fx;
       })
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.due_date = testDateAdd(1);
-        fx.data[0].attributes.due_time = '8:00:00';
+        fx.data[0].attributes.due_time = '9:00:00';
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.due_date = testDateAdd(1);
-        fx.data[1].attributes.due_time = '9:00:00';
+        fx.data[1].attributes.due_time = '10:00:00';
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.due_date = testDateAdd(1);
-        fx.data[2].attributes.due_time = '10:00:00';
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.due_date = testDateAdd(1);
-        fx.data[3].attributes.due_time = '11:00:00';
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
 
         return fx;
       })
       .visit('/schedule');
-
-    cy
-      .intercept('PATCH', '/api/actions/*', {
-        statusCode: 204,
-        body: {},
-      })
-      .as('patchAction');
 
     cy
       .get('.schedule-list__table')
@@ -1755,57 +1736,13 @@ context('schedule page', function() {
       .as('actionDayListRows')
       .first()
       .find('.js-select')
-      .should('exist');
-
-    cy
-      .get('@actionDayListRows')
-      .eq(1)
-      .find('.js-select')
       .should('not.exist');
-
-    cy
-      .get('@actionDayListRows')
-      .eq(2)
-      .find('.js-select')
-      .should('exist');
 
     cy
       .get('@actionDayListRows')
       .last()
       .find('.js-select')
       .should('not.exist');
-
-    cy
-      .get('[data-select-all-region]')
-      .click();
-
-    cy
-      .get('[data-filters-region]')
-      .find('.js-bulk-edit')
-      .should('contain', 'Edit 2 Actions')
-      .click();
-
-    cy
-      .get('.modal--sidebar')
-      .as('sidebar')
-      .find('[data-state-region]')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .contains('To Do')
-      .click();
-
-    cy
-      .get('@sidebar')
-      .find('.js-submit')
-      .click()
-      .wait(['@patchAction', '@patchAction']);
-
-    cy
-      .get('.alert-box')
-      .should('contain', '2 Actions have been updated');
   });
 
   specify('actions on a done-flow', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3978,6 +3978,8 @@ context('worklist page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
+        fx.data = _.first(fx.data, 3);
+
         const teamMemberClinician = _.find(fx.data, { id: '22222' });
         teamMemberClinician.attributes.name = 'Team Member';
         teamMemberClinician.relationships.team.data.id = '11111';
@@ -4030,7 +4032,26 @@ context('worklist page', function() {
       .find('.table-list__item')
       .first()
       .find('[data-owner-region]')
-      .find('button');
+      .find('button')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .eq(1)
+      .find('.js-picklist-item')
+      .should('have.length', 2)
+      .should('contain', 'Clinician McTester')
+      .next()
+      .should('contain', 'Team Member');
+
+    cy
+      .get('.picklist')
+      .find('.picklist__group')
+      .last()
+      .find('.js-picklist-item')
+      .should('have.length', 1)
+      .should('contain', 'Coordinator');
 
     cy
       .get('.app-frame__content')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3749,7 +3749,7 @@ context('worklist page', function() {
       .contains('No Actions');
   });
 
-  specify('actions without work:manage permission', function() {
+  specify('actions with only work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -3866,7 +3866,7 @@ context('worklist page', function() {
       .should('not.exist');
   });
 
-  specify('flows without work:manage permission', function() {
+  specify('flows with only work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -3965,6 +3965,187 @@ context('worklist page', function() {
       .get('@thirdRow')
       .find('[data-owner-region]')
       .should('contain', 'Coordinator')
+      .find('button')
+      .should('not.exist');
+  });
+
+  specify('actions with only work:team:manage permission', function() {
+    cy
+      .routeCurrentClinician(fx => {
+        fx.data.relationships.role = { data: { id: '77777' } };
+        fx.data.relationships.team = { data: { id: '11111', type: 'teams' } };
+
+        return fx;
+      })
+      .routeWorkspaceClinicians(fx => {
+        const teamMemberClinician = _.find(fx.data, { id: '22222' });
+        teamMemberClinician.attributes.name = 'Team Member';
+        teamMemberClinician.relationships.team.data.id = '11111';
+
+        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        nonTeamMemberClinician.attributes.name = 'Non Team Member';
+        nonTeamMemberClinician.relationships.team.data.id = '22222';
+
+        return fx;
+      })
+      .routeActions(fx => {
+        fx.data = _.sample(fx.data, 4);
+
+        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.created_at = testTsSubtract(1);
+        fx.data[0].relationships.state = { data: { id: '33333' } };
+        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+
+        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.created_at = testTsSubtract(2);
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+
+        fx.data[2].attributes.name = 'Owned by team member';
+        fx.data[2].attributes.created_at = testTsSubtract(3);
+        fx.data[2].relationships.state = { data: { id: '33333' } };
+        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
+
+        fx.data[3].attributes.name = 'Owned by non team member';
+        fx.data[3].attributes.created_at = testTsSubtract(4);
+        fx.data[3].relationships.state = { data: { id: '33333' } };
+        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+
+        return fx;
+      })
+      .visit('/worklist/owned-by')
+      .wait('@routeActions');
+
+    cy
+      .get('[data-select-all-region] button:enabled')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 2);
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(1)
+      .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(2)
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(3)
+      .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+  });
+
+  specify('flows with only work:team:manage permission', function() {
+    cy
+      .routeCurrentClinician(fx => {
+        fx.data.relationships.role = { data: { id: '77777' } };
+        fx.data.relationships.team = { data: { id: '11111', type: 'teams' } };
+
+        return fx;
+      })
+      .routeWorkspaceClinicians(fx => {
+        const teamMemberClinician = _.find(fx.data, { id: '22222' });
+        teamMemberClinician.attributes.name = 'Team Member';
+        teamMemberClinician.relationships.team.data.id = '11111';
+
+        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        nonTeamMemberClinician.attributes.name = 'Non Team Member';
+        nonTeamMemberClinician.relationships.team.data.id = '22222';
+
+        return fx;
+      })
+      .routeFlows(fx => {
+        fx.data = _.sample(fx.data, 4);
+
+        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.created_at = testTsSubtract(1);
+        fx.data[0].relationships.state = { data: { id: '33333' } };
+        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+
+        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.created_at = testTsSubtract(2);
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
+
+        fx.data[2].attributes.name = 'Owned by team member';
+        fx.data[2].attributes.created_at = testTsSubtract(3);
+        fx.data[2].relationships.state = { data: { id: '33333' } };
+        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
+
+        fx.data[3].attributes.name = 'Owned by non team member';
+        fx.data[3].attributes.created_at = testTsSubtract(4);
+        fx.data[3].relationships.state = { data: { id: '33333' } };
+        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+
+        return fx;
+      })
+      .routeActions()
+      .visit('/worklist/owned-by')
+      .wait('@routeActions');
+
+    cy
+      .get('.worklist-list__toggle')
+      .contains('Flows')
+      .click()
+      .wait('@routeFlows');
+
+    cy
+      .get('[data-select-all-region] button:enabled')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item.is-selected')
+      .should('have.length', 2);
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(1)
+      .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(2)
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(3)
+      .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
   });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -4076,12 +4076,17 @@ context('worklist page', function() {
         return fx;
       })
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 2);
+        fx.data = _.sample(fx.data, 3);
 
-        fx.data[0].attributes.name = 'Owned by another team';
+        fx.data[0].attributes.name = 'Owned by current clinician’s team';
         fx.data[0].attributes.created_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+
+        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.created_at = testTsSubtract(1);
+        fx.data[1].relationships.state = { data: { id: '33333' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
         fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.created_at = testTsSubtract(2);
@@ -4104,6 +4109,13 @@ context('worklist page', function() {
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
+      .find('[data-owner-region]')
+      .find('button');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(1)
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3751,7 +3751,7 @@ context('worklist page', function() {
       .contains('No Actions');
   });
 
-  specify('actions with only work:owned:manage permission', function() {
+  specify('actions with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -3868,7 +3868,7 @@ context('worklist page', function() {
       .should('not.exist');
   });
 
-  specify('flows with only work:owned:manage permission', function() {
+  specify('flows with work:owned:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '66666' } };
@@ -3971,7 +3971,7 @@ context('worklist page', function() {
       .should('not.exist');
   });
 
-  specify('actions with only work:team:manage permission', function() {
+  specify('actions with work:team:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
@@ -3993,7 +3993,7 @@ context('worklist page', function() {
         return fx;
       })
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 3);
 
         fx.data[0].attributes.name = 'Owned by current clinician’s team';
         fx.data[0].attributes.created_at = testTsSubtract(1);
@@ -4005,29 +4005,15 @@ context('worklist page', function() {
         fx.data[1].relationships.state = { data: { id: '33333' } };
         fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[2].attributes.name = 'Owned by team member';
+        fx.data[2].attributes.name = 'Owned by non team member';
         fx.data[2].attributes.created_at = testTsSubtract(3);
         fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.created_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[2].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
 
         return fx;
       })
       .visit('/worklist/owned-by')
       .wait('@routeActions');
-
-    cy
-      .get('[data-select-all-region] button:enabled')
-      .click();
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item.is-selected')
-      .should('have.length', 2);
 
     cy
       .get('.app-frame__content')
@@ -4066,20 +4052,13 @@ context('worklist page', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .eq(2)
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .eq(3)
+      .last()
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
   });
 
-  specify('flows with only work:team:manage permission', function() {
+  specify('flows with work:team:manage permission', function() {
     cy
       .routeCurrentClinician(fx => {
         fx.data.relationships.role = { data: { id: '77777' } };
@@ -4088,38 +4067,26 @@ context('worklist page', function() {
         return fx;
       })
       .routeWorkspaceClinicians(fx => {
-        const teamMemberClinician = _.find(fx.data, { id: '22222' });
-        teamMemberClinician.attributes.name = 'Team Member';
-        teamMemberClinician.relationships.team.data.id = '11111';
+        fx.data = _.first(fx.data, 2);
 
-        const nonTeamMemberClinician = _.find(fx.data, { id: '33333' });
+        const nonTeamMemberClinician = _.find(fx.data, { id: '22222' });
         nonTeamMemberClinician.attributes.name = 'Non Team Member';
         nonTeamMemberClinician.relationships.team.data.id = '22222';
 
         return fx;
       })
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 4);
+        fx.data = _.sample(fx.data, 2);
 
-        fx.data[0].attributes.name = 'Owned by current clinician’s team';
+        fx.data[0].attributes.name = 'Owned by another team';
         fx.data[0].attributes.created_at = testTsSubtract(1);
         fx.data[0].relationships.state = { data: { id: '33333' } };
-        fx.data[0].relationships.owner = { data: { id: '11111', type: 'teams' } };
+        fx.data[0].relationships.owner = { data: { id: '22222', type: 'teams' } };
 
-        fx.data[1].attributes.name = 'Owned by another team';
+        fx.data[1].attributes.name = 'Owned by non team member';
         fx.data[1].attributes.created_at = testTsSubtract(2);
         fx.data[1].relationships.state = { data: { id: '33333' } };
-        fx.data[1].relationships.owner = { data: { id: '22222', type: 'teams' } };
-
-        fx.data[2].attributes.name = 'Owned by team member';
-        fx.data[2].attributes.created_at = testTsSubtract(3);
-        fx.data[2].relationships.state = { data: { id: '33333' } };
-        fx.data[2].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
-
-        fx.data[3].attributes.name = 'Owned by non team member';
-        fx.data[3].attributes.created_at = testTsSubtract(4);
-        fx.data[3].relationships.state = { data: { id: '33333' } };
-        fx.data[3].relationships.owner = { data: { id: '33333', type: 'clinicians' } };
+        fx.data[1].relationships.owner = { data: { id: '22222', type: 'clinicians' } };
 
         return fx;
       })
@@ -4134,25 +4101,9 @@ context('worklist page', function() {
       .wait('@routeFlows');
 
     cy
-      .get('[data-select-all-region] button:enabled')
-      .click();
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item.is-selected')
-      .should('have.length', 2);
-
-    cy
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .eq(1)
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
@@ -4160,14 +4111,7 @@ context('worklist page', function() {
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
-      .eq(2)
-      .find('[data-owner-region]')
-      .find('button');
-
-    cy
-      .get('.app-frame__content')
-      .find('.table-list__item')
-      .eq(3)
+      .last()
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');


### PR DESCRIPTION
Shortcut Story ID: [sc-39262]

When a user has the `work:team:manage` permission, they can only edit actions that belong to team members (or the team itself).

And when that user is editing an action/flow, the owner droplist should be restricted so they can only assign work to users from their own team (or the team itself).

Still need to do the following:

- [x] Restrict owner component to only include the user’s team and team members (in all contexts)
- [x] Patient dashboard tests
- [x] Patient archive tests
- [x] Worklist bulk edit
- [x] Patient flow tests
- [x] Patient action sidebar tests
- [x] Patient flow sidebar tests