### PR TITLE
Clear localstorage on a 5xx error

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
@@ -27,12 +27,17 @@ export default Backbone.Model.extend({
   },
   initialize() {
     this.on('change', this.onChange);
+
+    this.listenTo(Radio.channel('event-router'), 'unknownError', this.removeStore);
   },
   getStoreKey() {
     return `reduced-schedule_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
   },
   getStore() {
     return store.get(this.getStoreKey());
+  },
+  removeStore() {
+    store.remove(this.getStoreKey());
   },
   onChange() {
     store.set(this.getStoreKey(), omit(this.attributes, 'filtersCount', 'searchQuery'));

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -44,12 +44,17 @@ const StateModel = Backbone.Model.extend({
   },
   initialize() {
     this.on('change', this.onChange);
+
+    this.listenTo(Radio.channel('event-router'), 'unknownError', this.removeStore);
   },
   getStoreKey() {
     return `schedule_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
   },
   getStore() {
     return store.get(this.getStoreKey());
+  },
+  removeStore() {
+    store.remove(this.getStoreKey());
   },
   onChange() {
     store.set(this.getStoreKey(), omit(this.attributes, 'filtersCount', 'lastSelectedIndex', 'searchQuery'));

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -58,12 +58,17 @@ const StateModel = Backbone.Model.extend({
   },
   initialize() {
     this.on('change', this.onChange);
+
+    this.listenTo(Radio.channel('event-router'), 'unknownError', this.removeStore);
   },
   getStoreKey(id) {
     return `${ id }_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
   },
   getStore(id) {
     return store.get(this.getStoreKey(id));
+  },
+  removeStore() {
+    store.remove(this.getStoreKey(this.id));
   },
   onChange() {
     store.set(this.getStoreKey(this.id), omit(this.attributes, 'lastSelectedIndex', 'searchQuery'));

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1832,4 +1832,55 @@ context('schedule page', function() {
       .find('.schedule-list__list-row .js-select')
       .should('not.exist');
   });
+
+  specify('500 error', function() {
+    cy
+      .routesForPatientAction()
+      .routeActions()
+      .visit('/schedule')
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=22222,33333');
+
+    cy
+      .intercept('GET', '/api/actions?*', {
+        statusCode: 500,
+        body: {},
+      })
+      .as('routeActions');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-states-filters-region]')
+      .find('[data-check-region]')
+      .eq(0)
+      .click();
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=33333');
+
+    cy
+      .routeActions();
+
+    cy
+      .get('.error-page')
+      .contains('Back to Your Workspace')
+      .click();
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=22222,33333');
+  });
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -4112,4 +4112,55 @@ context('worklist page', function() {
       .contains('Patient Last: A')
       .click();
   });
+
+  specify('500 error', function() {
+    cy
+      .routesForPatientAction()
+      .routeActions()
+      .visit('/worklist/owned-by')
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=22222,33333');
+
+    cy
+      .intercept('GET', '/api/actions?*', {
+        statusCode: 500,
+        body: {},
+      })
+      .as('routeActions');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-states-filters-region]')
+      .find('[data-check-region]')
+      .eq(0)
+      .click();
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=33333');
+
+    cy
+      .routeActions();
+
+    cy
+      .get('.error-page')
+      .contains('Back to Your Workspace')
+      .click();
+
+    cy
+      .wait('@routeActions')
+      .itsUrl()
+      .its('search')
+      .should('contain', 'filter[state]=22222,33333');
+  });
 });


### PR DESCRIPTION
Current 5xx errors cannot be handled explicitly by an onFail.  I think this is still correct, but we can detect when a page is routing to a 5xx error.  In these cases we can clear the localstorage for the current state which should help possibly prevent a 500 doom loop assuming the 500 isn’t occurring on the default filter set.

- [x] Erika is making a shortcut story shortly
Shortcut Story ID: [sc-53673]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error-handling mechanism to dynamically respond to "unknownError" events, improving state management and user experience.
  
- **Bug Fixes**
	- Enhanced error handling for server-side failures (HTTP 500) in various components, ensuring the application gracefully manages errors and maintains expected functionality.

- **Tests**
	- Added comprehensive test cases to validate error handling on the reduced schedule, schedule page, and worklist, ensuring robust user interaction in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->