### PR TITLE
Accommodate patient status api changes

### DIFF
--- a/src/js/apps/forms/widgets/widgets_header_app.js
+++ b/src/js/apps/forms/widgets/widgets_header_app.js
@@ -7,9 +7,12 @@ import { FormWidgetsHeaderView } from 'js/views/forms/form/widgets/widget_header
 
 export default App.extend({
   beforeStart({ patient, form }) {
-    return map(form.getWidgetFields(), fieldName => {
+    const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
+    const fields = map(form.getWidgetFields(), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
+
+    return [workspacePatient, ...fields];
   },
   onStart({ patient, form }) {
     const widgets = form.getWidgets();

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -16,9 +16,12 @@ export default App.extend({
     this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
-    return map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
+    const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
+    const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
+
+    return [workspacePatient, ...fields];
   },
   onStart({ patient }) {
     this.patient = patient;

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -13,11 +13,12 @@ export default App.extend({
   },
   beforeStart({ patient }) {
     const patientModel = Radio.request('entities', 'fetch:patients:model', patient.id);
+    const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
     const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
 
-    return [patientModel, ...fields];
+    return [patientModel, workspacePatient, ...fields];
   },
   onStart({ patient }) {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');

--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -63,6 +63,10 @@ const _Model = BaseModel.extend({
   getSortName() {
     return (this.get('last_name') + this.get('first_name')).toLowerCase();
   },
+  getStatus() {
+    const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
+    return workspacePatient.get('status');
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/entities/workspace-patients.js
+++ b/src/js/entities-service/entities/workspace-patients.js
@@ -1,0 +1,16 @@
+import Store from 'backbone.store';
+import BaseModel from 'js/base/model';
+
+const TYPE = 'workspace-patients';
+
+const _Model = BaseModel.extend({
+  type: TYPE,
+  urlRoot: '/api/workspace-patients',
+});
+
+const Model = Store(_Model, TYPE);
+
+export {
+  _Model,
+  Model,
+};

--- a/src/js/entities-service/index.js
+++ b/src/js/entities-service/index.js
@@ -42,4 +42,6 @@ import './teams';
 
 import './widgets';
 
+import './workspace-patients';
+
 import './workspaces';

--- a/src/js/entities-service/workspace-patients.js
+++ b/src/js/entities-service/workspace-patients.js
@@ -1,0 +1,25 @@
+import Radio from 'backbone.radio';
+import BaseEntity from 'js/base/entity-service';
+import { _Model, Model } from './entities/workspace-patients';
+import { v5 as uuid } from 'uuid';
+
+const Entity = BaseEntity.extend({
+  Entity: { _Model, Model },
+  radioRequests: {
+    'get:workspacePatients:model': 'getByPatient',
+    'fetch:workspacePatients:byPatient': 'fetchByPatient',
+  },
+  fetchByPatient(patientId) {
+    const model = this.getByPatient(patientId);
+
+    return model.fetch();
+  },
+  getByPatient(patientId) {
+    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const workspaceId = currentWorkspace.id;
+
+    return new Model({ id: uuid(patientId, workspaceId) });
+  },
+});
+
+export default new Entity();

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -65,10 +65,12 @@ const widgets = {
     template: hbs`{{formatMessage (intlGet "patients.widgets.widgets.sex") sex=sex}}`,
   },
   status: {
-    modelEvents: {
-      'change:status': 'render',
-    },
     template: hbs`<span class="widgets__status-{{ status }}">{{formatMessage (intlGet "patients.widgets.widgets.status") status=status}}</span>`,
+    templateContext() {
+      return {
+        status: this.model.getStatus(),
+      };
+    },
   },
   divider: {
     template: hbs`<div class="widgets__divider"></div>`,

--- a/test/fixtures/config/patients.js
+++ b/test/fixtures/config/patients.js
@@ -8,7 +8,6 @@ module.exports = {
       last_name: faker.name.lastName(),
       birth_date: faker.date.past(40, '2010-01-01'),
       sex: faker.random.arrayElement(['m', 'f']),
-      status: faker.random.arrayElement(['active', 'inactive']),
     };
   },
 };

--- a/test/fixtures/config/workspace-patients.js
+++ b/test/fixtures/config/workspace-patients.js
@@ -1,0 +1,20 @@
+const dayjs = require('dayjs');
+const faker = require('@roundingwellos/faker');
+
+module.exports = {
+  generate() {
+    const created = faker.date.between(
+      dayjs().subtract(1, 'week').format(),
+      dayjs().format(),
+    );
+
+    return {
+      created_at: created,
+      status: faker.random.arrayElement(['active', 'inactive', 'archived']),
+      updated_at: faker.date.between(
+        created,
+        dayjs().format(),
+      ),
+    };
+  },
+};

--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -1,6 +1,8 @@
 import { getErrors } from 'helpers/json-api';
 import stateColors from 'helpers/state-colors';
 
+import { workspaceOne } from 'support/api/workspaces';
+
 context('clinicians modal', function() {
   specify('add clinician', function() {
     cy
@@ -115,7 +117,7 @@ context('clinicians modal', function() {
         expect(data.attributes.email).to.equal('test.clinician@roundingwell.com');
         expect(data.relationships.role.data.id).to.equal('11111');
         expect(data.relationships.team.data.id).to.equal('22222');
-        expect(data.relationships.workspaces.data[0].id).to.equal('11111');
+        expect(data.relationships.workspaces.data[0].id).to.equal(workspaceOne.id);
       });
 
     cy

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -5,7 +5,7 @@ import stateColors from 'helpers/state-colors';
 
 import { teamCoordinator, teamNurse } from 'support/api/teams';
 import { roleAdmin, roleEmployee, roleManager } from 'support/api/roles';
-import { getWorkspaces } from 'support/api/workspaces';
+import { getWorkspaces, workspaceOne } from 'support/api/workspaces';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 
 const testClinician = getClinician({
@@ -63,14 +63,14 @@ context('clinician sidebar', function() {
       .as('routePatchClinician');
 
     cy
-      .intercept('POST', '/api/workspaces/11111/relationships/clinicians', {
+      .intercept('POST', `/api/workspaces/${ workspaceOne.id }/relationships/clinicians`, {
         statusCode: 204,
         body: {},
       })
       .as('routeAddWorkspaceClinician');
 
     cy
-      .intercept('DELETE', '/api/workspaces/11111/relationships/clinicians', {
+      .intercept('DELETE', `/api/workspaces/${ workspaceOne.id }/relationships/clinicians`, {
         statusCode: 204,
         body: {},
       })

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -22,7 +22,9 @@ import { FORM_RESPONSE_STATUS } from 'js/static';
 
 context('Patient Action Form', function() {
   beforeEach(function() {
-    cy.routesForDefault();
+    cy
+      .routeWorkspacePatient()
+      .routesForDefault();
   });
 
   specify('deleted action', function() {
@@ -1549,13 +1551,16 @@ context('Patient Action Form', function() {
             last_name: 'Last',
             birth_date: dob,
             sex: 'f',
-            status: 'active',
           },
           relationships: {
             'patient-fields': getRelationship([testField]),
           },
         });
 
+        return fx;
+      })
+      .routeWorkspacePatient(fx => {
+        fx.data.attributes.status = 'active';
         return fx;
       })
       .routePatientField(fx => {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -832,6 +832,7 @@ context('Patient Action Form', function() {
       .wait('@routeFormByAction')
       .wait('@routePatientByAction')
       .wait('@routeFormDefinition')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormResponse');
 
     cy
@@ -1576,6 +1577,7 @@ context('Patient Action Form', function() {
       .wait('@routePatientByAction')
       .wait('@routeAction')
       .wait('@routeWidgets')
+      .wait('@routeWorkspacePatient')
       .wait('@routePatientFieldtestField');
 
     cy
@@ -1631,6 +1633,7 @@ context('Patient Action Form', function() {
       .wait('@routeAction')
       .wait('@routeFormByAction')
       .wait('@routePatientByAction')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormDefinition');
 
     cy
@@ -1788,6 +1791,7 @@ context('Patient Action Form', function() {
       .wait('@routeAction')
       .wait('@routeFormByAction')
       .wait('@routePatientByAction')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormDefinition');
 
     cy
@@ -1845,6 +1849,7 @@ context('Patient Action Form', function() {
       .wait('@routeAction')
       .wait('@routeFormByAction')
       .wait('@routePatientByAction')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormDefinition');
 
     const errors = getErrors({

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -19,7 +19,9 @@ function getTestPatientField(name, value) {
 
 context('Noncontext Form', function() {
   beforeEach(function() {
-    cy.routesForDefault();
+    cy
+      .routeWorkspacePatient()
+      .routesForDefault();
   });
 
   specify('getClinicians', function() {

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -50,6 +50,7 @@ context('Patient Form', function() {
       .wait('@routePatient')
       .wait('@routeForm')
       .wait('@routeFormDefinition')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormFields');
 
     cy
@@ -571,6 +572,7 @@ context('Patient Form', function() {
       .wait('@routeFormFields')
       .wait('@routeWidgets')
       .wait('@routePatient')
+      .wait('@routeWorkspacePatient')
       .wait('@routePatientFieldtestField');
 
     cy
@@ -622,6 +624,7 @@ context('Patient Form', function() {
       .wait('@routeForm')
       .wait('@routePatient')
       .wait('@routeFormDefinition')
+      .wait('@routeWorkspacePatient')
       .wait('@routeFormFields');
 
     cy
@@ -749,6 +752,7 @@ context('Patient Form', function() {
       .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routeFormFields')
+      .wait('@routeWorkspacePatient')
       .wait('@routePatient');
 
     const errors = getErrors({

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -15,6 +15,11 @@ import { getWidget } from 'support/api/widgets';
 import { FORM_RESPONSE_STATUS } from 'js/static';
 
 context('Patient Form', function() {
+  beforeEach(function() {
+    cy
+      .routeWorkspacePatient();
+  });
+
   specify('submitting the form', function() {
     cy
       .routesForPatientAction()
@@ -541,13 +546,16 @@ context('Patient Form', function() {
             last_name: 'Last',
             birth_date: dob,
             sex: 'f',
-            status: 'active',
           },
           relationships: {
             'patient-fields': getRelationship([patientField]),
           },
         });
 
+        return fx;
+      })
+      .routeWorkspacePatient(fx => {
+        fx.data.attributes.status = 'active';
         return fx;
       })
       .routePatientField(fx => {

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -1,7 +1,10 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
+import { v5 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { testTs } from 'helpers/test-timestamp';
+
+import { workspaceOne, workspaceTwo } from 'support/api/workspaces';
 
 context('App Nav', function() {
   beforeEach(function() {
@@ -218,11 +221,11 @@ context('App Nav', function() {
       .visit()
       .wait('@routeActions')
       .its('request.headers')
-      .should('have.property', 'workspace', '11111')
+      .should('have.property', 'workspace', workspaceOne.id)
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('currentWorkspace'));
 
-        expect(storage).to.equal('11111');
+        expect(storage).to.equal(workspaceOne.id);
       });
 
     cy
@@ -247,11 +250,11 @@ context('App Nav', function() {
     cy
       .wait('@routeActions')
       .its('request.headers')
-      .should('have.property', 'workspace', '22222')
+      .should('have.property', 'workspace', workspaceTwo.id)
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('currentWorkspace'));
 
-        expect(storage).to.equal('22222');
+        expect(storage).to.equal(workspaceTwo.id);
       });
 
     cy
@@ -278,11 +281,11 @@ context('App Nav', function() {
     cy
       .wait('@routeActions')
       .its('request.headers')
-      .should('have.property', 'workspace', '11111')
+      .should('have.property', 'workspace', workspaceOne.id)
       .then(() => {
         const storage = JSON.parse(localStorage.getItem('currentWorkspace'));
 
-        expect(storage).to.equal('11111');
+        expect(storage).to.equal(workspaceOne.id);
       });
 
     cy
@@ -527,7 +530,7 @@ context('App Nav', function() {
       relationships: {
         team: { data: { id: '11111' } },
         workspaces: { data: _.times(10, n => {
-          return { id: `${ n }`, type: 'workspaces' };
+          return { id: uuid(`${ n }`, NIL_UUID), type: 'workspaces' };
         }) },
         role: { data: { id: '22222' } },
       },
@@ -542,7 +545,7 @@ context('App Nav', function() {
           data: _.times(10, n=> {
             const clone = _.clone(workspace);
 
-            clone.id = `${ n }`;
+            clone.id = uuid(`${ n }`, NIL_UUID);
             clone.attributes.name = `Workspace ${ n }`;
 
             return clone;
@@ -963,7 +966,7 @@ context('App Nav', function() {
       },
       relationships: {
         team: { data: { id: '11111' } },
-        workspaces: { data: [{ id: '11111' }] },
+        workspaces: { data: [{ id: workspaceOne.id }] },
         role: { data: { id: '22222' } },
       },
     };

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -4,6 +4,8 @@ import dayjs from 'dayjs';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
 
+import { workspaceOne } from 'support/api/workspaces';
+
 function createActionPostRoute(id) {
   cy
     .intercept('POST', '/api/patients/1/relationships/actions*', {
@@ -59,7 +61,7 @@ context('patient dashboard page', function() {
         fx.data.id = '1';
         fx.data.relationships.workspaces.data = [
           {
-            id: '11111',
+            id: workspaceOne.id,
             type: 'workspaces',
           },
         ];

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -6,6 +6,8 @@ import { testDate, testDateSubtract } from 'helpers/test-date';
 import { testTs } from 'helpers/test-timestamp';
 import { getResource } from 'helpers/json-api';
 
+import { workspaceOne } from 'support/api/workspaces';
+
 context('patient sidebar', function() {
   specify('display patient data', function() {
     const dob = testDateSubtract(10, 'years');
@@ -816,7 +818,7 @@ context('patient sidebar', function() {
     cy
       .getRadio(Radio => {
         const patient = Radio.request('entities', 'patients:model', '1');
-        patient.set({ _workspaces: [{ id: '11111' }] });
+        patient.set({ _workspaces: [{ id: workspaceOne.id }] });
       });
 
     cy

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -481,7 +481,6 @@ context('patient sidebar', function() {
           last_name: 'Last',
           birth_date: dob,
           sex: 'f',
-          status: 'active',
           identifiers: [
             {
               type: 'mrn',
@@ -503,6 +502,12 @@ context('patient sidebar', function() {
         return fx;
       }, fieldName);
     });
+
+    cy
+      .routeWorkspacePatient(fx => {
+        fx.data.attributes.status = 'active';
+        return fx;
+      });
 
     cy
       .visit('/patient/dashboard/1')

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -8,6 +8,8 @@ import { getRelationship } from 'helpers/json-api';
 import { getActivity } from 'support/api/events';
 import stateColors from 'helpers/state-colors';
 
+import { workspaceOne } from 'support/api/workspaces';
+
 context('action sidebar', function() {
   specify('display new action sidebar', function() {
     cy
@@ -591,7 +593,7 @@ context('action sidebar', function() {
         fx.data.relationships.workspaces = {
           data: [
             {
-              id: '11111',
+              id: workspaceOne.id,
               type: 'workspaces',
             },
           ],

--- a/test/integration/patients/sidebar/filter-sidebar.js
+++ b/test/integration/patients/sidebar/filter-sidebar.js
@@ -1,11 +1,13 @@
 import _ from 'underscore';
 import { NIL as NIL_UUID } from 'uuid';
 
+import { workspaceOne } from 'support/api/workspaces';
+
 const STATE_VERSION = 'v6';
 
 context('filter sidebar', function() {
   specify('worklist filtering', function() {
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       customFilters: {
         insurance: 'Medicare',
@@ -160,7 +162,7 @@ context('filter sidebar', function() {
       .contains('All')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.null;
       })
@@ -196,7 +198,7 @@ context('filter sidebar', function() {
       .contains('BCBS PPO 100')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.equal('BCBS PPO 100');
       })
@@ -221,7 +223,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.undefined;
       })
@@ -274,7 +276,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['33333']);
       })
@@ -299,7 +301,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal(['33333']);
       })
@@ -339,7 +341,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal([]);
       })
@@ -378,7 +380,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal([]);
       })
@@ -417,7 +419,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['33333']);
       })
@@ -454,7 +456,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['22222', '33333']);
       })
@@ -584,7 +586,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['66666']);
       })
@@ -621,7 +623,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`done-last-thirty-days_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['55555', '66666']);
       })
@@ -655,7 +657,7 @@ context('filter sidebar', function() {
   });
 
   specify('schedule filtering', function() {
-    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       customFilters: {
         insurance: 'Medicare',
       },
@@ -773,7 +775,7 @@ context('filter sidebar', function() {
       .contains('All')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.null;
       })
@@ -809,7 +811,7 @@ context('filter sidebar', function() {
       .contains('BCBS PPO 100')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.equal('BCBS PPO 100');
       })
@@ -834,7 +836,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.undefined;
       })
@@ -867,7 +869,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['33333']);
       })
@@ -895,7 +897,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal(['33333']);
       })
@@ -923,7 +925,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal([]);
       })
@@ -950,7 +952,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal([]);
       })
@@ -998,7 +1000,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['22222', '33333']);
       })
@@ -1065,7 +1067,7 @@ context('filter sidebar', function() {
   });
 
   specify('reduced schedule filtering', function() {
-    localStorage.setItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       customFilters: {
         insurance: 'Medicare',
       },
@@ -1193,7 +1195,7 @@ context('filter sidebar', function() {
       .contains('All')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.null;
       })
@@ -1229,7 +1231,7 @@ context('filter sidebar', function() {
       .contains('BCBS PPO 100')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.equal('BCBS PPO 100');
       })
@@ -1254,7 +1256,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.customFilters.insurance).to.be.undefined;
       })
@@ -1288,7 +1290,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['33333']);
       })
@@ -1316,7 +1318,7 @@ context('filter sidebar', function() {
       .first()
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal(['33333']);
       })
@@ -1344,7 +1346,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal([]);
       })
@@ -1371,7 +1373,7 @@ context('filter sidebar', function() {
       .eq(1)
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.flowStates).to.deep.equal([]);
       })
@@ -1419,7 +1421,7 @@ context('filter sidebar', function() {
       .find('.js-clear-filters')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.states).to.deep.equal(['22222', '33333']);
       })

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -6,6 +6,9 @@ import { getRelationship } from 'helpers/json-api';
 
 import { getActivity } from 'support/api/events';
 
+import { workspaceOne } from 'support/api/workspaces';
+
+
 context('flow sidebar', function() {
   specify('display flow sidebar', function() {
     cy
@@ -46,11 +49,10 @@ context('flow sidebar', function() {
             last_name: 'Last',
             birth_date: testDateSubtract(10, 'years'),
             sex: 'f',
-            status: 'active',
           },
           type: 'patients',
           relationships: {
-            workspaces: { data: [{ id: '11111', type: 'workspaces' }] },
+            workspaces: { data: [{ id: workspaceOne.id, type: 'workspaces' }] },
           },
         });
 

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -12,6 +12,7 @@ import { stateTodo, stateInProgress, stateDone } from 'support/api/states';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { roleEmployee, roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamNurse, teamCoordinator } from 'support/api/teams';
+import { workspaceOne } from 'support/api/workspaces';
 
 const testPatient1 = getPatient({
   id: '1',
@@ -102,7 +103,7 @@ context('schedule page', function() {
 
     const testTime = dayjs().hour(12).minute(0).valueOf();
 
-    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       clinicianId: '11111',
       customFilters: {},
       dateFilters: {
@@ -331,7 +332,7 @@ context('schedule page', function() {
   });
 
   specify('maximum list count reached', function() {
-    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       clinicianId: '11111',
       customFilters: {},
       dateFilters: {
@@ -454,7 +455,7 @@ context('schedule page', function() {
       .contains('Test Clinician')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.clinicianId).to.equal('test-id');
       });
@@ -480,7 +481,7 @@ context('schedule page', function() {
       .find('.js-today')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.relativeDate).to.equal('today');
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -503,7 +504,7 @@ context('schedule page', function() {
       .contains('Yesterday')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.relativeDate).to.equal('yesterday');
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -531,7 +532,7 @@ context('schedule page', function() {
       .find('.is-today')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.dateFilters.selectedDate, 'YYYY-MM-DD')).to.equal(testDate());
         expect(storage.dateFilters.relativeDate).to.be.null;
@@ -564,7 +565,7 @@ context('schedule page', function() {
       .find('.js-month')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.dateFilters.selectedMonth, 'MMM YYYY')).to.equal(formatDate(testDateAdd(1, 'month'), 'MMM YYYY'));
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -592,7 +593,7 @@ context('schedule page', function() {
       .find('.js-current-month')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.selectedMonth).to.be.null;
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -620,7 +621,7 @@ context('schedule page', function() {
       .find('.js-current-week')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.selectedMonth).to.be.null;
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -643,7 +644,7 @@ context('schedule page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.selectedMonth).to.be.null;
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -668,7 +669,7 @@ context('schedule page', function() {
       .contains('All Time')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`schedule_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.dateFilters.relativeDate).to.equal('alltime');
         expect(storage.dateFilters.selectedDate).to.be.null;
@@ -717,7 +718,7 @@ context('schedule page', function() {
   });
 
   specify('bulk edit', function() {
-    localStorage.setItem(`schedule_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`schedule_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       clinicianId: '11111',
       customFilters: {},
       dateFilters: {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -16,6 +16,7 @@ import { stateTodo, stateInProgress, stateDone } from 'support/api/states';
 import { getWidget } from 'support/api/widgets';
 import { roleAdmin, roleEmployee, roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
+import { workspaceOne } from 'support/api/workspaces';
 
 const testPatient1 = getPatient({
   id: '1',
@@ -37,7 +38,7 @@ const STATE_VERSION = 'v6';
 
 context('worklist page', function() {
   specify('flow list', function() {
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',
@@ -432,7 +433,7 @@ context('worklist page', function() {
 
     const testTime = dayjs(testDate()).hour(12).valueOf();
 
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',
@@ -887,7 +888,7 @@ context('worklist page', function() {
   });
 
   specify('maximum list count reached', function() {
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',
@@ -1335,7 +1336,7 @@ context('worklist page', function() {
     const testTime = dayjs(testDate()).hour(12).valueOf();
     const filterDate = testDateSubtract(1);
 
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',
@@ -1397,7 +1398,7 @@ context('worklist page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.be.equal(testDateSubtract(2));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1421,7 +1422,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.be.equal(filterDate);
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1444,7 +1445,7 @@ context('worklist page', function() {
       .contains('Last Week')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
         expect(storage.actionsDateFilters.selectedWeek).to.be.null;
@@ -1470,7 +1471,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedWeek, 'YYYY-MM-DD')).to.be.equal(dayjs(testDate()).startOf('week').format('YYYY-MM-DD'));
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1506,7 +1507,7 @@ context('worklist page', function() {
       .find('.js-current-month')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.equal('thismonth');
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1536,7 +1537,7 @@ context('worklist page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedMonth, 'MMM YYYY')).to.equal(formatDate(testDateSubtract(1, 'month'), 'MMM YYYY'));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1576,7 +1577,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedMonth, 'MMM YYYY')).to.equal(formatDate(testDateAdd(1, 'month'), 'MMM YYYY'));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1599,7 +1600,7 @@ context('worklist page', function() {
       .contains('Today')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.equal('today');
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1629,7 +1630,7 @@ context('worklist page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.equal(testDateSubtract(1));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1669,7 +1670,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.equal(formatDate(testDateAdd(1), 'YYYY-MM-DD'));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1693,7 +1694,7 @@ context('worklist page', function() {
       .contains('Yesterday')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.equal('yesterday');
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1721,7 +1722,7 @@ context('worklist page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.equal(testDateSubtract(2));
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1755,7 +1756,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(formatDate(storage.actionsDateFilters.selectedDate, 'YYYY-MM-DD')).to.equal(testDate());
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
@@ -1778,7 +1779,7 @@ context('worklist page', function() {
       .find('.js-month')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1805,7 +1806,7 @@ context('worklist page', function() {
       .find('.js-prev')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1835,7 +1836,7 @@ context('worklist page', function() {
       .find('.js-next')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.be.null;
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -1909,7 +1910,7 @@ context('worklist page', function() {
       .contains('All Time')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsDateFilters.relativeDate).to.equal('alltime');
         expect(storage.actionsDateFilters.selectedDate).to.be.null;
@@ -2422,7 +2423,7 @@ context('worklist page', function() {
   });
 
   specify('action sorting - preload', function() {
-    localStorage.setItem(`shared-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`shared-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'shared-by',
       actionsSortId: 'sortNotExisting',
       flowsSortId: 'sortUpdateDesc',
@@ -2450,7 +2451,7 @@ context('worklist page', function() {
       .contains('Added: Oldest - Newest')
       .click()
       .then(() => {
-        const storage = JSON.parse(localStorage.getItem(`shared-by_11111_11111-${ STATE_VERSION }`));
+        const storage = JSON.parse(localStorage.getItem(`shared-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`));
 
         expect(storage.actionsSortId).to.equal('sortCreatedAsc');
       });
@@ -2869,7 +2870,7 @@ context('worklist page', function() {
   specify('find in list', function() {
     const lastYear = dayjs().year() - 1;
 
-    localStorage.setItem(`owned-by_11111_11111-${ STATE_VERSION }`, JSON.stringify({
+    localStorage.setItem(`owned-by_11111_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
       id: 'owned-by',
       actionsSortId: 'sortUpdateDesc',
       flowsSortId: 'sortUpdateDesc',

--- a/test/support/api/workspace-patients.js
+++ b/test/support/api/workspace-patients.js
@@ -16,5 +16,5 @@ Cypress.Commands.add('routeWorkspacePatient', (mutator = _.identity) => {
     .intercept('GET', '/api/workspace-patients/*', {
       body: mutator({ data, included: [] }),
     })
-    .as('routeTags');
+    .as('routeWorkspacePatient');
 });

--- a/test/support/api/workspace-patients.js
+++ b/test/support/api/workspace-patients.js
@@ -1,0 +1,20 @@
+import _ from 'underscore';
+import { getResource } from 'helpers/json-api';
+
+import fxWorkspacePatients from 'fixtures/collections/workspace-patients';
+
+const TYPE = 'workspace-patients';
+
+export function getWorkspacePatient() {
+  return getResource(_.sample(fxWorkspacePatients), TYPE);
+}
+
+Cypress.Commands.add('routeWorkspacePatient', (mutator = _.identity) => {
+  const data = getWorkspacePatient();
+
+  cy
+    .intercept('GET', '/api/workspace-patients/*', {
+      body: mutator({ data, included: [] }),
+    })
+    .as('routeTags');
+});

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -41,6 +41,7 @@ Cypress.Commands.add('routesForPatientDashboard', () => {
     .routePatientActions()
     .routePatientFlows()
     .routePatientField()
+    .routeWorkspacePatient()
     .routePrograms()
     .routeAllProgramActions()
     .routeAllProgramFlows();

--- a/test/support/e2e.js
+++ b/test/support/e2e.js
@@ -43,4 +43,5 @@ import './api/states';
 import './api/tags';
 import './api/teams';
 import './api/widgets';
+import './api/workspace-patients';
 import './api/workspaces';


### PR DESCRIPTION
Shortcut Story ID: [sc-45378]

re: https://app.shortcut.com/roundingwell/story/44731/patient-status-should-be-workspace-specific

Testing this is going to be awful.  The uuid for this entity is a v5 based on the patient id.  This means the patient id for all tests that load that patient dashboard or a form for that patient must use a valid uuid for the patient.. so anywhere where we are loading `patient/dashboard/1` etc must be updated to a valid generated id..  easy-peasy relatively with the new system, but rather that refactor the code base, I'm going to manually go through and add `const patientId = uuid()`s places I guess to get by..  😿 