### PR TITLE
Fix `canEdit()` related coverage drop

### DIFF
--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1654,7 +1654,7 @@ context('action sidebar', function() {
         return fx;
       })
       .routeSettings(fx => {
-        fx.data.push({ id: 'upload_attachments', attributes: { value: false } });
+        fx.data.push({ id: 'upload_attachments', attributes: { value: true } });
 
         return fx;
       })
@@ -1672,8 +1672,17 @@ context('action sidebar', function() {
             state: { data: { id: '22222' } },
             form: { data: { id: '11111' } },
             files: { data: [{ id: '1' }] },
+            program_action: { data: { id: '1' } },
           },
         };
+
+        fx.included.push({
+          id: '1',
+          type: 'program-actions',
+          attributes: {
+            allowed_uploads: ['pdf'],
+          },
+        });
 
         return fx;
       })
@@ -1712,8 +1721,7 @@ context('action sidebar', function() {
 
     cy
       .get('[data-action-region]')
-      .find('.js-input')
-      .should('have.length', 2);
+      .find('.js-input');
 
     cy
       .get('[data-action-region]')


### PR DESCRIPTION
Shortcut Story ID: [sc-40641]

Missing branch coverage on this [line of code](https://github.com/RoundingWell/care-ops-frontend/blob/develop/src/js/entities-service/entities/actions.js#L167).

For the `Add an Attachment` button to show in the action sidebar, these things need to exist:

1. `upload_attachments: true` org setting.
2. `included.program_action.allowed_uploads: ['pdf']` data on the action.
3. Action must be in a `canEdit = true` state.

We need a test where the `canEdit` status of an action is the only thing stopping the `Add an Attachment` button from showing.