### PR TITLE
Add handlebars template widget

### DIFF
--- a/src/js/apps/forms/widgets/widgets_header_app.js
+++ b/src/js/apps/forms/widgets/widgets_header_app.js
@@ -11,8 +11,10 @@ export default App.extend({
     const fields = map(form.getWidgetFields(), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
+    const widgets = form.getWidgets();
+    const values = widgets.invoke('fetchValues', patient.id);
 
-    return [workspacePatient, ...fields];
+    return [workspacePatient, ...fields, ...values];
   },
   onStart({ patient, form }) {
     const widgets = form.getWidgets();

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -15,6 +15,8 @@ export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new SidebarView({ model: patient }));
 
+    this.widgets = Radio.request('bootstrap', 'sidebarWidgets');
+
     this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
@@ -22,17 +24,16 @@ export default App.extend({
     const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
+    const values = this.widgets.invoke('fetchValues', patient.id);
 
-    return [workspacePatient, ...fields];
+    return [workspacePatient, ...fields, ...values];
   },
   onStart({ patient }) {
     this.patient = patient;
 
-    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
-
     this.showView(new SidebarView({
       model: this.patient,
-      collection: widgets,
+      collection: this.widgets,
     }));
   },
   showPatientModal() {

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -9,6 +9,8 @@ export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new LayoutView({ model: patient }));
 
+    this.widgets = Radio.request('bootstrap', 'sidebarWidgets');
+
     this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
@@ -17,15 +19,14 @@ export default App.extend({
     const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
+    const values = this.widgets.invoke('fetchValues', patient.id);
 
-    return [patientModel, workspacePatient, ...fields];
+    return [patientModel, workspacePatient, ...fields, ...values];
   },
   onStart({ patient }) {
-    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
-
     this.showChildView('widgets', new SidebarWidgetsView({
       model: patient,
-      collection: widgets,
+      collection: this.widgets,
     }));
   },
   viewEvents: {

--- a/src/js/base/fontawesome.js
+++ b/src/js/base/fontawesome.js
@@ -1,5 +1,6 @@
 import { partial } from 'underscore';
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/dist/cjs/handlebars';
+import HandlebarsRuntime from 'handlebars/runtime';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
 function faHelper(prefix, iconName, { hash = {} }) {
@@ -12,10 +13,13 @@ function faHelper(prefix, iconName, { hash = {} }) {
 }
 
 // {{far "acorn"}} -> <svg ...>
-Handlebars.registerHelper({
+const helpers = {
   far: partial(faHelper, 'far'),
   fas: partial(faHelper, 'fas'),
   fal: partial(faHelper, 'fal'),
   fat: partial(faHelper, 'fat'),
   fa: faHelper,
-});
+};
+
+Handlebars.registerHelper(helpers);
+HandlebarsRuntime.registerHelper(helpers);

--- a/src/js/base/helpers.js
+++ b/src/js/base/helpers.js
@@ -1,10 +1,11 @@
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/dist/cjs/handlebars';
+import HandlebarsRuntime from 'handlebars/runtime';
 import dayjs from 'dayjs';
 
 import { formatDate } from './dayjs';
 import matchText from 'js/utils/formatting/match-text';
 
-Handlebars.registerHelper({
+const helpers = {
   matchText(text, query, { hash = {} }) {
     if (!query) return text;
 
@@ -12,9 +13,6 @@ Handlebars.registerHelper({
 
     return new Handlebars.SafeString(matchText(text, query));
   },
-});
-
-Handlebars.registerHelper({
   formatDateTime(date, format, { hash = {} }) {
     if (!date) return new Handlebars.SafeString(hash.defaultHtml || '');
 
@@ -27,4 +25,7 @@ Handlebars.registerHelper({
 
     return new Handlebars.SafeString(`<span class="u-text--nowrap">${ date }</span>`);
   },
-});
+};
+
+Handlebars.registerHelper(helpers);
+HandlebarsRuntime.registerHelper(helpers);

--- a/src/js/entities-service/entities/widget-values.js
+++ b/src/js/entities-service/entities/widget-values.js
@@ -1,0 +1,20 @@
+import Store from 'backbone.store';
+import BaseCollection from 'js/base/collection';
+import BaseModel from 'js/base/model';
+
+const TYPE = 'widget-values';
+
+const _Model = BaseModel.extend({
+  type: TYPE,
+});
+
+const Model = Store(_Model, TYPE);
+const Collection = BaseCollection.extend({
+  model: Model,
+});
+
+export {
+  _Model,
+  Model,
+  Collection,
+};

--- a/src/js/entities-service/entities/widgets.js
+++ b/src/js/entities-service/entities/widgets.js
@@ -1,4 +1,5 @@
 import { uniqueId } from 'underscore';
+import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -7,6 +8,9 @@ const TYPE = 'widgets';
 
 const _Model = BaseModel.extend({
   type: TYPE,
+  fetchValues(patientId) {
+    return Radio.request('entities', 'fetch:widgetValues:byPatient', this, patientId);
+  },
 });
 
 const Model = Store(_Model, TYPE);

--- a/src/js/entities-service/index.js
+++ b/src/js/entities-service/index.js
@@ -40,6 +40,8 @@ import './tags';
 
 import './teams';
 
+import './widget-values';
+
 import './widgets';
 
 import './workspace-patients';

--- a/src/js/entities-service/widget-values.js
+++ b/src/js/entities-service/widget-values.js
@@ -1,8 +1,7 @@
 import { isEmpty } from 'underscore';
-import Radio from 'backbone.radio';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model } from './entities/widget-values';
-import { v5 as uuid } from 'uuid';
+import { v5 as uuid, validate, NIL as NIL_UUID } from 'uuid';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model },
@@ -10,21 +9,21 @@ const Entity = BaseEntity.extend({
     'get:widgetValues:model': 'getByPatient',
     'fetch:widgetValues:byPatient': 'fetchByPatient',
   },
-  fetchByPatient(widgetName, patientId) {
-    const model = this.getByPatient(widgetName, patientId);
+  fetchByPatient(widget, patientId) {
+    const model = this.getByPatient(widget.id, patientId);
 
-    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
-
-    // Uses find as widgets have a modelId on the collection
-    const requestValues = widgets.find({ id: widgetName }).get('values');
+    const requestValues = widget.get('values');
 
     // If not expecting values don't fetch them
     if (isEmpty(requestValues)) return model;
 
     const data = { filter: { patient: patientId } };
-    return model.fetch({ url: `/api/widgets/${ widgetName }/values`, data });
+    return model.fetch({ url: `/api/widgets/${ widget.id }/values`, data });
   },
   getByPatient(widgetName, patientId) {
+    /* istanbul ignore next: makes patientId a uuid for cypress */
+    if (!validate(patientId)) patientId = uuid(patientId, NIL_UUID);
+
     return new Model({
       id: uuid(widgetName, patientId),
       name: widgetName,

--- a/src/js/entities-service/widget-values.js
+++ b/src/js/entities-service/widget-values.js
@@ -1,0 +1,35 @@
+import { isEmpty } from 'underscore';
+import Radio from 'backbone.radio';
+import BaseEntity from 'js/base/entity-service';
+import { _Model, Model } from './entities/widget-values';
+import { v5 as uuid } from 'uuid';
+
+const Entity = BaseEntity.extend({
+  Entity: { _Model, Model },
+  radioRequests: {
+    'get:widgetValues:model': 'getByPatient',
+    'fetch:widgetValues:byPatient': 'fetchByPatient',
+  },
+  fetchByPatient(widgetName, patientId) {
+    const model = this.getByPatient(widgetName, patientId);
+
+    const widgets = Radio.request('bootstrap', 'sidebarWidgets');
+
+    // Uses find as widgets have a modelId on the collection
+    const requestValues = widgets.find({ id: widgetName }).get('values');
+
+    // If not expecting values don't fetch them
+    if (isEmpty(requestValues)) return model;
+
+    const data = { filter: { patient: patientId } };
+    return model.fetch({ url: `/api/widgets/${ widgetName }/values`, data });
+  },
+  getByPatient(widgetName, patientId) {
+    return new Model({
+      id: uuid(widgetName, patientId),
+      name: widgetName,
+    });
+  },
+});
+
+export default new Entity();

--- a/src/js/i18n/index.js
+++ b/src/js/i18n/index.js
@@ -1,6 +1,7 @@
 import { extend, isString, keys, reduce } from 'underscore';
 import dayjs from 'dayjs';
-import Handlebars from 'handlebars/runtime';
+import Handlebars from 'handlebars/dist/cjs/handlebars';
+import HandlebarsRuntime from 'handlebars/runtime';
 import HandlebarsIntl from 'handlebars-intl';
 import { setRenderer } from 'marionette';
 
@@ -32,6 +33,7 @@ function setLocale(locale = 'en-US') {
 setLocale();
 
 HandlebarsIntl.registerWith(Handlebars);
+HandlebarsIntl.registerWith(HandlebarsRuntime);
 
 setRenderer(renderTemplate);
 

--- a/src/js/views/patients/widgets/README.md
+++ b/src/js/views/patients/widgets/README.md
@@ -8,6 +8,8 @@ Most are hardcoded such as `dob` which formats and displays the patient's Date o
 
 ## DEPRECATIONS
 
+All Custom Widgets have been deprecated
+
 Widget definition `field_name` has been deprecated for `key`.
 
 The following examples are equivalent:
@@ -70,6 +72,30 @@ Is equivalent to this widget with the deprecated `widget_type: "groups"`:
   }
 ```
 
+## Main Widget
+
+The main widget supports the optional `display_name` and a handlebars `template`.  Frontend handlebars helpers are available.
+
+The `values` of the widget inform the backend as to what data to provide to the widget. Reference backend documentation for current options.
+
+```json
+{
+  "type": "widgets",
+  "id": "template",
+  "attributes": {
+    "widget_type": "widget",
+    "definition": {
+      "template": "<hr><div>{{far 'calendar-days'}}Sex: <b>{{ sex }}</b></div><hr>",
+      "display_name": "Template"
+    },
+    "values": {
+      "sex": "@patient.sex"
+    }
+  }
+}
+```
+
+
 ## Hardcoded Widgets
 
 * dob
@@ -97,7 +123,7 @@ For displaying a standalone form in a widget area. Example:
 `is_modal` will display the form in a modal instead of the form page.
 `modal_size` can be `small` or `large` to override the default size
 
-## Custom Widgets
+## Custom Widgets (DEPRECATED)
 
 Custom widgets all support `default_html`. If supplied the `default_html` will display when the selected field is null/empty, allowing for a custom message (such as `<i>No Phone Number Available</i>`)
 

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -6,13 +6,15 @@ import parsePhoneNumber from 'libphonenumber-js/min';
 
 import hbs from 'handlebars-inline-precompile';
 
+import Handlebars from 'handlebars/dist/cjs/handlebars';
+
 import patientTemplate from 'js/utils/patient-template';
 
 import './widgets.scss';
 
 // NOTE: widget is a view or view definition
 export function buildWidget(widget, patient, widgetModel, options) {
-  if (isFunction(widget)) return new widget(extend({ model: patient }, options, widgetModel.get('definition')));
+  if (isFunction(widget)) return new widget(extend({ model: patient, widgetName: widgetModel.id }, options, widgetModel.get('definition')));
 
   return new View(extend({ model: patient }, options, widgetModel.get('definition'), widget));
 }
@@ -45,6 +47,19 @@ function getWidgetValue({ fields, name, key, childValue }) {
 // NOTE: These widgets are documented in ./README.md
 
 const widgets = {
+  widget: View.extend({
+    className: 'widgets-value',
+    initialize() {
+      const widgetName = this.getOption('widgetName');
+      const widgetValues = Radio.request('entities', 'get:widgetValues:model', widgetName, this.model.id);
+      this.values = widgetValues.get('values');
+
+      this.template = Handlebars.compile(this.template);
+    },
+    serializeData() {
+      return this.values;
+    },
+  }),
   dob: {
     modelEvents: {
       'change:birth_date': 'render',

--- a/test/fixtures/test/forms.json
+++ b/test/fixtures/test/forms.json
@@ -37,7 +37,7 @@
     "options": {
       "widgets": {
         "fields": ["testField"],
-        "widgets": ["dob", "sex", "status", "testFieldWidget"]
+        "widgets": ["dob", "sex", "status", "testFieldWidget", "hbsWidget"]
       }
     }
   },

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -1522,6 +1522,7 @@ context('Patient Action Form', function() {
       .routeFormDefinition()
       .routeActionActivity()
       .routeFormActionFields()
+      .routeWidgetValues()
       .routeAction(fx => {
         fx.data = getAction({
           id: '1',

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -522,9 +522,13 @@ context('Patient Form', function() {
       .routeForm(_.identity, '55555')
       .routeFormDefinition()
       .routeFormFields()
+      .routeWidgetValues(fx => {
+        fx.values = { sex: 'f' };
+        return fx;
+      })
       .routeLatestFormResponse()
       .routeWidgets(fx => {
-        const newWidget = getWidget({
+        fx.data.push(getWidget({
           id: 'testFieldWidget',
           attributes: {
             widget_type: 'fieldWidget',
@@ -533,9 +537,25 @@ context('Patient Form', function() {
               field_name: 'testField',
             },
           },
-        });
+        }));
 
-        fx.data.push(newWidget);
+        fx.data.push(getWidget({
+          id: 'hbsWidget',
+          attributes: {
+            widget_type: 'widget',
+            definition: {
+              display_name: 'Template',
+              template: `
+                <hr>
+                <div>{{far "calendar-days"}}Sex: <b>{{ sex }}</b></div>
+                <hr>
+              `,
+            },
+            values: {
+              sex: '@patient.sex',
+            },
+          },
+        }));
 
         return fx;
       })
@@ -589,7 +609,10 @@ context('Patient Form', function() {
       .should('contain', 'Active')
       .next()
       .should('contain', 'Test Field')
-      .should('contain', 'Test field widget');
+      .should('contain', 'Test field widget')
+      .next()
+      .should('contain', 'Template')
+      .should('contain', 'Sex: f');
   });
 
   specify('submit and go back button', function() {

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -95,6 +95,10 @@ context('patient sidebar', function() {
       .routeLatestFormResponse()
       .routeFormFields()
       .routeForm(_.identity, '33333')
+      .routeWidgetValues(fx => {
+        fx.values = { sex: 'f' };
+        return fx;
+      })
       .routeSettings(fx => {
         fx.data[0].attributes = {
           value: {
@@ -135,6 +139,7 @@ context('patient sidebar', function() {
               'arrayWidget-reject',
               'patientMRNIdentifier',
               'patientSSNIdentifier',
+              'hbsWidget',
             ],
             fields: _.keys(fields),
           },
@@ -472,6 +477,21 @@ context('patient sidebar', function() {
               identifier_type: 'ssn',
             },
           }),
+          addWidget({
+            id: 'hbsWidget',
+            widget_type: 'widget',
+            definition: {
+              template: `
+                <hr>
+                <div>{{far "calendar-days"}}Sex: <b>{{ sex }}</b></div>
+                <hr>
+              `,
+              display_name: 'Template',
+            },
+            values: {
+              sex: '@patient.sex',
+            },
+          }),
         ]);
 
         return fx;
@@ -526,6 +546,14 @@ context('patient sidebar', function() {
       .itsUrl()
       .its('pathname')
       .should('contain', '33333');
+
+    cy
+      .wait('@routeWidgetValues')
+      .itsUrl()
+      .then(({ pathname, search }) => {
+        expect(pathname).to.contain('hbsWidget');
+        expect(search).to.contain('filter[patient]=1');
+      });
 
     cy
       .get('.patient-sidebar')
@@ -676,7 +704,10 @@ context('patient sidebar', function() {
       .should('contain', 'A5432112345')
       .next()
       .should('contain', 'Patient Identifier With Empty Value')
-      .should('contain', 'No Identifier Found');
+      .should('contain', 'No Identifier Found')
+      .next()
+      .should('contain', 'Template')
+      .should('contain', 'Sex: f');
 
     // verifies that the ::before content ('-') is shown for empty widget values
     cy

--- a/test/support/api/widgets.js
+++ b/test/support/api/widgets.js
@@ -20,3 +20,11 @@ Cypress.Commands.add('routeWidgets', (mutator = _.identity) => {
     })
     .as('routeWidgets');
 });
+
+Cypress.Commands.add('routeWidgetValues', (mutator = _.identity) => {
+  cy
+    .intercept('GET', '/api/widgets/*/values*', {
+      body: mutator({ values: {} }),
+    })
+    .as('routeWidgetValues');
+});

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -41,6 +41,7 @@ Cypress.Commands.add('routesForPatientDashboard', () => {
     .routePatientActions()
     .routePatientFlows()
     .routePatientField()
+    .routeWidgetValues()
     .routeWorkspacePatient()
     .routePrograms()
     .routeAllProgramActions()


### PR DESCRIPTION
Shortcut Story ID: [sc-47977]

- [x] Add tests

So this was spicier than expected.  Mainly because our two handlebars solutions hardcode `handlebars/runtime`.

I could have required templates be precompiled so we could use the runtime, but then we'd be `eval()`ing the precompiled templates.. that seemed less of an issue than adding the handlebars compiler.

So the easiest fix was to add the helpers to both instances.  It's almost no duplicate code in the build, but there will be multiple instances of the handlebars runtime.. but it's relatively small.

some widget example:
```json
{
  "type": "widgets",
  "id": "template",
  "attributes": {
    "definition": {
      "widget_type": "widget",
      "template": "<hr><div>{{far 'calendar-days'}}Sex: <b>{{ sex }}</b></div><hr>",
      "display_name": "Template"
    },
    "values": {
      "sex": "@patient.sex"
    }
  }
}
```