### PR TITLE
Add cache buster to patient endpoint

### DIFF
--- a/src/js/entities-service/entities/patients.js
+++ b/src/js/entities-service/entities/patients.js
@@ -12,7 +12,12 @@ const TYPE = 'patients';
 
 const _Model = BaseModel.extend({
   type: TYPE,
-  urlRoot: '/api/patients',
+  url() {
+    if (this.isNew()) return '/api/patients';
+
+    const currentWorkspace = Radio.request('workspace', 'current');
+    return `/api/patients/${ this.id }?filter[workspace]=${ currentWorkspace.id }`;
+  },
 
   validate({ first_name, last_name, birth_date, sex }) {
     const errors = {};

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1225,7 +1225,7 @@ context('patient dashboard page', function() {
 
   specify('410 patient not found error', function() {
     cy
-      .intercept('GET', '/api/patients/1', {
+      .intercept('GET', '/api/patients/1*', {
         statusCode: 410,
         body: {},
       })

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -1009,7 +1009,7 @@ context('patient sidebar', function() {
       .type('New Test');
 
     cy
-      .intercept('PATCH', '/api/patients/1', {
+      .intercept('PATCH', '/api/patients/1*', {
         statusCode: 200,
         body: {
           data: {


### PR DESCRIPTION
Shortcut Story ID: [sc-52969]

This uses `filter[workspace]={id}`
For our usecase because workspace is in the header it doesn’t actually matter if this API is functional on it’s own for filtering.

It does affect PUT/PATCH, but I don't think that should be an issue either.

But this will prevent cross workspace caching of this particular endpoint.  This ought to be enough even including other `/api/patient/{id}/relationships/foo` endpoints as at least in our current implementation, a base patient call is always made prior to the relationship ones.
