### PR TITLE
Create GraphQL entities service for `icd($term)`

### DIFF
--- a/src/js/entities-service/graphql.js
+++ b/src/js/entities-service/graphql.js
@@ -1,5 +1,5 @@
 import BaseEntity from 'js/base/entity-service';
-import fetcher from 'js/base/fetch';
+import fetcher, { handleJSON } from 'js/base/fetch';
 
 const Entity = BaseEntity.extend({
   radioRequests: {
@@ -32,7 +32,7 @@ const Entity = BaseEntity.extend({
       method: 'POST',
       body: JSON.stringify({ query, variables }),
     })
-      .then(response => response.json());
+      .then(handleJSON);
   },
 });
 

--- a/src/js/entities-service/graphql.js
+++ b/src/js/entities-service/graphql.js
@@ -1,0 +1,40 @@
+import BaseEntity from 'js/base/entity-service';
+import fetcher from 'js/base/fetch';
+
+const Entity = BaseEntity.extend({
+  radioRequests: {
+    'fetch:icd:byTerm': 'fetchIcdByTerm',
+  },
+  fetchIcdByTerm(term) {
+    const variables = { term };
+    const query = `query ($term: String!) {
+      icdCodes(term: $term) {
+        code
+        description
+        hcc_v24
+        hcc_v28
+        parent {
+          code
+          description
+        }
+        children {
+          code
+          description
+        }
+      }
+    }`;
+
+    return fetcher('/api/graphql', {
+      header: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify({ query, variables }),
+    })
+      .then(response => response.json());
+  },
+});
+
+export default new Entity();
+

--- a/src/js/entities-service/index.js
+++ b/src/js/entities-service/index.js
@@ -18,6 +18,8 @@ import './forms';
 
 import './form-responses';
 
+import './graphql';
+
 import './patient-fields';
 
 import './patients';

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -58,8 +58,12 @@ function getDirectory(directoryName, query) {
   return router.getDirectory({ directoryName, query });
 }
 
+function getIcd(term) {
+  return router.getIcd({ term });
+}
+
 function getContext(contextScripts) {
-  return getScriptContext(contextScripts, { getClinicians, getDirectory, getField, updateField, Handlebars, TEMPLATES: {}, parsePhoneNumber });
+  return getScriptContext(contextScripts, { getClinicians, getDirectory, getField, updateField, getIcd, Handlebars, TEMPLATES: {}, parsePhoneNumber });
 }
 
 let prevSubmission;
@@ -226,6 +230,7 @@ const Router = Backbone.Router.extend({
       'fetch:directory': this.onFetchDirectory,
       'fetch:field': this.onFetchField,
       'update:field': this.onUpdateField,
+      'fetch:icd': this.onFetchIcd,
     });
   },
   request(message, args = {}) {
@@ -289,6 +294,15 @@ const Router = Backbone.Router.extend({
     return this.requestValue({ args, message, requestId });
   },
   onUpdateField(args) {
+    this.resolveValue(args);
+  },
+  getIcd(args) {
+    const message = 'fetch:icd';
+    const requestId = uniqueId('icd');
+
+    return this.requestValue({ args, message, requestId });
+  },
+  onFetchIcd(args) {
     this.resolveValue(args);
   },
   routes: {

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -43,6 +43,7 @@ export default App.extend({
     'clear:storedSubmission': 'clearStoredSubmission',
     'fetch:field': 'fetchField',
     'update:field': 'updateField',
+    'fetch:icd': 'fetchIcd',
     'version': 'checkVersion',
   },
   readyForm() {
@@ -158,6 +159,17 @@ export default App.extend({
       })
       .catch(({ responseData }) => {
         channel.request('send', 'fetch:directory', { error: responseData, requestId });
+      });
+  },
+  fetchIcd({ term, requestId }) {
+    const channel = this.getChannel();
+
+    return Promise.resolve(Radio.request('entities', 'fetch:icd:byTerm', term))
+      .then(icd => {
+        channel.request('send', 'fetch:icd', { value: get(icd, ['data', 'icdCodes']), requestId });
+      })
+      .catch(({ responseData }) => {
+        channel.request('send', 'fetch:icd', { error: responseData, requestId });
       });
   },
   fetchForm() {

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -477,6 +477,100 @@ context('Noncontext Form', function() {
       .click();
   });
 
+  specify('getIcd', function() {
+    cy
+      .routePatient(fx => {
+        fx.data = patient;
+
+        return fx;
+      })
+      .intercept('POST', '/api/graphql', {
+        body: {
+          data: {
+            icdCodes: [
+              {
+                code: 'X1',
+                description: 'Typhoid infection',
+                hcc_v24: null,
+                hcc_v28: null,
+                parent: null,
+                children: [
+                  {
+                    code: 'X3',
+                    description: 'Typhoid fever',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      })
+      .as('routeGetIcdCode')
+      .routeFormDefinition(fx => {
+        return {
+          display: 'form',
+          components: [
+            {
+              label: 'Test Get Icd Code',
+              action: 'custom',
+              key: 'test1',
+              type: 'button',
+              input: true,
+              custom: `
+                getIcd('X1')
+                  .then(value => {
+                    data.opts = [value[0].code];
+                  });
+              `,
+            },
+            {
+              label: 'Select Icd Code',
+              widget: 'choicesjs',
+              tableView: true,
+              dataSrc: 'custom',
+              data: {
+                custom: 'values = data.opts',
+              },
+              template: '<span>{{ item }}</span>',
+              refreshOn: 'data',
+              key: 'select',
+              type: 'select',
+              input: true,
+            },
+          ],
+        };
+      })
+      .routeLatestFormResponse()
+      .routeForm(_.identity, '11111')
+      .routeFormFields()
+      .visit(`/patient/${ patient.id }/form/11111`)
+      .wait('@routePatient')
+      .wait('@routeForm')
+      .wait('@routeFormFields')
+      .wait('@routeFormDefinition');
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Get Icd Code')
+      .click()
+      .wait('@routeGetIcdCode')
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('.formio-component-select .dropdown')
+      .click();
+
+    cy
+      .iframe()
+      .find('.choices__list--dropdown.is-active')
+      .find('.choices__item--selectable')
+      .should('contain', 'X1')
+      .first()
+      .click();
+  });
+
   specify('form scripts and reducers', { retries: 4 }, function() {
     cy
       .intercept('GET', '/appconfig.json', {


### PR DESCRIPTION
Shortcut Story ID: [sc-48884]

Implemented on the backend here: https://github.com/RoundingWell/care-ops-backend/pull/7540

To do:

- [x] Add cypress test for retrieving icd code
- [x] Handle `400` api request errors properly
- [x] Add cypress test when `getIcd()` request returns a `400` error