### PR TITLE
Support `work:submit` permissions to control action form submit

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -54,6 +54,15 @@ const _Model = BaseModel.extend({
     const owner = this.get('_owner');
     return Radio.request('entities', `${ owner.type }:model`, owner.id);
   },
+  isSameTeamAsUser() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const currentUsersTeam = currentUser.getTeam();
+
+    const owner = this.getOwner();
+    const ownersTeam = owner.type === 'teams' ? owner : owner.getTeam();
+
+    return currentUsersTeam === ownersTeam;
+  },
   getAuthor() {
     return Radio.request('entities', 'clinicians:model', this.get('_author'));
   },
@@ -107,13 +116,18 @@ const _Model = BaseModel.extend({
 
     if (currentUser.can('work:owned:manage') && this.getOwner() === currentUser) return true;
 
-    if (currentUser.can('work:team:manage')) {
-      const owner = this.getOwner();
-      const currentUsersTeam = currentUser.getTeam();
-      const ownersTeam = owner.type === 'teams' ? owner : owner.getTeam();
+    if (currentUser.can('work:team:manage') && this.isSameTeamAsUser()) return true;
 
-      if (currentUsersTeam === ownersTeam) return true;
-    }
+    return false;
+  },
+  canSubmit() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+
+    if (currentUser.can('work:submit')) return true;
+
+    if (currentUser.can('work:owned:submit') && this.getOwner() === currentUser) return true;
+
+    if (currentUser.can('work:team:submit') && this.isSameTeamAsUser()) return true;
 
     return false;
   },

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -117,6 +117,8 @@ careOptsFrontend:
           title: Form Preview
         readOnlyView:
           buttonText: Read Only
+        lockedSubmitView:
+          permissionMessage: You don’t have permission to edit or submit this form.
         saveView:
           droplistLabel: Your Submit Button Preference
           save:

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -47,7 +47,10 @@ export default App.extend({
     if (feVersion !== versions.frontend) window.location.reload();
   },
   isReadOnly() {
-    return (this.action && this.action.isLocked()) || this.form.isReadOnly();
+    const isLocked = this.action && this.action.isLocked();
+    const isSubmitRestricted = this.action && !this.action.canSubmit();
+
+    return this.form.isReadOnly() || isLocked || isSubmitRestricted;
   },
   getStoreId() {
     const actionId = get(this.action, 'id');

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -189,6 +189,30 @@
   font-size: 12px;
 }
 
+.form__submit-locked {
+  align-items: center;
+  border-left: 1px solid $black-80;
+  display: flex;
+  margin-left: 20px;
+  padding-left: 20px;
+}
+
+.form__submit-locked-icon {
+  font-size: 20px;
+  margin-right: 12px;
+
+  .icon {
+    color: $black-60;
+    font-size: 20px;
+    vertical-align: -0.125em;
+  }
+}
+
+.form__submit-locked-text {
+  font-size: 12px;
+  width: 160px;
+}
+
 .form__form-action {
   border-left: 1px solid $black-80;
   display: flex;

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -166,7 +166,7 @@
   }
 }
 
-.form__last-updated {
+.form__submit-status {
   align-items: center;
   border-left: 1px solid $black-80;
   display: flex;
@@ -174,7 +174,7 @@
   padding-left: 20px;
 }
 
-.form__last-updated-icon {
+.form__submit-status-icon {
   font-size: 20px;
   margin-right: 12px;
 
@@ -185,32 +185,13 @@
   }
 }
 
-.form__last-updated-text {
+.form__submit-status-text {
   font-size: 12px;
 }
 
-.form__submit-locked {
-  align-items: center;
-  border-left: 1px solid $black-80;
-  display: flex;
-  margin-left: 20px;
-  padding-left: 20px;
-}
-
-.form__submit-locked-icon {
-  font-size: 20px;
-  margin-right: 12px;
-
-  .icon {
-    color: $black-60;
-    font-size: 20px;
-    vertical-align: -0.125em;
-  }
-}
-
-.form__submit-locked-text {
+.form__submit-status-locked-text {
   font-size: 12px;
-  width: 160px;
+  max-width: 160px;
 }
 
 .form__form-action {

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -271,12 +271,12 @@ const ReadOnlyView = View.extend({
 });
 
 const LockedSubmitView = View.extend({
-  className: 'form__submit-locked',
+  className: 'form__submit-status',
   template: hbs`
-    <div class="form__submit-locked-icon">
+    <div class="form__submit-status-icon">
       {{far "lock-keyhole"}}
     </div>
-    <div class="form__submit-locked-text">
+    <div class="form__submit-status-locked-text">
       {{ @intl.forms.form.formViews.lockedSubmitView.permissionMessage }}
     </div>
   `,
@@ -313,12 +313,12 @@ const SaveButtonTypeDroplist = Droplist.extend({
 });
 
 const LastUpdatedView = View.extend({
-  className: 'form__last-updated',
+  className: 'form__submit-status',
   template: hbs`
-    <div class="form__last-updated-icon">
+    <div class="form__submit-status-icon">
       {{far "shield-check"}}
     </div>
-    <div class="form__last-updated-text">
+    <div class="form__submit-status-text">
       <div class="u-text--overflow">{{ @intl.forms.form.formViews.lastUpdatedView.storedWork }}</div>
       {{#if updated}}
         <div class="u-text--overflow">{{formatHTMLMessage (intlGet "forms.form.formViews.lastUpdatedView.updatedAt") updated=(formatDateTime updated "AGO_OR_TODAY")}}</div>

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -270,6 +270,18 @@ const ReadOnlyView = View.extend({
   `,
 });
 
+const LockedSubmitView = View.extend({
+  className: 'form__submit-locked',
+  template: hbs`
+    <div class="form__submit-locked-icon">
+      {{far "lock-keyhole"}}
+    </div>
+    <div class="form__submit-locked-text">
+      {{ @intl.forms.form.formViews.lockedSubmitView.permissionMessage }}
+    </div>
+  `,
+});
+
 const SaveButtonTypeDroplist = Droplist.extend({
   align: 'right',
   initialize({ model }) {
@@ -439,6 +451,7 @@ export {
   PreviewView,
   StatusView,
   ReadOnlyView,
+  LockedSubmitView,
   SaveView,
   UpdateView,
   HistoryView,

--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -15,7 +15,8 @@
       "work:delete",
       "work:authored:delete",
       "work:manage",
-      "work:owned:manage"
+      "work:owned:manage",
+      "work:submit"
     ]
   },
   {
@@ -34,7 +35,8 @@
       "work:delete",
       "work:manage",
       "work:owned:manage",
-      "work:own"
+      "work:own",
+      "work:submit"
     ]
   },
   {
@@ -47,7 +49,8 @@
       "app:worklist:clinician_filter",
       "work:manage",
       "work:owned:manage",
-      "work:own"
+      "work:own",
+      "work:submit"
     ]
   },
   {
@@ -80,6 +83,7 @@
     "permissions": [
       "work:owned:delete",
       "work:owned:manage",
+      "work:owned:submit",
       "work:own"
     ]
   },
@@ -93,6 +97,7 @@
       "app:worklist:clinician_filter",
       "work:authored:delete",
       "work:team:manage",
+      "work:team:submit",
       "work:own"
     ]
   }

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -137,7 +137,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a few seconds ago');
 
     cy
@@ -155,7 +155,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a minute ago');
   });
 
@@ -206,7 +206,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', `Last edit was ${ formatDate(testTs(), 'AGO_OR_TODAY') }`);
 
     cy
@@ -281,7 +281,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', 'Last edit was a few seconds ago');
 
     cy
@@ -305,7 +305,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a few seconds ago');
 
     cy
@@ -386,7 +386,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', 'Your work is stored automatically.')
       .should('contain', 'Last edit was a few seconds ago');
 
@@ -408,7 +408,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', 'Your work is stored automatically.')
       .should('not.contain', 'Last edit was');
 
@@ -423,7 +423,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a few seconds ago');
 
     cy
@@ -1153,7 +1153,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-locked')
+      .find('.form__submit-status')
       .should('contain', 'You don’t have permission to edit or submit this form.');
 
     cy
@@ -2153,7 +2153,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-locked')
+      .find('.form__submit-status')
       .should('contain', 'You don’t have permission to edit or submit this form.');
 
     cy
@@ -2339,7 +2339,7 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-locked')
+      .find('.form__submit-status')
       .should('contain', 'You don’t have permission to edit or submit this form.');
 
     cy

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -171,7 +171,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a few seconds ago');
 
     cy
@@ -189,7 +189,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated-text')
+      .find('.form__submit-status-text')
       .should('contain', 'Last edit was a minute ago');
   });
 
@@ -233,7 +233,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', `Last edit was ${ formatDate(testTs(), 'AGO_OR_TODAY') }`);
 
     cy
@@ -288,7 +288,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', `Last edit was ${ formatDate(testTs(), 'AGO_OR_TODAY') }`);
 
     cy
@@ -333,7 +333,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', 'Your work is stored automatically.')
       .should('contain', 'Last edit was a few seconds ago');
 
@@ -354,7 +354,7 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__last-updated')
+      .find('.form__submit-status')
       .should('contain', 'Your work is stored automatically.')
       .should('not.contain', 'Last edit was');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-42759]

Restricts a user's ability to submit action forms based on the ownership of the form's corresponding action.

Permissions to be supported:

* `work:submit`: allow the user to submit a form on any action.
* `work:owned:submit`: allow the user to submit a form on any action they own.
* `work:team:submit`: allow the user to submit a form on any action owned by their team.

When a user doesn't have the correct permissions to submit a form, a locked message is shown and the form renders in read only mode.

<img width="420" alt="Screenshot 2023-10-27 at 4 11 57 PM" src="https://github.com/RoundingWell/care-ops-frontend/assets/35355575/f9c55408-ce55-4158-bd86-856e3cd8f636">

Changes do not apply to patient forms. Only patient-action forms.

- [x] Incorporate `isLocked()` with the permissions added in this PR.
- [x] For `work:team:submit`, verify the submit is locked for an action owned by a non team member. Currently only testing that for the team itself.
- [x] Refactor the locked submit view scss styles that were added.
