### PR TITLE
In patient modal, only use `patient_creation_form.form_id` when creating a new patient

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -412,7 +412,7 @@ export default RouterApp.extend({
           .then(() => {
             patientModal.destroy();
 
-            if (patientFormId) {
+            if (patientFormId && patientClone.isNew()) {
               Radio.trigger('event-router', 'form:patient', patient.id, patientFormId);
               return;
             }

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -864,7 +864,7 @@ context('patient sidebar', function() {
     cy
       .routesForPatientDashboard()
       .routeSettings(fx => {
-        // NOTE: Ensures this submit text doesn't show for the submit button in this situation
+        // NOTE: Ensures this button submit text and form_id for routing aren't used in this situation
         fx.data.push({
           id: 'patient_creation_form',
           attributes: {
@@ -932,6 +932,10 @@ context('patient sidebar', function() {
       .contains('Save')
       .click()
       .wait('@routePatchPatient');
+
+    cy
+      .url()
+      .should('contain', '/patient/dashboard/1');
   });
 
   specify('view patient modal', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-47386]

Not sure how I missed this, but this should have been addressed in the original PR for fixing these patient modal bugs: https://github.com/RoundingWell/care-ops-frontend/pull/1222.

If this org/workspace setting is set:

```js
{
  "id": "patient_creation_form",
  "attributes": {
    "value": {
      "form_id": "11111",
      "submit_text": "Continue to Form 11111"
    }
  }
}
```

The `form_id` and `submit_text` should only be used in the create new patient modal. Not the edit patient or view patient versions of the modal. 

https://github.com/RoundingWell/care-ops-frontend/pull/1222 fixed the wrongful usage of `submit_text`. But did not fix the wrongful usage of `form_id`, which is where the user is routed to after creating a new patient.