### PR TITLE
Edit/View patient modal bugs

### DIFF
--- a/src/js/views/globals/patient-modal/patient-modal_views.js
+++ b/src/js/views/globals/patient-modal/patient-modal_views.js
@@ -234,12 +234,6 @@ const PatientModal = View.extend({
 mixinState(PatientModal);
 
 function getPatientModal(opts) {
-  const { submit_text: submitText } = Radio.request('bootstrap', 'setting', 'patient_creation_form') || {};
-
-  if (submitText) {
-    extend(opts, { submitText });
-  }
-
   const patient = opts.patient;
   const bodyView = new PatientModal({
     model: patient,
@@ -249,6 +243,11 @@ function getPatientModal(opts) {
 
   if (canEdit) {
     const type = patient.isNew() ? 'add' : 'edit';
+    const { submit_text: submitText } = Radio.request('bootstrap', 'setting', 'patient_creation_form') || {};
+
+    if (submitText) {
+      extend(opts, { submitText });
+    }
 
     return extend({
       bodyView,

--- a/src/js/views/globals/patient-modal/patient-modal_views.js
+++ b/src/js/views/globals/patient-modal/patient-modal_views.js
@@ -245,7 +245,7 @@ function getPatientModal(opts) {
     const type = patient.isNew() ? 'add' : 'edit';
     const { submit_text: submitText } = Radio.request('bootstrap', 'setting', 'patient_creation_form') || {};
 
-    if (submitText) {
+    if (submitText && patient.isNew()) {
       extend(opts, { submitText });
     }
 

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -863,6 +863,20 @@ context('patient sidebar', function() {
   specify('edit patient modal', function() {
     cy
       .routesForPatientDashboard()
+      .routeSettings(fx => {
+        // NOTE: Ensures this submit text doesn't show for the submit button in this situation
+        fx.data.push({
+          id: 'patient_creation_form',
+          attributes: {
+            value: {
+              form_id: '11111',
+              submit_text: 'Continue to Form 11111',
+            },
+          },
+        });
+
+        return fx;
+      })
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes.source = 'manual';
@@ -915,6 +929,7 @@ context('patient sidebar', function() {
     cy
       .get('@patientModal')
       .find('.js-submit')
+      .contains('Save')
       .click()
       .wait('@routePatchPatient');
   });

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -922,6 +922,20 @@ context('patient sidebar', function() {
   specify('view patient modal', function() {
     cy
       .routesForPatientDashboard()
+      .routeSettings(fx => {
+        // NOTE: Ensures this submit text doesn't show for the submit button in this situation
+        fx.data.push({
+          id: 'patient_creation_form',
+          attributes: {
+            value: {
+              form_id: '11111',
+              submit_text: 'Continue to Form 11111',
+            },
+          },
+        });
+
+        return fx;
+      })
       .routePatient(fx => {
         fx.data.id = '1';
         fx.data.attributes.first_name = 'Test';


### PR DESCRIPTION
Shortcut Story ID: [sc-46539]

We only want the `patient_creation_form.value.submit_text` org setting value to be the submit button text when creating a new patient.

We're currently showing that submit button text for both the edit and view patient modals. For example:

![Clipboard 2024-18-01 at 9 16 02 AM (1)](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/d5c890f1-f385-40d1-b2aa-fd7f218d9d53)

Instead the edit patient modal should have `Save` for it's submit button. And the view patient modal should have `Done`. 

For reference, the `patient_creation_form` org setting was initially implemented here: https://github.com/RoundingWell/care-ops-frontend/pull/1196.