### PR TITLE
Fix coverage branch miss in `alert-box_views.js` file

### DIFF
--- a/test/integration/services/alert.js
+++ b/test/integration/services/alert.js
@@ -83,6 +83,7 @@ context('Alert Service', function() {
       .get('.alert-box')
       .find('.js-dismiss')
       .click()
+      .click()
       .then(() => {
         expect(onComplete).to.be.calledOnce;
       })


### PR DESCRIPTION
Shortcut Story ID: [sc-41393]

There's an animation when the alert box is dismissed. The double `.click()` in the test verifies that nothing happens if a user clicks the alert box during that animation.

Was unkowingly removed in this commit: https://github.com/RoundingWell/care-ops-frontend/pull/1141/commits/9da4a0105a4587d38dfe8fad82dcf5d7c6c7b846

For reference: https://coveralls.io/builds/62997377/source?filename=src%2Fjs%2Fviews%2Fglobals%2Falert-box%2Falert-box_views.js#L57