### PR TITLE
Outreach: OTP code input updates

### DIFF
--- a/src/js/outreach/views/verify_views.js
+++ b/src/js/outreach/views/verify_views.js
@@ -70,14 +70,14 @@ const VerifyCodeView = View.extend({
     };
   },
   watchInput(event) {
-    const inputElements = this.ui.input;
-    const index = inputElements.index(event.target);
-
-    const value = String(event.target.value);
+    const value = String(event.target.value).replace(/\s/g, '');
     const first = value.charAt(0);
     const rest = value.substring(1);
 
     event.target.value = first;
+
+    const inputElements = this.ui.input;
+    const index = inputElements.index(event.target);
 
     const isLastInputEl = index === inputElements.length - 1;
     const didInsertContent = first !== undefined && value.length;

--- a/src/js/outreach/views/verify_views.js
+++ b/src/js/outreach/views/verify_views.js
@@ -52,10 +52,10 @@ const VerifyCodeView = View.extend({
     <h2 class="verify__heading-text">Enter your verification code.</h2>
     <p class="verify__info-text">We sent a text message with a verification code to the phone number XXX-XXX-{{ phoneEnd }}.</p>
     <div class="verify__code-fields">
-      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" />
-      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" />
-      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" />
-      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" />
+      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" inputmode="numeric" />
+      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" inputmode="numeric" />
+      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" inputmode="numeric" />
+      <input class="input-primary verify__code-input js-input{{#if hasInvalidCodeError}} has-error{{/if}}" inputmode="numeric" />
     </div>
     {{#if hasInvalidCodeError}}
       <p class="verify__error-text">Incorrect verification code. Please try again.</p>

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -256,7 +256,8 @@ context('Outreach', function() {
       .get('.verify__code-fields')
       .find('.js-input')
       .first()
-      .invoke('val', '1234')
+      // NOTE: ' 12 34' is used to ensure all empty spaces are automatically removed
+      .invoke('val', ' 12 34')
       .trigger('input');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-41142]

Two updates in this PR:

1. Add `inputmode='numeric'` to each OTP code input. OTP codes will be numerical, so this will allow browsers to display the correct virtual keyboard.
2. Using a regex, automatically remove any empty spaces when a user enters the OTP code. This includes if a user is entering the code one number at a time or copy-pasting the entire code at once.