### PR TITLE
Split bootstrap service into smaller services

### DIFF
--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -2,7 +2,11 @@ import { partial, invoke, defer, some } from 'underscore';
 import Radio from 'backbone.radio';
 import Backbone from 'backbone';
 
+import getWorkspaceRoute from 'js/utils/root-route';
+
 import App from 'js/base/app';
+
+import WorkspaceService from 'js/services/workspace';
 
 import SidebarService from 'js/services/sidebar';
 
@@ -11,41 +15,35 @@ import NavApp from './nav_app';
 export default App.extend({
   routers: [],
   onBeforeStart() {
-    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
     this.getRegion('content').empty();
 
     if (this.isRestarting()) return;
 
+    new WorkspaceService({ route: getWorkspaceRoute() });
+    const workspaceCh = Radio.channel('workspace');
+
+    this.listenTo(workspaceCh, 'change:workspace', this.restart);
+
     new NavApp({ region: this.getRegion('nav') });
     new SidebarService({ region: this.getRegion('sidebar') });
-
-    this.listenTo(Radio.channel('bootstrap'), 'change:workspace', this.restart);
-
-    this.currentUser = Radio.request('bootstrap', 'currentUser');
   },
   beforeStart() {
-    const isReduced = this.currentUser.can('app:schedule:reduced');
-    const hasDashboards = this.currentUser.can('dashboards:view');
-    const hasClinicians = this.currentUser.can('clinicians:manage');
-    const hasPrograms = this.currentUser.can('programs:manage');
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const isReduced = currentUser.can('app:schedule:reduced');
+    const hasDashboards = currentUser.can('dashboards:view');
+    const hasClinicians = currentUser.can('clinicians:manage');
+    const hasPrograms = currentUser.can('programs:manage');
 
     return [
+      Radio.request('workspace', 'fetch'),
       isReduced ? import('js/apps/patients/reduced-patients-main_app.js') : import('js/apps/patients/patients-main_app'),
       hasDashboards ? import('js/apps/dashboards/dashboards-main_app.js') : null,
       hasClinicians ? import('js/apps/clinicians/clinicians-main_app.js') : null,
       hasPrograms ? import('js/apps/programs/programs-main_app.js') : null,
       import('js/apps/forms/forms-main_app'),
-      Radio.request('entities', 'fetch:clinicians:byWorkspace', this.currentWorkspace.id),
-      Radio.request('entities', 'fetch:directories:filterable'),
-      Radio.request('entities', 'fetch:states:collection'),
-      Radio.request('entities', 'fetch:forms:collection'),
     ];
   },
-  onStart(options, PatientsMainApp, DashboardsMainApp, CliniciansMainApp, ProgramsMainApp, FormsApp, clinicians, directories) {
-    Radio.request('bootstrap', 'setDirectories', directories);
-
-    this.currentWorkspace.updateClinicians(clinicians);
-
+  onStart(options, currentWorkspace, PatientsMainApp, DashboardsMainApp, CliniciansMainApp, ProgramsMainApp, FormsApp) {
     this.initRouter(PatientsMainApp);
     this.initRouter(DashboardsMainApp);
     this.initRouter(CliniciansMainApp);

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -2,11 +2,7 @@ import { partial, invoke, defer, some } from 'underscore';
 import Radio from 'backbone.radio';
 import Backbone from 'backbone';
 
-import getWorkspaceRoute from 'js/utils/root-route';
-
 import App from 'js/base/app';
-
-import WorkspaceService from 'js/services/workspace';
 
 import SidebarService from 'js/services/sidebar';
 
@@ -19,7 +15,6 @@ export default App.extend({
 
     if (this.isRestarting()) return;
 
-    new WorkspaceService({ route: getWorkspaceRoute() });
     const workspaceCh = Radio.channel('workspace');
 
     this.listenTo(workspaceCh, 'change:workspace', this.restart);

--- a/src/js/apps/globals/error_app.js
+++ b/src/js/apps/globals/error_app.js
@@ -50,7 +50,7 @@ export default RouterApp.extend({
   handleUnknown() {
     const rootRoute = getRootRoute();
     if (contains(legacyRoots, rootRoute)) {
-      const workspace = Radio.request('bootstrap', 'currentWorkspace');
+      const workspace = Radio.request('workspace', 'current');
       this.replaceUrl(`/${ workspace.get('slug') }${ location.pathname }`);
       return;
     }

--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -149,7 +149,7 @@ export default RouterApp.extend({
     }, { 'root': rootRoute });
   },
   setWorkspace(slug, route) {
-    const workspace = Radio.request('bootstrap', 'setCurrentWorkspace', slug);
+    const workspace = Radio.request('workspace', 'current', slug);
     const workspaceSlug = workspace && workspace.get('slug');
 
     if (!workspaceSlug || route) return;
@@ -159,7 +159,7 @@ export default RouterApp.extend({
     });
   },
   getDefaultRoute() {
-    const workspace = Radio.request('bootstrap', 'currentWorkspace');
+    const workspace = Radio.request('workspace', 'current');
     const workspaceSlug = workspace.get('slug');
 
     const currentUser = Radio.request('bootstrap', 'currentUser');
@@ -176,9 +176,9 @@ export default RouterApp.extend({
   startAfterInitialized: true,
   channelName: 'nav',
   initialize() {
-    const bootstrapCh = Radio.channel('bootstrap');
+    const workspaceCh = Radio.channel('workspace');
 
-    this.listenTo(bootstrapCh, 'change:workspace', () => {
+    this.listenTo(workspaceCh, 'change:workspace', () => {
       this.setCanPatientCreate();
       this.showNav();
     });
@@ -312,7 +312,7 @@ export default RouterApp.extend({
     }
   },
   showMainNavDroplist() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const workspaces = currentUser.getWorkspaces();
 

--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -279,7 +279,7 @@ export default RouterApp.extend({
   },
   setCanPatientCreate() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
-    const hasManualPatientCreate = Radio.request('bootstrap', 'setting', 'manual_patient_creation');
+    const hasManualPatientCreate = Radio.request('settings', 'get', 'manual_patient_creation');
     this.canPatientCreate = hasManualPatientCreate && currentUser.can('patients:manage');
   },
   setSelectedAdminNavItem(appName) {
@@ -401,7 +401,7 @@ export default RouterApp.extend({
     return Radio.request('entities', 'patients:model');
   },
   showPatientModal(patient) {
-    const { form_id: patientFormId } = Radio.request('bootstrap', 'setting', 'patient_creation_form') || {};
+    const { form_id: patientFormId } = Radio.request('settings', 'get', 'patient_creation_form') || {};
 
     patient = patient || this.getNewPatient();
     const patientClone = patient.clone();

--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -11,7 +11,7 @@ export default App.extend({
     this.getRegion('content').startPreloader();
   },
   beforeStart({ patient }) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
     const filter = { state: states.groupByDone().done.getFilterIds() };
 

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -23,7 +23,7 @@ export default App.extend({
   },
 
   beforeStart({ patient }) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
     const filter = { state: states.groupByDone().notDone.getFilterIds() };
 

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -15,13 +15,13 @@ export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new SidebarView({ model: patient }));
 
-    this.widgets = Radio.request('bootstrap', 'sidebarWidgets');
+    this.widgets = Radio.request('widgets', 'sidebarWidgets');
 
     this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
     const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
-    const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
+    const fields = map(Radio.request('widgets', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
     const values = this.widgets.invoke('fetchValues', patient.id);

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
@@ -23,7 +23,7 @@ export default Backbone.Model.extend({
   },
   preinitialize() {
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    this.currentWorkspace = Radio.request('workspace', 'current');
   },
   initialize() {
     this.on('change', this.onChange);

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -40,7 +40,7 @@ const StateModel = Backbone.Model.extend({
   },
   preinitialize() {
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    this.currentWorkspace = Radio.request('workspace', 'current');
   },
   initialize() {
     this.on('change', this.onChange);

--- a/src/js/apps/patients/shared/filters_state.js
+++ b/src/js/apps/patients/shared/filters_state.js
@@ -5,7 +5,7 @@ import Radio from 'backbone.radio';
 
 export default Backbone.Model.extend({
   preinitialize() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
     const { done, notDone } = states.groupByDone();
     this.states = { done, notDone, all: states };

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -146,7 +146,7 @@ export default App.extend({
     });
   },
   showAttachments() {
-    const canUploadAttachments = !!Radio.request('bootstrap', 'setting', 'upload_attachments') && this.action.hasAllowedUploads();
+    const canUploadAttachments = !!Radio.request('settings', 'get', 'upload_attachments') && this.action.hasAllowedUploads();
 
     if (!canUploadAttachments && !this.attachments.length) return;
 

--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -29,7 +29,7 @@ export default App.extend({
     this.showChildView('header', headerView);
   },
   showCustomFiltersView() {
-    const collection = Radio.request('bootstrap', 'directories');
+    const collection = Radio.request('workspace', 'directories');
 
     const customFilters = Radio.request('settings', 'get', 'custom_filters');
 
@@ -55,7 +55,7 @@ export default App.extend({
       return;
     }
 
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
 
     const flowStatesFiltersView = new FlowStatesFiltersView({

--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -31,7 +31,7 @@ export default App.extend({
   showCustomFiltersView() {
     const collection = Radio.request('bootstrap', 'directories');
 
-    const customFilters = Radio.request('bootstrap', 'setting', 'custom_filters');
+    const customFilters = Radio.request('settings', 'get', 'custom_filters');
 
     if (customFilters && customFilters.length) {
       const filteredDirectories = collection.filter(directory => {

--- a/src/js/apps/patients/sidebar/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient-sidebar_app.js
@@ -9,14 +9,14 @@ export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new LayoutView({ model: patient }));
 
-    this.widgets = Radio.request('bootstrap', 'sidebarWidgets');
+    this.widgets = Radio.request('widgets', 'sidebarWidgets');
 
     this.getRegion('widgets').startPreloader();
   },
   beforeStart({ patient }) {
     const patientModel = Radio.request('entities', 'fetch:patients:model', patient.id);
     const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
-    const fields = map(Radio.request('bootstrap', 'sidebarWidgets:fields'), fieldName => {
+    const fields = map(Radio.request('widgets', 'sidebarWidgets:fields'), fieldName => {
       return Radio.request('entities', 'fetch:patientFields:model', patient.id, fieldName);
     });
     const values = this.widgets.invoke('fetchValues', patient.id);

--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -134,7 +134,7 @@ const defaultSortOptions = [
 ];
 
 function getSortOptions(listType) {
-  const customSort = Radio.request('bootstrap', 'setting', 'sorting');
+  const customSort = Radio.request('settings', 'get', 'sorting');
   const sortOpts = new SortOptions(union(defaultSortOptions, customSort));
 
   return sortOpts.getByType(listType);

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -54,7 +54,7 @@ const StateModel = Backbone.Model.extend({
   },
   preinitialize() {
     this.currentClinician = Radio.request('bootstrap', 'currentUser');
-    this.currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    this.currentWorkspace = Radio.request('workspace', 'current');
   },
   initialize() {
     this.on('change', this.onChange);

--- a/src/js/apps/programs/sidebar/action-sidebar_app.js
+++ b/src/js/apps/programs/sidebar/action-sidebar_app.js
@@ -27,7 +27,7 @@ export default App.extend({
     this.listenTo(this.action, 'change:allowed_uploads', this.showUploadsEnabled);
   },
   showUploadsEnabled() {
-    if (!Radio.request('bootstrap', 'setting', 'upload_attachments')) return;
+    if (!Radio.request('settings', 'get', 'upload_attachments')) return;
 
     const uploadsEnabledView = new UploadsEnabledView({
       isUploadsEnabled: !!size(this.action.get('allowed_uploads')),
@@ -45,7 +45,7 @@ export default App.extend({
     this.showChildView('allowUploads', uploadsEnabledView);
   },
   showFormSharing() {
-    if (!Radio.request('bootstrap', 'setting', 'care_team_outreach')) return;
+    if (!Radio.request('settings', 'get', 'care_team_outreach')) return;
 
     const form = this.action.getForm();
 

--- a/src/js/auth0.js
+++ b/src/js/auth0.js
@@ -105,7 +105,7 @@ function auth(success) {
     .then(setAuth0)
     .then(isAuthenticated => {
       if (location.pathname === '/logout') {
-        const federated = Radio.request('bootstrap', 'setting', 'federated_logout');
+        const federated = Radio.request('settings', 'get', 'federated_logout');
         auth0.logout({ logoutParams: { returnTo: location.origin, federated } });
         return;
       }

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -68,7 +68,7 @@ async function buildFetcher(url, options = {}) {
   }
 
   // Attach preferred workspace to request
-  const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+  const currentWorkspace = Radio.request('workspace', 'current');
   if (currentWorkspace) options.headers.Workspace = currentWorkspace.id;
 
   return registerFetcher(baseUrl, fetch(url, options), controller);

--- a/src/js/base/routerapp.js
+++ b/src/js/base/routerapp.js
@@ -66,13 +66,13 @@ export default App.extend({
 
   // For each route in the hash creates a routeTriggers hash
   getRouteTriggers() {
-    const currentWorkspace = Radio.request('workspace', 'current');
     return reduce(this._routes, function(routeTriggers, { route, root }, eventName) {
       if (root) {
         routeTriggers[eventName] = route;
         return routeTriggers;
       }
 
+      const currentWorkspace = Radio.request('workspace', 'current');
       const workspace = currentWorkspace.get('slug');
       routeTriggers[eventName] = route ? `${ workspace }/${ route }` : workspace;
 

--- a/src/js/base/routerapp.js
+++ b/src/js/base/routerapp.js
@@ -66,7 +66,7 @@ export default App.extend({
 
   // For each route in the hash creates a routeTriggers hash
   getRouteTriggers() {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     return reduce(this._routes, function(routeTriggers, { route, root }, eventName) {
       if (root) {
         routeTriggers[eventName] = route;

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,4 +1,4 @@
-import { get, size, invoke, map, compact } from 'underscore';
+import { get, size } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -63,13 +63,7 @@ const _Model = BaseModel.extend({
   getWidgets() {
     const formWidgets = get(this.get('options'), ['widgets', 'widgets']);
 
-    const allWidgets = Radio.request('bootstrap', 'widgets');
-
-    const widgets = map(formWidgets, slug => {
-      return allWidgets.find({ slug });
-    });
-
-    return Radio.request('entities', 'widgets:collection', invoke(compact(widgets), 'omit', 'id'));
+    return Radio.request('widgets', 'build', formWidgets);
   },
   getWidgetFields() {
     return get(this.get('options'), ['widgets', 'fields']);

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -40,7 +40,7 @@ const _Model = BaseModel.extend({
   },
   getAction({ patientId, flowId }) {
     const currentUser = Radio.request('bootstrap', 'currentUser');
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
 
     const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));

--- a/src/js/entities-service/entities/program-flows.js
+++ b/src/js/entities-service/entities/program-flows.js
@@ -49,7 +49,7 @@ const _Model = BaseModel.extend({
     return Radio.request('entities', 'teams:model', owner.id);
   },
   getFlow(patientId) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
 
     const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));

--- a/src/js/entities-service/workspace-patients.js
+++ b/src/js/entities-service/workspace-patients.js
@@ -15,7 +15,7 @@ const Entity = BaseEntity.extend({
     return model.fetch();
   },
   getByPatient(patientId) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
     const workspaceId = currentWorkspace.id;
 
     return new Model({ id: uuid(patientId, workspaceId), _patient: patientId, _workspace: workspaceId });

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -2,10 +2,13 @@ import { includes, reject } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
+import getWorkspaceRoute from 'js/utils/root-route';
+
 import App from 'js/base/app';
 
 import SettingsService from './settings';
 import WidgetsService from './widgets';
+import WorkspaceService from 'js/services/workspace';
 
 // NOTE: Roles are set only at login so they can be cached
 let activeRolesCache;
@@ -55,6 +58,9 @@ export default App.extend({
   },
   initialize({ name }) {
     this.organization = new Backbone.Model({ name });
+
+    // NOTE: handle pre-init'd workspace requests
+    Radio.reply('workspace', 'current');
   },
   beforeStart() {
     return [
@@ -75,6 +81,9 @@ export default App.extend({
     new SettingsService({ settings });
 
     new WidgetsService({ widgets });
+
+    Radio.reset('workspace');
+    new WorkspaceService({ route: getWorkspaceRoute() });
 
     this.resolvePromise(currentUser);
   },

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -1,4 +1,4 @@
-import { get, includes, reject, invoke, map, compact } from 'underscore';
+import { includes, reject } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 import store from 'store';
@@ -8,6 +8,8 @@ import getWorkspaceRoute from 'js/utils/root-route';
 import App from 'js/base/app';
 
 import SettingsService from './settings';
+import WidgetsService from './widgets';
+
 // NOTE: Roles are set only at login so they can be cached
 let activeRolesCache;
 
@@ -33,9 +35,6 @@ export default App.extend({
     'setDirectories': 'setDirectories',
     'roles': 'getActiveRoles',
     'teams': 'getTeams',
-    'sidebarWidgets': 'getSidebarWidgets',
-    'sidebarWidgets:fields': 'getSidebarWidgetFields',
-    'widgets': 'getWidgets',
     'fetch': 'fetchBootstrap',
   },
   getCurrentUser() {
@@ -96,21 +95,6 @@ export default App.extend({
   getTeams() {
     return this.teams.clone();
   },
-  getWidgets() {
-    return this.widgets.clone();
-  },
-  getSidebarWidgets() {
-    const sidebarWidgets = get(this.getSetting('widgets_patient_sidebar'), 'widgets');
-
-    const widgets = map(sidebarWidgets, slug => {
-      return this.widgets.find({ slug });
-    });
-
-    return Radio.request('entities', 'widgets:collection', invoke(compact(widgets), 'omit', 'id'));
-  },
-  getSidebarWidgetFields() {
-    return get(this.getSetting('widgets_patient_sidebar'), 'fields');
-  },
   initialize({ name }) {
     this.bootstrapPromise = new Promise((resolvePromise, rejectPromise) => {
       this.resolveBootstrap = resolvePromise;
@@ -133,12 +117,12 @@ export default App.extend({
     this.roles = roles;
     this.teams = teams;
     this.workspaces = workspaces;
-    this.widgets = widgets;
 
     this.setCurrentWorkspace();
     new SettingsService({ settings });
 
     this.resolveBootstrap(currentUser);
+    new WidgetsService({ widgets });
   },
   onFail(options, ...args) {
     this.rejectBootstrap(...args);

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -1,9 +1,6 @@
 import { includes, reject } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
-import store from 'store';
-
-import getWorkspaceRoute from 'js/utils/root-route';
 
 import App from 'js/base/app';
 
@@ -27,12 +24,8 @@ export default App.extend({
   channelName: 'bootstrap',
   radioRequests: {
     'currentUser': 'getCurrentUser',
-    'currentWorkspace': 'getCurrentWorkspace',
-    'setCurrentWorkspace': 'setCurrentWorkspace',
     'workspaces': 'getWorkspaces',
     'organization': 'getOrganization',
-    'directories': 'getDirectories',
-    'setDirectories': 'setDirectories',
     'roles': 'getActiveRoles',
     'teams': 'getTeams',
     'fetch': 'fetchBootstrap',
@@ -40,43 +33,8 @@ export default App.extend({
   getCurrentUser() {
     return this.currentUser;
   },
-  _getWorkspace(slug) {
-    const workspaces = this.currentUser.getWorkspaces();
-
-    if (!workspaces.length) throw 'No workspaces found';
-
-    return workspaces.find({ slug })
-      || workspaces.find({ id: store.get('currentWorkspace') })
-      || workspaces.at(0);
-  },
-  getCurrentWorkspace() {
-    return this.currentWorkspace;
-  },
-  setCurrentWorkspace(route) {
-    const workspaceRoute = route || getWorkspaceRoute();
-
-    if (this.currentWorkspace && !workspaceRoute) {
-      return this.currentWorkspace;
-    }
-
-    const workspace = this._getWorkspace(workspaceRoute);
-
-    if (workspace.id !== get(this.currentWorkspace, 'id')) {
-      store.set('currentWorkspace', workspace.id);
-      this.currentWorkspace = workspace;
-      this.getChannel().trigger('change:workspace', workspace);
-    }
-
-    return workspace;
-  },
   getOrganization() {
     return this.organization;
-  },
-  getDirectories() {
-    return this.directories.clone();
-  },
-  setDirectories(directories) {
-    this.directories = directories;
   },
   getWorkspaces() {
     return this.workspaces.clone();
@@ -96,10 +54,6 @@ export default App.extend({
     return this.teams.clone();
   },
   initialize({ name }) {
-    this.bootstrapPromise = new Promise((resolvePromise, rejectPromise) => {
-      this.resolveBootstrap = resolvePromise;
-      this.rejectBootstrap = rejectPromise;
-    });
     this.organization = new Backbone.Model({ name });
   },
   beforeStart() {
@@ -107,29 +61,34 @@ export default App.extend({
       Radio.request('entities', 'fetch:clinicians:current'),
       Radio.request('entities', 'fetch:roles:collection'),
       Radio.request('entities', 'fetch:teams:collection'),
-      Radio.request('entities', 'fetch:settings:collection'),
       Radio.request('entities', 'fetch:workspaces:collection'),
+      Radio.request('entities', 'fetch:settings:collection'),
       Radio.request('entities', 'fetch:widgets:collection'),
     ];
   },
-  onStart(options, currentUser, roles, teams, settings, workspaces, widgets) {
+  onStart(options, currentUser, roles, teams, workspaces, settings, widgets) {
     this.currentUser = currentUser;
     this.roles = roles;
     this.teams = teams;
     this.workspaces = workspaces;
 
-    this.setCurrentWorkspace();
     new SettingsService({ settings });
 
-    this.resolveBootstrap(currentUser);
     new WidgetsService({ widgets });
+
+    this.resolvePromise(currentUser);
   },
   onFail(options, ...args) {
-    this.rejectBootstrap(...args);
+    this.rejectPromise(...args);
   },
   fetchBootstrap() {
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      this.resolvePromise = resolvePromise;
+      this.rejectPromise = rejectPromise;
+    });
+
     this.start();
 
-    return this.bootstrapPromise;
+    return promise;
   },
 });

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -7,6 +7,7 @@ import getWorkspaceRoute from 'js/utils/root-route';
 
 import App from 'js/base/app';
 
+import SettingsService from './settings';
 // NOTE: Roles are set only at login so they can be cached
 let activeRolesCache;
 
@@ -30,7 +31,6 @@ export default App.extend({
     'organization': 'getOrganization',
     'directories': 'getDirectories',
     'setDirectories': 'setDirectories',
-    'setting': 'getSetting',
     'roles': 'getActiveRoles',
     'teams': 'getTeams',
     'sidebarWidgets': 'getSidebarWidgets',
@@ -82,18 +82,6 @@ export default App.extend({
   getWorkspaces() {
     return this.workspaces.clone();
   },
-  getSetting(settingName) {
-    /* istanbul ignore if: difficult to test settings prior to bootstrap */
-    if (!this.isRunning()) return;
-    const workspaceSettings = this.currentWorkspace.get('settings');
-    const workspaceSetting = get(workspaceSettings, settingName);
-    if (workspaceSetting) return workspaceSetting;
-
-    const setting = this.settings.get(settingName);
-    if (!setting) return;
-
-    return setting.get('value');
-  },
   // Returns roles that the current user can manage
   getActiveRoles() {
     if (activeRolesCache) return activeRolesCache;
@@ -144,11 +132,11 @@ export default App.extend({
     this.currentUser = currentUser;
     this.roles = roles;
     this.teams = teams;
-    this.settings = settings;
     this.workspaces = workspaces;
     this.widgets = widgets;
 
     this.setCurrentWorkspace();
+    new SettingsService({ settings });
 
     this.resolveBootstrap(currentUser);
   },

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -8,7 +8,7 @@ import App from 'js/base/app';
 
 import SettingsService from './settings';
 import WidgetsService from './widgets';
-import WorkspaceService from 'js/services/workspace';
+import WorkspaceService from './workspace';
 
 // NOTE: Roles are set only at login so they can be cached
 let activeRolesCache;

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -16,7 +16,7 @@ function getClinicians(teamId) {
     return team.getAssignableClinicians();
   }
 
-  const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+  const currentWorkspace = Radio.request('workspace', 'current');
   return currentWorkspace.getAssignableClinicians();
 }
 

--- a/src/js/services/settings.cy.js
+++ b/src/js/services/settings.cy.js
@@ -1,0 +1,40 @@
+import Radio from 'backbone.radio';
+
+import SettingsService from './settings';
+
+import { Model as Workspace } from 'js/entities-service/entities/workspaces';
+import { Collection as Settings } from 'js/entities-service/entities/settings';
+
+context('Settings Service', function() {
+  let service;
+
+  beforeEach(function() {
+    const currentWorkspace = new Workspace({ settings: { bar: 1 } });
+
+    Radio.reply('workspace', 'current', () => currentWorkspace);
+
+    const settings = new Settings([
+      { id: 'foo', value: 'value' },
+      { id: 'bar', value: 2 },
+    ]);
+
+    service = new SettingsService({ settings });
+  });
+
+  afterEach(function() {
+    Radio.reset('workspace');
+    service.destroy();
+  });
+
+  specify('Get Org Setting', function() {
+    const setting = Radio.request('settings', 'get', 'foo');
+
+    expect(setting).to.equal('value');
+  });
+
+  specify('Get Workspace Setting', function() {
+    const setting = Radio.request('settings', 'get', 'bar');
+
+    expect(setting).to.equal(1);
+  });
+});

--- a/src/js/services/settings.js
+++ b/src/js/services/settings.js
@@ -1,0 +1,27 @@
+import { get } from 'underscore';
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'settings',
+  radioRequests: {
+    'get': 'getSetting',
+  },
+  initialize({ settings }) {
+    this.settings = settings;
+  },
+  getSetting(settingName) {
+    const currentWorkspace = Radio.request('workspace', 'current');
+    const workspaceSettings = currentWorkspace.get('settings');
+    const workspaceSetting = get(workspaceSettings, settingName);
+
+    if (workspaceSetting) return workspaceSetting;
+
+    const setting = this.settings.get(settingName);
+
+    if (!setting) return;
+
+    return setting.get('value');
+  },
+});

--- a/src/js/services/widgets.cy.js
+++ b/src/js/services/widgets.cy.js
@@ -1,0 +1,58 @@
+import Radio from 'backbone.radio';
+
+import WidgetsService from './widgets';
+
+import { Collection as Widgets } from 'js/entities-service/entities/widgets';
+
+import fxTestWidgets from 'fixtures/test/widgets';
+
+context('Widgets Service', function() {
+  let service;
+
+  beforeEach(function() {
+    const widgetsPatientSidebar = {
+      widgets: ['dob', 'sex'],
+      fields: ['foo'],
+    };
+
+    Radio.reply('settings', 'get', () => widgetsPatientSidebar);
+
+    const widgets = new Widgets(fxTestWidgets);
+
+    service = new WidgetsService({ widgets });
+  });
+
+  afterEach(function() {
+    Radio.reset('settings');
+    service.destroy();
+  });
+
+  specify('sidebarWidgets', function() {
+    const widgets = Radio.request('widgets', 'sidebarWidgets');
+
+    expect(widgets.at(0).get('slug')).to.equal('dob');
+    expect(widgets.at(1).get('slug')).to.equal('sex');
+    expect(widgets.length).to.equal(2);
+  });
+
+  specify('sidebarWidgets:fields', function() {
+    const fields = Radio.request('widgets', 'sidebarWidgets:fields');
+
+    expect(fields[0]).to.equal('foo');
+  });
+
+  specify('build', function() {
+    const widgets = Radio.request('widgets', 'build', ['dob', 'divider', 'sex']);
+
+    expect(widgets.at(0).get('slug')).to.equal('dob');
+    expect(widgets.at(1).get('slug')).to.equal('divider');
+    expect(widgets.at(2).get('slug')).to.equal('sex');
+    expect(widgets.length).to.equal(3);
+  });
+
+  specify('find', function() {
+    const widget = Radio.request('widgets', 'find', 'dob');
+
+    expect(widget.get('slug')).to.equal('dob');
+  });
+});

--- a/src/js/services/widgets.js
+++ b/src/js/services/widgets.js
@@ -1,0 +1,37 @@
+import { get, map, invoke, compact } from 'underscore';
+import Radio from 'backbone.radio';
+
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'widgets',
+  radioRequests: {
+    'sidebarWidgets': 'getSidebarWidgets',
+    'sidebarWidgets:fields': 'getSidebarWidgetFields',
+    'build': 'buildWidgets',
+    'find': 'findWidget',
+  },
+  initialize({ widgets }) {
+    this.widgets = widgets;
+  },
+  findWidget(slug) {
+    return this.widgets.find({ slug });
+  },
+  getSidebarWidgets() {
+    const setting = Radio.request('settings', 'get', 'widgets_patient_sidebar');
+
+    return this.buildWidgets(get(setting, 'widgets'));
+  },
+  buildWidgets(widgetSlugs) {
+    const widgets = map(widgetSlugs, this.findWidget, this);
+
+    // NOTE: omit IDs so that widgets can be duplicated in a single list
+    const deIDdWidgets = invoke(compact(widgets), 'omit', 'id');
+
+    return Radio.request('entities', 'widgets:collection', deIDdWidgets);
+  },
+  getSidebarWidgetFields() {
+    const setting = Radio.request('settings', 'get', 'widgets_patient_sidebar');
+    return get(setting, 'fields');
+  },
+});

--- a/src/js/services/workspace.js
+++ b/src/js/services/workspace.js
@@ -22,10 +22,6 @@ export default App.extend({
       || workspaces.at(0);
   },
   _setCurrentWorkspace(route) {
-    if (this.currentWorkspace && !route) {
-      return this.currentWorkspace;
-    }
-
     const workspace = this._getWorkspace(route);
 
     if (workspace.id !== get(this.currentWorkspace, 'id')) {

--- a/src/js/services/workspace.js
+++ b/src/js/services/workspace.js
@@ -1,0 +1,86 @@
+import { get } from 'underscore';
+import Radio from 'backbone.radio';
+import store from 'store';
+
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'workspace',
+  radioRequests: {
+    'current': 'getCurrentWorkspace',
+    'directories': 'getDirectories',
+    'fetch': 'fetchWorkspace',
+  },
+  _getWorkspace(slug) {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const workspaces = currentUser.getWorkspaces();
+
+    if (!workspaces.length) throw 'No workspaces found';
+
+    return workspaces.find({ slug })
+      || workspaces.find({ id: store.get('currentWorkspace') })
+      || workspaces.at(0);
+  },
+  _setCurrentWorkspace(route) {
+    if (this.currentWorkspace && !route) {
+      return this.currentWorkspace;
+    }
+
+    const workspace = this._getWorkspace(route);
+
+    if (workspace.id !== get(this.currentWorkspace, 'id')) {
+      store.set('currentWorkspace', workspace.id);
+      this.currentWorkspace = workspace;
+      this.getChannel().trigger('change:workspace', workspace);
+    }
+
+    return workspace;
+  },
+  getCurrentWorkspace(route) {
+    if (route) {
+      return this._setCurrentWorkspace(route);
+    }
+
+    return this.currentWorkspace;
+  },
+  getDirectories() {
+    return this.directories.clone();
+  },
+  initialize({ route }) {
+    this._setCurrentWorkspace(route);
+  },
+  beforeStart() {
+    return [
+      Radio.request('entities', 'fetch:directories:filterable'),
+      Radio.request('entities', 'fetch:clinicians:byWorkspace', this.currentWorkspace.id),
+      Radio.request('entities', 'fetch:states:collection'),
+      Radio.request('entities', 'fetch:forms:collection'),
+    ];
+  },
+  onStart(options, directories, clinicians) {
+    this.directories = directories;
+
+    this.currentWorkspace.updateClinicians(clinicians);
+
+    this.resolvePromise(this.currentWorkspace);
+  },
+  onFail(options, ...args) {
+    this.rejectPromise(...args);
+  },
+  fetchWorkspace() {
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+      this.resolvePromise = resolvePromise;
+      this.rejectPromise = rejectPromise;
+    });
+
+    if (this.isRunning()) {
+      this.restart();
+
+      return promise;
+    }
+
+    this.start();
+
+    return promise;
+  },
+});

--- a/src/js/views/globals/app-nav/app-nav_views.js
+++ b/src/js/views/globals/app-nav/app-nav_views.js
@@ -39,7 +39,7 @@ const MainNavDroplist = Droplist.extend({
     `,
     templateContext() {
       const currentUser = Radio.request('bootstrap', 'currentUser');
-      const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+      const currentWorkspace = Radio.request('workspace', 'current');
 
       return {
         userName: currentUser.get('name'),
@@ -86,7 +86,7 @@ const MainNavDroplist = Droplist.extend({
     'picklist:item:select': 'onSelect',
   },
   onSelect({ model }) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
 
     if (model.id === currentWorkspace.id) return;
 

--- a/src/js/views/globals/app-nav/app-nav_views.js
+++ b/src/js/views/globals/app-nav/app-nav_views.js
@@ -75,7 +75,7 @@ const MainNavDroplist = Droplist.extend({
         return currentOrg.get('name');
       },
       infoText() {
-        const helpUrl = Radio.request('bootstrap', 'setting', 'help_url');
+        const helpUrl = Radio.request('settings', 'get', 'help_url');
 
         return helpUrl ?? 'https://help.roundingwell.com/';
       },

--- a/src/js/views/globals/patient-modal/patient-modal_views.js
+++ b/src/js/views/globals/patient-modal/patient-modal_views.js
@@ -237,7 +237,7 @@ function getPatientModal(opts) {
 
   if (canEdit) {
     const type = patient.isNew() ? 'add' : 'edit';
-    const { submit_text: submitText } = Radio.request('bootstrap', 'setting', 'patient_creation_form') || {};
+    const { submit_text: submitText } = Radio.request('settings', 'get', 'patient_creation_form') || {};
 
     if (submitText && patient.isNew()) {
       extend(opts, { submitText });

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -43,7 +43,7 @@ const EmptyView = View.extend({
     this.listenTo(this.state, 'change:search', this.render);
   },
   templateContext() {
-    const settings = Radio.request('bootstrap', 'setting', 'patient_search');
+    const settings = Radio.request('settings', 'get', 'patient_search');
     const canPatientCreate = this.state.get('canPatientCreate');
     return { settings, canPatientCreate };
   },

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -50,7 +50,7 @@ const FlowsStateComponent = StateComponent.extend({
     // We must hide the droplist before showing the modal
     this.popRegion.empty();
 
-    if (Radio.request('bootstrap', 'setting', 'require_done_flow')) {
+    if (Radio.request('settings', 'get', 'require_done_flow')) {
       Radio.request('modal', 'show:small', {
         bodyText: i18n.flowsStateComponent.requireDoneModal.bodyText,
         headingText: i18n.flowsStateComponent.requireDoneModal.headingText,

--- a/src/js/views/patients/shared/components/owner_component.js
+++ b/src/js/views/patients/shared/components/owner_component.js
@@ -109,7 +109,7 @@ export default Droplist.extend({
 
   initialize({ owner }) {
     this.lists = [];
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
 
     if (currentWorkspaceCache !== currentWorkspace.id) {
       teamsCollection = null;

--- a/src/js/views/patients/shared/components/state_component.js
+++ b/src/js/views/patients/shared/components/state_component.js
@@ -19,7 +19,7 @@ let statesCollection;
 
 function getStates() {
   if (statesCollection) return statesCollection;
-  const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+  const currentWorkspace = Radio.request('workspace', 'current');
   statesCollection = currentWorkspace.getStates();
   return statesCollection;
 }

--- a/src/js/views/patients/shared/flows_views.js
+++ b/src/js/views/patients/shared/flows_views.js
@@ -31,7 +31,7 @@ const FlowStateComponent = StateComponent.extend({
     // We must hide the droplist before showing the modal
     this.popRegion.empty();
 
-    if (Radio.request('bootstrap', 'setting', 'require_done_flow')) {
+    if (Radio.request('settings', 'get', 'require_done_flow')) {
       Radio.request('modal', 'show:small', {
         bodyText: i18n.requireDoneModal.bodyText,
         headingText: i18n.requireDoneModal.headingText,

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -198,8 +198,7 @@ const widgets = {
     },
     onRender() {
       each(this.nestedWidgets, slug => {
-        const allWidgets = Radio.request('bootstrap', 'widgets');
-        const widgetModel = allWidgets.find({ slug });
+        const widgetModel = Radio.request('widgets', 'find', slug);
         const widget = widgets[widgetModel.get('category')];
 
         this.showChildView(slug, buildWidget(widget, this.model, widgetModel, { tagName: 'span', childValue: this.childValue }));
@@ -223,8 +222,7 @@ const widgets = {
     },
     _getChildWidget(childWidget) {
       if (isString(childWidget)) {
-        const allWidgets = Radio.request('bootstrap', 'widgets');
-        return allWidgets.find({ slug: childWidget });
+        return Radio.request('widgets', 'find', childWidget);
       }
 
       return Radio.request('entities', 'widgets:model', childWidget);

--- a/src/js/views/programs/shared/components/form_component.js
+++ b/src/js/views/programs/shared/components/form_component.js
@@ -74,7 +74,7 @@ export default Droplist.extend({
     attr: 'name',
   },
   initialize({ form }) {
-    const currentWorkspace = Radio.request('bootstrap', 'currentWorkspace');
+    const currentWorkspace = Radio.request('workspace', 'current');
 
     if (currentWorkspaceCache !== currentWorkspace.id) {
       formsCollection = null;

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -122,17 +122,27 @@ context('Global Error Page', function() {
 
 
   specify('500 error', function() {
+    const errorStub = cy.stub();
+
+    cy.on('uncaught:exception', (err) => {
+      errorStub();
+
+      return false;
+    });
+
     cy
-      .intercept('GET', '/api/clinicians/me', {
+      .intercept('GET', '/api/states', {
         statusCode: 500,
         body: {},
       })
-      .as('routeCurrentClinician')
-      .visit({ noWait: true });
+      .as('routeStates')
+      .visit();
 
     cy
       .get('.error-page')
       .should('contain', 'Error code: 500.');
+
+    cy.routeStates();
 
     cy
       .get('.error-page')
@@ -141,6 +151,9 @@ context('Global Error Page', function() {
 
     cy
       .get('.error-page')
-      .should('not.exist');
+      .should('not.exist')
+      .then(() => {
+        expect(errorStub).to.be.calledOnce;
+      });;
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-52305]

We've never really tested the services directly.  I added tests for both the widgets and settings services, but haven't yet for workspaces / bootstrap.

This is for two reasons.. I'm about to change some of this functionality in the next portion of this work. And second these two are quite a bit harder to implement and so I'll come back around to it after the feature is complete.  We should still see line coverage from the e2e tests.