### PR TITLE
Remove adding adhoc actions

### DIFF
--- a/src/js/apps/patients/patient/action/action_app.js
+++ b/src/js/apps/patients/patient/action/action_app.js
@@ -1,42 +1,11 @@
-import { first } from 'underscore';
 import Radio from 'backbone.radio';
-import dayjs from 'dayjs';
 
 import intl from 'js/i18n';
-
-import { ACTION_OUTREACH, ACTION_SHARING, STATE_STATUS } from 'js/static';
 
 import App from 'js/base/app';
 
 export default App.extend({
   beforeStart({ actionId, patientId }) {
-    if (!actionId) {
-      const currentUser = Radio.request('bootstrap', 'currentUser');
-      const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
-      const states = currentWorkspace.getStates();
-
-      const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));
-
-      return Radio.request('entities', 'actions:model', {
-        _patient: patientId,
-        _state: defaultInitialState.id,
-        _owner: {
-          type: 'clinicians',
-          id: currentUser.id,
-        },
-        _author: {
-          type: 'clinicians',
-          id: currentUser.id,
-        },
-        outreach: ACTION_OUTREACH.DISABLED,
-        sharing: ACTION_SHARING.DISABLED,
-        duration: 0,
-        due_date: null,
-        due_time: null,
-        updated_at: dayjs().format(),
-      });
-    }
-
     return Radio.request('entities', 'fetch:actions:model', actionId);
   },
   onFail() {

--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -24,7 +24,4 @@ export default App.extend({
     this.collection = new Backbone.Collection([...actions.models, ...flows.models]);
     this.showChildView('content', new ListView({ collection: this.collection }));
   },
-  onEditAction(action) {
-    action.trigger('editing', true);
-  },
 });

--- a/src/js/apps/patients/patient/dashboard/add-workflow_app.js
+++ b/src/js/apps/patients/patient/dashboard/add-workflow_app.js
@@ -9,7 +9,6 @@ import { AddButtonView, i18n, itemClasses } from 'js/views/patients/shared/add-w
 const optEvents = {
   'program-actions': 'add:programAction',
   'program-flows': 'add:programFlow',
-  'new': 'add:newAction',
 };
 
 export default App.extend({
@@ -33,24 +32,8 @@ export default App.extend({
     programs.reset(addablePrograms);
 
     this.showView(new AddButtonView({
-      lists: this.getLists(programs),
+      lists: this.getProgramsOpts(programs),
     }));
-  },
-  getLists(programs) {
-    const lists = this.getProgramsOpts(programs);
-
-    const newActionOpt = {
-      itemType: 'program-actions',
-      text: i18n.newActionText,
-      onSelect: bind(this.triggerMethod, this, optEvents.new),
-    };
-
-    lists.unshift({
-      collection: new Backbone.Collection([newActionOpt]),
-      itemClassName: itemClasses.new,
-    });
-
-    return lists;
   },
   getProgramsOpts(programs) {
     return programs.map(program => {

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -49,14 +49,9 @@ export default App.extend({
     });
 
     this.listenTo(addworkflow, {
-      'add:newAction': this.onAddNewAction,
       'add:programAction': this.onAddProgramAction,
       'add:programFlow': this.onAddProgramFlow,
     });
-  },
-
-  onAddNewAction() {
-    Radio.trigger('event-router', 'patient:action:new', this.patient.id);
   },
 
   onAddProgramAction(programAction) {
@@ -76,13 +71,5 @@ export default App.extend({
     });
 
     return;
-  },
-
-  onEditAction(action) {
-    if (action.isNew()) {
-      this.collection.unshift(action);
-      return;
-    }
-    action.trigger('editing', true);
   },
 });

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -89,12 +89,12 @@ export default SubRouterApp.extend({
 
     if (!currentActionList.isRunning()) {
       this.listenToOnce(currentActionList, 'start', () => {
-        currentActionList.triggerMethod('edit:action', action);
+        action.trigger('editing', true);
       });
       return;
     }
 
-    currentActionList.triggerMethod('edit:action', action);
+    action.trigger('editing', true);
   },
 
   showSidebar() {

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -47,7 +47,7 @@ export default App.extend({
     this.showAction();
     this.showForm();
 
-    if (!this.action.isNew()) this.getRegion('activity').startPreloader();
+    this.getRegion('activity').startPreloader();
 
     this.showView();
   },
@@ -57,8 +57,6 @@ export default App.extend({
     this.stopListening(this.action);
   },
   beforeStart() {
-    if (this.action.isNew()) return;
-
     return [
       Radio.request('entities', 'fetch:actionEvents:collection', this.action.id),
       Radio.request('entities', 'fetch:comments:collection:byAction', this.action.id),
@@ -71,8 +69,6 @@ export default App.extend({
     if (this.isRunning()) this.showAttachments();
   },
   onStart(options, activity, comments, attachments) {
-    if (this.action.isNew()) return;
-
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);
     this.attachments = attachments;
 
@@ -183,13 +179,6 @@ export default App.extend({
     model.destroy();
   },
   onSave({ model }) {
-    if (model.isNew()) {
-      this.action.saveAll(model.attributes).then(() => {
-        Radio.trigger('event-router', 'patient:action', this.action.get('_patient'), this.action.id);
-      });
-      return;
-    }
-
     this.action.save(model.pick('name', 'details'));
   },
   onDelete() {
@@ -203,7 +192,6 @@ export default App.extend({
   },
   onStop() {
     this.action.trigger('editing', false);
-    if (this.action && this.action.isNew()) this.action.destroy();
 
     Radio.request('sidebar', 'close');
   },

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -8,8 +8,6 @@ import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 import JsonApiMixin from 'js/base/jsonapi-mixin';
 
-import trim from 'js/utils/formatting/trim';
-
 import { ACTION_OUTREACH, ACTION_SHARING } from 'js/static';
 
 const TYPE = 'patient-actions';
@@ -33,9 +31,6 @@ const _Model = BaseModel.extend({
     return '/api/actions';
   },
   type: TYPE,
-  validate({ name }) {
-    if (!trim(name)) return 'Action name required';
-  },
   hasTag(tagName) {
     return contains(this.get('tags'), tagName);
   },
@@ -99,9 +94,6 @@ const _Model = BaseModel.extend({
     const dueDateTime = dayjs(`${ date } ${ time }`);
 
     return dueDateTime.isBefore(dayjs(), 'day') || dueDateTime.isBefore(dayjs(), 'minute');
-  },
-  isAdHoc() {
-    return !this.get('_program_action') && !this.get('_flow');
   },
   hasOutreach() {
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -304,7 +304,6 @@ careOptsFrontend:
           addWorkflowOptlist:
             headingText: Add Flow or Action
             placeholderText: Find...
-          newActionText: New Action...
           noResultsText: No Published Actions
       bulkEdit:
         bulkEditViews:
@@ -445,8 +444,6 @@ careOptsFrontend:
       action:
         actionDetailsTemplate:
           placeholder: Add Details
-        actionNameTemplate:
-          placeholder: New Action
         actionSidebarTemplate:
           headingText: |
             {outreach, select,
@@ -459,8 +456,6 @@ careOptsFrontend:
             durationLabel: Duration
             ownerLabel: Owner
             stateLabel: State
-          disabledSaveView:
-            saveBtn: Save
           readOnlyActionView:
             dueDayLabel: Due
             durationLabel: Duration

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -42,9 +42,6 @@ const RowBehavior = Behavior.extend({
   onEditing(isEditing) {
     this.$el.toggleClass('is-selected', isEditing);
   },
-  onInitialize() {
-    if (this.view.model.isNew()) this.$el.addClass('is-selected');
-  },
 });
 
 const DoneBehavior = Behavior.extend({
@@ -118,8 +115,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const isDisabled = this.model.isNew();
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true, state: { isDisabled } });
+    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
 
     this.listenTo(stateComponent, 'change:state', state => {
       this.model.saveState(state);
@@ -134,11 +130,9 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const isDisabled = this.model.isNew();
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
       isCompact: true,
-      state: { isDisabled },
     });
 
     this.listenTo(ownerComponent, 'change:owner', owner => {
@@ -154,10 +148,9 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const isDisabled = this.model.isNew();
     const dueDateComponent = new DueComponent({
       date: this.model.get('due_date'),
-      isCompact: true, state: { isDisabled },
+      isCompact: true,
       isOverdue: this.model.isOverdue(),
     });
 
@@ -174,7 +167,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const isDisabled = this.model.isNew() || !this.model.get('due_date');
+    const isDisabled = !this.model.get('due_date');
     const dueTimeComponent = new TimeComponent({
       time: this.model.get('due_time'),
       isCompact: true, state: { isDisabled },
@@ -231,11 +224,9 @@ const FlowItemView = View.extend({
       return;
     }
 
-    const isDisabled = this.model.isNew();
     const ownerComponent = new OwnerComponent({
       owner: this.model.getOwner(),
       isCompact: true,
-      state: { isDisabled },
     });
 
     this.listenTo(ownerComponent, 'change:owner', owner => {

--- a/src/js/views/patients/shared/add-workflow/add-workflow_views.js
+++ b/src/js/views/patients/shared/add-workflow/add-workflow_views.js
@@ -43,7 +43,6 @@ const AddButtonView = View.extend({
       ui: this.$el,
       uiView: this,
       lists: this.getOption('lists'),
-      onNew: this.getOption('onNew'),
     });
 
     optionlist.show();

--- a/src/js/views/patients/sidebar/action/action-name.hbs
+++ b/src/js/views/patients/sidebar/action/action-name.hbs
@@ -1,6 +1,0 @@
-{{#if isReadOnly}}
-<div class="action-sidebar__name">{{ name }}</div>
-{{else}}
-<textarea class="input-primary textarea-flex__input js-input"{{#if isDisabled}} disabled{{/if}}{{#if isNew}} placeholder="{{ @intl.patients.sidebar.action.actionNameTemplate.placeholder }}"{{/if}}>{{ name }}</textarea>
-<div class="textarea-flex__container input-primary js-spacer">{{ name }} </div>
-{{/if}}

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -685,59 +685,6 @@ context('patient dashboard page', function() {
       .contains('Add')
       .click();
 
-    cy
-      .get('.picklist')
-      .contains('New Action')
-      .click();
-
-    cy
-      .get('.patient__list')
-      .find('.is-selected')
-      .should('contain', 'New Action')
-      .as('newAction');
-
-    cy
-      .get('@newAction')
-      .find('[data-state-region]')
-      .find('button')
-      .should('be.disabled')
-      .find('.fa-circle-exclamation');
-
-    cy
-      .get('@newAction')
-      .find('[data-owner-region]')
-      .find('button')
-      .should('be.disabled')
-      .should('contain', 'Clinician McTester');
-
-    cy
-      .get('@newAction')
-      .find('[data-due-date-region]')
-      .find('button')
-      .should('be.disabled');
-
-    cy
-      .get('@newAction')
-      .find('[data-due-time-region]')
-      .find('button')
-      .should('be.disabled');
-
-    cy
-      .get('.sidebar')
-      .find('.js-close')
-      .click();
-
-    cy
-      .get('.patient__list')
-      .should('not.contain', 'New Action')
-      .find('.is-selected')
-      .should('not.exist');
-
-    cy
-      .get('[data-add-workflow-region]')
-      .contains('Add')
-      .click();
-
     const headingOrder = [
       'Add Flow or Action',
       'No Actions, No Flows',
@@ -753,10 +700,6 @@ context('patient dashboard page', function() {
           expect($heading).to.contain(headingOrder[idx]);
         });
       });
-
-    cy
-      .get('.picklist')
-      .contains('New Action');
 
     cy
       .get('.picklist')
@@ -833,7 +776,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-name-region]')
+      .find('.action-sidebar__name')
       .should('contain', 'One of One');
 
     cy
@@ -893,7 +836,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-name-region]')
+      .find('.action-sidebar__name')
       .should('contain', 'One of Two');
 
     cy
@@ -947,7 +890,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('.sidebar')
-      .find('[data-name-region]')
+      .find('.action-sidebar__name')
       .should('contain', 'Two of Two');
 
     cy

--- a/test/integration/patients/patient/patient.js
+++ b/test/integration/patients/patient/patient.js
@@ -115,37 +115,5 @@ context('patient page', function() {
       .get('.patient__layout')
       .find('.patient__tab--selected')
       .contains('Archive');
-
-    cy
-      .get('.patient__layout')
-      .find('.js-dashboard')
-      .click();
-
-    cy
-      .get('[data-add-workflow-region]')
-      .contains('Add')
-      .click();
-
-    cy
-      .get('.picklist')
-      .contains('New Action')
-      .click();
-
-    cy
-      .get('.sidebar')
-      .find('[data-name-region] .js-input')
-      .should('have.attr', 'placeholder', 'New Action');
-
-    cy
-      .get('.sidebar')
-      .find('.js-close')
-      .click();
-
-    cy
-      .get('.sidebar')
-      .should('not.exist');
-
-    cy
-      .get('.patient-sidebar');
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-51161]

This did affect quite a bit of things.

There's likely some further clean up around `action.trigger('editing', true);` which I don't love.  the lists can probably state-wise understand if an action is being edited at render rather than waiting for it to run to then trigger.

- [x] Fix coverage drop