### PR TITLE
Make 401 errors only token related

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -136,7 +136,7 @@ const Application = App.extend({
   onFail(options, error) {
     addError(get(error, 'responseData', error));
 
-    if (error === 'No workspaces found' || get(error, ['response', 'status']) === 401 && get(error, ['responseData', 'errors', 0, 'code']) === '5000') {
+    if (error === 'No workspaces found' || get(error, ['response', 'status']) === 403) {
       this.getRegion('preloader').show(new PreloaderView({ notSetup: true }));
     }
   },

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -139,14 +139,6 @@ export function handleError(error) {
   if (error.name !== 'AbortError') throw error;
 }
 
-async function shouldLogout(response) {
-  if (response.status !== 401) return false;
-
-  const responseData = await response.clone().json();
-
-  return get(responseData, ['errors', 0, 'code']) !== '5000';
-}
-
 export default async(url, options) => {
   const fetcher = getActiveFetcher(url, options) || buildFetcher(url, options);
 
@@ -155,7 +147,7 @@ export default async(url, options) => {
       removeFetcher(url);
 
       if (!response.ok) {
-        if (await shouldLogout(response)) {
+        if (response.status === 401) {
           Radio.request('auth', 'logout');
         }
 

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -116,11 +116,10 @@ context('patient page', function() {
   specify('current clinician has been disabled', function() {
     cy
       .intercept('GET', '/api/clinicians/me', {
-        statusCode: 401,
+        statusCode: 403,
         body: {
           errors: getErrors({
-            status: '401',
-            code: '5000',
+            status: '403',
             title: 'Unauthorized',
             detail: 'Access token is valid, but user is disabled',
           }),

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -82,30 +82,6 @@ context('Global Error Page', function() {
       .should('contain', '/logout');
   });
 
-  specify('401 user error', function() {
-    cy
-      .intercept('GET', '/api/clinicians/me', {
-        statusCode: 401,
-        body: {
-          errors: getErrors({
-            status: '401',
-            code: '5000',
-            title: 'Unauthorized',
-            detail: 'Access token is valid, but user is disabled',
-          }),
-        },
-      })
-      .as('routeCurrentClinician')
-      .visit({ noWait: true });
-
-    cy
-      .wait('@routeCurrentClinician');
-
-    cy
-      .get('.prelogin')
-      .contains('Hold up');
-  });
-
   specify('non-json error', function() {
     cy
       .intercept('GET', '/api/clinicians/me', {
@@ -121,7 +97,7 @@ context('Global Error Page', function() {
   });
 
   specify('workspace error', function() {
-    cy.on('uncaught:exception', (err) => {
+    cy.on('uncaught:exception', () => {
       return false;
     });
 
@@ -143,7 +119,7 @@ context('Global Error Page', function() {
   specify('500 error', function() {
     const errorStub = cy.stub();
 
-    cy.on('uncaught:exception', (err) => {
+    cy.on('uncaught:exception', () => {
       errorStub();
 
       return false;
@@ -173,6 +149,6 @@ context('Global Error Page', function() {
       .should('not.exist')
       .then(() => {
         expect(errorStub).to.be.calledOnce;
-      });;
+      });
   });
 });


### PR DESCRIPTION
And handle 403 user disabled error

Shortcut Story ID: [sc-54174]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified error handling for unauthorized access, now treating 403 Forbidden errors consistently with "No workspaces found" errors.
  
- **Bug Fixes**
	- Updated application response to reflect changes in error codes, specifically changing endpoint responses from 401 to 403.
  
- **Tests**
	- Removed tests for 401 Unauthorized errors and simplified uncaught exception handling in integration tests, potentially impacting error coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->