### PR TITLE
Set popWidth option of pop region component before calculating height

### DIFF
--- a/src/js/components/datepicker/datepicker.cy.js
+++ b/src/js/components/datepicker/datepicker.cy.js
@@ -299,4 +299,31 @@ context('Datepicker', function() {
       .find('.js-month')
       .contains(formatDate(testDate(), 'MMM YYYY'));
   });
+
+  specify('Displaying from bottom', function() {
+    const testView = new TestView({
+      model: new Backbone.Model(),
+    });
+
+    testView.$el.css({ position: 'fixed', bottom: '10px' });
+
+    cy
+      .mount(rootView => {
+        Datepicker.setRegion(rootView.getRegion('pop'));
+
+        return testView;
+      })
+      .as('root');
+
+    cy
+      .get('@root')
+      .contains('Select Date')
+      .click();
+
+    cy
+      .get('.datepicker')
+      .should($datepicker => {
+        expect($datepicker.position().top).to.be.greaterThan(400);
+      });
+  });
 });

--- a/src/js/views/globals/root_views.js
+++ b/src/js/views/globals/root_views.js
@@ -152,19 +152,22 @@ const PopRegionView = TopRegionView.extend({
   },
   setLocation(popOptions) {
     const view = this.region.currentView;
+
+    if (popOptions.popWidth) {
+      view.$el.css({
+        width: px(popOptions.popWidth),
+      });
+    }
+
     const height = view.$el.outerHeight();
     const top = this.setDirection(height, popOptions);
     const width = popOptions.popWidth || view.$el.outerWidth();
     const left = this.setAlign(width, popOptions);
 
-    const css = {
+    view.$el.css({
       top: px(top),
       left: px(left),
-    };
-
-    if (popOptions.popWidth) css.width = px(width);
-
-    view.$el.css(css);
+    });
   },
   setAlign(width, { left, align, windowPadding, outerWidth }) {
     if (align === 'right') left += outerWidth - width;


### PR DESCRIPTION
Shortcut Story ID: [sc-39090]

This was bugging because it was measuring the height of the picker prior to constraining it's width... which meant it wasn't nearly as tall as it needed to be.

- [ ] Figure out a way to test this in the component testing 