### PR TITLE
Cache bust index.html

### DIFF
--- a/src/js/views/globals/root.hbs
+++ b/src/js/views/globals/root.hbs
@@ -13,6 +13,9 @@
     <meta name="msapplication-TileColor" content="#0582da">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1200, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
   </head>
   <body>
     <div style="display:none">{{{ htmlWebpackPlugin.options.faIconSymbols }}}</div>


### PR DESCRIPTION
This is the only FE file that requires cache-busting after a deploy.  We could remove that need with this change.

It only saves < 100k to cache this file.

Shortcut Story ID: [sc-###]

https://medium.com/swlh/cache-busting-for-an-angular-app-deployed-with-aws-s3-and-cloudfront-86cd52359578