### PR TITLE
Add prefixes graphql support for icd10 query

### DIFF
--- a/src/js/entities-service/graphql.js
+++ b/src/js/entities-service/graphql.js
@@ -3,12 +3,12 @@ import fetcher, { handleJSON } from 'js/base/fetch';
 
 const Entity = BaseEntity.extend({
   radioRequests: {
-    'fetch:icd:byTerm': 'fetchIcdByTerm',
+    'fetch:icd': 'fetchIcd',
   },
-  fetchIcdByTerm(term) {
-    const variables = { term };
-    const query = `query ($term: String!) {
-      icdCodes(term: $term) {
+  fetchIcd({ term, prefixes }) {
+    const variables = { term, prefixes };
+    const query = `query ($term: String!, $prefixes: [String!]) {
+      icdCodes(term: $term, prefixes: $prefixes) {
         code
         description
         hcc_v24

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -8,7 +8,7 @@ import 'scss/formapp/bootstrap.min.css';
 
 import 'scss/formapp-core.scss';
 
-import { extend, map, debounce, uniqueId, each, isEmpty } from 'underscore';
+import { extend, map, debounce, uniqueId, each, isEmpty, isObject } from 'underscore';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import Handlebars from 'handlebars/runtime';
@@ -58,8 +58,10 @@ function getDirectory(directoryName, query) {
   return router.getDirectory({ directoryName, query });
 }
 
-function getIcd(term) {
-  return router.getIcd({ term });
+function getIcd(by) {
+  // NOTE: Backwards compatible API
+  if (!isObject(by)) return router.getIcd({ by: { term: by } });
+  return router.getIcd({ by });
 }
 
 function getContext(contextScripts) {

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -172,8 +172,8 @@ export default App.extend({
         this.channelRequest('send', 'fetch:directory', { error: responseData, requestId });
       });
   },
-  fetchIcd({ term, requestId }) {
-    return Promise.resolve(Radio.request('entities', 'fetch:icd:byTerm', term))
+  fetchIcd({ by, requestId }) {
+    return Promise.resolve(Radio.request('entities', 'fetch:icd', by))
       .then(icd => {
         this.channelRequest('send', 'fetch:icd', { value: get(icd, ['data', 'icdCodes']), requestId });
       })

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -515,7 +515,7 @@ context('Noncontext Form', function() {
           display: 'form',
           components: [
             {
-              label: 'Test Get Icd Code',
+              label: 'Test Get Icd Code deprecated API',
               action: 'custom',
               key: 'test1',
               type: 'button',
@@ -528,13 +528,26 @@ context('Noncontext Form', function() {
               `,
             },
             {
+              label: 'Test Get Icd Code',
+              action: 'custom',
+              key: 'test1',
+              type: 'button',
+              input: true,
+              custom: `
+                getIcd({ term: 'X1' })
+                  .then(value => {
+                    data.opts = [value[0].description];
+                  });
+              `,
+            },
+            {
               label: 'Test Get Icd Code Error',
               action: 'custom',
               key: 'test1',
               type: 'button',
               input: true,
               custom: `
-                getIcd('X1')
+                getIcd({ term: 'X1' })
                   .catch(e => {
                     data.opts = ['Error'];
                   });


### PR DESCRIPTION
Shortcut Story ID: [sc-52760]

FE here is basically just passing term and/or prefixes through to the query.  It does support the current api for older forms using `getIcd('By this string')`