### PR TITLE
Add missing activity attribute to action sidebar test

### DIFF
--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -85,6 +85,7 @@ context('action sidebar', function() {
           getActivity({
             event_type: 'ActionCreated',
             source: 'api',
+            date: testTs(),
           }),
           getActivity({
             event_type: 'ActionClinicianAssigned',


### PR DESCRIPTION
Was wrongfully removed here: https://github.com/RoundingWell/care-ops-frontend/pull/1296/files#diff-adff54e124816bab35affa774dfcbf0896e91bcd1b42544a25750149685c4fe6R85-R88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the `getActivity` function calls in the action sidebar to include a timestamp, improving the accuracy of event tracking in tests.
- **Tests**
	- Updated testing scenarios to reflect more detailed tracking of activities by including a date parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->