### PR TITLE
Replace auth0 with kinde

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "CC-BY-4.0",
       "dependencies": {
-        "@auth0/auth0-spa-js": "^2.0.2",
         "@datadog/browser-logs": "^5.1.0",
         "@datadog/browser-rum": "^5.1.0",
         "@fortawesome/fontawesome-pro": "^6.1.0",
@@ -18,6 +17,7 @@
         "@fortawesome/pro-regular-svg-icons": "^6.1.0",
         "@fortawesome/pro-solid-svg-icons": "^6.1.0",
         "@fortawesome/pro-thin-svg-icons": "^6.4.0",
+        "@kinde-oss/kinde-auth-pkce-js": "^3.0.27",
         "animejs": "^3.2.1",
         "backbone": "^1.4.0",
         "backbone.eventrouter": "^1.0.1",
@@ -108,11 +108,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@auth0/auth0-spa-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz",
-      "integrity": "sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
@@ -2527,6 +2522,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kinde-oss/kinde-auth-pkce-js": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@kinde-oss/kinde-auth-pkce-js/-/kinde-auth-pkce-js-3.0.27.tgz",
+      "integrity": "sha512-EjtphbGMPZ/z7dg5An3294X0hH3/p+P9f2bHdCv+uhGRTB7BtdL1ujcNkUl9TlIwGKD05sMe5PsJGKp+IhnU1g==",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      }
+    },
+    "node_modules/@kinde-oss/kinde-auth-pkce-js/node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "CC-BY-4.0",
       "dependencies": {
+        "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^5.1.0",
         "@datadog/browser-rum": "^5.1.0",
         "@fortawesome/fontawesome-pro": "^6.1.0",
@@ -108,6 +109,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@auth0/auth0-spa-js": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz",
+      "integrity": "sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "yaml-loader": "^0.8.0"
   },
   "dependencies": {
+    "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^5.1.0",
     "@datadog/browser-rum": "^5.1.0",
     "@fortawesome/fontawesome-pro": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "yaml-loader": "^0.8.0"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^2.0.2",
     "@datadog/browser-logs": "^5.1.0",
     "@datadog/browser-rum": "^5.1.0",
     "@fortawesome/fontawesome-pro": "^6.1.0",
@@ -223,6 +222,7 @@
     "@fortawesome/pro-regular-svg-icons": "^6.1.0",
     "@fortawesome/pro-solid-svg-icons": "^6.1.0",
     "@fortawesome/pro-thin-svg-icons": "^6.4.0",
+    "@kinde-oss/kinde-auth-pkce-js": "^3.0.27",
     "animejs": "^3.2.1",
     "backbone": "^1.4.0",
     "backbone.eventrouter": "^1.0.1",

--- a/src/assets/appconfig.json
+++ b/src/assets/appconfig.json
@@ -4,7 +4,16 @@
     "stackId": "localhost",
     "name": "Salvation Clinic"
   },
-  "kinde": {
+  "auth0": {
+    "domain": "auth.roundingwell.com",
+    "clientId": "UVGIL27XqwGsJwsTfEyz50c1qg3Ll1p6",
+    "authorizationParams": {
+      "connection": "google-oauth2"
+    },
+    "cacheLocation": "localstorage",
+    "useRefreshTokens": true
+  },
+  "kinde2": {
     "createParams": {
       "audience": "care-ops-backend",
       "client_id": "af4a982eafc845fc9df2e185b42d9ea6",

--- a/src/assets/appconfig.json
+++ b/src/assets/appconfig.json
@@ -4,14 +4,17 @@
     "stackId": "localhost",
     "name": "Salvation Clinic"
   },
-  "auth0": {
-    "domain": "auth.roundingwell.com",
-    "clientId": "UVGIL27XqwGsJwsTfEyz50c1qg3Ll1p6",
-    "authorizationParams": {
-      "connection": "google-oauth2"
+  "kinde": {
+    "createParams": {
+      "audience": "care-ops-backend",
+      "client_id": "af4a982eafc845fc9df2e185b42d9ea6",
+      "domain": "https://kinde.roundingwell.com",
+      "is_dangerously_use_local_storage": true
     },
-    "cacheLocation": "localstorage",
-    "useRefreshTokens": true
+    "connections": {
+      "default": "conn_52f40d20db634985917ed7445d3167d0",
+      "roundingwell": "conn_52f40d20db634985917ed7445d3167d0"
+    }
   },
   "datadog": {
     "clientToken": "pubdf015273e710a5a7b64bd5c80f126b9a",

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -4,6 +4,8 @@ import createKindeClient from '@kinde-oss/kinde-auth-pkce-js';
 
 import { kindeConfig as config, appConfig } from './config';
 
+import { auth as auth0, logout as auth0Logout, setToken as auth0SetToken, getToken as auth0GetToken } from './auth0';
+
 import 'scss/app-root.scss';
 
 import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
@@ -14,15 +16,23 @@ const PATH_AUTHD = '/authenticated';
 const PATH_LOGIN = '/login';
 const PATH_LOGOUT = '/logout';
 
+function shouldAuth0() {
+  return !config.kindeConfig;
+}
+
 let kinde;
 let token;
 
 // Sets a token when not using auth0;
 function setToken(tokenString) {
+  if (shouldAuth0()) return auth0SetToken(tokenString);
+
   token = tokenString;
 }
 
 function getToken() {
+  if (shouldAuth0()) return auth0GetToken();
+
   if (token) return token;
   if (!kinde || !navigator.onLine) return;
 
@@ -34,6 +44,8 @@ function getToken() {
 }
 
 function logout() {
+  if (shouldAuth0()) return auth0Logout();
+
   token = null;
   window.location = '/logout';
 }
@@ -117,6 +129,8 @@ async function createKinde(success) {
  */
 async function auth(success) {
   if (!shouldAuth()) return success();
+
+  if (shouldAuth0()) return auth0(success);
 
   // NOTE: Set path before await create to avoid redirect replaceState changing the value
   const pathName = location.pathname;

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -1,24 +1,20 @@
 import { extend } from 'underscore';
 import Radio from 'backbone.radio';
-import { createAuth0Client } from '@auth0/auth0-spa-js';
+import createKindeClient from '@kinde-oss/kinde-auth-pkce-js';
 
-import { auth0Config as config, appConfig } from './config';
+import { kindeConfig as config, appConfig } from './config';
 
 import 'scss/app-root.scss';
 
 import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
 
-const RWELL_KEY = 'rw';
-const RWELL_CONNECTION = 'google-oauth2';
-const AUTHD_PATH = '/authenticated';
+const PATH_ROOT = '/';
+const PATH_RWELL = '/rw';
+const PATH_AUTHD = '/authenticated';
+const PATH_LOGIN = '/login';
+const PATH_LOGOUT = '/logout';
 
-let auth0;
-
-function setAuth0(auth0Client) {
-  auth0 = auth0Client;
-  return auth0.isAuthenticated();
-}
-
+let kinde;
 let token;
 
 // Sets a token when not using auth0;
@@ -28,114 +24,12 @@ function setToken(tokenString) {
 
 function getToken() {
   if (token) return token;
-  if (!auth0 || !navigator.onLine) return;
+  if (!kinde || !navigator.onLine) return;
 
-  return auth0
-    .getTokenSilently()
+  return kinde
+    .getToken()
     .catch(() => {
       logout();
-    });
-}
-
-/*
- * Modifies the current history state
- */
-function replaceState(state) {
-  window.history.replaceState({}, document.title, state);
-}
-
-/*
- * authenticate parses the implicit flow hash to determine the token
- * if there is an error it forces a new authorization with a new login
- * If successful, redirects to the initial path and sends the app
- * the token and config org name
- */
-function authenticate(success) {
-  return auth0.handleRedirectCallback()
-    .then(({ appState }) => {
-      if (appState === '/login') appState = '/';
-
-      if (appState === RWELL_KEY) {
-        appState = '/';
-        localStorage.setItem(RWELL_KEY, 1);
-      }
-
-      replaceState(appState);
-      success();
-    })
-    .catch(() => {
-      forceLogin();
-    });
-}
-
-/*
- *  Take appconfig.auth0 and extend it with the default config
- */
-function getConfig() {
-  config.authorizationParams = extend({
-    redirect_uri: location.origin + AUTHD_PATH,
-    audience: 'care-ops-backend',
-  }, config.authorizationParams);
-
-  if (localStorage.getItem(RWELL_KEY)) {
-    config.authorizationParams.connection = RWELL_CONNECTION;
-  }
-
-  return config;
-}
-
-/*
- * login will occur for any pre-auth flow
- * initially requesting auth0 authorization
- * And authenticating authorization if auth0 redirected to AUTHD_PATH
- */
-function login(success) {
-  if (appConfig.cypress) {
-    setToken(appConfig.cypress);
-    success();
-    return;
-  }
-
-  if (!navigator.onLine) {
-    success();
-    return;
-  }
-
-  createAuth0Client(getConfig())
-    .then(setAuth0)
-    .then(isAuthenticated => {
-      if (location.pathname === '/logout') {
-        const federated = Radio.request('bootstrap', 'setting', 'federated_logout');
-        auth0.logout({ logoutParams: { returnTo: location.origin, federated } });
-        return;
-      }
-
-      // RWell specific login
-      if (location.pathname === `/${ RWELL_KEY }`) {
-        loginWithRedirect({
-          appState: RWELL_KEY,
-          authorizationParams: {
-            connection: RWELL_CONNECTION,
-          },
-        });
-        return;
-      }
-
-      if (location.pathname === AUTHD_PATH) {
-        authenticate(success);
-        return;
-      }
-
-      if (!isAuthenticated) {
-        forceLogin(location.pathname);
-        return;
-      }
-
-      if (location.pathname === '/login') {
-        replaceState('/');
-      }
-
-      success();
     });
 }
 
@@ -144,40 +38,112 @@ function logout() {
   window.location = '/logout';
 }
 
-function loginWithRedirect(opts) {
-  auth0.loginWithRedirect(extend({ prompt: 'login' }, opts));
-}
-
-function forceLogin(appState = '/') {
-  // iframe buster
-  if (top !== self) {
-    top.location = '/login';
-    return;
-  }
-
-  const connection = String(config.authorizationParams.connection);
-
-  if (connection === 'Username-Password-Authentication' || connection.includes('-userpass')) {
-    return loginWithRedirect({ appState });
-  }
-
-  replaceState('/login');
-
-  const loginPromptView = new LoginPromptView();
-
-  loginPromptView.on('click:login', ()=> {
-    loginWithRedirect({ appState });
-  });
-
-  loginPromptView.render();
-}
-
 Radio.reply('auth', {
   logout,
   setToken,
   getToken,
 });
 
+/*
+ * Modifies the current history state
+ */
+function replaceState(state) {
+  window.history.replaceState({}, document.title, state);
+}
+
+function login(path = PATH_ROOT, connection = config.connections.default) {
+  // iframe buster
+  if (top !== self) {
+    top.location = PATH_LOGIN;
+    return;
+  }
+
+  replaceState(PATH_LOGIN);
+
+  const loginPromptView = new LoginPromptView();
+
+  loginPromptView.on('click:login', ()=> {
+    kinde.register({
+      app_state: { path },
+      authUrlParams: { connection_id: connection },
+    });
+  });
+
+  loginPromptView.render();
+}
+
+function shouldAuth() {
+  if (appConfig.cypress) {
+    setToken(appConfig.cypress);
+    return false;
+  }
+
+  if (!navigator.onLine) {
+    return false;
+  }
+
+  return true;
+}
+
+async function createKinde(success) {
+  const kindeCreateParams = {
+    redirect_uri: location.origin + PATH_AUTHD,
+    logout_uri: location.origin,
+    on_redirect_callback: (user, { path } = {}) => {
+      if (!user) {
+        login(path);
+        return;
+      }
+
+      if (path === PATH_LOGIN) path = PATH_ROOT;
+
+      if (path === PATH_RWELL) {
+        path = PATH_ROOT;
+        localStorage.setItem(PATH_RWELL, 1);
+      }
+
+      replaceState(path);
+
+      success();
+    },
+  };
+
+  return createKindeClient(extend(kindeCreateParams, config.createParams));
+}
+
+/*
+ * Requests kinde authorization
+ * And authenticates authorization if kinde redirected to PATH_AUTHD
+ */
+async function auth(success) {
+  if (!shouldAuth()) return success();
+
+  // NOTE: Set path before await create to avoid redirect replaceState changing the value
+  const pathName = location.pathname;
+
+  kinde = await createKinde(success);
+
+  if (pathName === PATH_AUTHD) return;
+
+  if (pathName === PATH_LOGOUT) {
+    kinde.logout();
+    return;
+  }
+
+  // RWell specific login
+  if (pathName === PATH_RWELL || localStorage.getItem(PATH_RWELL)) {
+    login(PATH_RWELL, config.connections.roundingwell);
+    return;
+  }
+
+  if (!await kinde.getUser()) {
+    login(pathName);
+    return;
+  }
+
+  success();
+}
+
 export {
-  login,
+  auth,
 };

--- a/src/js/auth0.js
+++ b/src/js/auth0.js
@@ -1,0 +1,180 @@
+import { extend } from 'underscore';
+import Radio from 'backbone.radio';
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+import { auth0Config as config, appConfig } from './config';
+
+import 'scss/app-root.scss';
+
+import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
+
+const RWELL_KEY = 'rw';
+const RWELL_CONNECTION = 'google-oauth2';
+const AUTHD_PATH = '/authenticated';
+
+let auth0;
+
+function setAuth0(auth0Client) {
+  auth0 = auth0Client;
+  return auth0.isAuthenticated();
+}
+
+let token;
+
+// Sets a token when not using auth0;
+function setToken(tokenString) {
+  token = tokenString;
+}
+
+function getToken() {
+  if (token) return token;
+  if (!auth0 || !navigator.onLine) return;
+
+  return auth0
+    .getTokenSilently()
+    .catch(() => {
+      logout();
+    });
+}
+
+/*
+ * Modifies the current history state
+ */
+function replaceState(state) {
+  window.history.replaceState({}, document.title, state);
+}
+
+/*
+ * authenticate parses the implicit flow hash to determine the token
+ * if there is an error it forces a new authorization with a new login
+ * If successful, redirects to the initial path and sends the app
+ * the token and config org name
+ */
+function authenticate(success) {
+  return auth0.handleRedirectCallback()
+    .then(({ appState }) => {
+      if (appState === '/login') appState = '/';
+
+      if (appState === RWELL_KEY) {
+        appState = '/';
+        localStorage.setItem(RWELL_KEY, 1);
+      }
+
+      replaceState(appState);
+      success();
+    })
+    .catch(() => {
+      forceLogin();
+    });
+}
+
+/*
+ *  Take appconfig.auth0 and extend it with the default config
+ */
+function getConfig() {
+  config.authorizationParams = extend({
+    redirect_uri: location.origin + AUTHD_PATH,
+    audience: 'care-ops-backend',
+  }, config.authorizationParams);
+
+  if (localStorage.getItem(RWELL_KEY)) {
+    config.authorizationParams.connection = RWELL_CONNECTION;
+  }
+
+  return config;
+}
+
+/*
+ * login will occur for any pre-auth flow
+ * initially requesting auth0 authorization
+ * And authenticating authorization if auth0 redirected to AUTHD_PATH
+ */
+function auth(success) {
+  if (appConfig.cypress) {
+    setToken(appConfig.cypress);
+    success();
+    return;
+  }
+
+  if (!navigator.onLine) {
+    success();
+    return;
+  }
+
+  createAuth0Client(getConfig())
+    .then(setAuth0)
+    .then(isAuthenticated => {
+      if (location.pathname === '/logout') {
+        const federated = Radio.request('bootstrap', 'setting', 'federated_logout');
+        auth0.logout({ logoutParams: { returnTo: location.origin, federated } });
+        return;
+      }
+
+      // RWell specific login
+      if (location.pathname === `/${ RWELL_KEY }`) {
+        loginWithRedirect({
+          appState: RWELL_KEY,
+          authorizationParams: {
+            connection: RWELL_CONNECTION,
+          },
+        });
+        return;
+      }
+
+      if (location.pathname === AUTHD_PATH) {
+        authenticate(success);
+        return;
+      }
+
+      if (!isAuthenticated) {
+        forceLogin(location.pathname);
+        return;
+      }
+
+      if (location.pathname === '/login') {
+        replaceState('/');
+      }
+
+      success();
+    });
+}
+
+function logout() {
+  token = null;
+  window.location = '/logout';
+}
+
+function loginWithRedirect(opts) {
+  auth0.loginWithRedirect(extend({ prompt: 'login' }, opts));
+}
+
+function forceLogin(appState = '/') {
+  // iframe buster
+  if (top !== self) {
+    top.location = '/login';
+    return;
+  }
+
+  const connection = String(config.authorizationParams.connection);
+
+  if (connection === 'Username-Password-Authentication' || connection.includes('-userpass')) {
+    return loginWithRedirect({ appState });
+  }
+
+  replaceState('/login');
+
+  const loginPromptView = new LoginPromptView();
+
+  loginPromptView.on('click:login', ()=> {
+    loginWithRedirect({ appState });
+  });
+
+  loginPromptView.render();
+}
+
+export {
+  auth,
+  logout,
+  setToken,
+  getToken,
+};

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,5 +1,6 @@
 import { extend } from 'underscore';
 
+const auth0Config = {};
 const kindeConfig = {};
 const datadogConfig = {};
 const appConfig = {};
@@ -9,6 +10,7 @@ function fetchConfig(success) {
   fetch(`/appconfig.json?${ new URLSearchParams({ _: _NOW_ }) }`)
     .then(response => response.json())
     .then(config => {
+      extend(auth0Config, config.auth0);
       extend(kindeConfig, config.kinde);
       extend(datadogConfig, config.datadog);
       extend(appConfig, config.app);
@@ -18,6 +20,7 @@ function fetchConfig(success) {
 }
 
 export {
+  auth0Config,
   fetchConfig,
   kindeConfig,
   datadogConfig,

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,6 +1,6 @@
 import { extend } from 'underscore';
 
-const auth0Config = {};
+const kindeConfig = {};
 const datadogConfig = {};
 const appConfig = {};
 const versions = {};
@@ -9,7 +9,7 @@ function fetchConfig(success) {
   fetch(`/appconfig.json?${ new URLSearchParams({ _: _NOW_ }) }`)
     .then(response => response.json())
     .then(config => {
-      extend(auth0Config, config.auth0);
+      extend(kindeConfig, config.kinde);
       extend(datadogConfig, config.datadog);
       extend(appConfig, config.app);
       extend(versions, config.versions);
@@ -19,7 +19,7 @@ function fetchConfig(success) {
 
 export {
   fetchConfig,
-  auth0Config,
+  kindeConfig,
   datadogConfig,
   appConfig,
   versions,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -43,8 +43,8 @@ function startFormService() {
 
 function startAuth() {
   import(/* webpackPrefetch: true, webpackChunkName: "auth" */ './auth')
-    .then(({ login }) => {
-      login(start);
+    .then(({ auth }) => {
+      auth(start);
     });
 }
 


### PR DESCRIPTION
Includes the kinde management api as the audience as a placeholder

Shortcut Story ID: [sc-46537]

A release branch https://github.com/RoundingWell/care-ops-frontend/tree/release/kinde was built off of this and should be enough to continue with kinde implementation elsewhere.  So we can set composer to use `release/kinde` if we want to test this on a deploy.

`is_dangerously_use_local_storage` needs to be `true` for any non `*.roundingwell.com` domain or users will have to relogin on hard refresh.

With auth0 we were removing the login prompt if the connect type was an auth0 user/password login.  I think we might need to do something similar here still once we get that far.

The experience of running this now is that everything login related works, but sending the kinde token to the auth0 api will 401 and immediately log you out.