### PR TITLE
Refactor cypress `.route()` usage to `.intercept()` in `test/support/api` files

### DIFF
--- a/test/helpers/json-api.js
+++ b/test/helpers/json-api.js
@@ -1,6 +1,8 @@
 import _ from 'underscore';
 
 function getResource(data, type) {
+  data = JSON.parse(JSON.stringify(data));
+
   if (_.isArray(data)) {
     return _.map(data, _.partial(getResource, _, type));
   }

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -6,6 +6,8 @@ import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
 import stateColors from 'helpers/state-colors';
 
+import fxTestActionEvents from 'fixtures/test/action-events';
+
 context('action sidebar', function() {
   specify('display new action sidebar', function() {
     cy
@@ -339,7 +341,7 @@ context('action sidebar', function() {
         return fx;
       })
       .routeActionActivity(fx => {
-        fx.data = [...this.fxEvents, {}];
+        fx.data = [...fxTestActionEvents, {}];
         fx.data[0].relationships.editor.data = null;
         fx.data[0].attributes.date = testTs();
 
@@ -1127,8 +1129,8 @@ context('action sidebar', function() {
       .routesForPatientAction()
       .routeActionActivity(fx => {
         fx.data = [];
-        fx.data[0] = this.fxEvents[0];
-        fx.data[1] = this.fxEvents[1];
+        fx.data[0] = fxTestActionEvents[0];
+        fx.data[1] = fxTestActionEvents[1];
 
         fx.data[0].attributes.date = testTsSubtract(8);
         fx.data[1].attributes.date = testTs();
@@ -1399,8 +1401,8 @@ context('action sidebar', function() {
       .routeActionActivity(fx => {
         fx.included = [];
         fx.data = [];
-        fx.data[0] = this.fxEvents[0];
-        fx.data[1] = this.fxEvents[1];
+        fx.data[0] = fxTestActionEvents[0];
+        fx.data[1] = fxTestActionEvents[1];
         fx.data[0].relationships.editor.data = null;
         fx.data[0].attributes.date = testTs();
 

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -4,8 +4,6 @@ import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDateAdd } from 'helpers/test-date';
 
-import fxFlows from 'fixtures/collections/flows';
-
 const tomorrow = testDateAdd(1);
 
 context('Worklist bulk editing', function() {
@@ -42,11 +40,15 @@ context('Worklist bulk editing', function() {
         fx.data[3].attributes.due_time = '07:00:00';
         fx.data[3].relationships.state = { data: { id: '22222' } };
 
-
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
         });
 
         return fx;
@@ -665,7 +667,12 @@ context('Worklist bulk editing', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
         });
 
         return fx;
@@ -1143,8 +1150,12 @@ context('Worklist bulk editing', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' })
-          ,
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
         });
 
         return fx;

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -12,15 +12,6 @@ context('Worklist bulk editing', function() {
   specify('date and time components', function() {
     cy
       .routeActions(fx => {
-        const flowInclude = {
-          id: '1',
-          type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-            id: '1',
-          }),
-        };
-
         fx.data = _.sample(fx.data, 4);
 
         fx.data[0].id = '1';
@@ -52,7 +43,11 @@ context('Worklist bulk editing', function() {
         fx.data[3].relationships.state = { data: { id: '22222' } };
 
 
-        fx.included.push(flowInclude);
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+        });
 
         return fx;
       })
@@ -606,15 +601,6 @@ context('Worklist bulk editing', function() {
   specify('bulk actions editing', function() {
     cy
       .routeActions(fx => {
-        const flowInclude = {
-          id: '1',
-          type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-            id: '1',
-          }),
-        };
-
         fx.data = _.sample(fx.data, 4);
         fx.data[0] = {
           id: '1',
@@ -676,7 +662,11 @@ context('Worklist bulk editing', function() {
         fx.data[3].attributes.created_at = testTsSubtract(2);
         fx.data[3].relationships.state = { data: { id: '33333' } };
 
-        fx.included.push(flowInclude);
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+        });
 
         return fx;
       })
@@ -1143,15 +1133,6 @@ context('Worklist bulk editing', function() {
     cy
       .routeFlows()
       .routeActions(fx => {
-        const flowInclude = {
-          id: '1',
-          type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-            id: '1',
-          }),
-        };
-
         fx.data = _.sample(fx.data, 2);
         fx.data[0].id = '1';
         fx.data[0].relationships.state = { data: { id: '22222' } };
@@ -1159,7 +1140,12 @@ context('Worklist bulk editing', function() {
         fx.data[1].id = '3';
         fx.data[1].relationships.state = { data: { id: '55555' } };
 
-        fx.included.push(flowInclude);
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' })
+          ,
+        });
 
         return fx;
       })

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -4,6 +4,8 @@ import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDateAdd } from 'helpers/test-date';
 
+import fxFlows from 'fixtures/collections/flows';
+
 const tomorrow = testDateAdd(1);
 
 context('Worklist bulk editing', function() {
@@ -13,7 +15,7 @@ context('Worklist bulk editing', function() {
         const flowInclude = {
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
             id: '1',
           }),
@@ -607,7 +609,7 @@ context('Worklist bulk editing', function() {
         const flowInclude = {
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
             id: '1',
           }),
@@ -1144,7 +1146,7 @@ context('Worklist bulk editing', function() {
         const flowInclude = {
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
             id: '1',
           }),

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -2,6 +2,9 @@ import _ from 'underscore';
 
 import { testDate, testDateAdd } from 'helpers/test-date';
 
+import fxPatients from 'fixtures/collections/patients';
+import fxFlows from 'fixtures/collections/flows';
+
 const states = ['22222', '33333'];
 
 context('reduced schedule page', function() {
@@ -50,7 +53,7 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'Test',
               last_name: 'Patient',
             }),
@@ -58,7 +61,7 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'flows',
-            attributes: _.extend(_.sample(this.fxFlows), {
+            attributes: _.extend(_.sample(fxFlows), {
               name: 'Complex Care Management',
             }),
           },
@@ -390,7 +393,7 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'Test',
               last_name: 'Patient',
             }),

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -53,17 +53,12 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'Test',
-              last_name: 'Patient',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
           },
           {
             id: '1',
             type: 'flows',
-            attributes: _.extend(_.sample(fxFlows), {
-              name: 'Complex Care Management',
-            }),
+            attributes: _.extend({}, _.sample(fxFlows), { name: 'Complex Care Management' }),
           },
         );
 
@@ -393,10 +388,7 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'Test',
-              last_name: 'Patient',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
           },
         );
 

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -1,9 +1,7 @@
 import _ from 'underscore';
 
 import { testDate, testDateAdd } from 'helpers/test-date';
-
-import fxPatients from 'fixtures/collections/patients';
-import fxFlows from 'fixtures/collections/flows';
+import { testTs } from 'helpers/test-timestamp';
 
 const states = ['22222', '33333'];
 
@@ -49,16 +47,25 @@ context('reduced schedule page', function() {
 
         fx.data = fx.data.slice(0, 3);
 
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: {
+            name: 'Complex Care Management',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
+        });
+
         fx.included.push(
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
-          },
-          {
-            id: '1',
-            type: 'flows',
-            attributes: _.extend({}, _.sample(fxFlows), { name: 'Complex Care Management' }),
+            attributes: {
+              first_name: 'Test',
+              last_name: 'Patient',
+            },
           },
         );
 
@@ -388,7 +395,10 @@ context('reduced schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
+            attributes: {
+              first_name: 'Test',
+              last_name: 'Patient',
+            },
           },
         );
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -4,6 +4,10 @@ import dayjs from 'dayjs';
 import formatDate from 'helpers/format-date';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 
+import fxFlows from 'fixtures/collections/flows';
+import fxPatients from 'fixtures/collections/patients';
+import fxActions from 'fixtures/collections/actions';
+
 const states = ['22222', '33333'];
 
 const STATE_VERSION = 'v6';
@@ -80,7 +84,7 @@ context('schedule page', function() {
           {
             id: '1',
             type: 'flows',
-            attributes: _.extend(_.sample(this.fxFlows), {
+            attributes: _.extend(_.sample(fxFlows), {
               name: 'Complex Care Management',
               id: '1',
             }),
@@ -88,7 +92,7 @@ context('schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'Test',
               last_name: 'Patient',
               id: '1',
@@ -97,7 +101,7 @@ context('schedule page', function() {
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'LongTest',
               last_name: 'PatientName',
               id: '1',
@@ -1069,7 +1073,7 @@ context('schedule page', function() {
           {
             id: 1,
             type: 'flows',
-            attributes: _.extend(_.sample(this.fxActions), {
+            attributes: _.extend(_.sample(fxActions), {
               name: 'Parent Flow',
               id: '1',
             }),
@@ -1077,7 +1081,7 @@ context('schedule page', function() {
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'Test',
               last_name: 'Patient',
             }),
@@ -1085,7 +1089,7 @@ context('schedule page', function() {
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend(_.sample(this.fxPatients), {
+            attributes: _.extend(_.sample(fxPatients), {
               first_name: 'LongTest',
               last_name: 'PatientName',
             }),
@@ -1758,7 +1762,7 @@ context('schedule page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Done Test Flow',
           }),
           relationships: {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -3,9 +3,7 @@ import dayjs from 'dayjs';
 
 import formatDate from 'helpers/format-date';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
-
-import fxFlows from 'fixtures/collections/flows';
-import fxPatients from 'fixtures/collections/patients';
+import { testTs } from 'helpers/test-timestamp';
 
 const states = ['22222', '33333'];
 
@@ -79,21 +77,33 @@ context('schedule page', function() {
           action.relationships.state.data.id = idx % 2 === 0 ? states[0] : states[1];
         });
 
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: {
+            name: 'Complex Care Management',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
+        });
+
         fx.included.push(
           {
             id: '1',
-            type: 'flows',
-            attributes: _.extend({}, _.sample(fxFlows), { name: 'Complex Care Management' }),
-          },
-          {
-            id: '1',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
+            attributes: {
+              first_name: 'Test',
+              last_name: 'Patient',
+            },
           },
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'LongTest', last_name: 'PatientName' }),
+            attributes: {
+              first_name: 'LongTest',
+              last_name: 'PatientName',
+            },
           },
         );
 
@@ -1057,21 +1067,33 @@ context('schedule page', function() {
           }
         });
 
-        fx.included.push(
-          {
-            id: 1,
-            type: 'flows',
-            attributes: _.extend({}, _.sample(fxFlows), { name: 'Parent Flow' }),
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: {
+            name: 'Parent Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
           },
+        });
+
+        fx.included.push(
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
+            attributes: {
+              first_name: 'Test',
+              last_name: 'Patient',
+            },
           },
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'LongTest', last_name: 'PatientName' }),
+            attributes: {
+              first_name: 'LongTest',
+              last_name: 'PatientName',
+            },
           },
         );
 
@@ -1741,9 +1763,11 @@ context('schedule page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Done Test Flow' }),
-          relationships: {
-            state: { data: { id: '55555' } },
+          attributes: {
+            name: 'Done Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
           },
         });
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -6,7 +6,6 @@ import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 
 import fxFlows from 'fixtures/collections/flows';
 import fxPatients from 'fixtures/collections/patients';
-import fxActions from 'fixtures/collections/actions';
 
 const states = ['22222', '33333'];
 
@@ -84,28 +83,17 @@ context('schedule page', function() {
           {
             id: '1',
             type: 'flows',
-            attributes: _.extend(_.sample(fxFlows), {
-              name: 'Complex Care Management',
-              id: '1',
-            }),
+            attributes: _.extend({}, _.sample(fxFlows), { name: 'Complex Care Management' }),
           },
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'Test',
-              last_name: 'Patient',
-              id: '1',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
           },
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'LongTest',
-              last_name: 'PatientName',
-              id: '1',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'LongTest', last_name: 'PatientName' }),
           },
         );
 
@@ -1073,26 +1061,17 @@ context('schedule page', function() {
           {
             id: 1,
             type: 'flows',
-            attributes: _.extend(_.sample(fxActions), {
-              name: 'Parent Flow',
-              id: '1',
-            }),
+            attributes: _.extend({}, _.sample(fxFlows), { name: 'Parent Flow' }),
           },
           {
             id: '1',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'Test',
-              last_name: 'Patient',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'Test', last_name: 'Patient' }),
           },
           {
             id: '2',
             type: 'patients',
-            attributes: _.extend(_.sample(fxPatients), {
-              first_name: 'LongTest',
-              last_name: 'PatientName',
-            }),
+            attributes: _.extend({}, _.sample(fxPatients), { first_name: 'LongTest', last_name: 'PatientName' }),
           },
         );
 
@@ -1762,9 +1741,7 @@ context('schedule page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Done Test Flow',
-          }),
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Done Test Flow' }),
           relationships: {
             state: { data: { id: '55555' } },
           },

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2819,6 +2819,14 @@ context('worklist page', function() {
   specify('action sorting - patient field', function() {
     cy
       .routesForPatientAction()
+      .routeSettings(fx => {
+        const sortingSettings = _.find(fx.data, setting => setting.id === 'sorting');
+        _.each(sortingSettings.attributes.value, function(sortMethod) {
+          sortMethod.sort_type = 'alphanumeric';
+        });
+
+        return fx;
+      })
       .routeActions(fx => {
         fx.data = _.sample(fx.data, 3);
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -467,17 +467,6 @@ context('worklist page', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
-        const flowInclude = {
-          id: '1',
-          type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-          }),
-          relationships: {
-            state: { data: { id: '33333' } },
-          },
-        };
-
         fx.data = actions;
 
         fx.included.push({
@@ -489,7 +478,12 @@ context('worklist page', function() {
           },
         });
 
-        fx.included.push(flowInclude);
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          relationships: { state: { data: { id: '33333' } } },
+        });
 
         return fx;
       })
@@ -905,12 +899,8 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-          }),
-          relationships: {
-            state: { data: { id: '55555' } },
-          },
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          relationships: { state: { data: { id: '55555' } } },
         });
 
         return fx;
@@ -3757,15 +3747,6 @@ context('worklist page', function() {
         return fx;
       })
       .routeActions(fx => {
-        const flowInclude = {
-          id: '1',
-          type: 'flows',
-          attributes: _.extend(_.sample(fxFlows), {
-            name: 'Test Flow',
-            id: '1',
-          }),
-        };
-
         fx.data = _.sample(fx.data, 4);
         fx.data[0] = {
           id: '1',
@@ -3831,7 +3812,11 @@ context('worklist page', function() {
         fx.data[3].relationships.owner = { data: { id: '11111', type: 'teams' } };
         fx.data[3].relationships.state = { data: { id: '33333' } };
 
-        fx.included.push(flowInclude);
+        fx.included.push({
+          id: '1',
+          type: 'flows',
+          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+        });
 
         return fx;
       })

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2819,14 +2819,6 @@ context('worklist page', function() {
   specify('action sorting - patient field', function() {
     cy
       .routesForPatientAction()
-      .routeSettings(fx => {
-        const sortingSettings = _.find(fx.data, setting => setting.id === 'sorting');
-        _.each(sortingSettings.attributes.value, function(sortMethod) {
-          sortMethod.sort_type = 'alphanumeric';
-        });
-
-        return fx;
-      })
       .routeActions(fx => {
         fx.data = _.sample(fx.data, 3);
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -7,6 +7,8 @@ import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getResource } from 'helpers/json-api';
 
+import fxFlows from 'fixtures/collections/flows';
+
 const STATE_VERSION = 'v6';
 
 context('worklist page', function() {
@@ -463,15 +465,12 @@ context('worklist page', function() {
     ];
 
     cy
-      .fixture('collections/flows').as('fxFlows');
-
-    cy
       .routesForPatientAction()
       .routeActions(fx => {
         const flowInclude = {
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
           }),
           relationships: {
@@ -906,7 +905,7 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
           }),
           relationships: {
@@ -3761,7 +3760,7 @@ context('worklist page', function() {
         const flowInclude = {
           id: '1',
           type: 'flows',
-          attributes: _.extend(_.sample(this.fxFlows), {
+          attributes: _.extend(_.sample(fxFlows), {
             name: 'Test Flow',
             id: '1',
           }),

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -7,8 +7,6 @@ import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getResource } from 'helpers/json-api';
 
-import fxFlows from 'fixtures/collections/flows';
-
 const STATE_VERSION = 'v6';
 
 context('worklist page', function() {
@@ -481,7 +479,12 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
           relationships: { state: { data: { id: '33333' } } },
         });
 
@@ -899,7 +902,12 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
           relationships: { state: { data: { id: '55555' } } },
         });
 
@@ -3815,7 +3823,12 @@ context('worklist page', function() {
         fx.included.push({
           id: '1',
           type: 'flows',
-          attributes: _.extend({}, _.sample(fxFlows), { name: 'Test Flow' }),
+          attributes: {
+            name: 'Test Flow',
+            details: null,
+            created_at: testTs(),
+            updated_at: testTs(),
+          },
         });
 
         return fx;

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -1,15 +1,18 @@
 import _ from 'underscore';
-import patientFixture from 'fixtures/collections/patients.json';
+
 import { getRelationship, getIncluded } from 'helpers/json-api';
+
+import fxPatients from 'fixtures/collections/patients';
 
 context('Patient Quick Search', function() {
   beforeEach(function() {
-    const patients = _.map(_.sample(patientFixture, 10), (patient, index) => {
-      patient.id = `${ index }`;
-      patient.first_name = 'Test';
-      patient.last_name = `${ index } Patient`;
-      patient.identifiers = index % 2 ? [] : [{ type: 'mrn', value: 'identifier-001' }];
-      return patient;
+    const patients = _.map(_.sample(fxPatients, 10), (patient, index) => {
+      return _.extend({}, patient, {
+        id: `${ index }`,
+        first_name: 'Test',
+        last_name: `${ index } Patient`,
+        identifiers: index % 2 ? [] : [{ type: 'mrn', value: 'identifier-001' }],
+      });
     });
 
     const data = _.map(patients, patient => {

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -1,108 +1,97 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
 import { getResource, getRelationship } from 'helpers/json-api';
-import fxWorkspaces from 'fixtures/test/workspaces.json';
-import fxClinicians from 'fixtures/test/clinicians.json';
-import fxTeams from 'fixtures/test/teams.json';
-import fxRoles from 'fixtures/test/roles.json';
+
+import fxTestWorkspaces from 'fixtures/test/workspaces.json';
+import fxTestClinicians from 'fixtures/test/clinicians.json';
+import fxTestTeams from 'fixtures/test/teams.json';
+import fxTestRoles from 'fixtures/test/roles.json';
 
 function getClinicianRelationships(clinician) {
   if (clinician.id === '11111') return clinician.relationships;
 
   return {
     team: {
-      data: getRelationship(_.sample(fxTeams), 'teams'),
+      data: getRelationship(_.sample(fxTestTeams), 'teams'),
     },
     workspaces: {
-      data: getRelationship(fxWorkspaces, 'workspaces'),
+      data: getRelationship(fxTestWorkspaces, 'workspaces'),
     },
     role: {
-      data: getRelationship(_.find(fxRoles, { id: '11111' }), 'roles'),
+      data: getRelationship(_.find(fxTestRoles, { id: '11111' }), 'roles'),
     },
   };
 }
 
 Cypress.Commands.add('routeCurrentClinician', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/clinicians/me',
-    response() {
-      const clinician = getResource(_.find(fxClinicians, { id: '11111' }), 'clinicians');
+  const clinician = getResource(_.find(fxTestClinicians, { id: '11111' }), 'clinicians');
 
-      clinician.attributes.last_active_at = dayjs.utc().format();
+  clinician.attributes.last_active_at = dayjs.utc().format();
 
-      clinician.relationships.workspaces = {
-        data: getRelationship(fxWorkspaces, 'workspaces'),
-      };
+  clinician.relationships.workspaces = {
+    data: getRelationship(fxTestWorkspaces, 'workspaces'),
+  };
 
-      clinician.relationships.team = {
-        data: getRelationship(_.find(fxTeams, { id: '22222' }), 'teams'),
-      };
+  clinician.relationships.team = {
+    data: getRelationship(_.find(fxTestTeams, { id: '22222' }), 'teams'),
+  };
 
-      clinician.relationships.role = {
-        data: getRelationship(_.find(fxRoles, { id: '11111' }), 'roles'),
-      };
+  clinician.relationships.role = {
+    data: getRelationship(_.find(fxTestRoles, { id: '11111' }), 'roles'),
+  };
 
-      return mutator({
-        data: clinician,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/clinicians/me', {
+    body: mutator({
+      data: clinician,
+      included: [],
+    }),
   })
     .as('routeCurrentClinician');
 });
 
 Cypress.Commands.add('routeClinicians', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/clinicians',
-    response() {
-      // Remove current clinician
-      const clinicians = getResource(_.rest(fxClinicians), 'clinicians');
+  // Remove current clinician
+  const clinicians = getResource(_.rest(fxTestClinicians), 'clinicians');
 
-      _.each(clinicians, clinician => {
-        clinician.relationships = getClinicianRelationships(clinician);
-      });
+  _.each(clinicians, clinician => {
+    clinician.relationships = getClinicianRelationships(clinician);
+  });
 
-      return mutator({
-        data: clinicians,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/clinicians', {
+    body: mutator({
+      data: clinicians,
+      included: [],
+    }),
   })
     .as('routeClinicians');
 });
 
 Cypress.Commands.add('routeWorkspaceClinicians', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/workspaces/**/relationships/clinicians*',
-    response() {
-      const clinicians = getResource(fxClinicians, 'clinicians');
+  const clinicians = getResource(fxTestClinicians, 'clinicians');
 
-      _.each(clinicians, clinician => {
-        clinician.relationships = getClinicianRelationships(clinician);
-      });
+  _.each(clinicians, clinician => {
+    clinician.relationships = getClinicianRelationships(clinician);
+  });
 
-      return mutator({
-        data: clinicians,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/workspaces/**/relationships/clinicians*', {
+    body: mutator({
+      data: clinicians,
+      included: [],
+    }),
   })
     .as('routeWorkspaceClinicians');
 });
 
 Cypress.Commands.add('routeClinician', (mutator = _.identity) => {
-  cy.route({
-    url: /\/api\/clinicians\/[^me]+/,
-    response() {
-      const clinician = getResource(_.sample(fxClinicians), 'clinicians');
+  const clinician = getResource(_.sample(fxTestClinicians), 'clinicians');
 
-      clinician.relationships = getClinicianRelationships(clinician);
+  clinician.relationships = getClinicianRelationships(clinician);
 
-      return mutator({
-        data: clinician,
-        included: [],
-      });
-    },
+  cy.intercept('GET', /\/api\/clinicians\/[^me]+/, {
+    body: mutator({
+      data: clinician,
+      included: [],
+    }),
   })
     .as('routeClinician');
 });

--- a/test/support/api/comments.js
+++ b/test/support/api/comments.js
@@ -1,27 +1,24 @@
 import _ from 'underscore';
 import { getResource, getRelationship } from 'helpers/json-api';
 
+import fxComments from 'fixtures/collections/comments';
+
+import fxTestClinicians from 'fixtures/test/clinicians';
+
 Cypress.Commands.add('routeActionComments', (mutator = _.identity) => {
-  cy
-    .fixture('collections/comments').as('fxComments')
-    .fixture('test/clinicians').as('fxClinicians');
+  const data = getResource(_.sample(fxComments, 5), 'comments');
 
-  cy.route({
-    url: '/api/actions/**/relationships/comments',
-    response() {
-      const data = getResource(_.sample(this.fxComments, 5), 'comments');
+  _.each(data, comment => {
+    comment.relationships = {
+      clinician: { data: getRelationship(_.sample(fxTestClinicians), 'clinicians') },
+    };
+  });
 
-      _.each(data, comment => {
-        comment.relationships = {
-          clinician: { data: getRelationship(_.sample(this.fxClinicians), 'clinicians') },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/actions/**/relationships/comments', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeActionComments');
 });

--- a/test/support/api/dashboards.js
+++ b/test/support/api/dashboards.js
@@ -1,34 +1,24 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routeDashboards', (mutator = _.identity) => {
-  cy
-    .fixture('test/dashboards').as('fxTestDashboards');
+import fxTestDashboards from 'fixtures/test/dashboards';
 
-  cy.route({
-    url: '/api/dashboards',
-    response() {
-      return mutator({
-        data: getResource(this.fxTestDashboards, 'dashboards'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routeDashboards', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/dashboards', {
+    body: mutator({
+      data: getResource(fxTestDashboards, 'dashboards'),
+      included: [],
+    }),
   })
     .as('routeDashboards');
 });
 
 Cypress.Commands.add('routeDashboard', (mutator = _.identity) => {
-  cy
-    .fixture('test/dashboards').as('fxTestDashboards');
-
-  cy.route({
-    url: '/api/dashboards/*',
-    response() {
-      return mutator({
-        data: getResource(_.sample(this.fxTestDashboards), 'dashboards'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/dashboards/*', {
+    body: mutator({
+      data: getResource(_.sample(fxTestDashboards), 'dashboards'),
+      included: [],
+    }),
   })
     .as('routeDashboard');
 });

--- a/test/support/api/directories.js
+++ b/test/support/api/directories.js
@@ -1,14 +1,11 @@
 import _ from 'underscore';
 
 Cypress.Commands.add('routeDirectories', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/directories*',
-    response() {
-      return mutator({
-        data: [],
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/directories*', {
+    body: mutator({
+      data: [],
+      included: [],
+    }),
   })
     .as('routeDirectories');
 });

--- a/test/support/api/events.js
+++ b/test/support/api/events.js
@@ -1,36 +1,27 @@
 import _ from 'underscore';
 
+import fxTestActionEvents from 'fixtures/test/action-events';
+import fxTestFlowEvents from 'fixtures/test/flow-events';
+
 Cypress.Commands.add('routeActionActivity', (mutator = _.identity) => {
-  cy
-    .fixture('test/action-events').as('fxEvents');
+  let events = _.clone(fxTestActionEvents);
+  const createEvent = events.shift();
+  events = _.sample(events, 4);
+  events.unshift(createEvent);
 
-  cy.route({
-    url: '/api/actions/**/activity*',
-    response() {
-      let events = _.clone(this.fxEvents);
-      const createEvent = events.shift();
-      events = _.sample(events, 4);
-      events.unshift(createEvent);
-
-      return mutator({
-        data: events,
-      });
-    },
+  cy.intercept('GET', '/api/actions/**/activity*', {
+    body: mutator({
+      data: events,
+    }),
   })
     .as('routeActionActivity');
 });
 
 Cypress.Commands.add('routeFlowActivity', (mutator = _.identity) => {
-  cy
-    .fixture('test/flow-events').as('fxEvents');
-
-  cy.route({
-    url: '/api/flows/**/activity*',
-    response() {
-      return mutator({
-        data: this.fxEvents,
-      });
-    },
+  cy.intercept('GET', '/api/flows/**/activity*', {
+    body: mutator({
+      data: fxTestFlowEvents,
+    }),
   })
     .as('routeFlowActivity');
 });

--- a/test/support/api/files.js
+++ b/test/support/api/files.js
@@ -1,14 +1,11 @@
 import _ from 'underscore';
 
 Cypress.Commands.add('routeActionFiles', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/actions/**/relationships/files?urls=download,view',
-    response() {
-      return mutator({
-        data: [],
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/actions/**/relationships/files?urls=download,view', {
+    body: mutator({
+      data: [],
+      included: [],
+    }),
   })
     .as('routeActionFiles');
 });

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -1,164 +1,126 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
 import { getResource } from 'helpers/json-api';
-import fxForms from 'fixtures/test/forms.json';
-import fxFormResponse from 'fixtures/test/form-response.json';
+
+import fxTestForms from 'fixtures/test/forms';
+import fxTestFormResponse from 'fixtures/test/form-response';
+import fxTestFormDefinition from 'fixtures/test/form-definition';
+import fxTestFormFields from 'fixtures/test/form-fields';
 
 Cypress.Commands.add('routeForms', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/forms',
-    response() {
-      // form.options is no longer included in the '/api/forms' api request
-      const fxTestForms = _.map(fxForms, form => {
-        form = _.clone(form);
-        form.options = {};
-        return form;
-      });
+  // form.options is no longer included in the '/api/forms' api request
+  const fxForms = _.map(fxTestForms, form => {
+    form = _.clone(form);
+    form.options = {};
+    return form;
+  });
 
-      return mutator({
-        data: getResource(fxTestForms, 'forms'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/forms', {
+    body: mutator({
+      data: getResource(fxForms, 'forms'),
+      included: [],
+    }),
   })
     .as('routeForms');
 });
 
 Cypress.Commands.add('routeForm', (mutator = _.identity, formId = '11111') => {
-  cy.route({
-    url: '/api/forms/*',
-    response() {
-      return mutator({
-        data: getResource(_.find(fxForms, { id: formId }), 'forms'),
-        included: [],
-      });
+  cy.intercept('GET', '/api/forms/*', {
+    body: {
+      data: getResource(_.find(fxTestForms, { id: formId }), 'forms'),
+      included: [],
     },
   })
     .as('routeForm');
 });
 
 Cypress.Commands.add('routeFormByAction', (mutator = _.identity, formId = '11111') => {
-  cy.route({
-    url: '/api/actions/*/form',
-    response() {
-      return mutator({
-        data: getResource(_.find(fxForms, { id: formId }), 'forms'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/actions/*/form', {
+    body: mutator({
+      data: getResource(_.find(fxTestForms, { id: formId }), 'forms'),
+      included: [],
+    }),
   })
     .as('routeFormByAction');
 });
 
 Cypress.Commands.add('routeFormDefinition', (mutator = _.identity) => {
-  cy
-    .fixture('test/form-definition').as('fxTestFormDefinition');
-
-  cy.route({
-    url: '/api/forms/*/definition',
-    response() {
-      return mutator(this.fxTestFormDefinition);
-    },
+  cy.intercept('GET', '/api/forms/*/definition', {
+    body: mutator(fxTestFormDefinition),
   })
     .as('routeFormDefinition');
 });
 
 Cypress.Commands.add('routeFormActionDefinition', (mutator = _.identity) => {
-  cy
-    .fixture('test/form-definition').as('fxTestFormDefinition');
-
-  cy.route({
-    url: '/api/actions/*/form/definition',
-    response() {
-      return mutator(this.fxTestFormDefinition);
-    },
+  cy.intercept('GET', '/api/actions/*/form/definition', {
+    body: mutator(fxTestFormDefinition),
   })
     .as('routeFormActionDefinition');
 });
 
 Cypress.Commands.add('routeFormResponse', (mutator = _.identity) => {
-  cy
-    .intercept({
-      method: 'GET',
-      url: '/api/form-responses/*',
-    }, {
-      body: mutator({
-        data: {
-          id: '11111',
-          type: 'form-responses',
-          attributes: {
-            created_at: dayjs.utc().format(),
-            response: fxFormResponse,
-            status: 'submitted',
-          },
+  cy.intercept('GET', '/api/form-responses/*', {
+    body: mutator({
+      data: {
+        id: '11111',
+        type: 'form-responses',
+        attributes: {
+          created_at: dayjs.utc().format(),
+          response: fxTestFormResponse,
+          status: 'submitted',
         },
-      }),
-    })
+      },
+    }),
+  })
     .as('routeFormResponse');
 });
 
 Cypress.Commands.add('routeFormFields', (mutator = _.identity) => {
-  cy
-    .fixture('test/form-fields').as('fxTestFormFields');
-
-  cy
-    .route({
-      url: '/api/forms/**/fields*',
-      response() {
-        return mutator({
-          data: getResource(_.sample(this.fxTestFormFields), 'form-fields'),
-          included: [],
-        });
-      },
-    })
+  cy.intercept('GET', '/api/forms/**/fields*', {
+    body: mutator({
+      data: getResource(_.sample(fxTestFormFields), 'form-fields'),
+      included: [],
+    }),
+  })
     .as('routeFormFields');
 });
 
 Cypress.Commands.add('routeFormActionFields', (mutator = _.identity) => {
-  cy
-    .fixture('test/form-fields').as('fxTestFormFields');
-
-  cy
-    .route({
-      url: '/api/actions/**/form/fields*',
-      response() {
-        return mutator({
-          data: getResource(_.sample(this.fxTestFormFields), 'form-fields'),
-          included: [],
-        });
-      },
-    })
+  cy.intercept('GET', '/api/actions/**/form/fields*', {
+    body: mutator({
+      data: getResource(_.sample(fxTestFormFields), 'form-fields'),
+      included: [],
+    }),
+  })
     .as('routeFormActionFields');
 });
 
 Cypress.Commands.add('routeLatestFormSubmission', (mutator = _.identity) => {
-  cy
-    .intercept({
-      method: 'GET',
-      url: /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=submitted).*$/,
-    }, {
-      body: mutator({
-        data: {
-          id: '11111',
-          type: 'form-responses',
-          attributes: {
-            created_at: dayjs.utc().format(),
-            response: fxFormResponse,
-            status: 'submitted',
-          },
+  const urlRegex = /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=submitted).*$/;
+
+  cy.intercept('GET', urlRegex, {
+    body: mutator({
+      data: {
+        id: '11111',
+        type: 'form-responses',
+        attributes: {
+          created_at: dayjs.utc().format(),
+          response: fxTestFormResponse,
+          status: 'submitted',
         },
-      }),
-    })
+      },
+    }),
+  })
     .as('routeLatestFormSubmission');
 });
 
 Cypress.Commands.add('routeLatestFormResponse', (mutator = _.identity) => {
+  const urlRegex = /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=draft).*$/;
   const body = mutator();
-  cy.intercept({
-    method: 'GET',
-    url: /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=draft).*$/,
-  }, {
+
+  cy.intercept('GET', urlRegex, {
     statusCode: body ? 200 : 204,
     body,
-  }).as('routeLatestFormResponse');
+  })
+    .as('routeLatestFormResponse');
 });

--- a/test/support/api/outreach.js
+++ b/test/support/api/outreach.js
@@ -1,20 +1,18 @@
 import _ from 'underscore';
 
 Cypress.Commands.add('routeOutreachStatus', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/outreach?*',
-    response() {
-      return mutator({
-        data: {
-          type: 'Outreach',
-          id: '11111',
-          attributes: {
-            phone_end: '1234',
-          },
+  cy.intercept('GET', '/api/outreach?*', {
+    body: mutator({
+      data: {
+        type: 'Outreach',
+        id: '11111',
+        attributes: {
+          phone_end: '1234',
         },
-        included: [],
-      });
-    },
+      },
+      included: [],
+
+    }),
   })
     .as('routeOutreachStatus');
 });

--- a/test/support/api/patient-fields.js
+++ b/test/support/api/patient-fields.js
@@ -1,22 +1,16 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routePatientField', (mutator = _.identity, fieldName) => {
-  cy
-    .fixture('collections/patient-fields').as('fxPatientFields');
+import fxPatientFields from 'fixtures/collections/patient-fields';
 
+Cypress.Commands.add('routePatientField', (mutator = _.identity, fieldName) => {
   const alias = fieldName ? `routePatientField${ fieldName }` : 'routePatientField';
 
-  cy.route({
-    url: `/api/patients/**/fields/${ fieldName || '**' }`,
-    response() {
-      const data = getResource(_.sample(this.fxPatientFields), 'patient-fields');
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', `/api/patients/**/fields/${ fieldName || '**' }`, {
+    body: mutator({
+      data: getResource(_.sample(fxPatientFields), 'patient-fields'),
+      included: [],
+    }),
   })
     .as(alias);
 });

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -1,22 +1,20 @@
 import _ from 'underscore';
 import { getResource, getIncluded, getRelationship } from 'helpers/json-api';
 
-function patientFixtures() {
-  cy
-    .fixture('collections/patients').as('fxPatients')
-    .fixture('collections/actions').as('fxActions')
-    .fixture('collections/patient-fields').as('fxPatientFields')
-    .fixture('test/workspaces').as('fxWorkspaces');
-}
+import fxPatients from 'fixtures/collections/patients';
+import fxActions from 'fixtures/collections/actions';
+import fxPatientFields from 'fixtures/collections/patient-fields';
+
+import fxTestWorkspaces from 'fixtures/test/workspaces';
 
 function generatePatientData() {
-  const data = getResource(_.sample(this.fxPatients), 'patients');
-  const action = _.sample(this.fxActions, 10);
-  const fields = _.sample(this.fxPatientFields, 5);
+  const data = getResource(_.sample(fxPatients), 'patients');
+  const action = _.sample(fxActions, 10);
+  const fields = _.sample(fxPatientFields, 5);
 
   data.relationships = {
     'actions': { data: getRelationship(action, 'patient-actions') },
-    'workspaces': { data: getRelationship(this.fxWorkspaces, 'workspaces') },
+    'workspaces': { data: getRelationship(fxTestWorkspaces, 'workspaces') },
     'patient-fields': { data: getRelationship(fields, 'patient-fields') },
   };
 
@@ -32,13 +30,8 @@ function generatePatientData() {
 }
 
 Cypress.Commands.add('routePatient', (mutator = _.identity) => {
-  patientFixtures();
-
-  cy.route({
-    url: '/api/patients/**?*',
-    response() {
-      return mutator(generatePatientData.call(this));
-    },
+  cy.intercept('GET', '/api/patients/**?*', {
+    body: mutator(generatePatientData()),
   })
     .as('routePatient');
 
@@ -46,25 +39,15 @@ Cypress.Commands.add('routePatient', (mutator = _.identity) => {
 });
 
 Cypress.Commands.add('routePatientByAction', (mutator = _.identity) => {
-  patientFixtures();
-
-  cy.route({
-    url: '/api/actions/**/patient',
-    response() {
-      return mutator(generatePatientData.call(this));
-    },
+  cy.intercept('GET', '/api/actions/**/patient', {
+    body: mutator(generatePatientData()),
   })
     .as('routePatientByAction');
 });
 
 Cypress.Commands.add('routePatientByFlow', (mutator = _.identity) => {
-  patientFixtures();
-
-  cy.route({
-    url: '/api/flows/**/patient',
-    response() {
-      return mutator(generatePatientData.call(this));
-    },
+  cy.intercept('GET', '/api/flows/**/patient', {
+    body: mutator(generatePatientData()),
   })
     .as('routePatientByFlow');
 });

--- a/test/support/api/program-actions.js
+++ b/test/support/api/program-actions.js
@@ -1,112 +1,86 @@
 import _ from 'underscore';
 import { getResource, getRelationship } from 'helpers/json-api';
 
-Cypress.Commands.add('routeProgramAction', (mutator = _.identity) => {
-  cy
-    .fixture('collections/program-actions').as('fxProgramActions');
+import fxProgramActions from 'fixtures/collections/program-actions';
+import fxPrograms from 'fixtures/collections/programs';
+import fxProgramFlows from 'fixtures/collections/program-flows';
 
-  cy.route({
-    url: '/api/program-actions/*',
-    response() {
-      return mutator({
-        data: getResource(_.sample(this.fxProgramActions), 'program-actions'),
-        included: [],
-      });
-    },
+import fxTestTeams from 'fixtures/test/teams';
+
+Cypress.Commands.add('routeProgramAction', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/program-actions/*', {
+    body: mutator({
+      data: getResource(_.sample(fxProgramActions), 'program-actions'),
+      included: [],
+    }),
   })
     .as('routeProgramAction');
 });
 
 Cypress.Commands.add('routeProgramActions', (mutator = _.identity, programId) => {
-  cy
-    .fixture('collections/program-actions').as('fxProgramActions')
-    .fixture('collections/programs').as('fxPrograms')
-    .fixture('test/teams').as('fxTeams');
+  const data = getResource(_.sample(fxProgramActions, 20), 'program-actions');
+  const program = _.sample(fxPrograms);
+  program.id = programId;
 
-  cy.route({
-    url: '/api/programs/**/relationships/actions*',
-    response() {
-      const data = getResource(_.sample(this.fxProgramActions, 20), 'program-actions');
-      const program = _.sample(this.fxPrograms);
-      program.id = programId;
+  _.each(data, action => {
+    action.relationships = {
+      program: { data: getRelationship(program, 'programs') },
+      owner: { data: _.random(1) ? null : getRelationship(_.sample(fxTestTeams), 'teams') },
+      form: { data: null },
+    };
+  });
 
-      _.each(data, action => {
-        action.relationships = {
-          program: { data: getRelationship(program, 'programs') },
-          owner: { data: _.random(1) ? null : getRelationship(_.sample(this.fxTeams), 'teams') },
-          form: { data: null },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/programs/**/relationships/actions*', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeProgramActions');
 });
 
 Cypress.Commands.add('routeProgramFlowActions', (mutator = _.identity, flowId = '1') => {
-  cy
-    .fixture('collections/program-actions').as('fxProgramActions')
-    .fixture('collections/programs').as('fxPrograms')
-    .fixture('collections/program-flows').as('fxProgramFlows')
-    .fixture('test/teams').as('fxTeams');
+  const data = getResource(_.sample(fxProgramActions, 20), 'program-actions');
+  const program = _.sample(fxPrograms);
+  const programFlow = _.sample(fxProgramFlows);
+  programFlow.id = flowId;
 
-  cy.route({
-    url: '/api/program-flows/**/actions',
-    response() {
-      const data = getResource(_.sample(this.fxProgramActions, 20), 'program-actions');
-      const program = _.sample(this.fxPrograms);
-      const programFlow = _.sample(this.fxProgramFlows);
-      programFlow.id = flowId;
+  _.each(data, action => {
+    action.relationships = {
+      'program-flow': { data: getRelationship(programFlow, 'program-flows') },
+      'program': { data: getRelationship(program, 'programs') },
+      'owner': { data: _.random(1) ? null : getRelationship(_.sample(fxTestTeams), 'teams') },
+      'form': { data: null },
+    };
+  });
 
-      _.each(data, action => {
-        action.relationships = {
-          'program-flow': { data: getRelationship(programFlow, 'program-flows') },
-          'program': { data: getRelationship(program, 'programs') },
-          'owner': { data: _.random(1) ? null : getRelationship(_.sample(this.fxTeams), 'teams') },
-          'form': { data: null },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/program-flows/**/actions', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeProgramFlowActions');
 });
 
 Cypress.Commands.add('routeAllProgramActions', (mutator = _.identity, programIds) => {
-  cy
-    .fixture('collections/program-actions').as('fxProgramActions')
-    .fixture('collections/programs').as('fxPrograms')
-    .fixture('test/teams').as('fxTeams');
+  const data = getResource(_.sample(fxProgramActions, 20), 'program-actions');
+  const program = _.sample(fxPrograms);
+  program.id = _.sample(programIds);
 
-  cy.route({
-    url: '/api/program-actions?*',
-    response() {
-      const data = getResource(_.sample(this.fxProgramActions, 20), 'program-actions');
-      const program = _.sample(this.fxPrograms);
-      program.id = _.sample(programIds);
+  _.each(data, action => {
+    action.relationships = {
+      program: { data: getRelationship(program, 'programs') },
+      owner: { data: _.random(1) ? null : getRelationship(_.sample(fxTestTeams), 'teams') },
+      form: { data: null },
+    };
+  });
 
-      _.each(data, action => {
-        action.relationships = {
-          program: { data: getRelationship(program, 'programs') },
-          owner: { data: _.random(1) ? null : getRelationship(_.sample(this.fxTeams), 'teams') },
-          form: { data: null },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/program-actions?*', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeAllProgramActions');
 });
-

--- a/test/support/api/program-flows.js
+++ b/test/support/api/program-flows.js
@@ -1,91 +1,72 @@
 import _ from 'underscore';
 import { getResource, getRelationship } from 'helpers/json-api';
 
+import fxProgramFlows from 'fixtures/collections/program-flows';
+import fxProgramActions from 'fixtures/collections/program-actions';
+import fxPrograms from 'fixtures/collections/programs';
+
+import fxTestTeams from 'fixtures/test/teams';
+
 Cypress.Commands.add('routeProgramFlow', (mutator = _.identity) => {
-  cy
-    .fixture('collections/program-flows').as('fxProgramFlows')
-    .fixture('collections/program-actions').as('fxProgramActions')
-    .fixture('collections/programs').as('fxPrograms');
+  const data = getResource(_.sample(fxProgramFlows), 'program-flows');
+  const program = _.sample(fxPrograms);
+  const flowActions = _.sample(fxProgramActions, 10);
 
-  cy.route({
-    url: '/api/program-flows/*',
-    response() {
-      const data = getResource(_.sample(this.fxProgramFlows), 'program-flows');
-      const program = _.sample(this.fxPrograms);
-      const flowActions = _.sample(this.fxProgramActions, 10);
+  data.relationships = {
+    'program': { data: getRelationship(program, 'programs') },
+    'program-actions': { data: getRelationship(flowActions, 'program-actions') },
+    'owner': { data: null },
+  };
 
-      data.relationships = {
-        'program': { data: getRelationship(program, 'programs') },
-        'program-actions': { data: getRelationship(flowActions, 'program-actions') },
-        'owner': { data: null },
-      };
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/program-flows/*', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeProgramFlow');
 });
 
 Cypress.Commands.add('routeProgramFlows', (mutator = _.identity, programId) => {
-  cy
-    .fixture('collections/program-flows').as('fxProgramFlows')
-    .fixture('collections/programs').as('fxPrograms')
-    .fixture('test/teams').as('fxTeams');
+  const data = getResource(_.sample(fxProgramFlows, 20), 'program-flows');
+  const program = _.sample(fxPrograms);
+  program.id = programId;
 
-  cy.route({
-    url: '/api/programs/**/relationships/flows*',
-    response() {
-      const data = getResource(_.sample(this.fxProgramFlows, 20), 'program-flows');
-      const program = _.sample(this.fxPrograms);
-      program.id = programId;
+  _.each(data, flow => {
+    flow.relationships = {
+      program: { data: getRelationship(program, 'programs') },
+      owner: { data: _.random(1) ? null : getRelationship(_.sample(fxTestTeams), 'teams') },
+    };
+  });
 
-      _.each(data, flow => {
-        flow.relationships = {
-          program: { data: getRelationship(program, 'programs') },
-          owner: { data: _.random(1) ? null : getRelationship(_.sample(this.fxTeams), 'teams') },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/programs/**/relationships/flows*', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeProgramFlows');
 });
 
 Cypress.Commands.add('routeAllProgramFlows', (mutator = _.identity, programId) => {
-  cy
-    .fixture('collections/program-actions').as('fxProgramActions')
-    .fixture('collections/program-flows').as('fxProgramFlows')
-    .fixture('collections/programs').as('fxPrograms')
-    .fixture('test/teams').as('fxTeams');
+  const data = getResource(_.sample(fxProgramFlows, 20), 'program-flows');
+  const programFlowActions = getResource(_.sample(fxProgramActions, 10), 'program-actions');
+  const program = _.sample(fxPrograms);
+  program.id = programId;
 
-  cy.route({
-    url: '/api/program-flows?*',
-    response() {
-      const data = getResource(_.sample(this.fxProgramFlows, 20), 'program-flows');
-      const programFlowActions = getResource(_.sample(this.fxProgramActions, 10), 'program-actions');
-      const program = _.sample(this.fxPrograms);
-      program.id = programId;
+  _.each(data, (flow, index) => {
+    flow.relationships = {
+      'program': { data: getRelationship(program, 'programs') },
+      'program-actions': { data: getRelationship(programFlowActions[index], 'program-actions') },
+      'owner': { data: _.random(1) ? null : getRelationship(_.sample(fxTestTeams), 'teams') },
+    };
+  });
 
-      _.each(data, (flow, index) => {
-        flow.relationships = {
-          'program': { data: getRelationship(program, 'programs') },
-          'program-actions': { data: getRelationship(programFlowActions[index], 'program-actions') },
-          'owner': { data: _.random(1) ? null : getRelationship(_.sample(this.fxTeams), 'teams') },
-        };
-      });
-
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/program-flows?*', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeAllProgramFlows');
 });

--- a/test/support/api/programs.js
+++ b/test/support/api/programs.js
@@ -1,50 +1,34 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routePrograms', (mutator = _.identity) => {
-  cy
-    .fixture('collections/programs').as('fxPrograms');
+import fxPrograms from 'fixtures/collections/programs';
 
-  cy.route({
-    url: '/api/programs',
-    response() {
-      return mutator({
-        data: getResource(_.sample(this.fxPrograms, 10), 'programs'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routePrograms', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/programs', {
+    body: mutator({
+      data: getResource(_.sample(fxPrograms, 10), 'programs'),
+      included: [],
+    }),
   })
     .as('routePrograms');
 });
 
 Cypress.Commands.add('routeProgram', (mutator = _.identity) => {
-  cy
-    .fixture('collections/programs').as('fxPrograms');
-
-  cy.route({
-    url: '/api/programs/*',
-    response() {
-      return mutator({
-        data: getResource(_.sample(this.fxPrograms), 'programs'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/programs/*', {
+    body: mutator({
+      data: getResource(_.sample(fxPrograms), 'programs'),
+      included: [],
+    }),
   })
     .as('routeProgram');
 });
 
 Cypress.Commands.add('routeProgramByProgramFlow', (mutator = _.identity) => {
-  cy
-    .fixture('collections/programs').as('fxPrograms');
-
-  cy.route({
-    url: '/api/program-flows/**/program',
-    response() {
-      return mutator({
-        data: getResource(_.sample(this.fxPrograms), 'programs'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/program-flows/**/program', {
+    body: mutator({
+      data: getResource(_.sample(fxPrograms), 'programs'),
+      included: [],
+    }),
   })
     .as('routeProgramByProgramFlow');
 });

--- a/test/support/api/roles.js
+++ b/test/support/api/roles.js
@@ -1,16 +1,14 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
-import fxTestRoles from 'fixtures/test/roles.json';
+
+import fxTestRoles from 'fixtures/test/roles';
 
 Cypress.Commands.add('routeRoles', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/roles',
-    response() {
-      return mutator({
-        data: getResource(fxTestRoles, 'roles'),
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/roles', {
+    body: mutator({
+      data: getResource(fxTestRoles, 'roles'),
+      included: [],
+    }),
   })
     .as('routeRoles');
 });

--- a/test/support/api/settings.js
+++ b/test/support/api/settings.js
@@ -1,18 +1,14 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routeSettings', (mutator = _.identity) => {
-  cy
-    .fixture('test/settings').as('fxTestSettings');
+import fxTestSettings from 'fixtures/test/settings';
 
-  cy.route({
-    url: '/api/settings',
-    response() {
-      return mutator({
-        data: getResource(this.fxTestSettings, 'settings'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routeSettings', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/settings', {
+    body: mutator({
+      data: getResource(fxTestSettings, 'settings'),
+      included: [],
+    }),
   })
     .as('routeSettings');
 });

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -1,18 +1,14 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routeStates', (mutator = _.identity) => {
-  cy
-    .fixture('test/states').as('fxTestStates');
+import fxTestStates from 'fixtures/test/states';
 
-  cy.route({
-    url: '/api/states',
-    response() {
-      return mutator({
-        data: getResource(this.fxTestStates, 'states'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routeStates', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/states', {
+    body: mutator({
+      data: getResource(fxTestStates, 'states'),
+      included: [],
+    }),
   })
     .as('routeStates');
 });

--- a/test/support/api/tags.js
+++ b/test/support/api/tags.js
@@ -1,13 +1,10 @@
 import _ from 'underscore';
 
 Cypress.Commands.add('routeTags', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/tags',
-    response() {
-      return mutator({
-        data: ['foo-tag'],
-      });
-    },
+  cy.intercept('GET', '/api/tags', {
+    body: mutator({
+      data: ['foo-tag'],
+    }),
   })
     .as('routeTags');
 });

--- a/test/support/api/teams.js
+++ b/test/support/api/teams.js
@@ -1,18 +1,14 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routeTeams', (mutator = _.identity) => {
-  cy
-    .fixture('test/teams').as('fxTestTeams');
+import fxTestTeams from 'fixtures/test/teams';
 
-  cy.route({
-    url: '/api/teams',
-    response() {
-      return mutator({
-        data: getResource(this.fxTestTeams, 'teams'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routeTeams', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/teams', {
+    body: mutator({
+      data: getResource(fxTestTeams, 'teams'),
+      included: [],
+    }),
   })
     .as('routeTeams');
 });

--- a/test/support/api/widgets.js
+++ b/test/support/api/widgets.js
@@ -1,18 +1,14 @@
 import _ from 'underscore';
 import { getResource } from 'helpers/json-api';
 
-Cypress.Commands.add('routeWidgets', (mutator = _.identity) => {
-  cy
-    .fixture('test/widgets').as('fxTestWidgets');
+import fxTestWidgets from 'fixtures/test/widgets';
 
-  cy.route({
-    url: '/api/widgets*',
-    response() {
-      return mutator({
-        data: getResource(this.fxTestWidgets, 'widgets'),
-        included: [],
-      });
-    },
+Cypress.Commands.add('routeWidgets', (mutator = _.identity) => {
+  cy.intercept('GET', '/api/widgets*', {
+    body: mutator({
+      data: getResource(fxTestWidgets, 'widgets'),
+      included: [],
+    }),
   })
     .as('routeWidgets');
 });

--- a/test/support/api/workspaces.js
+++ b/test/support/api/workspaces.js
@@ -1,30 +1,28 @@
 import _ from 'underscore';
 import { getResource, getRelationship } from 'helpers/json-api';
-import fxWorkspaces from 'fixtures/test/workspaces.json';
-import fxClinicians from 'fixtures/test/clinicians.json';
-import fxForms from 'fixtures/test/forms.json';
-import fxStates from 'fixtures/test/states.json';
+
+import fxTestWorkspaces from 'fixtures/test/workspaces.json';
+import fxTestClinicians from 'fixtures/test/clinicians.json';
+import fxTestForms from 'fixtures/test/forms.json';
+import fxTestStates from 'fixtures/test/states.json';
 
 
 Cypress.Commands.add('routeWorkspaces', (mutator = _.identity) => {
-  cy.route({
-    url: '/api/workspaces',
-    response() {
-      const data = getResource(fxWorkspaces, 'workspaces');
+  const data = getResource(fxTestWorkspaces, 'workspaces');
 
-      _.each(data, workspace => {
-        workspace.relationships = {
-          clinicians: { data: getRelationship(fxClinicians, 'clinicians') },
-          forms: { data: getRelationship(fxForms, 'forms') },
-          states: { data: getRelationship(fxStates, 'states') },
-        };
-      });
+  _.each(data, workspace => {
+    workspace.relationships = {
+      clinicians: { data: getRelationship(fxTestClinicians, 'clinicians') },
+      forms: { data: getRelationship(fxTestForms, 'forms') },
+      states: { data: getRelationship(fxTestStates, 'states') },
+    };
+  });
 
-      return mutator({
-        data,
-        included: [],
-      });
-    },
+  cy.intercept('GET', '/api/workspaces', {
+    body: mutator({
+      data,
+      included: [],
+    }),
   })
     .as('routeWorkspaces');
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-38071]

`.route()` was deprecated by Cypress, this switches the `test/support/api` files to `.intercept()`.

First phase was complete in https://github.com/RoundingWell/care-ops-frontend/pull/1078.