### PR TITLE
Add form submit reducers

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -32,6 +32,7 @@ const _Model = BaseModel.extend({
       loaderReducers: this.getLoaderReducers(),
       changeReducers: this.getChangeReducers(),
       beforeSubmit: this.getBeforeSubmit(),
+      submitReducers: this.getSubmitReducers(),
     };
   },
   getContextScripts() {
@@ -45,6 +46,9 @@ const _Model = BaseModel.extend({
   },
   getBeforeSubmit() {
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
+  },
+  getSubmitReducers() {
+    return get(this.get('options'), 'submitReducers', []);
   },
   getWidgets() {
     const formWidgets = get(this.get('options'), 'widgets');

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -26,22 +26,22 @@ const _Model = BaseModel.extend({
   isSubmitHidden() {
     return get(this.get('options'), 'submit_hidden');
   },
-  getReducers() {
-    return get(this.get('options'), 'reducers', [defaultReducer]);
-  },
   getContext() {
     return {
       contextScripts: this.getContextScripts(),
-      reducers: this.getReducers(),
+      loaderReducers: this.getLoaderReducers(),
       changeReducers: this.getChangeReducers(),
       beforeSubmit: this.getBeforeSubmit(),
     };
   },
-  getChangeReducers() {
-    return get(this.get('options'), 'changeReducers', []);
-  },
   getContextScripts() {
     return get(this.get('options'), 'context', []);
+  },
+  getLoaderReducers() {
+    return get(this.get('options'), 'reducers', [defaultReducer]);
+  },
+  getChangeReducers() {
+    return get(this.get('options'), 'changeReducers', []);
   },
   getBeforeSubmit() {
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,4 +1,4 @@
-import { get } from 'underscore';
+import { get, size } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -13,6 +13,12 @@ const defaultReducer = `
   subm.patient.fields = _.extend({}, _.get(formSubmission, 'patient.fields'), _.get(formData, 'patient.fields'));
 
   return subm;
+`;
+
+const defaultSubmitReducer = `
+  formData.fields = formSubmission.fields || _.get(formSubmission, 'patient.fields');
+
+  return formData;
 `;
 
 const defaultBeforeSubmit = 'return formSubmission;';
@@ -48,7 +54,9 @@ const _Model = BaseModel.extend({
     return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
   },
   getSubmitReducers() {
-    return get(this.get('options'), 'submitReducers', []);
+    const submitReducers = get(this.get('options'), 'submitReducers');
+
+    return size(submitReducers) ? submitReducers : [defaultSubmitReducer];
   },
   getWidgets() {
     const formWidgets = get(this.get('options'), 'widgets');

--- a/src/js/entities-service/forms.js
+++ b/src/js/entities-service/forms.js
@@ -12,14 +12,14 @@ const Entity = BaseEntity.extend({
     'fetch:forms:model': 'fetchModel',
     'fetch:forms:collection': 'fetchCollection',
     'fetch:forms:definition': 'fetchDefinition',
-    'fetch:forms:fields': 'fetchFields',
+    'fetch:forms:data': 'fetchFormData',
     'fetch:forms:byAction': 'fetchByAction',
     'fetch:forms:definition:byAction': 'fetchDefinitionByAction',
   },
   fetchDefinition(formId) {
     return fetcher(`/api/forms/${ formId }/definition`).then(handleJSON);
   },
-  fetchFields(actionId, patientId, formId) {
+  fetchFormData(actionId, patientId, formId) {
     const model = new BaseModel();
     if (actionId) {
       return model.fetch({ url: `/api/actions/${ actionId }/form/fields` });

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -77,10 +77,10 @@ const onChange = function(form, changeReducers) {
 
 const onChangeDebounce = debounce(onChange, 100);
 
-async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, reducers, changeReducers, contextScripts, beforeSubmit }) {
+async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, loaderReducers, changeReducers, contextScripts, beforeSubmit }) {
   const evalContext = await getContext(contextScripts);
 
-  const submission = storedSubmission || await getSubmission(formData, formSubmission, reducers, evalContext);
+  const submission = storedSubmission || await getSubmission(formData, formSubmission, loaderReducers, evalContext);
   prevSubmission = structuredClone(submission);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
@@ -176,10 +176,10 @@ async function renderResponse({ definition, formSubmission, contextScripts }) {
   });
 }
 
-async function renderPdf({ definition, formData, formSubmission, reducers, contextScripts }) {
+async function renderPdf({ definition, formData, formSubmission, loaderReducers, contextScripts }) {
   const evalContext = await getContext(contextScripts);
 
-  const submission = await getSubmission(formData, formSubmission, reducers, evalContext);
+  const submission = await getSubmission(formData, formSubmission, loaderReducers, evalContext);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -23,6 +23,7 @@ import {
   getScriptContext,
   getSubmission,
   getChangeReducers,
+  getResponse,
 } from 'js/formapp/utils';
 
 import 'js/formapp/components';
@@ -77,7 +78,7 @@ const onChange = function(form, changeReducers) {
 
 const onChangeDebounce = debounce(onChange, 100);
 
-async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, loaderReducers, changeReducers, contextScripts, beforeSubmit }) {
+async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, loaderReducers, changeReducers, submitReducers, contextScripts, beforeSubmit }) {
   const evalContext = await getContext(contextScripts);
 
   const submission = storedSubmission || await getSubmission(formData, formSubmission, loaderReducers, evalContext);
@@ -145,7 +146,9 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
       return;
     }
 
-    router.request('submit:form', { response: extend({}, response, { data }) });
+    const submitResponse = extend(getResponse(form, submitReducers, data), response, { data });
+
+    router.request('submit:form', { response: submitResponse });
   });
 
   router.request('ready:form');

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -70,8 +70,16 @@ function getChangeReducers(form, changeReducers, curSubmission, prevSubmission) 
   }, curSubmission);
 }
 
+function getResponse(form, submitReducers, formSubmission) {
+  return reduce(submitReducers, (memo, reducer) => {
+    const context = form.evalContext({ formSubmission, formData: memo });
+    return FormioUtils.evaluate(reducer, context) || memo;
+  }, { fields: {}, action: {}, flow: {} });
+}
+
 export {
   getScriptContext,
   getSubmission,
   getChangeReducers,
+  getResponse,
 };

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -1,5 +1,5 @@
 /* global Formio, FormioUtils */
-import { extend, reduce } from 'underscore';
+import { extend, reduce, values } from 'underscore';
 import { addError } from 'js/datadog';
 
 // Note: Allows for setting the submission at form instantiation
@@ -71,10 +71,15 @@ function getChangeReducers(form, changeReducers, curSubmission, prevSubmission) 
 }
 
 function getResponse(form, submitReducers, formSubmission) {
+  const formData = { fields: {}, action: {}, flow: {} };
+
   return reduce(submitReducers, (memo, reducer) => {
     const context = form.evalContext({ formSubmission, formData: memo });
-    return FormioUtils.evaluate(reducer, context) || memo;
-  }, { fields: {}, action: {}, flow: {} });
+    const reducerFunction = evaluator(reducer, context);
+
+    // User evaluate directly to throw errors
+    return evaluate(reducerFunction, values(context)) || memo;
+  }, formData);
 }
 
 export {

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -28,7 +28,7 @@ const ActionFormApp = App.extend({
           formData: fields.attributes,
           formSubmission: response.getResponse(),
           contextScripts: form.getContextScripts(),
-          reducers: form.getReducers(),
+          loaderReducers: form.getLoaderReducers(),
         } }, window.origin);
       });
   },
@@ -70,7 +70,7 @@ const FormApp = App.extend({
       formData: fields.attributes,
       formSubmission: response.getResponse(),
       contextScripts: form.getContextScripts(),
-      reducers: form.getReducers(),
+      loaderReducers: form.getLoaderReducers(),
     } }, window.origin);
   },
 });

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -14,18 +14,18 @@ const ActionFormApp = App.extend({
     return [
       Radio.request('entities', 'fetch:forms:byAction', actionId),
       Radio.request('entities', 'fetch:forms:definition:byAction', actionId),
-      Radio.request('entities', 'fetch:forms:fields', actionId),
+      Radio.request('entities', 'fetch:forms:data', actionId),
       Radio.request('entities', 'fetch:actions:model', actionId),
     ];
   },
-  onStart(opts, form, definition, fields, action) {
+  onStart(opts, form, definition, data, action) {
     const filter = this._getPrefillFilters(form, action);
 
     return Promise.resolve(Radio.request('entities', 'fetch:formResponses:latest', filter))
       .then(response => {
         parent.postMessage({ message: 'form:pdf', args: {
           definition,
-          formData: fields.attributes,
+          formData: data.attributes,
           formSubmission: response.getResponse(),
           contextScripts: form.getContextScripts(),
           loaderReducers: form.getLoaderReducers(),
@@ -60,14 +60,14 @@ const FormApp = App.extend({
     return [
       Radio.request('entities', 'fetch:forms:model', formId),
       Radio.request('entities', 'fetch:forms:definition', formId),
-      Radio.request('entities', 'fetch:forms:fields', null, patientId, formId),
+      Radio.request('entities', 'fetch:forms:data', null, patientId, formId),
       Radio.request('entities', 'fetch:formResponses:model', responseId),
     ];
   },
-  onStart(opts, form, definition, fields, response) {
+  onStart(opts, form, definition, data, response) {
     parent.postMessage({ message: 'form:pdf', args: {
       definition,
-      formData: fields.attributes,
+      formData: data.attributes,
       formSubmission: response.getResponse(),
       contextScripts: form.getContextScripts(),
       loaderReducers: form.getLoaderReducers(),

--- a/src/js/outreach/apps/form_app.js
+++ b/src/js/outreach/apps/form_app.js
@@ -18,7 +18,7 @@ export default App.extend({
     return [
       Radio.request('entities', 'fetch:forms:byAction', actionId),
       Radio.request('entities', 'fetch:forms:definition:byAction', actionId),
-      Radio.request('entities', 'fetch:forms:fields', actionId),
+      Radio.request('entities', 'fetch:forms:data', actionId),
     ];
   },
   /* istanbul ignore next: Don't handle non-API errors */
@@ -27,11 +27,11 @@ export default App.extend({
     dialogView.showChildView('content', new ErrorView());
     this.showView(dialogView);
   },
-  onStart({ actionId }, form, definition, fields) {
+  onStart({ actionId }, form, definition, data) {
     this.actionId = actionId;
     this.form = form;
     this.definition = definition;
-    this.fields = fields;
+    this.formData = data.attributes;
     this.setView(new iFrameFormView({ model: this.form }));
     this.startService();
     this.showFormSaveDisabled();
@@ -49,7 +49,7 @@ export default App.extend({
   getFormPrefill() {
     this.channel.request('send', 'fetch:form:data', {
       definition: this.definition,
-      formData: this.fields.attributes,
+      formData: this.formData,
       formSubmission: {},
       ...this.form.getContext(),
     });

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -1,4 +1,4 @@
-import { map, get, debounce, isEmpty } from 'underscore';
+import { map, get, debounce, omit } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 
@@ -162,9 +162,7 @@ export default App.extend({
       channel.request('send', 'fetch:form:data', {
         definition,
         storedSubmission: submission,
-        contextScripts: this.form.getContextScripts(),
-        changeReducers: this.form.getChangeReducers(),
-        beforeSubmit: this.form.getBeforeSubmit(),
+        ...omit(this.form.getContext(), 'loaderReducers'),
       });
     });
   },

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -10,11 +10,6 @@ import { FORM_RESPONSE_STATUS } from 'js/static';
 
 import { versions } from 'js/config';
 
-/* istanbul ignore next: Temporary patch */
-function patchEvernorthHistory(submission) {
-  if (isEmpty(submission.history)) delete submission.history;
-}
-
 export default App.extend({
   startAfterInitialized: true,
   channelName() {
@@ -159,9 +154,6 @@ export default App.extend({
       });
   },
   fetchFormStoreSubmission({ submission }) {
-    // NOTE: Remove after 2023/10/19
-    patchEvernorthHistory(submission);
-
     const channel = this.getChannel();
 
     return Promise.all([

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -195,13 +195,13 @@ export default App.extend({
 
     return Promise.all([
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      Radio.request('entities', 'fetch:forms:fields', actionId, patientId, this.form.id),
+      Radio.request('entities', 'fetch:forms:data', actionId, patientId, this.form.id),
       Radio.request('entities', 'fetch:formResponses:latest', filter),
-    ]).then(([definition, fields, response]) => {
+    ]).then(([definition, data, response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,
         isReadOnly,
-        formData: fields.attributes,
+        formData: data.attributes,
         formSubmission: response.getResponse(),
         ...this.form.getContext(),
       });
@@ -225,13 +225,13 @@ export default App.extend({
 
     return Promise.all([
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      Radio.request('entities', 'fetch:forms:fields', get(this.action, 'id'), this.patient.id, this.form.id),
+      Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
       Radio.request('entities', 'fetch:formResponses:model', get(firstResponse, 'id')),
-    ]).then(([definition, fields, response]) => {
+    ]).then(([definition, data, response]) => {
       channel.request('send', 'fetch:form:data', {
         definition,
         isReadOnly,
-        formData: fields.attributes,
+        formData: data.attributes,
         formSubmission: response.getResponse(),
         ...this.form.getContext(),
       });

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -69,5 +69,14 @@
     "options": {
       "beforeSubmit": "syntaxError('foo;"
     }
+  },
+  {
+    "id": "AAAAA",
+    "name": "Submit Reducer Error",
+    "options": {
+      "submitReducers": [
+        "syntaxError('foo;"
+      ]
+    }
   }
 ]

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -1005,6 +1005,8 @@ context('Patient Action Form', function() {
         expect(data.attributes.response.data.patient.fields.foo).to.equal('bar');
         expect(data.attributes.response.data.patient.fields.weight).to.equal(192);
         expect(data.attributes.response.data.fields.survey).to.eql([]);
+        expect(data.attributes.response.fields.survey).to.eql([]);
+        expect(data.attributes.response.flow).to.be.undefined;
       });
 
     cy

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -440,4 +440,55 @@ context('Noncontext Form', function() {
       .get('@consoleError')
       .should('be.calledTwice');
   });
+
+  specify('form submitReducer error', function() {
+    cy
+      .routePatient(fx => {
+        fx.data.id = '1';
+        return fx;
+      })
+      .routeForm(_.identity, 'AAAAA')
+      .routeFormDefinition()
+      .routeLatestFormResponse()
+      .routeFormFields()
+      .visit('/patient/1/form/AAAAA')
+      .wait('@routePatient')
+      .wait('@routeForm')
+      .wait('@routeFormFields')
+      .wait('@routeFormDefinition');
+
+    cy
+      .get('iframe')
+      .its('0.contentWindow')
+      .should('not.be.empty')
+      .then(win => {
+        cy
+          .stub(win.console, 'error')
+          .as('consoleError');
+
+        cy
+          .iframe()
+          .find('textarea[name="data[familyHistory]"]')
+          .type('familyHistory');
+
+        cy
+          .iframe()
+          .find('textarea[name="data[storyTime]"]')
+          .type('storyTime');
+      });
+
+    cy
+      .get('.form__controls')
+      .find('.js-save-button')
+      .click();
+
+    cy
+      .iframe()
+      .find('.alert')
+      .contains('Failed to submit form. Please try again.');
+
+    cy
+      .get('@consoleError')
+      .should('be.called');
+  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-43837]

This also does a bit of renaming.

What was `form:fields` is now `form:data` and `reducers` were renamed to `loaderReducers` where possible without needing to update form definitions.

We should be able to release this without affecting any current forms.

- [x] Add Tests
- [x] Add a default reducer