### PR TITLE
Keep `.is-selected` on the program-flow header when it's edited via the sidebar

### DIFF
--- a/src/js/apps/programs/program/flow/flow_app.js
+++ b/src/js/apps/programs/program/flow/flow_app.js
@@ -4,7 +4,7 @@ import SubRouterApp from 'js/base/subrouterapp';
 
 import ActionApp from 'js/apps/programs/program/action/action_app';
 
-import { LayoutView, ContextTrailView, HeaderView, ListView } from 'js/views/programs/program/flow/flow_views';
+import { LayoutView, ContextTrailView, HeaderView, AddActionView, ListView } from 'js/views/programs/program/flow/flow_views';
 import { SidebarView } from 'js/views/programs/program/sidebar/sidebar-views';
 
 export default SubRouterApp.extend({
@@ -43,6 +43,7 @@ export default SubRouterApp.extend({
     }));
 
     this.showHeader();
+    this.showAddAction();
     this.showActionList();
     this.showProgramSidebar();
   },
@@ -63,12 +64,21 @@ export default SubRouterApp.extend({
 
     this.listenTo(headerView, {
       'edit': this.onEditFlow,
+    });
+
+    this.showChildView('header', headerView);
+  },
+
+  showAddAction() {
+    const addActionView = new AddActionView();
+
+    this.listenTo(addActionView, {
       'click:addAction': () => {
         Radio.trigger('event-router', 'programFlow:action:new', this.flow.id);
       },
     });
 
-    this.showChildView('header', headerView);
+    this.showChildView('addAction', addActionView);
   },
 
   showActionList() {

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -678,10 +678,9 @@ careOptsFrontend:
         actionItemTemplate:
           newProgramFlowAction: New Flow Action
         flowViews:
+          addActionBtn: Action
           contextBackBtn: Back to List
           emptyView: No Actions
-        headerTemplate:
-          action: Action
       programViews:
         contextBackBtn: Back to List
       sidebar:

--- a/src/js/views/programs/program/flow/flow_views.js
+++ b/src/js/views/programs/program/flow/flow_views.js
@@ -51,12 +51,13 @@ const ContextTrailView = View.extend({
 });
 
 const HeaderView = View.extend({
+  className: 'program-flow__header',
   modelEvents: {
     'editing': 'onEditing',
     'change': 'render',
   },
   onEditing(isEditing) {
-    this.ui.flow.toggleClass('is-selected', isEditing);
+    this.$el.toggleClass('is-selected', isEditing);
   },
   template: HeaderTemplate,
   regions: {
@@ -64,11 +65,7 @@ const HeaderView = View.extend({
     owner: '[data-owner-region]',
   },
   triggers: {
-    'click @ui.flow': 'edit',
-    'click .js-add-action': 'click:addAction',
-  },
-  ui: {
-    flow: '.js-flow',
+    'click': 'edit',
   },
   onRender() {
     this.showBehavior();
@@ -94,6 +91,18 @@ const HeaderView = View.extend({
     });
 
     this.showChildView('owner', ownerComponent);
+  },
+});
+
+const AddActionView = View.extend({
+  className: 'program-flow__actions',
+  template: hbs`
+    <button class="button-primary js-add-action">
+      {{far "circle-plus"}}<span>{{ @intl.programs.program.flow.flowViews.addActionBtn }}</span>
+    </button>
+  `,
+  triggers: {
+    'click .js-add-action': 'click:addAction',
   },
 });
 
@@ -223,6 +232,7 @@ const LayoutView = View.extend({
     <div class="program-flow__layout">
       <div data-context-trail-region></div>
       <div data-header-region></div>
+      <div data-add-action-region></div>
       <div data-action-list-region></div>
     </div>
     <div class="program-flow__sidebar" data-sidebar-region></div>
@@ -233,6 +243,7 @@ const LayoutView = View.extend({
       replaceElement: true,
     },
     header: '[data-header-region]',
+    addAction: '[data-add-action-region]',
     sidebar: '[data-sidebar-region]',
     actionList: {
       el: '[data-action-list-region]',
@@ -246,5 +257,6 @@ export {
   LayoutView,
   ContextTrailView,
   HeaderView,
+  AddActionView,
   ListView,
 };

--- a/src/js/views/programs/program/flow/header.hbs
+++ b/src/js/views/programs/program/flow/header.hbs
@@ -1,17 +1,12 @@
-<div class="program-flow__header js-flow">
-  <h1 class="program-flow__name">{{fas "folder-open"}} {{ name }}</h1>
-  <div>
-    <p class="program-flow__details">
-    {{#if details}}
-      {{ details }}
-    {{ else }}
-      <button class="program-flow__meta button-secondary">{{far "pen-to-square"}} Add Details</button>
-    {{/if}}
-    </p>{{~ remove_whitespace ~}}
-    <span class="program-flow__meta" data-behavior-region></span>
-    <span class="program-flow__meta" data-owner-region></span>
-  </div>
-</div>
-<div class="program-flow__actions">
-  <button class="button-primary js-add-action">{{far "circle-plus"}}<span>{{ @intl.programs.program.flow.headerTemplate.action }}</span></button>
+<h1 class="program-flow__name">{{fas "folder-open"}} {{ name }}</h1>
+<div>
+  <p class="program-flow__details">
+  {{#if details}}
+    {{ details }}
+  {{ else }}
+    <button class="program-flow__meta button-secondary">{{far "pen-to-square"}} Add Details</button>
+  {{/if}}
+  </p>{{~ remove_whitespace ~}}
+  <span class="program-flow__meta" data-behavior-region></span>
+  <span class="program-flow__meta" data-owner-region></span>
 </div>

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -205,7 +205,7 @@ context('flow sidebar', function() {
       .as('routePatchFlow');
 
     cy
-      .get('.js-flow')
+      .get('.program-flow__header')
       .as('flowHeader')
       .click('right')
       .should('have.class', 'is-selected');
@@ -222,6 +222,7 @@ context('flow sidebar', function() {
 
     cy
       .get('@flowHeader')
+      .should('not.have.class', 'is-selected')
       .click('right');
 
     cy
@@ -278,6 +279,7 @@ context('flow sidebar', function() {
 
     cy
       .get('@flowHeader')
+      .should('have.class', 'is-selected')
       .should('contain', 'Here are some details');
 
     cy
@@ -494,7 +496,7 @@ context('flow sidebar', function() {
       .wait('@routeProgramFlow');
 
     cy
-      .get('.js-flow')
+      .get('.program-flow__header')
       .as('flowHeader')
       .click('right');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-42651]

`.is-selected` gives the program flow header a grey background to indicate that it's currently being edited via the sidebar:

![Screenshot 2023-10-24 at 4 13 45 PM](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/4812f462-eca8-4472-b41f-44de9c2df1de)

When a user makes a change via the program-flow sidebar, the `.is-selected` class was being dropped when that header view re-rendered. But as long as the sidebar is open and the user is editing the program-flow, we want the `.is-selected` class to remain.