### PR TITLE
Add patient sidebar menu options for patient status

### DIFF
--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -42,9 +42,11 @@ export default SubRouterApp.extend({
     return Radio.request('entities', 'fetch:patients:model', patientId);
   },
 
-  onFail() {
-    Radio.trigger('event-router', 'notFound');
-    this.stop();
+  onFail(options, { response }) {
+    if (response.status === 410) {
+      Radio.trigger('event-router', 'notFound');
+      this.stop();
+    }
   },
 
   onStart({ currentRoute }, patient) {

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -42,6 +42,11 @@ export default SubRouterApp.extend({
     return Radio.request('entities', 'fetch:patients:model', patientId);
   },
 
+  onFail() {
+    Radio.trigger('event-router', 'notFound');
+    this.stop();
+  },
+
   onStart({ currentRoute }, patient) {
     this.patient = patient;
 

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -30,9 +30,6 @@ export default App.extend({
     const currentUser = Radio.request('bootstrap', 'currentUser');
     this.canManagePatients = currentUser.can('patients:manage');
 
-    this.showSidebar();
-  },
-  showSidebar() {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
     this.showView(new SidebarView({
@@ -46,10 +43,8 @@ export default App.extend({
   },
   toggleActiveStatus() {
     this.patient.toggleActiveStatus();
-    this.showSidebar();
   },
   archivePatient() {
     this.patient.setArchivedStatus();
-    this.showSidebar();
   },
 });

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -27,15 +27,12 @@ export default App.extend({
   },
   onStart({ patient }) {
     this.patient = patient;
-    const currentUser = Radio.request('bootstrap', 'currentUser');
-    this.canManagePatients = currentUser.can('patients:manage');
 
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
     this.showView(new SidebarView({
       model: this.patient,
       collection: widgets,
-      canManagePatients: this.canManagePatients,
     }));
   },
   showPatientModal() {

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -9,6 +9,8 @@ export default App.extend({
   viewEvents: {
     'click:patientEdit': 'showPatientModal',
     'click:patientView': 'showPatientModal',
+    'click:activeStatus': 'toggleActiveStatus',
+    'click:archivedStatus': 'archivePatient',
   },
   onBeforeStart({ patient }) {
     this.showView(new SidebarView({ model: patient }));
@@ -25,15 +27,29 @@ export default App.extend({
   },
   onStart({ patient }) {
     this.patient = patient;
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    this.canManagePatients = currentUser.can('patients:manage');
 
+    this.showSidebar();
+  },
+  showSidebar() {
     const widgets = Radio.request('bootstrap', 'sidebarWidgets');
 
     this.showView(new SidebarView({
       model: this.patient,
       collection: widgets,
+      canManagePatients: this.canManagePatients,
     }));
   },
   showPatientModal() {
     Radio.request('nav', 'patient', this.patient);
+  },
+  toggleActiveStatus() {
+    this.patient.toggleActiveStatus();
+    this.showSidebar();
+  },
+  archivePatient() {
+    this.patient.setArchivedStatus();
+    this.showSidebar();
   },
 });

--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -52,6 +52,18 @@ const _Model = BaseModel.extend({
     const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
     return workspacePatient.get('status');
   },
+  toggleActiveStatus() {
+    const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
+    const currentStatus = workspacePatient.get('status');
+    const newStatus = currentStatus !== 'active' ? 'active' : 'inactive';
+
+    workspacePatient.setNewStatus(newStatus, this);
+  },
+  setArchivedStatus() {
+    const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
+
+    workspacePatient.setNewStatus('archived', this);
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -6,6 +6,8 @@ import dayjs from 'dayjs';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
+import { PATIENT_STATUS } from 'js/static';
+
 const TYPE = 'patients';
 
 const _Model = BaseModel.extend({
@@ -55,14 +57,14 @@ const _Model = BaseModel.extend({
   toggleActiveStatus() {
     const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
     const currentStatus = workspacePatient.get('status');
-    const newStatus = currentStatus !== 'active' ? 'active' : 'inactive';
+    const newStatus = currentStatus !== PATIENT_STATUS.ACTIVE ? PATIENT_STATUS.ACTIVE : PATIENT_STATUS.INACTIVE;
 
     workspacePatient.saveAll({ status: newStatus });
   },
   setArchivedStatus() {
     const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
 
-    workspacePatient.saveAll({ status: 'archived' });
+    workspacePatient.saveAll({ status: PATIENT_STATUS.ARCHIVED });
   },
 });
 

--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -57,12 +57,12 @@ const _Model = BaseModel.extend({
     const currentStatus = workspacePatient.get('status');
     const newStatus = currentStatus !== 'active' ? 'active' : 'inactive';
 
-    workspacePatient.setNewStatus(newStatus, this);
+    workspacePatient.saveAll({ status: newStatus });
   },
   setArchivedStatus() {
     const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
 
-    workspacePatient.setNewStatus('archived', this);
+    workspacePatient.saveAll({ status: 'archived' });
   },
 });
 

--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -50,12 +50,11 @@ const _Model = BaseModel.extend({
   getSortName() {
     return (this.get('last_name') + this.get('first_name')).toLowerCase();
   },
-  getStatus() {
-    const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
-    return workspacePatient.get('status');
+  getWorkspacePatient() {
+    return Radio.request('entities', 'get:workspacePatients:model', this.id);
   },
   toggleActiveStatus() {
-    const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.id);
+    const workspacePatient = this.getWorkspacePatient();
     const currentStatus = workspacePatient.get('status');
     const newStatus = currentStatus !== PATIENT_STATUS.ACTIVE ? PATIENT_STATUS.ACTIVE : PATIENT_STATUS.INACTIVE;
 

--- a/src/js/entities-service/entities/workspace-patients.js
+++ b/src/js/entities-service/entities/workspace-patients.js
@@ -1,4 +1,3 @@
-import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseModel from 'js/base/model';
 
@@ -7,15 +6,12 @@ const TYPE = 'workspace-patients';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/workspace-patients',
-  setNewStatus(newStatus, patient) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-
-    const attrs = { status: newStatus };
+  saveAll(attrs) {
     const opts = { type: 'PUT' };
 
     const relationships = {
-      'workspace': this.toRelation(currentWorkspace, 'workspaces'),
-      'patient': this.toRelation(patient, 'patients'),
+      'workspace': this.toRelation(this.get('_workspace'), 'workspaces'),
+      'patient': this.toRelation(this.get('_patient'), 'patients'),
     };
 
     this.save(attrs, { relationships }, opts);

--- a/src/js/entities-service/entities/workspace-patients.js
+++ b/src/js/entities-service/entities/workspace-patients.js
@@ -1,3 +1,4 @@
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseModel from 'js/base/model';
 
@@ -6,6 +7,19 @@ const TYPE = 'workspace-patients';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/workspace-patients',
+  setNewStatus(newStatus, patient) {
+    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+
+    const attrs = { status: newStatus };
+    const opts = { type: 'PUT' };
+
+    const relationships = {
+      'workspace': this.toRelation(currentWorkspace, 'workspaces'),
+      'patient': this.toRelation(patient, 'patients'),
+    };
+
+    this.save(attrs, { relationships }, opts);
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/entities/workspace-patients.js
+++ b/src/js/entities-service/entities/workspace-patients.js
@@ -1,3 +1,4 @@
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseModel from 'js/base/model';
 
@@ -15,6 +16,11 @@ const _Model = BaseModel.extend({
     };
 
     this.save(attrs, { relationships }, opts);
+  },
+  canEdit() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+
+    return currentUser.can('patients:manage');
   },
 });
 

--- a/src/js/entities-service/workspace-patients.js
+++ b/src/js/entities-service/workspace-patients.js
@@ -18,7 +18,7 @@ const Entity = BaseEntity.extend({
     const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
     const workspaceId = currentWorkspace.id;
 
-    return new Model({ id: uuid(patientId, workspaceId) });
+    return new Model({ id: uuid(patientId, workspaceId), _patient: patientId, _workspace: workspaceId });
   },
 });
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -263,8 +263,11 @@ careOptsFrontend:
           patientUpdateSuccess: Patient account updated successfully
         sidebarViews:
           menuOptions:
+            activate: Activate Patient
+            archive: Archive Patient
             edit: Edit Account Details
             headingText: Patient Menu
+            inactivate: Inactivate Patient
             view: View Account Details
     schedule:
       scheduleApp:

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -269,10 +269,10 @@ careOptsFrontend:
           menuOptions:
             activate: Activate Patient
             archive: Archive Patient
-            edit: Edit Account Details
-            headingText: Patient Menu
+            edit: Edit Patient Details
+            headingText: Patient Account Menu
             inactivate: Inactivate Patient
-            view: View Account Details
+            view: View Patient Details
     schedule:
       scheduleApp:
         bulkEditFailure: Something went wrong. Please try again.

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -262,6 +262,10 @@ careOptsFrontend:
         sidebarApp:
           patientUpdateSuccess: Patient account updated successfully
         sidebarViews:
+          archiveModal:
+            bodyText: Are you sure you want to archive this patient?
+            headingText: Confirm Archive Patient
+            submitText: Archive Patient
           menuOptions:
             activate: Activate Patient
             archive: Archive Patient

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -263,7 +263,7 @@ careOptsFrontend:
           patientUpdateSuccess: Patient account updated successfully
         sidebarViews:
           archiveModal:
-            bodyText: Are you sure you want to archive this patient?
+            bodyText: Are you sure you want to archive this patient? The patient will no longer be accessible in this workspace.
             headingText: Confirm Archive Patient
             submitText: Archive Patient
           menuOptions:

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -65,6 +65,12 @@ const STATE_STATUS = {
   DONE: 'done',
 };
 
+const PATIENT_STATUS = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+  ARCHIVED: 'archived',
+};
+
 export {
   ACTION_OUTREACH,
   ACTION_SHARING,
@@ -72,4 +78,5 @@ export {
   PROGRAM_BEHAVIORS,
   RELATIVE_DATE_RANGES,
   STATE_STATUS,
+  PATIENT_STATUS,
 };

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -3,6 +3,7 @@ import Backbone from 'backbone';
 import { View } from 'marionette';
 import hbs from 'handlebars-inline-precompile';
 
+import { PATIENT_STATUS } from 'js/static';
 import intl from 'js/i18n';
 
 import PreloadRegion from 'js/regions/preload_region';
@@ -73,11 +74,11 @@ const SidebarView = View.extend({
 
     if (canEdit && canManagePatients) {
       menuOptions.push({
-        text: patientStatus !== 'active' ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
+        text: patientStatus !== PATIENT_STATUS.ACTIVE ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
         onSelect: bind(this.triggerMethod, this, 'click:activeStatus'),
       });
 
-      if (patientStatus !== 'archived') {
+      if (patientStatus !== PATIENT_STATUS.ARCHIVED) {
         menuOptions.push({
           text: i18n.menuOptions.archive,
           onSelect: bind(this.triggerMethod, this, 'click:archivedStatus'),

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -61,21 +61,35 @@ const SidebarView = View.extend({
   },
   onClickMenu() {
     const canEdit = this.model.canEdit();
+    const patientStatus = this.model.getStatus();
+    const canManagePatients = this.getOption('canManagePatients');
 
     const menuOptions = new Backbone.Collection([
       {
+        text: canEdit ? i18n.menuOptions.edit : i18n.menuOptions.view,
         onSelect: bind(this.triggerMethod, this, canEdit ? 'click:patientEdit' : 'click:patientView'),
       },
     ]);
+
+    if (canEdit && canManagePatients) {
+      menuOptions.push({
+        text: patientStatus !== 'active' ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
+        onSelect: bind(this.triggerMethod, this, 'click:activeStatus'),
+      });
+
+      if (patientStatus !== 'archived') {
+        menuOptions.push({
+          text: i18n.menuOptions.archive,
+          onSelect: bind(this.triggerMethod, this, 'click:archivedStatus'),
+        });
+      }
+    }
 
     const optionlist = new Optionlist({
       ui: this.ui.menu,
       uiView: this,
       headingText: i18n.menuOptions.headingText,
       itemTemplate: hbs`{{ text }}`,
-      itemTemplateContext: {
-        text: canEdit ? i18n.menuOptions.edit : i18n.menuOptions.view,
-      },
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -1,4 +1,5 @@
 import { bind } from 'underscore';
+import Radio from 'backbone.radio';
 import Backbone from 'backbone';
 import { View } from 'marionette';
 import hbs from 'handlebars-inline-precompile';
@@ -82,7 +83,9 @@ const SidebarView = View.extend({
       if (workspacePatientStatus !== PATIENT_STATUS.ARCHIVED) {
         menuOptions.push({
           text: i18n.menuOptions.archive,
-          onSelect: bind(this.triggerMethod, this, 'click:archivedStatus'),
+          onSelect: () => {
+            this.showConfirmArchiveModal();
+          },
         });
       }
     }
@@ -98,6 +101,18 @@ const SidebarView = View.extend({
     });
 
     optionlist.show();
+  },
+  showConfirmArchiveModal() {
+    const modal = Radio.request('modal', 'show:small', {
+      bodyText: i18n.archiveModal.bodyText,
+      headingText: i18n.archiveModal.headingText,
+      submitText: i18n.archiveModal.submitText,
+      buttonClass: 'button--red',
+      onSubmit: () => {
+        modal.destroy();
+        this.triggerMethod('click:archivedStatus');
+      },
+    });
   },
 });
 

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -62,7 +62,7 @@ const SidebarView = View.extend({
   },
   onClickMenu() {
     const canEdit = this.model.canEdit();
-    const patientStatus = this.model.getStatus();
+    const patientStatus = this.model.getWorkspacePatient().get('status');
     const canManagePatients = this.getOption('canManagePatients');
 
     const menuOptions = new Backbone.Collection([

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -61,24 +61,25 @@ const SidebarView = View.extend({
     menu: '.js-menu',
   },
   onClickMenu() {
-    const canEdit = this.model.canEdit();
-    const patientStatus = this.model.getWorkspacePatient().get('status');
-    const canManagePatients = this.getOption('canManagePatients');
+    const workspacePatient = this.model.getWorkspacePatient();
+    const workspacePatientStatus = workspacePatient.get('status');
+
+    const canEditPatient = this.model.canEdit();
 
     const menuOptions = new Backbone.Collection([
       {
-        text: canEdit ? i18n.menuOptions.edit : i18n.menuOptions.view,
-        onSelect: bind(this.triggerMethod, this, canEdit ? 'click:patientEdit' : 'click:patientView'),
+        text: canEditPatient ? i18n.menuOptions.edit : i18n.menuOptions.view,
+        onSelect: bind(this.triggerMethod, this, canEditPatient ? 'click:patientEdit' : 'click:patientView'),
       },
     ]);
 
-    if (canEdit && canManagePatients) {
+    if (workspacePatient.canEdit()) {
       menuOptions.push({
-        text: patientStatus !== PATIENT_STATUS.ACTIVE ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
+        text: workspacePatientStatus !== PATIENT_STATUS.ACTIVE ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
         onSelect: bind(this.triggerMethod, this, 'click:activeStatus'),
       });
 
-      if (patientStatus !== PATIENT_STATUS.ARCHIVED) {
+      if (workspacePatientStatus !== PATIENT_STATUS.ARCHIVED) {
         menuOptions.push({
           text: i18n.menuOptions.archive,
           onSelect: bind(this.triggerMethod, this, 'click:archivedStatus'),

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -67,15 +67,13 @@ const widgets = {
   status: View.extend({
     template: hbs`<span class="widgets__status-{{ status }}">{{formatMessage (intlGet "patients.widgets.widgets.status") status=status}}</span>`,
     initialize() {
-      const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.model.get('id'));
+      this.workspacePatient = this.model.getWorkspacePatient();
 
-      this.listenTo(workspacePatient, 'change:status', () => {
-        this.render();
-      });
+      this.listenTo(this.workspacePatient, 'change:status', this.render);
     },
     templateContext() {
       return {
-        status: this.model.getWorkspacePatient().get('status'),
+        status: this.workspacePatient.get('status'),
       };
     },
   }),

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -64,14 +64,21 @@ const widgets = {
     },
     template: hbs`{{formatMessage (intlGet "patients.widgets.widgets.sex") sex=sex}}`,
   },
-  status: {
+  status: View.extend({
     template: hbs`<span class="widgets__status-{{ status }}">{{formatMessage (intlGet "patients.widgets.widgets.status") status=status}}</span>`,
+    initialize() {
+      const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.model.get('id'));
+
+      this.listenTo(workspacePatient, 'change:status', () => {
+        this.render(); 
+      });
+    },
     templateContext() {
       return {
         status: this.model.getStatus(),
       };
     },
-  },
+  }),
   divider: {
     template: hbs`<div class="widgets__divider"></div>`,
   },

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -70,12 +70,12 @@ const widgets = {
       const workspacePatient = Radio.request('entities', 'get:workspacePatients:model', this.model.get('id'));
 
       this.listenTo(workspacePatient, 'change:status', () => {
-        this.render(); 
+        this.render();
       });
     },
     templateContext() {
       return {
-        status: this.model.getStatus(),
+        status: this.model.getWorkspacePatient().get('status'),
       };
     },
   }),

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -1191,4 +1191,23 @@ context('patient sidebar', function() {
       .should('contain', 'Inactivate Patient')
       .should('contain', 'Archive Patient');
   });
+
+  specify('410 patient not found error', function() {
+    cy
+      .intercept('GET', '/api/patients/1', {
+        statusCode: 410,
+        body: {},
+      })
+      .as('routePatient')
+      .visit('/patient/dashboard/1');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Something went wrong.')
+      .and('contain', ' This page doesn\'t exist.');
+
+    cy
+      .url()
+      .should('contain', '/404');
+  });
 });

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -1056,6 +1056,7 @@ context('patient sidebar', function() {
         return fx;
       })
       .visit('/patient/dashboard/1')
+      .wait('@routeWorkspacePatient')
       .wait('@routePatient');
 
     cy

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -898,8 +898,8 @@ context('patient sidebar', function() {
 
     cy
       .get('.picklist')
-      .should('contain', 'Patient Menu')
-      .contains('Edit Account Details')
+      .should('contain', 'Patient Account Menu')
+      .contains('Edit Patient Details')
       .click();
 
     cy
@@ -962,7 +962,7 @@ context('patient sidebar', function() {
       })
       .routeCurrentClinician(fx => {
         // NOTE: ensures patient status menu options don't show for users without the 'patients:manage' permission
-        // NOTE: in this test, the only menu option should be 'View Account Details'
+        // NOTE: in this test, the only menu option should be 'View Patient Details'
         fx.data.relationships.role.data.id = '33333';
         return fx;
       })
@@ -977,13 +977,13 @@ context('patient sidebar', function() {
 
     cy
       .get('.picklist')
-      .should('contain', 'Patient Menu')
+      .should('contain', 'Patient Account Menu')
       .find('.picklist__item')
       .should('have.length', 1);
 
     cy
       .get('.picklist')
-      .contains('View Account Details')
+      .contains('View Patient Details')
       .click();
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-46925]

Adds two new options to the patient sidebar menu to allow a user to update a patient's status:

1. Toggle between `active` & `inactive` status.
2. Set a patient as `archived`.

This PR also implements the `patients:manage` permission. These menu options won't be shown to users that don't have that permission.

Still yet to do:

- [x] Refactoring
- [x] Add confirmation modal before setting archived status
- [x] Add/update tests
- [x] Update language in menu & archive confirmation modal