### PR TITLE
Switch from created_at to updated_at for form-responses

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -1,6 +1,5 @@
 import { extend } from 'underscore';
 import Radio from 'backbone.radio';
-import dayjs from 'dayjs';
 import store from 'store';
 
 import App from 'js/base/app';
@@ -120,8 +119,6 @@ export default App.extend({
 
       return;
     }
-
-    response.set({ _created_at: dayjs().format() });
 
     this.showForm(response.id);
     this.showChildView('status', new StatusView({ model: response }));

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -23,7 +23,7 @@ const Entity = BaseEntity.extend({
     const data = {
       include: ['form-responses'],
       fields: {
-        'form-responses': ['status', 'created_at', 'editor'],
+        'form-responses': ['status', 'updated_at', 'editor'],
       },
     };
 

--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -35,7 +35,7 @@ const _Model = BaseModel.extend({
     if (this.get('status') !== FORM_RESPONSE_STATUS.DRAFT) return;
 
     return {
-      updated: this.get('created_at'),
+      updated: this.get('updated_at'),
       submission: this.getResponse(),
     };
   },
@@ -54,7 +54,7 @@ const Collection = BaseCollection.extend({
   model: Model,
   parseRelationship: _parseRelationship,
   comparator(responseA, responseB) {
-    return alphaSort('desc', responseA.get('created_at'), responseB.get('created_at'));
+    return alphaSort('desc', responseA.get('updated_at'), responseB.get('updated_at'));
   },
   getFirstSubmission() {
     return this.find({ status: FORM_RESPONSE_STATUS.SUBMITTED });

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -260,7 +260,7 @@ const PreviewView = View.extend({
 
 const StatusView = View.extend({
   className: 'u-text-align--right',
-  template: hbs`{{formatHTMLMessage (intlGet "forms.form.formViews.statusView.label") date=(formatDateTime created_at "AT_TIME")}}`,
+  template: hbs`{{formatHTMLMessage (intlGet "forms.form.formViews.statusView.label") date=(formatDateTime updated_at "AT_TIME")}}`,
 });
 
 const ReadOnlyView = View.extend({
@@ -407,10 +407,10 @@ const UpdateView = View.extend({
 const HistoryDroplist = Droplist.extend({
   viewOptions: {
     className: 'button-filter',
-    template: hbs`{{far "clock-rotate-left"}}{{formatDateTime created_at "AT_TIME"}}{{far "angle-down"}}`,
+    template: hbs`{{far "clock-rotate-left"}}{{formatDateTime updated_at "AT_TIME"}}{{far "angle-down"}}`,
   },
   picklistOptions: {
-    itemTemplate: hbs`{{formatDateTime created_at "AT_TIME"}}`,
+    itemTemplate: hbs`{{formatDateTime updated_at "AT_TIME"}}`,
   },
 });
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -193,7 +193,7 @@ context('Patient Action Form', function() {
             id: '1',
             attributes: {
               status: FORM_RESPONSE_STATUS.DRAFT,
-              created_at: testTsSubtract(1),
+              updated_at: testTsSubtract(1),
               response: {
                 data: {
                   fields: { foo: 'bar' },
@@ -246,7 +246,7 @@ context('Patient Action Form', function() {
     const formResponse = getFormResponse({
       attributes: {
         status: FORM_RESPONSE_STATUS.DRAFT,
-        created_at: testTs(),
+        updated_at: testTs(),
         response: {
           data: { fields: { foo: 'bar' } },
         },
@@ -341,7 +341,7 @@ context('Patient Action Form', function() {
     const formResponse = getFormResponse({
       attributes: {
         status: FORM_RESPONSE_STATUS.DRAFT,
-        created_at: testTsSubtract(1),
+        updated_at: testTsSubtract(1),
         response: {
           data: { fields: { foo: 'bazinga' } },
         },
@@ -676,7 +676,7 @@ context('Patient Action Form', function() {
   specify('update a form with response field', function() {
     const formResponse = getFormResponse({
       attributes: {
-        created_at: testTs(),
+        updated_at: testTs(),
         status: FORM_RESPONSE_STATUS.SUBMITTED,
         response: { data: { fields: { foo: 'bar' } } },
       },
@@ -733,7 +733,7 @@ context('Patient Action Form', function() {
       getFormResponse({
         id: '1',
         attributes: {
-          created_at: testTs(),
+          updated_at: testTs(),
           status: FORM_RESPONSE_STATUS.SUBMITTED,
           response: {
             data: {
@@ -746,7 +746,7 @@ context('Patient Action Form', function() {
       getFormResponse({
         id: '2',
         attributes: {
-          created_at: testTs(),
+          updated_at: testTs(),
           status: FORM_RESPONSE_STATUS.SUBMITTED,
           response: { data: { fields: { foo: 'bar' } } },
         },
@@ -1129,7 +1129,7 @@ context('Patient Action Form', function() {
   specify('action locked form', function() {
     const formResponse = getFormResponse({
       attributes: {
-        created_at: testTs(),
+        updated_at: testTs(),
         status: FORM_RESPONSE_STATUS.SUBMITTED,
         response: { data: { fields: { foo: 'bar' } } },
       },
@@ -1253,12 +1253,12 @@ context('Patient Action Form', function() {
   });
 
   specify('routing to form-response', function() {
-    const createdAt = testTs();
+    const updatedAt = testTs();
 
     const formResponse = getFormResponse({
       id: '1',
       attributes: {
-        created_at: createdAt,
+        updated_at: updatedAt,
         status: FORM_RESPONSE_STATUS.SUBMITTED,
         response: { data: { fields: { foo: 'bar' } } },
       },
@@ -1316,7 +1316,7 @@ context('Patient Action Form', function() {
     cy
       .get('.form__frame')
       .should('contain', 'Last submitted')
-      .and('contain', formatDate(createdAt, 'AT_TIME'))
+      .and('contain', formatDate(updatedAt, 'AT_TIME'))
       .find('button')
       .contains('Update')
       .click();

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -235,7 +235,7 @@ context('Patient Form', function() {
           data: getFormResponse({
             attributes: {
               status: FORM_RESPONSE_STATUS.DRAFT,
-              created_at: testTs(),
+              updated_at: testTs(),
               response: {
                 data: {
                   fields: { foo: 'bar' },
@@ -290,7 +290,7 @@ context('Patient Form', function() {
           data: getFormResponse({
             attributes: {
               status: FORM_RESPONSE_STATUS.DRAFT,
-              created_at: testTsSubtract(1),
+              updated_at: testTsSubtract(1),
               response: {
                 data: {
                   fields: { foo: 'bar' },

--- a/test/support/api/form-responses.js
+++ b/test/support/api/form-responses.js
@@ -21,6 +21,7 @@ export function getFormResponse(data) {
   const resource = getResource({
     id: '11111',
     created_at: dayjs.utc().format(),
+    updated_at: dayjs.utc().format(),
     response: fxTestFormResponse,
     status: FORM_RESPONSE_STATUS.SUBMITTED,
   }, TYPE, defaultRelationships);


### PR DESCRIPTION
Shortcut Story ID: [sc-47063]

Previously we always created new responses.  When we switched to updating responses we needed to sort by and display the `updated_ts` date

