### PR TITLE
Use `/flow` route as a fallback when using the form `Go Back` link or `Submit + Go Back` button

### DIFF
--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -135,6 +135,11 @@ export default App.extend({
     if (this.shouldSaveAndGoBack()) {
       this.listenTo(this.loadingModal, 'destroy', () => {
         Radio.request('history', 'go:back', () => {
+          if (this.action.get('_flow')) {
+            Radio.trigger('event-router', 'flow', this.action.get('_flow'));
+            return;
+          }
+
           Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
         });
       });

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -35,11 +35,19 @@ const ContextTrailView = View.extend({
   },
   onClickBack() {
     Radio.request('history', 'go:back', () => {
+      if (this.action.get('_flow')) {
+        this.routeToFlow();
+        return;
+      }
+
       this.routeToPatient();
     });
   },
   onClickDashboard() {
     this.routeToPatient();
+  },
+  routeToFlow() {
+    Radio.trigger('event-router', 'flow', this.action.get('_flow'));
   },
   routeToPatient() {
     Radio.trigger('event-router', 'patient:dashboard', this.patient.id);


### PR DESCRIPTION
Shortcut Story ID: [sc-38686]

When a user loads a form URL directly (no browser route history) and then clicks the `Go Back` link or `Submit + Go Back` button, we take them to the patient's dashboard as the fallback.

Instead we want to take them to the `/flow` page (when possible). On an action form, if the action doesn't belong to a flow, we route them to the patient dashboard.

Since patient forms don't have an action or flow, they'll continue to route to the patient dashboard in this situation.