### PR TITLE
Prevent handling stale form service async requests

### DIFF
--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -169,7 +169,7 @@ export default async(url, options) => {
           }
         }
 
-        if (response.status >= 500) {
+        if (response.status >= 500 || !response.status) {
           Radio.trigger('event-router', 'unknownError', response.status);
         }
       }


### PR DESCRIPTION
Shortcut Story ID: [sc-51213]

If an API request is long enough that a user can go back on the form and reload it prior to that endpoint resolving, the resolution would happen on the previous form service.  That service was destroyed so it no longer handles the request on the radio channel, but it did request on the channel and since the services shared channels both requests would resolve and render the form.

Additionally I think the delay was due to the user's poor connection resulting in a `0` status.. not handling that was odd, so we should through the uh-oh for now as likely the best case is for the user to reload whatever they were doing.

Also there's no test for `statusCode:0` as Cypress can't test it.  We also don't code coverage the base files.