### PR TITLE
Switch report forms to filter by submitted instead of created

### DIFF
--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -42,7 +42,7 @@ const ActionFormApp = App.extend({
 
     const isReport = form.isReport();
 
-    if (isReport) opts.created = `<=${ action.get('created_at') }`;
+    if (isReport) opts.submitted = `<=${ action.get('submitted_at') }`;
 
     const prefillActionTag = form.getPrefillActionTag();
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -210,7 +210,7 @@ export default App.extend({
 
     const isReport = form.isReport();
 
-    if (isReport) opts.created = `<=${ this.action.get('created_at') }`;
+    if (isReport) opts.submitted = `<=${ this.action.get('submitted_at') }`;
 
     const prefillActionTag = form.getPrefillActionTag();
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -2459,12 +2459,12 @@ context('Patient Action Form', function() {
   });
 
   specify('report form', function() {
-    const createdAt = testTs();
+    const submittedAt = testTs();
     cy
       .routeAction(fx => {
         fx.data = getAction({
           attributes: {
-            created_at: createdAt,
+            submitted_at: submittedAt,
             tags: ['prefill-latest-response'],
           },
         });
@@ -2491,7 +2491,7 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[created]=<=${ createdAt }`);
+      .should('contain', `filter[submitted]=<=${ submittedAt }`);
   });
 
   specify('refresh stale form', function() {

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -156,7 +156,7 @@ context('Formservice', function() {
   });
 
   specify('action formservice latest response from action tags', function() {
-    const createdAt = testTs();
+    const submittedAt = testTs();
 
     cy
       .routeFormByAction(_.identity, 'BBBBB')
@@ -167,7 +167,7 @@ context('Formservice', function() {
         fx.data = getAction({
           id: '1',
           attributes: {
-            created_at: createdAt,
+            submitted_at: submittedAt,
             tags: ['prefill-latest-response'],
           },
           relationships: {
@@ -189,7 +189,7 @@ context('Formservice', function() {
       .should('contain', 'filter[action.tags]=foo-tag')
       .should('contain', 'filter[flow]=1')
       .should('contain', 'filter[patient]=1')
-      .should('contain', `filter[created]=<=${ createdAt }`);
+      .should('contain', `filter[submitted]=<=${ submittedAt }`);
   });
 
   specify('action formservice iframe makes correct api requests', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-54904]

@zfixler  I'm not entirely sure how to test this, but this is a pretty small change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the handling of report forms to use the `submitted_at` timestamp instead of the `created_at` timestamp.
- **Tests**
  - Modified the integration tests for report forms to reflect the changes in the application's handling of the `submitted_at` timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->