### PR TITLE
Add is_report option to forms

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -29,6 +29,9 @@ const _Model = BaseModel.extend({
   isReadOnly() {
     return get(this.get('options'), 'read_only');
   },
+  isReport() {
+    return get(this.get('options'), 'is_report');
+  },
   isSubmitHidden() {
     return get(this.get('options'), 'submit_hidden');
   },

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -34,25 +34,27 @@ const ActionFormApp = App.extend({
       });
   },
   _getPrefillFilters(form, action) {
+    const opts = {
+      status: FORM_RESPONSE_STATUS.SUBMITTED,
+      flow: action.get('_flow'),
+      patient: action.get('_patient'),
+    };
+
+    const isReport = form.isReport();
+
+    if (isReport) opts.created = `<=${ action.get('created_at') }`;
+
     const prefillActionTag = form.getPrefillActionTag();
-    const flowId = action.get('_flow');
-    const patientId = action.get('_patient');
 
     if (prefillActionTag) {
-      return {
-        'status': FORM_RESPONSE_STATUS.SUBMITTED,
-        'action.tags': prefillActionTag,
-        'flow': flowId,
-        'patient': patientId,
-      };
+      opts['action.tags'] = prefillActionTag;
+
+      return opts;
     }
 
-    return {
-      'status': FORM_RESPONSE_STATUS.SUBMITTED,
-      'action': action.id,
-      'flow': flowId,
-      'patient': patientId,
-    };
+    opts.action = action.id;
+
+    return opts;
   },
 });
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -185,23 +185,27 @@ export default App.extend({
     });
   },
   _getPrefillFilters({ flowId, patientId }, form) {
-    const prefillActionTag = form.getPrefillActionTag();
-
-    if (prefillActionTag) {
-      return {
-        'status': FORM_RESPONSE_STATUS.SUBMITTED,
-        'action.tags': prefillActionTag,
-        'flow': flowId,
-        'patient': patientId,
-      };
-    }
-
-    return {
+    const opts = {
       status: FORM_RESPONSE_STATUS.SUBMITTED,
-      form: form.getPrefillFormId(),
       flow: flowId,
       patient: patientId,
     };
+
+    const isReport = form.isReport();
+
+    if (isReport) opts.created = `<=${ this.action.get('created_at') }`;
+
+    const prefillActionTag = form.getPrefillActionTag();
+
+    if (prefillActionTag) {
+      opts['action.tags'] = prefillActionTag;
+
+      return opts;
+    }
+
+    opts.form = form.getPrefillFormId();
+
+    return opts;
   },
   fetchLatestFormSubmission(flowId) {
     const channel = this.getChannel();

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -81,5 +81,13 @@
         "syntaxError('foo;"
       ]
     }
+  },
+  {
+    "id": "BBBBB",
+    "name": "Report Form",
+    "options": {
+      "is_report": true,
+      "prefill_action_tag": "foo-tag"
+    }
   }
 ]

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 
+import { testTs } from 'helpers/test-timestamp';
 import { getRelationship } from 'helpers/json-api';
 
 import { getAction } from 'support/api/actions';
@@ -155,8 +156,10 @@ context('Formservice', function() {
   });
 
   specify('action formservice latest response from action tags', function() {
+    const createdAt = testTs();
+
     cy
-      .routeFormByAction(_.identity, '77777')
+      .routeFormByAction(_.identity, 'BBBBB')
       .routeFormActionDefinition()
       .routeLatestFormResponse()
       .routeFormActionFields()
@@ -164,10 +167,11 @@ context('Formservice', function() {
         fx.data = getAction({
           id: '1',
           attributes: {
+            created_at: createdAt,
             tags: ['prefill-latest-response'],
           },
           relationships: {
-            'form': getRelationship('77777', 'forms'),
+            'form': getRelationship('BBBBB', 'forms'),
             'flow': getRelationship('1', 'flows'),
             'patient': getRelationship('1', 'patients'),
           },
@@ -184,7 +188,8 @@ context('Formservice', function() {
       .its('search')
       .should('contain', 'filter[action.tags]=foo-tag')
       .should('contain', 'filter[flow]=1')
-      .should('contain', 'filter[patient]=1');
+      .should('contain', 'filter[patient]=1')
+      .should('contain', `filter[created]=<=${ createdAt }`);
   });
 
   specify('action formservice iframe makes correct api requests', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-47120]

This adds it to both the form app and the pdf form service.

We should probably really only be using this option with `action.tags`