### PR TITLE
Override formio datetime component

### DIFF
--- a/src/js/formapp/components.js
+++ b/src/js/formapp/components.js
@@ -1,5 +1,5 @@
 /* global Formio */
-import { debounce } from 'underscore';
+import { debounce, isString } from 'underscore';
 const NestedComponent = Formio.Components.components.nested;
 const SelectComponent = Formio.Components.components.select;
 
@@ -11,6 +11,16 @@ class SurveyComponent extends Formio.Components.components.survey {
 }
 
 Formio.Components.components.survey = SurveyComponent;
+
+class DateTimeComponent extends Formio.Components.components.datetime {
+  formatValue(date) {
+    if (!isString(date) || !date.length) return date;
+
+    return Formio.Utils.moment(date).format();
+  }
+}
+
+Formio.Components.components.datetime = DateTimeComponent;
 
 class SnippetComponent extends NestedComponent {
   constructor(...args) {


### PR DESCRIPTION
This formats a date for the user’s timezone as the datepicker widget expects a timezone.

Shortcut Story ID: [sc-47330]

It kind of makes sense that we would have these components available in the form app as well.   I think maybe we should extract our formio extends into a separate OSS repo that also sets the version.  Otherwise we should technically be keeping a bunch of things in sync.  I suppose the forms repo does have the frontend as a dependency.. so we _could_ import theses as well.. Anyhow.. something to chew on..  