### PR TITLE
Change list meta section width from `475px` -> `478px`

### DIFF
--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -82,7 +82,7 @@
 
 .patient-flow__meta {
   padding-left: 16px;
-  width: 475px;
+  width: 478px;
 }
 
 .patient-flow__actions {

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -140,7 +140,7 @@
 }
 
 .patient__list-meta {
-  width: 475px;
+  width: 478px;
 }
 
 .patient__action-attachment {


### PR DESCRIPTION
Shortcut Story ID: [sc-54586]

On patient dashboard and flow pages.

Fixes this bug seen in production:

<img width="739" alt="image (14)" src="https://github.com/user-attachments/assets/b7297639-6efd-42ba-9272-3078c16cf374">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the width of the patient flow interface elements for improved layout.
	- Updated the width of the patient list metadata display for better alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->