### PR TITLE
For program actions/flows, switch from using `relationships.visible_to` => `relationships.teams`

### DIFF
--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -83,13 +83,13 @@ const _Model = BaseModel.extend({
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;
   },
   isVisibleToCurrentUser() {
-    const visibleToList = this.get('_visible_to');
+    const visibleToTeamsList = this.get('_teams');
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const currentUserTeam = currentUser.getTeam();
 
-    if (!size(visibleToList)) return true;
+    if (!size(visibleToTeamsList)) return true;
 
-    return !!visibleToList.find(team => team.id === currentUserTeam.id);
+    return !!visibleToTeamsList.find(team => team.id === currentUserTeam.id);
   },
   saveForm(form) {
     form = this.toRelation(form);

--- a/src/js/entities-service/entities/program-flows.js
+++ b/src/js/entities-service/entities/program-flows.js
@@ -84,13 +84,13 @@ const _Model = BaseModel.extend({
     return this.getActions().filterAddable();
   },
   isVisibleToCurrentUser() {
-    const visibleToList = this.get('_visible_to');
+    const visibleToTeamsList = this.get('_teams');
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const currentUserTeam = currentUser.getTeam();
 
-    if (!size(visibleToList)) return true;
+    if (!size(visibleToTeamsList)) return true;
 
-    return !!visibleToList.find(team => team.id === currentUserTeam.id);
+    return !!visibleToTeamsList.find(team => team.id === currentUserTeam.id);
   },
   parseRelationship: _parseRelationship,
 });

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -429,7 +429,7 @@ context('patient dashboard page', function() {
         relationships: {
           owner: getRelationship(teamCoordinator),
           form: getRelationship(testForm),
-          visible_to: getRelationship([teamNurse]),
+          teams: getRelationship([teamNurse]),
         },
       }),
       getAction({
@@ -492,7 +492,7 @@ context('patient dashboard page', function() {
           days_until_due: 1,
         },
         relationships: {
-          visible_to: getRelationship([teamCoordinator]),
+          teams: getRelationship([teamCoordinator]),
         },
       }),
     ];
@@ -509,7 +509,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[0], 'programs'),
           state: getRelationship(stateTodo),
           owner: getRelationship(teamOther),
-          visible_to: getRelationship([teamNurse]),
+          teams: getRelationship([teamNurse]),
         },
       }),
       getFlow({
@@ -576,7 +576,7 @@ context('patient dashboard page', function() {
         },
         relationships: {
           program: getRelationship(testProgramIds[1], 'programs'),
-          visible_to: getRelationship([teamCoordinator]),
+          teams: getRelationship([teamCoordinator]),
         },
       }),
     ];

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -437,7 +437,7 @@ context('patient flow page', function() {
       relationships: {
         owner: getRelationship(),
         form: getRelationship(testForm),
-        visible_to: getRelationship([teamNurse]),
+        teams: getRelationship([teamNurse]),
       },
     });
 
@@ -517,7 +517,7 @@ context('patient flow page', function() {
               sequence: 1,
             },
             relationships: {
-              visible_to: getRelationship([teamCoordinator]),
+              teams: getRelationship([teamCoordinator]),
             },
           }),
         ];


### PR DESCRIPTION
Shortcut Story ID: [sc-52130]

This is used to determine when a program action/flow should be addable by a clinician.

If a program action/flow has an empty teams relationship, its treated as visible to all teams.

Corresponding BE change: https://github.com/RoundingWell/care-ops-backend/pull/8065.