### PR TITLE
Pass patient relationship to outreach auth

### DIFF
--- a/src/js/outreach/apps/verify_app.js
+++ b/src/js/outreach/apps/verify_app.js
@@ -30,8 +30,9 @@ export default App.extend({
 
     this.showNotAvailableView();
   },
-  onStart(options, { outreachId, patientPhoneEnd }) {
+  onStart(options, { outreachId, patientPhoneEnd, patientId }) {
     this.outreachId = outreachId;
+    this.patientId = patientId;
     this.patientPhoneEnd = patientPhoneEnd;
 
     const dialogView = new DialogView();
@@ -66,7 +67,11 @@ export default App.extend({
     });
 
     this.listenTo(verifyCodeView, 'submit:code', code => {
-      validateVerificationCode({ outreachId: this.outreachId, code })
+      validateVerificationCode({
+        outreachId: this.outreachId,
+        patientId: this.patientId,
+        code,
+      })
         .then(() => {
           this.stop({ isVerified: true });
         })

--- a/src/js/outreach/entities/index.js
+++ b/src/js/outreach/entities/index.js
@@ -25,6 +25,7 @@ function getPatientInfo({ actionId }) {
     .then(({ data }) => {
       return {
         outreachId: data.id,
+        patientId: data.relationships.patient.data.id,
         patientPhoneEnd: data.attributes.phone_end,
       };
     });
@@ -43,11 +44,14 @@ function createVerificationCode({ actionId }) {
     .then(handleJSON);
 }
 
-function validateVerificationCode({ outreachId, code }) {
+function validateVerificationCode({ outreachId, code, patientId }) {
   const data = {
     id: outreachId,
     type: 'outreach',
     attributes: { code },
+    relationships: {
+      patient: getRelationship(patientId, 'patients'),
+    },
   };
 
   return fetcher('/api/outreach/auth', {

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -1,8 +1,9 @@
 import _ from 'underscore';
 
-import { getErrors } from 'helpers/json-api';
+import { getErrors, getRelationship } from 'helpers/json-api';
 
 import { getFormFields } from 'support/api/form-fields';
+import { getPatient } from 'support/api/patients';
 
 context('Outreach', function() {
   beforeEach(function() {
@@ -147,8 +148,13 @@ context('Outreach', function() {
   });
 
   specify('User verification success', function() {
+    const testPatient = getPatient;
     cy
-      .routeOutreachStatus()
+      .routeOutreachStatus(fx => {
+        fx.data.relationships.patient = getRelationship(testPatient);
+
+        return fx;
+      })
       .routeFormByAction(_.identity, '11111')
       .routeFormActionDefinition()
       .routeFormActionFields()
@@ -299,6 +305,7 @@ context('Outreach', function() {
         expect(data.type).to.equal('outreach');
         expect(data.id).to.equal('11111');
         expect(data.attributes.code).to.equal('1234');
+        expect(data.relationships.patient.data.id).to.equal(testPatient.id);
       });
 
     cy

--- a/test/support/api/outreach.js
+++ b/test/support/api/outreach.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
-import { getResource } from 'helpers/json-api';
-
+import { getResource, getRelationship } from 'helpers/json-api';
+import { getPatient } from './patients';
 
 const TYPE = 'outreach';
 
@@ -10,7 +10,9 @@ const fxOutreach = {
 };
 
 Cypress.Commands.add('routeOutreachStatus', (mutator = _.identity) => {
-  const data = getResource(fxOutreach, TYPE);
+  const data = getResource(fxOutreach, TYPE, {
+    patient: getRelationship(getPatient()),
+  });
 
   cy
     .intercept('GET', '/api/outreach?*', {


### PR DESCRIPTION
Shortcut Story ID: [sc-47715]

We send relationships.patient back with GET /api/outreach and we need it sent back on POST /api/outreach/auth