### PR TITLE
Set `sessionReplaySampleRate: 100` datadog option

### DIFF
--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -54,6 +54,7 @@ function initRum({ isForm }) {
     defaultPrivacyLevel: 'allow',
     enableExperimentalFeatures: ['clickmap'],
     startSessionReplayRecordingManually: true,
+    sessionReplaySampleRate: 100,
     beforeSend(event, context) {
       // Add header/response context to api errors
       if (event.type === 'resource' && event.resource.type === 'fetch') {


### PR DESCRIPTION
Shortcut Story ID: [sc-44189]

Since https://github.com/RoundingWell/care-ops-frontend/pull/1184, no session replays are being recorded. This hopefully solves that issue.