### PR TITLE
In add clinician modal, workspaces should be added back to the droplist after removal

### DIFF
--- a/src/js/views/clinicians/shared/clinicians_views.js
+++ b/src/js/views/clinicians/shared/clinicians_views.js
@@ -17,8 +17,7 @@ const i18n = intl.clinicians.shared.clinicianViews;
 const WorkspacesComponent = WorkspacesManagerComponent.extend({
   removeMemberWorkspace(workspace) {
     if (this.member.isNew()) {
-      this.memberWorkspaces.remove(workspace);
-      this.triggerMethod('remove:member', this.member, workspace);
+      WorkspacesManagerComponent.prototype.removeMemberWorkspace.call(this, workspace);
       return;
     }
 
@@ -32,9 +31,7 @@ const WorkspacesComponent = WorkspacesManagerComponent.extend({
       buttonClass: 'button--red',
       onSubmit: () => {
         modal.destroy();
-        this.memberWorkspaces.remove(workspace);
-        this.workspaces.add(workspace);
-        this.triggerMethod('remove:member', this.member, workspace);
+        WorkspacesManagerComponent.prototype.removeMemberWorkspace.call(this, workspace);
       },
     });
   },

--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -106,6 +106,16 @@ context('clinicians modal', function() {
 
     cy
       .get('@modal')
+      .get('[data-workspaces-region] .list-manager__droplist')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .should('contain', 'Workspace Two');
+
+    cy
+      .get('@modal')
       .find('.js-submit')
       .click();
 


### PR DESCRIPTION
Shortcut Story ID: [sc-48049]

Below is an example of the bug this fixes. In that scenario, the `All Patients` workspace should be added back to the droplist after being removed as a selection.


https://github.com/RoundingWell/care-ops-frontend/assets/35355575/eee1dac6-35d9-4ab2-9f51-61fb1fba9814


Also fixes this coverage drop: https://coveralls.io/jobs/135883378/source_files/20988475378#L112. Which was originally caused by https://github.com/RoundingWell/care-ops-frontend/pull/1223.