### PR TITLE
Remove experimentalSingleTabRunMode for Firefox

### DIFF
--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -22,7 +22,6 @@ export default defineConfig({
       webpackConfig: webpackOptions,
     },
     setupNodeEvents,
-    experimentalSingleTabRunMode: true,
   },
   e2e: {
     baseUrl: 'http://localhost:8090/',


### PR DESCRIPTION
Firefox doesn’t support `experimentalSingleTabRunMode` causing the dailies to fail

Since this is mostly inconsequential to anything, I'm just going to merge it.

There's no docs as to this being the case on cypress, but it is:
https://docs.cypress.io/guides/references/experiments#Component-Testing