### PR TITLE
Expose form response data to loader reducers

### DIFF
--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -1,4 +1,4 @@
-import { get } from 'underscore';
+import { get, omit } from 'underscore';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -41,6 +41,9 @@ const _Model = BaseModel.extend({
   },
   getResponse() {
     return get(this.get('response'), 'data', {});
+  },
+  getFormData() {
+    return omit(this.get('response'), 'data');
   },
   parseRelationship: _parseRelationship,
 });

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -82,10 +82,10 @@ const onChange = function(form, changeReducers) {
 
 const onChangeDebounce = debounce(onChange, 100);
 
-async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, loaderReducers, changeReducers, submitReducers, contextScripts, beforeSubmit }) {
+async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, responseData, loaderReducers, changeReducers, submitReducers, contextScripts, beforeSubmit }) {
   const evalContext = await getContext(contextScripts);
 
-  const submission = storedSubmission || await getSubmission(formData, formSubmission, loaderReducers, evalContext);
+  const submission = storedSubmission || await getSubmission(formData, formSubmission, responseData, loaderReducers, evalContext);
   prevSubmission = structuredClone(submission);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
@@ -193,10 +193,10 @@ async function renderResponse({ definition, formSubmission, contextScripts }) {
   });
 }
 
-async function renderPdf({ definition, formData, formSubmission, loaderReducers, contextScripts }) {
+async function renderPdf({ definition, formData, formSubmission, responseData, loaderReducers, contextScripts }) {
   const evalContext = await getContext(contextScripts);
 
-  const submission = await getSubmission(formData, formSubmission, loaderReducers, evalContext);
+  const submission = await getSubmission(formData, formSubmission, responseData, loaderReducers, evalContext);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -48,10 +48,10 @@ function getScriptContext(contextScripts, baseContext) {
   });
 }
 
-function getSubmission(formData, formSubmission, reducers, evalContext) {
+function getSubmission(formData, formSubmission, responseData, reducers, evalContext) {
   return Formio.createForm(document.createElement('div'), {}, { evalContext }).then(form => {
     const submission = reduce(reducers, (memo, reducer) => {
-      return FormioUtils.evaluate(reducer, form.evalContext({ formSubmission: memo, formData })) || memo;
+      return FormioUtils.evaluate(reducer, form.evalContext({ formSubmission: memo, formData, responseData })) || memo;
     }, formSubmission);
 
     form.destroy();

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -26,6 +26,7 @@ const ActionFormApp = App.extend({
         parent.postMessage({ message: 'form:pdf', args: {
           definition,
           formData: data.attributes,
+          responseData: response.getFormData(),
           formSubmission: response.getResponse(),
           contextScripts: form.getContextScripts(),
           loaderReducers: form.getLoaderReducers(),
@@ -68,6 +69,7 @@ const FormApp = App.extend({
     parent.postMessage({ message: 'form:pdf', args: {
       definition,
       formData: data.attributes,
+      responseData: response.getFormData(),
       formSubmission: response.getResponse(),
       contextScripts: form.getContextScripts(),
       loaderReducers: form.getLoaderReducers(),

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -220,6 +220,7 @@ export default App.extend({
         definition,
         isReadOnly,
         formData: data.attributes,
+        responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         ...this.form.getContext(),
       });
@@ -250,6 +251,7 @@ export default App.extend({
         definition,
         isReadOnly,
         formData: data.attributes,
+        responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         ...this.form.getContext(),
       });
@@ -264,6 +266,7 @@ export default App.extend({
     ]).then(([definition, response]) => {
       channel.request('send', 'fetch:form:response', {
         definition,
+        responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         contextScripts: this.form.getContextScripts(),
       });

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -53,7 +53,10 @@
     "name": "Test Prefill Action Tag",
     "options": {
       "prefill_form_id": "11111",
-      "prefill_action_tag": "foo-tag"
+      "prefill_action_tag": "foo-tag",
+      "reducers": [
+        "formSubmission.storyTime = responseData.flow.storyTime"
+      ]
     }
   },
   {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -633,9 +633,9 @@ context('Patient Action Form', function() {
             response: {
               data: {
                 familyHistory: 'Prefilled family history',
-                storyTime: 'Prefilled story time',
                 fields: { foo: 'bar' },
               },
+              flow: { storyTime: 'Prefilled response story time' },
             },
           },
         });
@@ -665,7 +665,7 @@ context('Patient Action Form', function() {
     cy
       .iframe()
       .find('textarea[name="data[storyTime]"]')
-      .should('have.value', 'Prefilled story time');
+      .should('have.value', 'Prefilled response story time');
 
     cy
       .iframe()


### PR DESCRIPTION
Shortcut Story ID: [sc-47117]

Previous `response` data that isn't the form.io response is now exposed to the script context available to loader reducers as `responseData` which should equate to the `formData` of the prefilled form submission with the `state` and `metadata` that is attached from form.io
