### PR TITLE
Move filterable directories request from `bootstrap` => `app-frame_app`

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -30,11 +30,14 @@ export default App.extend({
   beforeStart() {
     return [
       Radio.request('entities', 'fetch:clinicians:byWorkspace', this.currentWorkspace.id),
+      Radio.request('entities', 'fetch:directories:filterable'),
       Radio.request('entities', 'fetch:states:collection'),
       Radio.request('entities', 'fetch:forms:collection'),
     ];
   },
-  onStart(options, clinicians) {
+  onStart(options, clinicians, directories) {
+    Radio.request('bootstrap', 'setDirectories', directories);
+
     this.currentWorkspace.updateClinicians(clinicians);
 
     const currentUser = Radio.request('bootstrap', 'currentUser');

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -29,6 +29,7 @@ export default App.extend({
     'workspaces': 'getWorkspaces',
     'organization': 'getOrganization',
     'directories': 'getDirectories',
+    'setDirectories': 'setDirectories',
     'setting': 'getSetting',
     'roles': 'getActiveRoles',
     'teams': 'getTeams',
@@ -74,6 +75,9 @@ export default App.extend({
   },
   getDirectories() {
     return this.directories.clone();
+  },
+  setDirectories(directories) {
+    this.directories = directories;
   },
   getWorkspaces() {
     return this.workspaces.clone();
@@ -131,18 +135,16 @@ export default App.extend({
       Radio.request('entities', 'fetch:clinicians:current'),
       Radio.request('entities', 'fetch:roles:collection'),
       Radio.request('entities', 'fetch:teams:collection'),
-      Radio.request('entities', 'fetch:directories:filterable'),
       Radio.request('entities', 'fetch:settings:collection'),
       Radio.request('entities', 'fetch:workspaces:collection'),
       Radio.request('entities', 'fetch:widgets:collection'),
     ];
   },
-  onStart(options, currentUser, roles, teams, directories, settings, workspaces, widgets) {
+  onStart(options, currentUser, roles, teams, settings, workspaces, widgets) {
     this.currentUser = currentUser;
     this.roles = roles;
     this.teams = teams;
     this.settings = settings;
-    this.directories = directories;
     this.workspaces = workspaces;
     this.widgets = widgets;
 

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -233,8 +233,23 @@ context('App Nav', function() {
 
         return fx;
       })
+      .routeDirectories(fx => {
+        fx.data = [
+          {
+            attributes: {
+              name: 'Insurance Plans',
+              slug: 'insurance',
+              value: ['BCBS PPO 100', 'Medicare'],
+            },
+          },
+        ];
+
+        return fx;
+      })
       .visit()
       .wait('@routeActions')
+      .wait('@routeWorkspaces')
+      .wait('@routeDirectories')
       .its('request.headers')
       .should('have.property', 'workspace', workspaceOne.id)
       .then(() => {
@@ -257,6 +272,22 @@ context('App Nav', function() {
       .click();
 
     cy
+      .intercept('GET', '/api/directories*', {
+        statusCode: 200,
+        body: {
+          data: [
+            {
+              attributes: {
+                name: 'ACO',
+                slug: 'aco',
+                value: ['Basic', 'Premier'],
+              },
+            },
+          ],
+        },
+      }).as('routeDirectories');
+
+    cy
       .get('.picklist')
       .find('.picklist__group')
       .find('.picklist__item')
@@ -267,6 +298,7 @@ context('App Nav', function() {
       .click();
 
     cy
+      .wait('@routeDirectories')
       .wait('@routeActions')
       .its('request.headers')
       .should('have.property', 'workspace', workspaceTwo.id)
@@ -279,6 +311,19 @@ context('App Nav', function() {
     cy
       .url()
       .should('contain', '/two/worklist/owned-by');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-filter-button]')
+      .first()
+      .get('.sidebar__label')
+      .should('contain', 'ACO');
 
     cy
       .get('.app-nav')


### PR DESCRIPTION
Shortcut Story ID: [sc-49745]

Backend will now filter directories by workspace. On the FE, this ensures the filterable directories request is made when a user switches workspaces (`GET /api/directories?filter[filterable]=true`).

Related backend PR: https://github.com/RoundingWell/care-ops-backend/pull/7696.