### PR TITLE
Handle non-json errors

### DIFF
--- a/src/js/apps/globals/error_app.js
+++ b/src/js/apps/globals/error_app.js
@@ -28,9 +28,9 @@ export default RouterApp.extend({
       route: '404',
       root: true,
     },
-    'error': {
-      action: 'show500',
-      route: '500',
+    'unknownError': {
+      action: 'showError',
+      route: 'unknown-error',
       root: true,
     },
   },
@@ -61,8 +61,8 @@ export default RouterApp.extend({
   show404() {
     this.showView(new ErrorView({ is404: true }));
   },
-  show500() {
-    this.showView(new ErrorView({ is500: true }));
+  showError(status) {
+    this.showView(new ErrorView({ status }));
   },
 });
 

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -161,10 +161,16 @@ export default async(url, options) => {
 
         if (response.status >= 400) {
           logResponse(url, options, response);
+
+          const contentType = String(response.headers.get('Content-Type'));
+
+          if (!contentType.includes('json')) {
+            Radio.trigger('event-router', 'unknownError', response.status);
+          }
         }
 
         if (response.status >= 500) {
-          Radio.trigger('event-router', 'error');
+          Radio.trigger('event-router', 'unknownError', response.status);
         }
       }
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -175,10 +175,8 @@ careOptsFrontend:
       errorTemplate:
         backBtn: Back to Your Workspace
         errorHeader: Uh-oh.
-        errorInfo: "Error code: 500."
+        errorInfo: "Error code: { status }."
         errorMessage: Something went wrong.
-        forbiddenInfo: An error occurred when processing your request.
-        forbiddenMessage: Forbidden.
         notFoundInfo: This page doesn't exist.
         notFoundMessage: Something went wrong.
     modal:

--- a/src/js/outreach/apps/error_app.js
+++ b/src/js/outreach/apps/error_app.js
@@ -11,8 +11,8 @@ import {
 
 export default RouterApp.extend({
   eventRoutes: {
-    'error': {
-      route: 'outreach/500',
+    'unknownError': {
+      route: 'outreach/unknown-error',
       action: 'show500',
       root: true,
     },

--- a/src/js/views/globals/error/error.hbs
+++ b/src/js/views/globals/error/error.hbs
@@ -11,17 +11,13 @@
       </div>
       <div class="error-page__section">
         <p>
-          {{#if is403}}
-            {{ @intl.globals.error.errorTemplate.forbiddenMessage }}<br>
-            {{ @intl.globals.error.errorTemplate.forbiddenInfo }}
-          {{/if}}
           {{#if is404}}
             {{ @intl.globals.error.errorTemplate.notFoundMessage }}<br>
             {{ @intl.globals.error.errorTemplate.notFoundInfo }}
           {{/if}}
-          {{#if is500}}
+          {{#if status}}
             {{ @intl.globals.error.errorTemplate.errorMessage }}<br>
-            {{ @intl.globals.error.errorTemplate.errorInfo }}
+            {{formatMessage (intlGet "globals.error.errorTemplate.errorInfo") status=status}}
           {{/if}}
         </p>
         <a class="js-back button--blue u-margin--t-16">{{ @intl.globals.error.errorTemplate.backBtn }}</a>

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -28,7 +28,7 @@ context('Patient Action Form', function() {
   specify('deleted action', function() {
     const errors = getErrors({
       status: '410',
-      title: 'Not Founddddd',
+      title: 'Not Found',
       detail: 'Cannot find action',
     });
 

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -106,6 +106,20 @@ context('Global Error Page', function() {
       .contains('Hold up');
   });
 
+  specify('non-json error', function() {
+    cy
+      .intercept('GET', '/api/clinicians/me', {
+        statusCode: 403,
+        body: '<html><body>403 Forbidden</body></html>',
+      })
+      .as('routeCurrentClinician')
+      .visit({ noWait: true });
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Error code: 403.');
+  });
+
 
   specify('500 error', function() {
     cy

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -679,7 +679,7 @@ context('Outreach', function() {
 
     cy
       .url()
-      .should('contain', 'outreach/500');
+      .should('contain', 'outreach/unknown-error');
 
     cy
       .get('body')
@@ -712,7 +712,7 @@ context('Outreach', function() {
 
     cy
       .url()
-      .should('contain', 'outreach/500');
+      .should('contain', 'outreach/unknown-error');
 
     cy
       .get('body')
@@ -754,7 +754,7 @@ context('Outreach', function() {
 
     cy
       .url()
-      .should('contain', 'outreach/500');
+      .should('contain', 'outreach/unknown-error');
 
     cy
       .get('body')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDateAdd, testDateSubtract } from 'helpers/test-date';
+import { getErrors } from 'helpers/json-api';
 
 const tomorrow = testDateAdd(1);
 
@@ -635,12 +636,19 @@ context('patient flow page', function() {
   });
 
   specify('failed flow', function() {
+    const errors = getErrors({
+      status: '410',
+      title: 'Not Found',
+      detail: 'Cannot find flow',
+    });
+
     cy
       .routesForPatientAction()
       .routePatientByFlow()
       .routeFlowActions()
       .intercept('GET', '/api/flows/1**', {
-        statusCode: 404,
+        statusCode: 410,
+        body: { errors },
       })
       .visit('/flow/1');
 


### PR DESCRIPTION
Shortcut Story ID: [sc-46174]

This change will show our uh-oh screen for a non-json error coming back from an `/api/*` request