### PR TITLE
Fix coverage drop related to handling `410` error in the patient app

### DIFF
--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -43,6 +43,7 @@ export default SubRouterApp.extend({
   },
 
   onFail(options, { response }) {
+    /* istanbul ignore else: other error scenarios handled elsewhere */
     if (response.status === 410) {
       Radio.trigger('event-router', 'notFound');
       this.stop();

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1070,4 +1070,23 @@ context('patient dashboard page', function() {
       .find('button')
       .should('not.exist');
   });
+
+  specify('410 patient not found error', function() {
+    cy
+      .intercept('GET', '/api/patients/1', {
+        statusCode: 410,
+        body: {},
+      })
+      .as('routePatient')
+      .visit('/patient/dashboard/1');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Something went wrong.')
+      .and('contain', ' This page doesn\'t exist.');
+
+    cy
+      .url()
+      .should('contain', '/404');
+  });
 });

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -1196,23 +1196,4 @@ context('patient sidebar', function() {
       .should('contain', 'Inactivate Patient')
       .should('contain', 'Archive Patient');
   });
-
-  specify('410 patient not found error', function() {
-    cy
-      .intercept('GET', '/api/patients/1', {
-        statusCode: 410,
-        body: {},
-      })
-      .as('routePatient')
-      .visit('/patient/dashboard/1');
-
-    cy
-      .get('.error-page')
-      .should('contain', 'Something went wrong.')
-      .and('contain', ' This page doesn\'t exist.');
-
-    cy
-      .url()
-      .should('contain', '/404');
-  });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-47198]

Fixes coverage drop here: https://coveralls.io/builds/65582818/source?filename=src%2Fjs%2Fapps%2Fpatients%2Fpatient%2Fpatient_app.js#L46 that was introduced in https://github.com/RoundingWell/care-ops-frontend/pull/1227.

Which is an `else` branch not being covered when we show a `410` not found error on patient app related pages.

To fix it, we added an `istanbul ignore else` since other error scenarios besides `410` are handled elsewhere in the codebase. So there's nothing to do in the tests for this specific `else` scenario.