### PR TITLE
Support offline mode for 204 and 410 statuses

### DIFF
--- a/src/js/sw.js
+++ b/src/js/sw.js
@@ -75,7 +75,7 @@ if (self.location.hostname !== 'localhost') {
       cacheName: 'cache-api',
       plugins: [
         new CacheableResponsePlugin({
-          statuses: [0, 200, 404],
+          statuses: [0, 200, 204, 404, 410],
         }),
       ],
     }),


### PR DESCRIPTION
Shortcut Story ID: [sc-52894]

Honestly I'm not sure how we've gone so long without this..  if the latest response 204'd offline mode would fail and throw an error during the action load which is kind of awkwardly showing that no action alert.  410s also weren't added, but probably should be