### PR TITLE
Bugfix: error alert is not shown on `formResponse.saveAll()` 403 error

### DIFF
--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -155,7 +155,9 @@ export default App.extend({
   onFormServiceError(errors) {
     if (this.loadingModal) this.loadingModal.destroy();
 
-    if (errors[0].status === 403) {
+    const status = parseInt(errors[0].status, 10);
+
+    if (status === 403) {
       Radio.request('alert', 'show:error', intl.forms.form.formViews.lockedSubmitView.permissionMessage);
     }
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -1809,7 +1809,7 @@ context('Patient Action Form', function() {
           errors: [
             {
               id: '1',
-              status: 403,
+              status: '403',
               title: 'Forbidden',
               detail: 'Insufficient permissions',
             },


### PR DESCRIPTION
Shortcut Story ID: [sc-42760]

We're checking for `status === 403` but in that context the status code is a string (`status === '403'`).