### PR TITLE
Re-render all nav after change:workspace

### DIFF
--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -178,7 +178,10 @@ export default RouterApp.extend({
   initialize() {
     const bootstrapCh = Radio.channel('bootstrap');
 
-    this.listenTo(bootstrapCh, 'change:workspace', this.showMainNavDroplist);
+    this.listenTo(bootstrapCh, 'change:workspace', () => {
+      this.setCanPatientCreate();
+      this.showNav();
+    });
 
     const routerCh = Radio.channel('event-router');
 
@@ -222,8 +225,6 @@ export default RouterApp.extend({
     this.getView().removeSelected();
   },
   onChangeIsMinimized() {
-    this.showMainNavDroplist();
-    this.showBottomNavView();
     this.showNav();
 
     if (this.navMatch) {
@@ -257,9 +258,6 @@ export default RouterApp.extend({
   onStart() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
 
-    const hasManualPatientCreate = Radio.request('bootstrap', 'setting', 'manual_patient_creation');
-    this.canPatientCreate = hasManualPatientCreate && currentUser.can('patients:manage');
-
     if (!currentUser.can('clinicians:manage')) {
       adminNavMenu.remove('CliniciansApp');
     }
@@ -274,11 +272,15 @@ export default RouterApp.extend({
 
     this.setView(new AppNavView({ model: this.getState() }));
 
-    this.showMainNavDroplist();
+    this.setCanPatientCreate();
     this.showNav();
-    this.showBottomNavView();
 
     this.showView();
+  },
+  setCanPatientCreate() {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const hasManualPatientCreate = Radio.request('bootstrap', 'setting', 'manual_patient_creation');
+    this.canPatientCreate = hasManualPatientCreate && currentUser.can('patients:manage');
   },
   setSelectedAdminNavItem(appName) {
     if (!adminNavMenu.length) return;
@@ -339,6 +341,8 @@ export default RouterApp.extend({
     }));
   },
   showNav() {
+    this.showMainNavDroplist();
+
     const navView = new PatientsAppNav({
       model: this.getState(),
     });
@@ -358,6 +362,8 @@ export default RouterApp.extend({
     });
 
     this.showChildView('navContent', navView);
+
+    this.showBottomNavView();
   },
   showSearch(prefillText) {
     const navView = this.getChildView('navContent');

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
 
-import { getRelationship } from 'helpers/json-api';
+import { getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import { testTs } from 'helpers/test-timestamp';
 
@@ -225,6 +225,14 @@ context('App Nav', function() {
   specify('switch workspaces', function() {
     cy
       .routeActions()
+      .routeWorkspaces(fx => {
+        fx.data = [
+          mergeJsonApi(workspaceOne, { attributes: { settings: { manual_patient_creation: true } } }),
+          mergeJsonApi(workspaceTwo, { attributes: { settings: { manual_patient_creation: false } } }),
+        ];
+
+        return fx;
+      })
       .visit()
       .wait('@routeActions')
       .its('request.headers')
@@ -238,6 +246,10 @@ context('App Nav', function() {
     cy
       .url()
       .should('contain', '/one/worklist/owned-by');
+
+    cy
+      .get('.app-nav')
+      .find('.js-add-patient');
 
     cy
       .get('.app-nav__header')
@@ -267,6 +279,11 @@ context('App Nav', function() {
     cy
       .url()
       .should('contain', '/two/worklist/owned-by');
+
+    cy
+      .get('.app-nav')
+      .find('.js-add-patient')
+      .should('not.exist');
 
     cy
       .get('.app-nav__header')


### PR DESCRIPTION
`change:workspace` was only calling `this.showMainNavDroplist` but due to workspace related settings, all the nav needs to be re-rendered.

Shortcut Story ID: [sc-48192]
