### PR TITLE
Remove patient workspace modifications

### DIFF
--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -12,12 +12,11 @@ const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/patients',
   /* eslint-disable complexity */
-  validate({ first_name, last_name, birth_date, sex, _workspaces }) {
+  validate({ first_name, last_name, birth_date, sex }) {
     const errors = {};
 
     if (!first_name || !last_name) errors.name = 'required';
     if (!sex) errors.sex = 'required';
-    if (!_workspaces || !_workspaces.length) errors.workspaces = 'required';
 
     if (!birth_date) errors.birth_date = 'required';
     else if (dayjs(birth_date).isAfter()) errors.birth_date = 'invalidDate';
@@ -34,28 +33,14 @@ const _Model = BaseModel.extend({
     const fields = this.getFields();
     return fields.find({ name });
   },
-  addWorkspace(workspace) {
-    const workspaces = this.getWorkspaces();
-    workspaces.add(workspace);
-    this.set('_workspaces', workspaces.map(model => model.pick('id')));
-  },
-  removeWorkspace(workspace) {
-    const workspaces = this.getWorkspaces();
-    workspaces.remove(workspace);
-    this.set('_workspaces', workspaces.map(model => model.pick('id')));
-  },
   saveAll(attrs) {
     attrs = extend({}, this.attributes, attrs);
-
-    const relationships = {
-      'workspaces': this.toRelation(attrs._workspaces, 'workspaces'),
-    };
 
     const opts = { wait: true };
 
     if (this.isNew()) opts.type = 'PUT';
 
-    return this.save(attrs, { relationships }, opts);
+    return this.save(attrs, {}, opts);
   },
   canEdit() {
     return this.isNew() || this.get('source') === 'manual';

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -192,10 +192,10 @@ careOptsFrontend:
         addPatient: Add Patient
         dateOfBirth: Date of Birth
         firstName: First Name
-        workspaces: Workspaces
         lastName: Last Name
         patientAccount: Patient Account
         sex: Sex
+        workspaces: Workspaces
       patientModalViews:
         errorView:
           errors:

--- a/src/js/views/globals/patient-modal/patient-modal.hbs
+++ b/src/js/views/globals/patient-modal/patient-modal.hbs
@@ -2,4 +2,6 @@
 <div class="u-margin--b-8 flex"><div class="modal__form-label">{{ @intl.globals.patientModal.patientModalTemplate.lastName }}</div><div class="flex-grow" data-last-name-region></div></div>
 <div class="u-margin--b-8 flex"><div class="modal__form-label">{{ @intl.globals.patientModal.patientModalTemplate.dateOfBirth }}</div><div data-dob-region></div></div>
 <div class="u-margin--b-8 flex"><div class="modal__form-label">{{ @intl.globals.patientModal.patientModalTemplate.sex }}</div><div data-sex-region></div></div>
-<div class="u-margin--b-8 flex"><div class="modal__form-label">{{ @intl.globals.patientModal.patientModalTemplate.workspaces }}</div><div class="modal__form-component" data-workspaces-region></div></div>
+{{#unless isNew}}
+  <div class="u-margin--b-8 flex"><div class="modal__form-label">{{ @intl.globals.patientModal.patientModalTemplate.workspaces }}</div><div class="modal__form-component" data-workspaces-region></div></div>
+{{/unless}}

--- a/src/js/views/globals/patient-modal/patient-modal_views.js
+++ b/src/js/views/globals/patient-modal/patient-modal_views.js
@@ -213,21 +213,15 @@ const PatientModal = View.extend({
     });
   },
   showWorkspacesComponent() {
+    if (this.model.isNew()) return;
+
     const currentUser = Radio.request('bootstrap', 'currentUser');
-    const workspacesManager = this.showChildView('workspaces', new WorkspacesManagerComponent({
+
+    this.showChildView('workspaces', new WorkspacesManagerComponent({
       member: this.model,
       workspaces: currentUser.getWorkspaces(),
-      isDisabled: !this.model.canEdit(),
+      isDisabled: true,
     }));
-
-    this.listenTo(workspacesManager, {
-      'add:member'(patient, workspace) {
-        this.model.addWorkspace(workspace);
-      },
-      'remove:member'(patient, workspace) {
-        this.model.removeWorkspace(workspace);
-      },
-    });
   },
 });
 

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -1,6 +1,5 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v5 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { getRelationship } from 'helpers/json-api';
 
@@ -537,29 +536,13 @@ context('App Nav', function() {
       },
       relationships: {
         team: getRelationship(teamCoordinator),
-        workspaces: getRelationship(_.times(10, n => {
-          return { id: uuid(`${ n }`, NIL_UUID), type: 'workspaces' };
-        })),
+        workspaces: getRelationship([workspaceOne]),
         role: getRelationship(roleAdmin),
       },
     });
 
     cy
       .routesForPatientDashboard()
-      .routeWorkspaces(fx => {
-        const workspace = _.sample(fx.data);
-
-        return {
-          data: _.times(10, n=> {
-            const clone = _.clone(workspace);
-
-            clone.id = uuid(`${ n }`, NIL_UUID);
-            clone.attributes.name = `Workspace ${ n }`;
-
-            return clone;
-          }),
-        };
-      })
       .routeSettings(fx => {
         fx.data.push({ id: 'manual_patient_creation', attributes: { value: true } });
 
@@ -661,38 +644,6 @@ context('App Nav', function() {
     cy
       .get('.picklist')
       .find('.js-picklist-item')
-      .first()
-      .click();
-
-    cy
-      .get('@addPatientModal')
-      .find('.js-submit')
-      .should('be.disabled');
-
-    let i = 10;
-    while (i > 0) {
-      cy
-        .get('@addPatientModal')
-        .find('[data-workspaces-region] [data-droplist-region] button')
-        .click();
-
-      cy
-        .get('.picklist')
-        .find('.js-picklist-item')
-        .first()
-        .click();
-
-      i--;
-    }
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region] [data-droplist-region] button')
-      .should('be.disabled');
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region] .js-remove')
       .first()
       .click();
 
@@ -813,22 +764,6 @@ context('App Nav', function() {
       .find('.js-picklist-item')
       .first()
       .click();
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region] [data-droplist-region] button')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .first()
-      .click();
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region]')
-      .contains('Workspace One');
 
     cy
       .get('@addPatientModal')
@@ -960,58 +895,6 @@ context('App Nav', function() {
     cy
       .get('.modal')
       .should('not.exist');
-  });
-
-  specify('add patient - clinician in one workspace', function() {
-    const testClinician = getClinician({
-      id: '1',
-      attributes: {
-        name: 'Test Clinician',
-        email: 'test.clinician@roundingwell.com',
-        enabled: true,
-        last_active_at: testTs(),
-      },
-      relationships: {
-        team: getRelationship(teamCoordinator),
-        workspaces: getRelationship([workspaceOne]),
-        role: getRelationship(roleAdmin),
-      },
-    });
-
-    cy
-      .routesForPatientDashboard()
-      .routeWorkspaces()
-      .routeSettings(fx => {
-        fx.data.push({ id: 'manual_patient_creation', attributes: { value: true } });
-
-        return fx;
-      })
-      .routeWorkspaceClinicians(fx => {
-        fx.data = [testClinician];
-
-        return fx;
-      })
-      .routeCurrentClinician(fx => {
-        fx.data = testClinician;
-
-        return fx;
-      })
-      .visit('/', { isRoot: true });
-
-    cy
-      .get('.app-nav')
-      .find('.js-add-patient')
-      .click();
-
-    cy
-      .get('.modal')
-      .find('[data-workspaces-region] .list-manager__item')
-      .should('contain', 'Workspace One');
-
-    cy
-      .get('.modal')
-      .find('[data-workspaces-region] [data-droplist-region] button')
-      .should('be.disabled');
   });
 
   specify('manual add patient disabled', function() {
@@ -1153,22 +1036,6 @@ context('App Nav', function() {
       .find('.js-picklist-item')
       .first()
       .click();
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region] [data-droplist-region] button')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .first()
-      .click();
-
-    cy
-      .get('@addPatientModal')
-      .find('[data-workspaces-region]')
-      .contains('Workspace One');
 
     cy
       .routePatient()


### PR DESCRIPTION
Shortcut Story ID: [sc-46927]

This PR makes it so users cannot add or remove the workspaces a patient belong to in the UI. So when a patient is created, the FE won't send any workspace data to the backend. And the patient will be added to the user's workspaces automatically.

Changes to the different versions of the patient modal:

* `Add New Patient`: entire workspaces section will not be shown. And the workspaces data will not be sent with the api request. ([screenshot](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/ddca1b03-62aa-4726-9a9c-d1278d877b4b))
* `Edit Patient Details`: workspaces section will be shown as before, but the droplist component is disabled and only displays a list of that patient's workspaces. So workspaces will be in a read only state. ([screenshot](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/fc173968-ff50-46b8-978b-495290f71496))
* `View Patient Details`: remains the same as before where the workspaces are in a read only state. The droplist component is disabled and only displays a list of that patient's workspaces. ([screenshot](https://github.com/RoundingWell/care-ops-frontend/assets/35355575/defb5564-974b-43a5-b89b-34a8125aeb96))

To do:

- [x] Remove ability to select workspaces in add patient modal.
- [x] Make workspace list view only in edit patient modal.
- [x] Confirm the view patient model remains unchanged.
- [x] Figure out why `schedule => display schedule` test is failing. Potentially addressed in a separate PR. I don't think it's related to this PR. Fixed in a separate PR: https://github.com/RoundingWell/care-ops-frontend/pull/1224.