### PR TITLE
Move test fixture imports as support exports

### DIFF
--- a/src/js/services/widgets.cy.js
+++ b/src/js/services/widgets.cy.js
@@ -4,7 +4,7 @@ import WidgetsService from './widgets';
 
 import { Collection as Widgets } from 'js/entities-service/entities/widgets';
 
-import fxTestWidgets from 'fixtures/test/widgets';
+import { fxTestWidgets } from 'support/api/widgets';
 
 context('Widgets Service', function() {
   let service;

--- a/test/integration/forms/preview.js
+++ b/test/integration/forms/preview.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 
 import { testDate } from 'helpers/test-date';
 
-import fxTestFormKitchenSink from 'fixtures/test/form-kitchen-sink';
+import { fxTestFormKitchenSink } from 'support/api/form-responses';
 
 context('Preview Form', function() {
   specify('routing to form', function() {

--- a/test/support/api/form-responses.js
+++ b/test/support/api/form-responses.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxTestFormResponse from 'fixtures/test/form-response';
+import fxTestFormKitchenSink from 'fixtures/test/form-kitchen-sink';
 
 import { getCurrentClinician } from 'support/api/clinicians';
 
@@ -62,3 +63,7 @@ Cypress.Commands.add('routeLatestFormResponse', (mutator = _.identity) => {
     })
     .as('routeLatestFormResponse');
 });
+
+export {
+  fxTestFormKitchenSink,
+};

--- a/test/support/api/widgets.js
+++ b/test/support/api/widgets.js
@@ -28,3 +28,8 @@ Cypress.Commands.add('routeWidgetValues', (mutator = _.identity) => {
     })
     .as('routeWidgetValues');
 });
+
+export {
+  fxTestWidgets,
+};
+


### PR DESCRIPTION
So after the patient search merge-json-ifying these were the last two files importing fixtures outside of the `support/api` directory.. kinda makes me want to move the fixtures in there and import them relative to the support files.

Didn't make a card.. seems trivial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new test fixtures for forms and widgets, enhancing the testing capabilities of the application.
- **Improvements**
	- Restructured import statements for better modularity and clarity in test organization.
	- Expanded available resources for testing by adding new exports for `fxTestFormKitchenSink` and `fxTestWidgets`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->