### PR TITLE
Websocket general implementation

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -107,8 +107,6 @@ export default SubRouterApp.extend({
     if (category !== 'ActionCreated') return;
     const { action } = payload;
 
-    if (this.actions.get(action.id)) return;
-
     const fetchAction = Radio.request('entities', 'fetch:actions:model', action.id);
     fetchAction.then(bind(this._addAction, this));
   },

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -69,6 +69,15 @@ export default Backbone.Model.extend(extend({
 
     return Backbone.Model.prototype.save.call(this, attrs, opts);
   },
+  set() {
+    const isValid = Backbone.Model.prototype.set.apply(this, arguments);
+
+    if (!isValid) return false;
+
+    this.attributes.__cached_ts = dayjs.utc().format();
+
+    return this;
+  },
   isCached() {
     return this.has('__cached_ts');
   },

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -1,5 +1,6 @@
-import { extend, isEmpty, pick, reduce } from 'underscore';
+import { extend, isEmpty, isFunction, pick, reduce, result } from 'underscore';
 import Backbone from 'backbone';
+import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Model.extend(extend({
@@ -80,5 +81,19 @@ export default Backbone.Model.extend(extend({
   },
   isCached() {
     return this.has('__cached_ts');
+  },
+  _getMessageHandler(category) {
+    const messages = result(this, 'messages', {});
+
+    return isFunction(messages[category]) ? messages[category] : this[messages[category]];
+  },
+  handleMessage({ category, timestamp, payload }) {
+    // Ignores messages that may be from recent local events
+    if (dayjs(this.get('__cached_ts')).add(10, 'seconds').isAfter(timestamp)) return;
+
+    const handler = this._getMessageHandler(category);
+    if (handler) handler.call(this, payload);
+
+    this.trigger('message', { category, payload });
   },
 }, JsonApiMixin));

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -6,7 +6,17 @@ const datadogConfig = {};
 const appConfig = {};
 const versions = {};
 
-function fetchConfig(success) {
+// Temporary solution for getting env ws url
+function fetchWebsocket(success) {
+  fetch('/api/websockets')
+    .then(response => response.json())
+    .then(({ data }) => {
+      if (data.is_enabled) appConfig.ws = data.endpoint;
+      success();
+    });
+}
+
+function fetchConfig(success, isForm) {
   fetch(`/appconfig.json?${ new URLSearchParams({ _: _NOW_ }) }`)
     .then(response => response.json())
     .then(config => {
@@ -15,7 +25,13 @@ function fetchConfig(success) {
       extend(datadogConfig, config.datadog);
       extend(appConfig, config.app);
       extend(versions, config.versions);
-      success();
+
+      if (isForm) {
+        success();
+        return;
+      }
+
+      fetchWebsocket(success);
     });
 }
 

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -20,6 +20,14 @@ const _parseRelationship = function(relationship, key) {
 };
 
 const _Model = BaseModel.extend({
+  messages: {
+    OwnerChanged({ owner, attributes = {} }) {
+      this.set({ _owner: owner, ...attributes });
+    },
+    StateChanged({ state, attributes = {} }) {
+      this.set({ _state: state.id, ...attributes });
+    },
+  },
   urlRoot() {
     if (this.isNew()) {
       const flow = this.get('_flow');

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -47,7 +47,8 @@ const _Model = BaseModel.extend({
   },
   getOwner() {
     const owner = this.get('_owner');
-    return Radio.request('entities', `${ owner.type }:model`, owner.id);
+    const Owner = Store.get(owner.type);
+    return new Owner({ id: owner.id });
   },
   isSameTeamAsUser() {
     const currentUser = Radio.request('bootstrap', 'currentUser');

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -15,6 +15,14 @@ const _parseRelationship = function(relationship, key) {
 };
 
 const _Model = BaseModel.extend({
+  messages: {
+    OwnerChanged({ owner, attributes = {} }) {
+      this.set({ _owner: owner, ...attributes });
+    },
+    StateChanged({ state, attributes = {} }) {
+      this.set({ _state: state.id, ...attributes });
+    },
+  },
   urlRoot() {
     if (this.isNew()) return `/api/patients/${ this.get('_patient') }/relationships/flows`;
 

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -26,7 +26,8 @@ const _Model = BaseModel.extend({
   },
   getOwner() {
     const owner = this.get('_owner');
-    return Radio.request('entities', `${ owner.type }:model`, owner.id);
+    const Owner = Store.get(owner.type);
+    return new Owner({ id: owner.id });
   },
   getAuthor() {
     return Radio.request('entities', 'clinicians:model', this.get('_author'));

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -90,5 +90,5 @@ document.addEventListener('DOMContentLoaded', () => {
     initDataDog({ isForm });
 
     startApps({ isForm, isOutreach });
-  });
+  }, isForm);
 });

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -151,6 +151,8 @@ context('WS Service', function() {
   });
 
   specify('Message handling', function() {
+    service.start();
+
     const channel = Radio.channel('ws');
 
     const handler = cy.stub();
@@ -158,10 +160,11 @@ context('WS Service', function() {
     service.listenTo(channel, 'message', handler);
 
     channel.request('subscribe', {});
-    cy.sendWs({ id: 'foo', category: 'Test' });
 
-    cy.then(() => {
-      expect(handler).to.be.calledWith({ id: 'foo', category: 'Test' });
-    });
+    cy
+      .sendWs({ id: 'foo', category: 'Test' })
+      .then(() => {
+        expect(handler).to.be.calledWith({ id: 'foo', category: 'Test' });
+      });
   });
 });

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -1,6 +1,7 @@
 import { each, values, isArray } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import Store from 'backbone.store';
 
 import App from 'js/base/app';
 
@@ -59,11 +60,16 @@ export default App.extend({
     this.ws.addEventListener('open', () => this.ws.send(data));
   },
 
-  // TODO: handle message
   _onMessage(event) {
     const channel = this.getChannel();
 
     const data = JSON.parse(event.data);
+
+    if (data.resource) {
+      const Resource = Store.get(data.resource.type);
+      const resource = new Resource({ id: data.resource.id });
+      resource.handleMessage(data);
+    }
 
     channel.trigger('message', data);
   },

--- a/src/js/views/patients/shared/read-only_views.js
+++ b/src/js/views/patients/shared/read-only_views.js
@@ -32,8 +32,9 @@ const ReadOnlyOwnerView = View.extend({
   },
   template: hbs`{{far "circle-user" classes="u-margin--r-8"}}<span>{{ owner }}</span>`,
   templateContext() {
+    const owner = this.model.getOwner();
     return {
-      owner: this.model.getOwner().get('name'),
+      owner: owner.get(owner.type === 'teams' ? 'abbr' : 'name'),
     };
   },
 });

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2083,13 +2083,13 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .get('.alert-box')
-      .should('contain', '2 Actions have been updated');
-
-    cy
       .get('[data-header-region]')
       .next()
       .find('.button--checkbox:disabled');
+
+    cy
+      .get('.alert-box')
+      .should('contain', '2 Actions have been updated');
   });
 
   specify('actions with work:team:manage permission', function() {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import { testTs, testTsSubtract } from 'helpers/test-timestamp';
+import { testTs, testTsSubtract, testTsAdd } from 'helpers/test-timestamp';
 import { testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getErrors, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
@@ -545,35 +545,66 @@ context('patient flow page', function() {
         return fx;
       })
       .routePatientByFlow()
-      .routeFlowActions()
+      .routeFlowActions(fx => {
+        fx.data = [
+          getAction({
+            attributes: {
+              sequence: 1,
+            },
+            relationships: {
+              flow: getRelationship(testFlow),
+            },
+          }),
+          getAction({
+            attributes: {
+              sequence: 2,
+            },
+            relationships: {
+              flow: getRelationship(testFlow),
+            },
+          }),
+          getAction({
+            attributes: {
+              sequence: 3,
+            },
+            relationships: {
+              flow: getRelationship(testFlow),
+            },
+          }),
+        ];
+
+        return fx;
+      })
       .routeActionActivity()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
       .wait('@routeFlowActions');
 
+    const conditionalAction = getAction({
+      attributes: {
+        name: 'Conditional',
+        updated_at: testTs(),
+        due_time: null,
+        sequence: 4,
+      },
+      relationships: {
+        'flow': getRelationship(testFlow),
+      },
+    });
+
     cy
       .intercept('POST', '/api/flows/**/relationships/actions', {
         statusCode: 201,
         body: {
-          data: {
-            id: testProgramAction.id,
-            attributes: {
-              updated_at: testTs(),
-              due_time: null,
-            },
-          },
+          data: conditionalAction,
         },
       })
       .as('routePostAction');
 
     cy
       .routeAction(fx => {
-        fx.data = getAction({
-          attributes: {
-            name: 'Conditional',
-          },
-        });
+        fx.data = conditionalAction;
 
         return fx;
       });
@@ -614,12 +645,66 @@ context('patient flow page', function() {
     cy
       .wait('@routeAction')
       .url()
-      .should('contain', `flow/${ testFlow.id }/action/${ testProgramAction.id }`);
+      .should('contain', `flow/${ testFlow.id }/action/${ conditionalAction.id }`);
 
     cy
       .get('[data-content-region]')
       .find('.is-selected')
       .contains('Conditional');
+
+    const otherAction = getAction({
+      attributes: {
+        name: 'Socket Action',
+      },
+      relationships: {
+        'flow': getRelationship(testFlow),
+      },
+    });
+
+    cy
+      .routeAction(fx => {
+        fx.data = otherAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ActionCreated',
+      timestamp: testTs(),
+      resource: {
+        type: 'flows',
+        id: testFlow.id,
+      },
+      payload: {
+        action: {
+          type: 'patient-actions',
+          id: conditionalAction.id,
+        },
+      },
+    });
+
+    cy.sendWs({
+      category: 'ActionCreated',
+      timestamp: testTsAdd(300),
+      resource: {
+        type: 'flows',
+        id: testFlow.id,
+      },
+      payload: {
+        action: {
+          type: 'patient-actions',
+          id: otherAction.id,
+        },
+      },
+    });
+
+    cy.wait('@routeAction');
+
+    cy
+      .get('[data-content-region]')
+      .find('.is-selected')
+      .next()
+      .contains('Socket Action');
   });
 
   specify('failed flow', function() {
@@ -2096,5 +2181,153 @@ context('patient flow page', function() {
       .find('[data-owner-region]')
       .find('button')
       .should('not.exist');
+  });
+
+  specify('socket notifications', function() {
+    const testSocketFlow = getFlow({
+      attributes: {
+        name: 'Flow Test',
+      },
+      relationships: {
+        state: getRelationship(stateInProgress),
+        owner: getRelationship(teamNurse),
+      },
+    });
+
+    const testSocketAction = getAction({
+      attributes: {
+        name: 'Action Test',
+      },
+      relationships: {
+        flow: getRelationship(testSocketFlow),
+        state: getRelationship(stateTodo),
+        owner: getRelationship(teamOther),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routeFlow(fx => {
+        fx.data = testSocketFlow;
+
+        return fx;
+      })
+      .routePatientByFlow()
+      .routeFlowActions(fx => {
+        fx.data = [
+          testSocketAction,
+        ];
+
+        return fx;
+      })
+      .routeActionActivity()
+      .visit(`/flow/${ testSocketFlow.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatientByFlow')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('.patient-flow__progress')
+      .should('have.value', 0);
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      timestamp: testTsAdd(300),
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: 'teams',
+          id: teamCoordinator.id,
+        },
+      },
+    });
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      timestamp: testTsAdd(300),
+      resource: {
+        type: 'flows',
+        id: testSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: 'teams',
+          id: teamCoordinator.id,
+        },
+      },
+    });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      timestamp: testTsSubtract(30000),
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: 'states',
+          id: stateDone.id,
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__progress')
+      .should('have.value', 0);
+
+    cy.sendWs({
+      category: 'StateChanged',
+      timestamp: testTsAdd(100),
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: 'states',
+          id: stateDone.id,
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__progress')
+      .should('have.value', 1);
+
+    cy.sendWs({
+      category: 'StateChanged',
+      timestamp: testTsAdd(300),
+      resource: {
+        type: 'flows',
+        id: testSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: 'states',
+          id: stateDone.id,
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item')
+      .should($action => {
+        expect($action.find('.fa-circle-check')).to.exist;
+        expect($action.find('[data-owner-region]')).to.contain('CO');
+      });
+
+    cy
+      .get('[data-header-region]')
+      .find('[data-owner-region]')
+      .contains('CO');
+
+    cy
+      .get('[data-header-region]')
+      .find('[data-state-region] .fa-circle-check');
   });
 });

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -910,7 +910,7 @@ context('patient flow page', function() {
     cy
       .get('[data-header-region]')
       .find('[data-owner-region]')
-      .should('contain', 'Nurse')
+      .should('contain', 'NU')
       .find('button')
       .should('not.exist');
   });
@@ -1989,7 +1989,7 @@ context('patient flow page', function() {
     cy
       .get('.picklist')
       .find('.js-picklist-item')
-      .contains('Nurse')
+      .contains('NU')
       .click();
 
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3835,7 +3835,7 @@ context('worklist page', function() {
     cy
       .get('@secondRow')
       .find('[data-owner-region]')
-      .should('contain', 'Coordinator')
+      .should('contain', 'CO')
       .find('button')
       .should('not.exist');
 
@@ -3855,7 +3855,7 @@ context('worklist page', function() {
     cy
       .get('@thirdRow')
       .find('[data-owner-region]')
-      .should('contain', 'Coordinator')
+      .should('contain', 'CO')
       .find('button')
       .should('not.exist');
   });


### PR DESCRIPTION
This is a simple example of how we can implement websocket messages across entities..  subscriptions would be managed per app context, and then can optionally be handled per-entity, but then the messages are also globally published for app-specific handling.  But the main purpose is to updated invalidated FE cache contextually.

We could at some point extend updating the cache to _any_ cached entity such that, if the user has loaded a model, it will be updated behind the scenes such that it would not need to be refetched on navigation..  we could potentially purge neglected cached models after a period of time as well... or keep a stack of possible subscriptions where as things that fall off are cleared.

But for now this seems reasonable.

This is a WIP as we negotiate message structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced flow management with improved tracking of actions and progress.
  - New message handlers for real-time updates on action creation and state changes.
  - Dynamic action handling with structured action objects for better flow routing.
  - Improved WebSocket support for interactive patient flow updates.

- **Bug Fixes**
  - Refactored methods to streamline flow progress updates and message handling.

- **Tests**
  - Expanded test cases for handling WebSocket notifications and dynamic action states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->