### PR TITLE
Add `this.startRoute(currentRoute)` to program flow app

### DIFF
--- a/src/js/apps/programs/program/flow/flow_app.js
+++ b/src/js/apps/programs/program/flow/flow_app.js
@@ -45,6 +45,8 @@ export default SubRouterApp.extend({
     this.showHeader();
     this.showActionList();
     this.showProgramSidebar();
+
+    this.startRoute(currentRoute);
   },
 
   maintainFlowActions() {

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -644,4 +644,41 @@ context('program flow page', function() {
       .contains('Delete Program Action')
       .click();
   });
+
+  specify('route directly to flow action', function() {
+    cy
+      .routeTags()
+      .routeForm()
+      .routeAction()
+      .routeProgramFlow(fx => {
+        fx.data.id = '1';
+        fx.data.relationships['program-actions'].data = [{ id: '1' }];
+
+        return fx;
+      })
+      .routeProgramFlowActions(fx => {
+        fx.data = _.sample(fx.data, 1);
+
+        fx.data[0].id = '1';
+        fx.data[0].relationships['program-flow'] = { data: { id: '1', type: 'program-actions' } };
+
+        return fx;
+      })
+      .routeProgramAction(fx => {
+        fx.data.id = '1';
+
+        return fx;
+      })
+      .routePrograms()
+      .routeProgramByProgramFlow()
+      .visit('/program-flow/1/action/1')
+      .wait('@routeProgramFlow')
+      .wait('@routeProgramAction')
+      .wait('@routeProgramFlowActions')
+      .wait('@routeProgramByProgramFlow');
+
+    cy
+      .get('.sidebar')
+      .should('exist');
+  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-42671]

To fix a bug where the action sidebar wasn't opening when directly loading the `/program-flow/:id/action/:id` url.

Still need to:

- [x] Find somewhere in the tests to verify this happens correctly.