### PR TITLE
Reduce default samples and set default mutators

### DIFF
--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1420,7 +1420,7 @@ context('action sidebar', function() {
       .should('contain', 'Clinician McTester (Nurse) added this action from the Test Program program')
       .children()
       .its('length')
-      .should('equal', 7);
+      .should('equal', 5);
 
     cy
       .routePatientByAction();

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2877,7 +2877,7 @@ context('worklist page', function() {
           relationships: {
             patient: getRelationship(testPatient2),
           },
-        }, { sample: 7 });
+        }, { sample: 3 });
 
         fx.data = [
           getFlow({
@@ -2933,14 +2933,14 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('not.contain', '10 Flows');
+      .should('not.contain', '6 Flows');
 
     cy
       .wait('@routeFlows');
 
     cy
       .get('[data-count-region]')
-      .should('contain', '10 Flows');
+      .should('contain', '6 Flows');
 
     cy
       .get('.list-page__header')
@@ -2979,12 +2979,12 @@ context('worklist page', function() {
 
     cy
       .get('[data-count-region]')
-      .should('contain', '10 Flows');
+      .should('contain', '6 Flows');
 
     cy
       .get('@flowList')
       .find('.work-list__item')
-      .should('have.length', 10);
+      .should('have.length', 6);
 
     cy
       .get('@listSearch')
@@ -3077,7 +3077,7 @@ context('worklist page', function() {
     cy
       .get('@flowList')
       .find('.work-list__item .fa-square-check')
-      .should('have.length', 10)
+      .should('have.length', 6)
       .first()
       .click();
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2124,11 +2124,11 @@ context('worklist page', function() {
 
     cy
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patientB) } }),
+          getFlow({ relationships: { patient: getRelationship(patientC) } }),
+          getFlow({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(patientA, patientB, patientC);
 
@@ -2230,11 +2230,11 @@ context('worklist page', function() {
 
     cy
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patientB) } }),
+          getFlow({ relationships: { patient: getRelationship(patientC) } }),
+          getFlow({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(fieldA, fieldB, patientA, patientB, patientC);
 
@@ -2344,11 +2344,11 @@ context('worklist page', function() {
         return fx;
       })
       .routeFlows(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patient2);
-        fx.data[1].relationships.patient = getRelationship(patient3);
-        fx.data[2].relationships.patient = getRelationship(patient1);
+        fx.data = [
+          getFlow({ relationships: { patient: getRelationship(patient2) } }),
+          getFlow({ relationships: { patient: getRelationship(patient3) } }),
+          getFlow({ relationships: { patient: getRelationship(patient1) } }),
+        ];
 
         fx.included.push(field1, field2, patient1, patient2, patient3);
 
@@ -2693,11 +2693,11 @@ context('worklist page', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getAction({ relationships: { patient: getRelationship(patientB) } }),
+          getAction({ relationships: { patient: getRelationship(patientC) } }),
+          getAction({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(patientA, patientB, patientC);
 
@@ -2793,11 +2793,11 @@ context('worklist page', function() {
     cy
       .routesForPatientAction()
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
-
-        fx.data[0].relationships.patient = getRelationship(patientB);
-        fx.data[1].relationships.patient = getRelationship(patientC);
-        fx.data[2].relationships.patient = getRelationship(patientA);
+        fx.data = [
+          getAction({ relationships: { patient: getRelationship(patientB) } }),
+          getAction({ relationships: { patient: getRelationship(patientC) } }),
+          getAction({ relationships: { patient: getRelationship(patientA) } }),
+        ];
 
         fx.included.push(fieldA, fieldB, patientA, patientB, patientC);
 
@@ -3211,7 +3211,7 @@ context('worklist page', function() {
   specify('click+shift multiselect', function() {
     cy
       .routeActions(fx => {
-        fx.data = _.sample(fx.data, 3);
+        fx.data = getActions({}, { sample: 3 });
 
         return fx;
       })

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -39,7 +39,7 @@ export function getAction(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getActions({ attributes, relationships, meta } = {}, { sample = 20, depth = 0 } = {}) {
+export function getActions({ attributes, relationships, meta } = {}, { sample = 3, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getAction({ attributes, relationships, meta }, { depth }));
 }
@@ -59,7 +59,7 @@ Cypress.Commands.add('routeAction', (mutator = _.identity) => {
 });
 
 function routeActions() {
-  const patients = getPatients({}, { sample: 5 });
+  const patients = getPatients({}, { sample: 3 });
 
   const data = getActions({
     relationships() {

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -58,7 +58,7 @@ Cypress.Commands.add('routeAction', (mutator = _.identity) => {
     .as('routeAction');
 });
 
-Cypress.Commands.add('routeActions', (mutator = _.identity) => {
+function routeActions() {
   const patients = getPatients({}, { sample: 5 });
 
   const data = getActions({
@@ -71,6 +71,13 @@ Cypress.Commands.add('routeActions', (mutator = _.identity) => {
 
   const included = [...patients];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routeActions', (mutator = routeActions) => {
+  const data = {};
+  const included = [];
+
   const body = mutator({ data, included });
 
   if (!body.meta) body.meta = { actions: { total: body.data.length } };
@@ -80,7 +87,7 @@ Cypress.Commands.add('routeActions', (mutator = _.identity) => {
     .as('routeActions');
 });
 
-Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
+function routePatientActions() {
   const patient = getPatient();
 
   const data = getActions({
@@ -91,6 +98,13 @@ Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
 
   const included = [patient];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routePatientActions', (mutator = routePatientActions) => {
+  const data = {};
+  const included = [];
+
   cy
     .intercept('GET', '/api/patients/**/relationships/actions*', {
       body: mutator({ data, included }),
@@ -98,7 +112,7 @@ Cypress.Commands.add('routePatientActions', (mutator = _.identity) => {
     .as('routePatientActions');
 });
 
-Cypress.Commands.add('routeFlowActions', (mutator = _.identity) => {
+function routeFlowActions() {
   const patient = getPatient();
   const flow = getFlow();
 
@@ -110,6 +124,13 @@ Cypress.Commands.add('routeFlowActions', (mutator = _.identity) => {
   });
 
   const included = [patient, flow];
+
+  return { data, included };
+}
+
+Cypress.Commands.add('routeFlowActions', (mutator = routeFlowActions) => {
+  const data = {};
+  const included = [];
 
   cy
     .intercept('GET', '/api/flows/**/relationships/actions', {

--- a/test/support/api/comments.js
+++ b/test/support/api/comments.js
@@ -20,7 +20,7 @@ export function getComment(data) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getComments({ attributes, relationships, meta } = {}, { sample = 5 } = {}) {
+export function getComments({ attributes, relationships, meta } = {}, { sample = 3 } = {}) {
   return _.times(sample, () => getComment({ attributes, relationships, meta }));
 }
 

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -39,7 +39,7 @@ export function getFlow(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getFlows({ attributes, relationships, meta } = {}, { sample = 10, depth = 0 } = {}) {
+export function getFlows({ attributes, relationships, meta } = {}, { sample = 6, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getFlow({ attributes, relationships, meta }, { depth }));
 }
@@ -71,8 +71,8 @@ Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
     .as('routeFlow');
 });
 
-Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
-  const patients = getPatients({}, { sample: 5 });
+function routeFlows() {
+  const patients = getPatients({}, { sample: 3 });
 
   const data = getFlows({
     relationships() {
@@ -84,6 +84,13 @@ Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
 
   const included = [...patients];
 
+  return { data, included };
+}
+
+Cypress.Commands.add('routeFlows', (mutator = routeFlows) => {
+  const data = {};
+  const included = [];
+
   const body = mutator({ data, included });
 
   if (!body.meta) body.meta = { flows: { total: body.data.length } };
@@ -93,7 +100,7 @@ Cypress.Commands.add('routeFlows', (mutator = _.identity) => {
     .as('routeFlows');
 });
 
-Cypress.Commands.add('routePatientFlows', (mutator = _.identity) => {
+function routePatientFlows() {
   const patient = getPatient();
 
   const data = getFlows({
@@ -103,6 +110,13 @@ Cypress.Commands.add('routePatientFlows', (mutator = _.identity) => {
   });
 
   const included = [patient];
+
+  return { data, included };
+}
+
+Cypress.Commands.add('routePatientFlows', (mutator = routePatientFlows) => {
+  const data = {};
+  const included = [];
 
   cy
     .intercept('GET', '/api/patients/**/relationships/flows*', {

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -39,14 +39,14 @@ export function getFlow(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getFlows({ attributes, relationships, meta } = {}, { sample = 6, depth = 0 } = {}) {
+export function getFlows({ attributes, relationships, meta } = {}, { sample = 3, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getFlow({ attributes, relationships, meta }, { depth }));
 }
 
 Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
   const program = getProgram();
-  const programActions = getProgramActions({}, { sample: 10 });
+  const programActions = getProgramActions({});
   const programFlow = getProgramFlow({
     relationships: {
       'program': getRelationship(program),

--- a/test/support/api/patient-fields.js
+++ b/test/support/api/patient-fields.js
@@ -14,7 +14,7 @@ export function getPatientField(data) {
   return mergeJsonApi(resource, data);
 }
 
-export function getPatientFields({ attributes, relationships, meta } = {}, { sample = 5 } = {}) {
+export function getPatientFields({ attributes, relationships, meta } = {}, { sample = 3 } = {}) {
   return _.times(sample, () => getPatientField({ attributes, relationships, meta }));
 }
 

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -15,9 +15,9 @@ export function getPatient(data, { depth = 0 } = {}) {
   if (depth++ > 2) return;
 
   const defaultRelationships = {
-    'actions': getRelationship(getActions({}, { sample: 10, depth })),
-    'flows': getRelationship(getFlows({}, { sample: 5, depth })),
-    'patient-fields': getRelationship(getPatientFields({}, { sample: 5 })),
+    'actions': getRelationship(getActions({}, { sample: 3, depth })),
+    'flows': getRelationship(getFlows({}, { sample: 2, depth })),
+    'patient-fields': getRelationship(getPatientFields({}, { sample: 3 })),
     'visits': getRelationship([]),
     'workspaces': getRelationship(getWorkspaces()),
   };
@@ -29,7 +29,7 @@ export function getPatient(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getPatients({ attributes, relationships, meta } = {}, { sample = 20, depth = 0 } = {}) {
+export function getPatients({ attributes, relationships, meta } = {}, { sample = 3, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getPatient({ attributes, relationships, meta }, { depth }));
 }

--- a/test/support/api/program-actions.js
+++ b/test/support/api/program-actions.js
@@ -27,7 +27,7 @@ export function getProgramAction(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getProgramActions({ attributes, relationships, meta } = {}, { sample = 20, depth = 0 } = {}) {
+export function getProgramActions({ attributes, relationships, meta } = {}, { sample = 3, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getProgramAction({ attributes, relationships, meta }, { depth }));
 }

--- a/test/support/api/program-flows.js
+++ b/test/support/api/program-flows.js
@@ -15,7 +15,7 @@ export function getProgramFlow(data, { depth = 0 } = {}) {
   const defaultRelationships = {
     'owner': _.random(1) ? getRelationship(getTeam()) : getRelationship(),
     'program': getRelationship(getProgram({}, { depth })),
-    'program-actions': getRelationship(getProgramActions({}, { sample: 10, depth })),
+    'program-actions': getRelationship(getProgramActions({}, { sample: 3, depth })),
   };
 
   const resource = getResource(_.sample(fxProgramFlows), TYPE, defaultRelationships);
@@ -25,7 +25,7 @@ export function getProgramFlow(data, { depth = 0 } = {}) {
   return mergeJsonApi(resource, data, { VALID: { relationships: _.keys(defaultRelationships) } });
 }
 
-export function getProgramFlows({ attributes, relationships, meta } = {}, { sample = 10, depth = 0 } = {}) {
+export function getProgramFlows({ attributes, relationships, meta } = {}, { sample = 3, depth = 0 } = {}) {
   if (depth + 1 > 2) return;
   return _.times(sample, () => getProgramFlow({ attributes, relationships, meta }, { depth }));
 }
@@ -59,7 +59,7 @@ Cypress.Commands.add('routeAllProgramFlows', (mutator = _.identity) => {
     relationships() {
       return {
         'program': getRelationship(getProgram()),
-        'program-actions': getRelationship(getProgramActions({}, { sample: 10 })),
+        'program-actions': getRelationship(getProgramActions({}, { sample: 3 })),
       };
     },
   });

--- a/test/support/api/programs.js
+++ b/test/support/api/programs.js
@@ -15,8 +15,8 @@ export function getProgram(data, { depth = 0, fixture } = {}) {
   if (depth++ > 2) return;
   const defaultRelationships = {
     'workspaces': getRelationship(getWorkspaces({}, { depth: 0 })),
-    'program-actions': getRelationship(getProgramActions({}, { sample: 20, depth })),
-    'program-flows': getRelationship(getProgramFlows({}, { sample: 5, depth })),
+    'program-actions': getRelationship(getProgramActions({}, { sample: 10, depth })),
+    'program-flows': getRelationship(getProgramFlows({}, { sample: 3, depth })),
   };
 
   const resource = getResource(fixture || _.sample(fxPrograms), TYPE, defaultRelationships);


### PR DESCRIPTION
This is for flow and action.

Setting the default mutator instead of having defaults means that we can no longer sample the mutator for collections.

Shortcut Story ID: [sc-54386]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the construction of patient relationships for better readability and maintainability.
  - Converted inline arrow functions to named functions in the Cypress testing framework for enhanced clarity.
  - Reduced sample sizes in various functions for more manageable data processing and improved performance.

- **Bug Fixes**
  - Addressed potential unpredictability in test scenarios by eliminating randomness in patient relationship definitions.
  - Updated test assertions to reflect changes in expected application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->