### PR TITLE
WIP: Use default mutator for collection mocking

### DIFF
--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2124,11 +2124,11 @@ context('worklist page', function() {
 
     cy
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patientB) } }),
+          getFlow({ relationships: { patient: getRelationship(patientC) } }),
+          getFlow({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(patientA, patientB, patientC);
 
@@ -2230,11 +2230,11 @@ context('worklist page', function() {
 
     cy
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patientB) } }),
+          getFlow({ relationships: { patient: getRelationship(patientC) } }),
+          getFlow({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(fieldA, fieldB, patientA, patientB, patientC);
 
@@ -2344,11 +2344,11 @@ context('worklist page', function() {
         return fx;
       })
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patient2);
-        fx.data[1].relationships.patient = getRelationship(patient3);
-        fx.data[2].relationships.patient = getRelationship(patient1);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patient2) } }),
+          getFlow({ relationships: { patient: getRelationship(patient3) } }),
+          getFlow({ relationships: { patient: getRelationship(patient1) } }),
+        ];
 
         fx.included.push(field1, field2, patient1, patient2, patient3);
 
@@ -2693,11 +2693,11 @@ context('worklist page', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getAction({ relationships: { patient: getRelationship(patientB) } }),
+          getAction({ relationships: { patient: getRelationship(patientC) } }),
+          getAction({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(patientA, patientB, patientC);
 
@@ -2793,11 +2793,11 @@ context('worklist page', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getAction({ relationships: { patient: getRelationship(patientB) } }),
+          getAction({ relationships: { patient: getRelationship(patientC) } }),
+          getAction({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(fieldA, fieldB, patientA, patientB, patientC);
 
@@ -3211,7 +3211,7 @@ context('worklist page', function() {
   specify('click+shift multiselect', function() {
     cy
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
+        fx.data = getActions({}, { sample: 3 });
 
         return fx;
       })

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -58,7 +58,7 @@ Cypress.Commands.add('routeAction', (mutator = _.identity) => {
     .as('routeAction');
 });
 
-Cypress.Commands.add('routeActions', (mutator = _.identity) => {
+function routeActions() {
   const patients = getPatients({}, { sample: 5 });
 
   const data = getActions({
@@ -71,6 +71,13 @@ Cypress.Commands.add('routeActions', (mutator = _.identity) => {
 
   const included = [...patients];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routeActions', (mutator = routeActions) => {
+  const data = {};
+  const included = [];
+
   const body = mutator({ data, included });
 
   if (!body.meta) body.meta = { actions: { total: body.data.length } };
@@ -80,7 +87,7 @@ Cypress.Commands.add('routeActions', (mutator = _.identity) => {
     .as('routeActions');
 });
 
-Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
+function routePatientActions() {
   const patient = getPatient();
 
   const data = getActions({
@@ -91,6 +98,13 @@ Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
 
   const included = [patient];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routePatientActions', (mutator = routePatientActions) => {
+  const data = {};
+  const included = [];
+
   cy
     .intercept('GET', '/api/patients/**/relationships/actions*', {
       body: mutator({ data, included }),
@@ -98,7 +112,7 @@ Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
     .as('routePatientActions');
 });
 
-Cypress.Commands.add('routeFlowActions', (mutator = _.identity) => {
+function routeFlowActions() {
   const patient = getPatient();
   const flow = getFlow();
 
@@ -110,6 +124,13 @@ Cypress.Commands.add('routeFlowActions', (mutator = _.identity) => {
   });
 
   const included = [patient, flow];
+
+  return { data, included };
+}
+
+Cypress.Commands.add('routeFlowActions', (mutator = routeFlowActions) => {
+  const data = {};
+  const included = [];
 
   cy
     .intercept('GET', '/api/flows/**/relationships/actions', {

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -39,7 +39,7 @@ export function getFlow(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getFlows({ attributes, relationships, meta } = {}, { sample = 10, depth = 0 } = {}) {
+export function getFlows({ attributes, relationships, meta } = {}, { sample = 6, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getFlow({ attributes, relationships, meta }, { depth }));
 }
@@ -71,8 +71,8 @@ Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
     .as('routeFlow');
 });
 
-Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
-  const patients = getPatients({}, { sample: 5 });
+function routeFlows() {
+  const patients = getPatients({}, { sample: 3 });
 
   const data = getFlows({
     relationships() {
@@ -84,6 +84,13 @@ Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
 
   const included = [...patients];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routeFlows', (mutator = routeFlows) => {
+  const data = {};
+  const included = [];
+
   const body = mutator({ data, included });
 
   if (!body.meta) body.meta = { flows: { total: body.data.length } };
@@ -93,7 +100,7 @@ Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
     .as('routeFlows');
 });
 
-Cypress.Commands.add('routePatientFlows', (mutator = _.identity) => {
+function routePatientFlows() {
   const patient = getPatient();
 
   const data = getFlows({
@@ -103,6 +110,13 @@ Cypress.Commands.add('routePatientFlows', (mutator = _.identity) => {
   });
 
   const included = [patient];
+
+  return { data, included };
+}
+
+Cypress.Commands.add('routePatientFlows', (mutator = routePatientFlows) => {
+  const data = {};
+  const included = [];
 
   cy
     .intercept('GET', '/api/patients/**/relationships/flows*', {


### PR DESCRIPTION
This probably can’t be implemented until all the merge json api refactoring is complete, but one thing I’ve noticed is a steady slowing down of tests on CI.

In particular the worklist tests are taking 11 minutes on CI.

I _think_ this is because often we’ll setup a generic stub of a collection, by completely replacing it, meaning it has to do a lot of setup that is unncessary for the routes for a test.

There’s almost certainly more filtering we can do as right now we’re always including all relationationships possible on collections, when they’re reduced on prod.

But this should prove it can be improved.

I'm also interested to see what coderabbit says 😆 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of patient relationships on the worklist page for enhanced clarity and predictability.
	- Streamlined data flow by reducing sample sizes in flow generation.
  
- **Bug Fixes**
	- Resolved issues related to random sampling of patient data, replacing it with structured data retrieval methods.
  
- **Refactor**
	- Refactored Cypress commands for better readability and maintainability by transitioning to named functions.
  
- **Chores**
	- Minor adjustments to parameters for better performance and efficiency in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->