### PR TITLE
Remove session replay flag for form iframe

### DIFF
--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -52,7 +52,7 @@ function initRum({ isForm }) {
     trackUserInteractions: true,
     defaultPrivacyLevel: 'allow',
     enableExperimentalFeatures: ['clickmap'],
-    startSessionReplayRecordingManually: true,
+    startSessionReplayRecordingManually: !isForm,
     sessionReplaySampleRate: 100,
     beforeSend(event, context) {
       // Add header/response context to api errors


### PR DESCRIPTION
Shortcut Story ID: [sc-54896]

I'd like to squeeze this into the release as at best this is an easy fix and at worst it'll change nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced session replay recording behavior based on form context, improving the relevance of recorded sessions. 

- **Bug Fixes**
	- Adjusted session replay recording to be conditional, ensuring it only activates when not interacting with forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->