### PR TITLE
Improve form test flake

### DIFF
--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -874,7 +874,12 @@ context('Patient Action Form', function() {
     cy
       .get('@expandButton')
       .trigger('mouseout')
-      .click();
+      .click()
+      .wait('@routeActionActivity')
+      .wait('@routePatientField')
+      .wait('@routeWorkspacePatient')
+      .wait('@routeActionComments')
+      .wait('@routeActionFiles');
 
     cy
       .get('@expandButton')
@@ -1754,7 +1759,7 @@ context('Patient Action Form', function() {
       });
 
     cy
-      .tick(5000)
+      .tick(5100)
       .url()
       .should('contain', '/flow/1');
   });
@@ -1821,7 +1826,7 @@ context('Patient Action Form', function() {
       .wait('@routePostResponse');
 
     cy
-      .tick(5000)
+      .tick(5100)
       .url()
       .should('contain', '/patient/dashboard/1');
   });

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -732,7 +732,7 @@ context('Patient Form', function() {
       });
 
     cy
-      .tick(5000)
+      .tick(5100)
       .url()
       .should('contain', '/patient/dashboard/1');
   });


### PR DESCRIPTION
Couple of small things.. the loading would render the sidebar which would kill the tooltip.. so waiting fixes that.  I'm not sure if that happens in the wild..  it's very difficult to try and move that quickly, but I don't think it is happening.. rather I suspect this has to do with the synthetic jquery event we're triggering to test the pointer in cypress.

Then we destroy the loading modal after 5000 ms and then navigate.. but the navigate is deferred.. I'm not certain, but I think maybe sometimes the test isn't successful because the defer is outside of the tick... depending on how quickly the tick is run with the form submission... this is a bit of a guess, but it won't hurt anything and it doesn't increase the test length.  The reason I think it is tick related is that it doesn't route _after_ the test fails either..  so the navigate never happens.. this seems pretty unlikely that the code isn't run