### PR TITLE
Make jsonapi local relationship always a resource

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -143,7 +143,7 @@ const Application = App.extend({
   },
 
   onStart(options, currentUser, { default: AppFrameApp }) {
-    if (!currentUser.hasTeam() || !currentUser.get('enabled')) {
+    if (!currentUser.hasTeam() || !currentUser.isEnabled()) {
       this.getRegion('preloader').show(new PreloaderView({ notSetup: true }));
       return;
     }

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -131,8 +131,9 @@ export default App.extend({
   onFormServiceSuccess(response) {
     if (this.shouldSaveAndGoBack()) {
       Radio.request('history', 'go:back', () => {
-        if (this.action.get('_flow')) {
-          Radio.trigger('event-router', 'flow', this.action.get('_flow'));
+        const flow = this.action.getFlow();
+        if (flow) {
+          Radio.trigger('event-router', 'flow', flow.id);
           return;
         }
 

--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -394,7 +394,7 @@ export default RouterApp.extend({
 
     if (workspaces.length === 1) {
       return Radio.request('entities', 'patients:model', {
-        _workspaces: [{ id: workspaces.first().id }],
+        _workspaces: [workspaces.first().getResource()],
       });
     }
 

--- a/src/js/apps/globals/search_app.js
+++ b/src/js/apps/globals/search_app.js
@@ -14,7 +14,7 @@ export default App.extend({
 
     this.listenTo(patientSearchModal, {
       'search:select'(result) {
-        Radio.trigger('event-router', 'patient:dashboard', result.get('_patient'));
+        Radio.trigger('event-router', 'patient:dashboard', result.get('_patient').id);
         patientSearchModal.destroy();
       },
       'click:addPatient'() {

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -55,7 +55,7 @@ export default App.extend({
   },
 
   onAddProgramAction(programAction) {
-    const action = programAction.getAction({ patientId: this.patient.id });
+    const action = programAction.createAction({ patient: this.patient });
     action.saveAll().then(() => {
       this.collection.unshift(action);
 
@@ -64,7 +64,7 @@ export default App.extend({
   },
 
   onAddProgramFlow(programFlow) {
-    const flow = programFlow.getFlow(this.patient.id);
+    const flow = programFlow.createFlow(this.patient);
 
     flow.saveAll().then(() => {
       Radio.trigger('event-router', 'flow', flow.id);

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -258,7 +258,7 @@ export default SubRouterApp.extend({
   },
 
   onAddProgramAction(programAction) {
-    const action = programAction.getAction({ flowId: this.flow.id });
+    const action = programAction.createAction({ flow: this.flow });
     action.saveAll().then(() => {
       this._addAction(action);
 

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -187,8 +187,8 @@ export default App.extend(extend({
 
     const newCommentFormView = this.showFooterView('comment', new CommentFormView({
       model: Radio.request('entities', 'comments:model', {
-        _action: this.action.id,
-        _clinician: clinician.id,
+        _action: this.action.getResource(),
+        _clinician: clinician.getResource(),
       }),
     }));
 
@@ -232,8 +232,8 @@ export default App.extend(extend({
   },
   onAddAttachment(file) {
     const attachment = this.attachments.add({
-      _action: this.action.id,
-      _patient: this.action.getPatient().id,
+      _action: this.action.getResource(),
+      _patient: this.action.getPatient().getResource(),
       created_at: dayjs.utc().format(),
     });
     attachment.upload(file);

--- a/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
@@ -15,14 +15,14 @@ const StateModel = Backbone.Model.extend({
     this.initBulkDuration(collection, initModel);
   },
   initBulkState(collection, initModel) {
-    const stateId = initModel.getState().id;
+    const state = initModel.getState().getResource();
     const stateMulti = collection.some(item => {
-      return item.getState().id !== stateId;
+      return item.getState().id !== state.id;
     });
 
     this.set({
       stateMulti,
-      stateId: stateMulti ? null : stateId,
+      state: stateMulti ? null : state,
     });
   },
   initBulkOwner(collection, initModel) {
@@ -74,7 +74,7 @@ const StateModel = Backbone.Model.extend({
     });
   },
   setState(state) {
-    return this.set({ stateId: state.id, stateMulti: false, stateChanged: true });
+    return this.set({ state: state.getResource(), stateMulti: false, stateChanged: true });
   },
   setOwner(owner) {
     return this.set({ owner, ownerMulti: false, ownerChanged: true });
@@ -99,7 +99,7 @@ const StateModel = Backbone.Model.extend({
   getData() {
     const {
       stateChanged,
-      stateId,
+      state,
       ownerChanged,
       owner,
       dateChanged,
@@ -112,7 +112,7 @@ const StateModel = Backbone.Model.extend({
 
     const saveData = {};
 
-    if (stateChanged) saveData._state = stateId;
+    if (stateChanged) saveData._state = pick(state, 'id', 'type');
     if (ownerChanged) saveData._owner = pick(owner, 'id', 'type');
     if (dateChanged) saveData.due_date = date;
     if (timeChanged) saveData.due_time = time;

--- a/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
@@ -12,14 +12,14 @@ const StateModel = Backbone.Model.extend({
     this.initBulkOwner(collection, initModel);
   },
   initBulkState(collection, initModel) {
-    const stateId = initModel.getState().id;
+    const state = initModel.getState().getResource();
     const stateMulti = collection.some(item => {
-      return item.getState().id !== stateId;
+      return item.getState().id !== state.id;
     });
 
     this.set({
       stateMulti,
-      stateId: stateMulti ? null : stateId,
+      state: stateMulti ? null : state,
     });
   },
   initBulkOwner(collection, initModel) {
@@ -38,7 +38,7 @@ const StateModel = Backbone.Model.extend({
     });
   },
   setState(state) {
-    return this.set({ stateId: state.id, stateMulti: false, stateChanged: true });
+    return this.set({ state: state.getResource(), stateMulti: false, stateChanged: true });
   },
   setOwner(owner) {
     return this.set({ owner, ownerMulti: false, ownerChanged: true });
@@ -51,14 +51,14 @@ const StateModel = Backbone.Model.extend({
   getData() {
     const {
       stateChanged,
-      stateId,
+      state,
       ownerChanged,
       owner,
     } = this.attributes;
 
     const saveData = {};
 
-    if (stateChanged) saveData._state = stateId;
+    if (stateChanged) saveData._state = pick(state, 'id', 'type');
     if (ownerChanged) saveData._owner = pick(owner, 'id', 'type');
 
     return saveData;

--- a/src/js/apps/patients/sidebar/flow-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/flow-sidebar_app.js
@@ -58,7 +58,7 @@ export default App.extend(extend({
       onSubmit: () => {
         this.flow.destroy({ wait: true })
           .then(() => {
-            Radio.trigger('event-router', 'patient:dashboard', this.flow.get('_patient'));
+            Radio.trigger('event-router', 'patient:dashboard', this.flow.getPatient().id);
           })
           .catch(({ responseData }) => {
             Radio.request('alert', 'show:apiError', responseData);

--- a/src/js/apps/programs/program/action/action_app.js
+++ b/src/js/apps/programs/program/action/action_app.js
@@ -15,8 +15,8 @@ export default App.extend({
   beforeStart({ actionId, programId, flowId }) {
     if (!actionId) {
       return Radio.request('entities', 'programActions:model', {
-        _program: programId,
-        _program_flow: flowId,
+        _program: { id: programId, type: 'programs' },
+        _program_flow: flowId ? { id: flowId, type: 'program-flows' } : null,
         _owner: null,
         days_until_due: null,
         behavior: PROGRAM_BEHAVIORS.STANDARD,

--- a/src/js/apps/programs/program/flow/flow_app.js
+++ b/src/js/apps/programs/program/flow/flow_app.js
@@ -57,10 +57,7 @@ export default SubRouterApp.extend({
 
   maintainFlowActions() {
     this.listenTo(this.actions, 'change:id destroy', () => {
-      const programActions = this.actions.map(({ id }) => {
-        return { id };
-      });
-      this.flow.set('_program_actions', programActions);
+      this.flow.setActions(this.actions);
     });
   },
 

--- a/src/js/apps/programs/program/program_app.js
+++ b/src/js/apps/programs/program/program_app.js
@@ -88,7 +88,7 @@ export default SubRouterApp.extend({
 
   startFlowSidebar(programId) {
     const flow = Radio.request('entities', 'programFlows:model', {
-      _program: programId,
+      _program: { id: programId, type: 'programs' },
       _owner: null,
       published_at: null,
       archived_at: null,

--- a/src/js/apps/programs/sidebar/action-sidebar_app.js
+++ b/src/js/apps/programs/sidebar/action-sidebar_app.js
@@ -8,12 +8,12 @@ import { ACTION_OUTREACH } from 'js/static';
 import { SidebarMixin } from 'js/services/sidebar';
 
 import {
-  SidebarView, 
-  MenuView, 
-  HeadingView, 
-  TimestampsView, 
-  FormSharingButtonView, 
-  FormSharingView, 
+  SidebarView,
+  MenuView,
+  HeadingView,
+  TimestampsView,
+  FormSharingButtonView,
+  FormSharingView,
   UploadsEnabledView,
 } from 'js/views/programs/sidebar/action/action-sidebar_views';
 
@@ -121,14 +121,14 @@ export default App.extend(extend({
     if (model.isNew()) {
       this.action.saveAll(model.attributes)
         .then(() => {
-          const flowId = this.action.get('_program_flow');
+          const programFlow = this.action.getProgramFlow();
 
-          if (flowId) {
-            Radio.trigger('event-router', 'programFlow:action', flowId, this.action.id);
+          if (programFlow) {
+            Radio.trigger('event-router', 'programFlow:action', programFlow.id, this.action.id);
             return;
           }
 
-          Radio.trigger('event-router', 'program:action', this.action.get('_program'), this.action.id);
+          Radio.trigger('event-router', 'program:action', this.action.getProgram().id, this.action.id);
         });
       return;
     }

--- a/src/js/apps/programs/sidebar/flow-sidebar_app.js
+++ b/src/js/apps/programs/sidebar/flow-sidebar_app.js
@@ -64,7 +64,7 @@ export default App.extend({
       onSubmit: () => {
         this.flow.destroy({ wait: true })
           .then(() => {
-            Radio.trigger('event-router', 'program:details', this.flow.get('_program'));
+            Radio.trigger('event-router', 'program:details', this.flow.getProgram().id);
           })
           .catch(({ responseData }) => {
             Radio.request('alert', 'show:apiError', responseData);

--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -4,6 +4,9 @@ import Backbone from 'backbone';
 import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Collection.extend(extend({
+  getResources() {
+    return this.invoke('getResource');
+  },
   fetch(options = {}) {
     const fetcher = Backbone.Collection.prototype.fetch.call(this, options);
 

--- a/src/js/base/entity-service.js
+++ b/src/js/base/entity-service.js
@@ -1,8 +1,17 @@
 import { isObject } from 'underscore';
 import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+import Store from 'backbone.store';
 import { MnObject } from 'marionette';
 import { cacheIncluded } from './jsonapi-mixin';
 import fetcher from 'js/base/fetch';
+
+export function getStore(resource) {
+  const Model = Store.get(resource.type);
+  return new Model({ id: resource.id });
+}
+
+Radio.reply('entities', 'get:store', getStore);
 
 export default MnObject.extend({
   channelName: 'entities',

--- a/src/js/base/jsonapi-mixin.js
+++ b/src/js/base/jsonapi-mixin.js
@@ -22,14 +22,10 @@ export default {
   },
   // Override to handle specific relationships
   parseRelationship(relationship) {
-    if (!relationship) return relationship;
-
-    if (!isArray(relationship)) {
-      return relationship.id;
-    }
+    if (!relationship || !isArray(relationship)) return relationship;
 
     return map(relationship, item => {
-      const itemRelationship = { id: item.id };
+      const itemRelationship = { id: item.id, type: item.type };
 
       if (item.meta) {
         each(item.meta, (value, key) => {

--- a/src/js/base/jsonapi-mixin.js
+++ b/src/js/base/jsonapi-mixin.js
@@ -1,13 +1,12 @@
 import { each, isArray, isNull, isObject, isUndefined, map, pick } from 'underscore';
 import dayjs from 'dayjs';
-import Store from 'backbone.store';
-
 import underscored from 'js/utils/formatting/underscored';
+
+import { getStore } from './entity-service';
 
 export function cacheIncluded(included) {
   each(included, data => {
-    const Model = Store.get(data.type);
-    const model = new Model({ id: data.id });
+    const model = getStore(data);
     model.set(model.parseModel(data));
   });
 }

--- a/src/js/base/jsonapi-mixin.js
+++ b/src/js/base/jsonapi-mixin.js
@@ -1,4 +1,4 @@
-import { each, isArray, isNull, isObject, isUndefined, map, pick } from 'underscore';
+import { each, isArray, isNull, isUndefined, map, pick } from 'underscore';
 import dayjs from 'dayjs';
 import underscored from 'js/utils/formatting/underscored';
 
@@ -54,7 +54,7 @@ export default {
 
     return this.parseRelationships(modelData, data.relationships);
   },
-  toRelation(entity, entityType) {
+  toRelation(entity) {
     if (isUndefined(entity)) return;
 
     if (isNull(entity)) return { data: null };
@@ -69,22 +69,12 @@ export default {
 
     if (isArray(entity)) {
       return {
-        data: map(entity, item => {
-          const id = item.id ? item.id : item;
-          return { id, type: entityType };
+        data: map(entity, ({ id, type }) => {
+          return { id, type };
         }),
       };
     }
 
-    if (isObject(entity)) {
-      return { data: pick(entity, 'id', 'type') };
-    }
-
-    return {
-      data: {
-        id: entity,
-        type: entityType,
-      },
-    };
+    return { data: pick(entity, 'id', 'type') };
   },
 };

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -11,6 +11,12 @@ export default Backbone.Model.extend(extend({
     if (!relationship) return;
     return getStore(relationship);
   },
+  getResource() {
+    return {
+      id: this.id,
+      type: this.type,
+    };
+  },
   destroy(options) {
     // isDeleted means the model is already deleted from the db
     if (options && options.isDeleted) {

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -3,7 +3,13 @@ import Backbone from 'backbone';
 import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
 
+import { getStore } from './entity-service';
+
 export default Backbone.Model.extend(extend({
+  getRelationship(key) {
+    const relationship = this.get(key);
+    return getStore(relationship);
+  },
   destroy(options) {
     // isDeleted means the model is already deleted from the db
     if (options && options.isDeleted) {

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -8,6 +8,7 @@ import { getStore } from './entity-service';
 export default Backbone.Model.extend(extend({
   getRelationship(key) {
     const relationship = this.get(key);
+    if (!relationship) return;
     return getStore(relationship);
   },
   destroy(options) {

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -89,9 +89,7 @@ const _Model = BaseModel.extend({
     return Radio.request('entities', 'patients:model', this.get('_patient'));
   },
   getOwner() {
-    const owner = this.get('_owner');
-    const Owner = Store.get(owner.type);
-    return new Owner({ id: owner.id });
+    return this.getRelationship('_owner');
   },
   isSameTeamAsUser() {
     const currentUser = Radio.request('bootstrap', 'currentUser');

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import { contains, extend, keys, reduce, size, union } from 'underscore';
+import { contains, extend, keys, reduce, size } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import dayjs from 'dayjs';
@@ -16,7 +16,7 @@ const _Model = BaseModel.extend({
       this.set({ _owner: owner, ...attributes });
     },
     StateChanged({ state, attributes }) {
-      this.set({ _state: state.id, ...attributes });
+      this.set({ _state: state, ...attributes });
     },
     ActionDueChanged({ attributes }) {
       this.set(attributes);
@@ -39,7 +39,7 @@ const _Model = BaseModel.extend({
         message: attributes.message,
         created_at: dayjs.utc().format(),
         edited_at: null,
-        _clinician: author,
+        _clinician: { id: author, type: 'clinicians' },
       });
 
       this.trigger('ws:add:comment', commentModel);
@@ -49,8 +49,8 @@ const _Model = BaseModel.extend({
         id: file.id,
         path: attributes.path,
         created_at: dayjs.utc().format(),
-        _action: this.id,
-        _patient: this.getPatient().id,
+        _action: this.getResource(),
+        _patient: this.getPatient().getResource(),
         _view: attributes.urls.view,
         _download: attributes.urls.download,
       });
@@ -65,31 +65,48 @@ const _Model = BaseModel.extend({
   },
   urlRoot() {
     if (this.isNew()) {
-      const flow = this.get('_flow');
+      const flow = this.getFlow();
+      const patient = this.getPatient();
       return flow ?
-        `/api/flows/${ flow }/relationships/actions` :
-        `/api/patients/${ this.get('_patient') }/relationships/actions`;
+        `/api/flows/${ flow.id }/relationships/actions` :
+        `/api/patients/${ patient.id }/relationships/actions`;
     }
 
     return '/api/actions';
   },
   type: TYPE,
-  hasTag(tagName) {
-    return contains(this.get('tags'), tagName);
-  },
   getForm() {
-    const formId = this.get('_form');
-    if (!formId) return;
-    return Radio.request('entities', 'forms:model', formId);
+    return this.getRelationship('_form');
   },
   getFormResponses() {
     return Radio.request('entities', 'formResponses:collection', this.get('_form_responses'));
   },
+  getFiles() {
+    return Radio.request('entities', 'files:collection', this.get('_files'));
+  },
   getPatient() {
-    return Radio.request('entities', 'patients:model', this.get('_patient'));
+    return this.getRelationship('_patient');
   },
   getOwner() {
     return this.getRelationship('_owner');
+  },
+  getAuthor() {
+    return this.getRelationship('_author');
+  },
+  getFlow() {
+    return this.getRelationship('_flow');
+  },
+  getState() {
+    return this.getRelationship('_state');
+  },
+  getProgram() {
+    return this.getRelationship('_program');
+  },
+  getProgramAction() {
+    return this.getRelationship('_program_action');
+  },
+  getPreviousState() {
+    return Radio.request('entities', 'states:model', this.previous('_state'));
   },
   isSameTeamAsUser() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
@@ -99,23 +116,6 @@ const _Model = BaseModel.extend({
     const ownersTeam = owner.type === 'teams' ? owner : owner.getTeam();
 
     return currentUsersTeam === ownersTeam;
-  },
-  getAuthor() {
-    return Radio.request('entities', 'clinicians:model', this.get('_author'));
-  },
-  getFlow() {
-    if (!this.get('_flow')) return;
-
-    return Radio.request('entities', 'flows:model', this.get('_flow'));
-  },
-  getState() {
-    return Radio.request('entities', 'states:model', this.get('_state'));
-  },
-  getProgram() {
-    return Radio.request('entities', 'programs:model', this.get('_program'));
-  },
-  getPreviousState() {
-    return Radio.request('entities', 'states:model', this.previous('_state'));
   },
   isLocked() {
     return !!this.get('locked_at');
@@ -140,11 +140,24 @@ const _Model = BaseModel.extend({
 
     return dueDateTime.isBefore(dayjs(), 'day') || dueDateTime.isBefore(dayjs(), 'minute');
   },
+  hasTag(tagName) {
+    return contains(this.get('tags'), tagName);
+  },
   hasOutreach() {
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;
   },
   hasSharing() {
     return this.get('sharing') !== ACTION_SHARING.DISABLED;
+  },
+  hasAttachments() {
+    return !!this.getFiles().length;
+  },
+  hasAllowedUploads() {
+    if (!this.canEdit()) return false;
+
+    const programAction = this.getProgramAction();
+
+    return !!size(programAction.get('allowed_uploads'));
   },
   canEdit() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
@@ -195,7 +208,7 @@ const _Model = BaseModel.extend({
     return this.save({ due_time: time });
   },
   saveState(state) {
-    const saveOpts = { _state: state.id };
+    const saveOpts = { _state: state.getResource() };
     const sharing = this.get('sharing');
 
     if (state.isDone() && ![ACTION_SHARING.DISABLED, ACTION_SHARING.RESPONDED].includes(sharing)) {
@@ -209,7 +222,7 @@ const _Model = BaseModel.extend({
     });
   },
   saveOwner(owner) {
-    return this.save({ _owner: owner }, {
+    return this.save({ _owner: owner.getResource() }, {
       relationships: {
         owner: this.toRelation(owner),
       },
@@ -219,37 +232,27 @@ const _Model = BaseModel.extend({
     if (this.isNew()) attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
-      'flow': this.toRelation(attrs._flow, 'flows'),
-      'form': this.toRelation(attrs._form, 'forms'),
+      'flow': this.toRelation(attrs._flow),
+      'form': this.toRelation(attrs._form),
       'owner': this.toRelation(attrs._owner),
-      'state': this.toRelation(attrs._state, 'states'),
-      'program-action': this.toRelation(attrs._program_action, 'program-actions'),
+      'state': this.toRelation(attrs._state),
+      'program-action': this.toRelation(attrs._program_action),
     };
 
     return this.save(attrs, { relationships }, { wait: true });
   },
-  hasAttachments() {
-    return !!size(this.get('_files'));
+
+  addFile(file) {
+    const files = this.getFiles();
+    files.add(file);
+
+    this.set({ _files: files.getResources() });
   },
-  hasAllowedUploads() {
-    if (!this.canEdit()) return false;
+  removeFile(file) {
+    const files = this.getFiles();
+    files.remove(file);
 
-    const programAction = Radio.request('entities', 'programActions:model', this.get('_program_action'));
-
-    return !!size(programAction.get('allowed_uploads'));
-  },
-  addFile(resource) {
-    const newFilesRelationship = union(this.get('_files'), [{ id: resource.id, type: 'files' }]);
-
-    this.set({ _files: newFilesRelationship });
-  },
-  removeFile(resource) {
-    const files = this.get('_files');
-    const newFilesRelationship = files.filter(file => {
-      return file.id !== resource.id;
-    });
-
-    this.set({ _files: newFilesRelationship });
+    this.set({ _files: files.getResources() });
   },
 });
 

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -6,18 +6,9 @@ import dayjs from 'dayjs';
 
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import JsonApiMixin from 'js/base/jsonapi-mixin';
-
 import { ACTION_OUTREACH, ACTION_SHARING } from 'js/static';
 
 const TYPE = 'patient-actions';
-const { parseRelationship } = JsonApiMixin;
-
-const _parseRelationship = function(relationship, key) {
-  if (!relationship || key === 'owner') return relationship;
-
-  return parseRelationship(relationship, key);
-};
 
 const _Model = BaseModel.extend({
   messages: {
@@ -262,14 +253,12 @@ const _Model = BaseModel.extend({
 
     this.set({ _files: newFilesRelationship });
   },
-  parseRelationship: _parseRelationship,
 });
 
 const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/actions',
   model: Model,
-  parseRelationship: _parseRelationship,
   save(attrs) {
     const saves = this.invoke('saveAll', attrs);
 

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -1,4 +1,4 @@
-import { first, last, reject, size, union, extend, includes } from 'underscore';
+import { first, last, extend, includes } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -30,10 +30,10 @@ const _Model = BaseModel.extend({
   },
   onChangeTeam() {
     const previousTeam = Radio.request('entities', 'teams:model', this.previous('_team'));
-    previousTeam.set('_clinicians', reject(previousTeam.get('_clinicians'), { id: this.id }));
+    const team = this.getTeam();
 
-    const team = Radio.request('entities', 'teams:model', this.get('_team'));
-    team.set('_clinicians', union(team.get('_clinicians'), [{ id: this.id }]));
+    previousTeam && previousTeam.removeClinician(this);
+    team && team.addClinician(this);
   },
   getWorkspaces() {
     return Radio.request('entities', 'workspaces:collection', this.get('_workspaces'));
@@ -41,23 +41,29 @@ const _Model = BaseModel.extend({
   addWorkspace(workspace) {
     const workspaces = this.getWorkspaces();
     workspaces.add(workspace);
-    this.set('_workspaces', this.toRelation(workspaces, 'workspaces').data);
+    this.set('_workspaces', workspaces.getResources());
   },
   removeWorkspace(workspace) {
     const workspaces = this.getWorkspaces();
     workspaces.remove(workspace);
-    this.set('_workspaces', this.toRelation(workspaces, 'workspaces').data);
+    this.set('_workspaces', workspaces.getResources());
+  },
+  setTeam(team) {
+    this.set('_team', team.getResource());
   },
   getTeam() {
-    return Radio.request('entities', 'teams:model', this.get('_team'));
+    return this.getRelationship('_team');
   },
   hasTeam() {
-    const team = this.get('_team');
+    const team = this.getTeam();
 
-    return team && team !== NIL_UUID;
+    return team && team.id !== NIL_UUID;
+  },
+  setRole(role) {
+    this.set('_role', role.getResource());
   },
   getRole() {
-    return Radio.request('entities', 'roles:model', this.get('_role'));
+    return this.getRelationship('_role');
   },
   can(prop) {
     const role = this.getRole();
@@ -65,14 +71,14 @@ const _Model = BaseModel.extend({
     return includes(permissions, prop);
   },
   saveRole(role) {
-    return this.save({ _role: role.id }, {
+    return this.save({ _role: role.getResource() }, {
       relationships: {
         role: this.toRelation(role),
       },
     });
   },
   saveTeam(team) {
-    return this.save({ _team: team.id }, {
+    return this.save({ _team: team.getResource() }, {
       relationships: {
         team: this.toRelation(team),
       },
@@ -82,9 +88,9 @@ const _Model = BaseModel.extend({
     attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
-      'workspaces': this.toRelation(attrs._workspaces, 'workspaces'),
-      'team': this.toRelation(attrs._team, 'teams'),
-      'role': this.toRelation(attrs._role, 'roles'),
+      'workspaces': this.toRelation(attrs._workspaces),
+      'team': this.toRelation(attrs._team),
+      'role': this.toRelation(attrs._role),
     };
 
     return this.save(attrs, { relationships }, { wait: true });
@@ -101,10 +107,13 @@ const _Model = BaseModel.extend({
   },
   isActive() {
     const hasTeam = this.hasTeam();
-    const hasWorkspaces = !!size(this.get('_workspaces'));
+    const hasWorkspaces = !!this.getWorkspaces().length;
     const lastActive = this.get('last_active_at');
 
     return hasTeam && hasWorkspaces && lastActive;
+  },
+  isEnabled() {
+    return this.get('enabled');
   },
 });
 
@@ -117,7 +126,7 @@ const Collection = BaseCollection.extend({
     const clone = this.clone();
 
     const assignable = this.filter(clinician => {
-      return clinician.isActive() && clinician.get('enabled') && clinician.can('work:own');
+      return clinician.isActive() && clinician.isEnabled() && clinician.can('work:own');
     });
 
     clone.reset(assignable);

--- a/src/js/entities-service/entities/comments.js
+++ b/src/js/entities-service/entities/comments.js
@@ -1,4 +1,3 @@
-import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -19,7 +18,7 @@ const _Model = BaseModel.extend({
     },
   },
   urlRoot() {
-    if (this.isNew()) return `/api/actions/${ this.get('_action') }/relationships/comments`;
+    if (this.isNew()) return `/api/actions/${ this.getAction().id }/relationships/comments`;
 
     return '/api/comments';
   },
@@ -27,7 +26,10 @@ const _Model = BaseModel.extend({
     if (!trim(message)) return 'Comment message required.';
   },
   getClinician() {
-    return Radio.request('entities', 'clinicians:model', this.get('_clinician'));
+    return this.getRelationship('_clinician');
+  },
+  getAction() {
+    return this.getRelationship('_action');
   },
 });
 

--- a/src/js/entities-service/entities/events.js
+++ b/src/js/entities-service/entities/events.js
@@ -9,32 +9,29 @@ const _Model = BaseModel.extend({
   type: TYPE,
 
   getClinician() {
-    return Radio.request('entities', 'clinicians:model', this.get('_clinician'));
+    return this.getRelationship('_clinician');
   },
   getRecipient() {
-    if (!this.get('_recipient')) return;
-    return Radio.request('entities', 'patients:model', this.get('_recipient'));
+    return this.getRelationship('_recipient');
   },
   getEditor() {
     if (!this.get('_editor')) {
       return Radio.request('entities', 'clinicians:model', { name: 'RoundingWell' });
     }
 
-    return Radio.request('entities', 'clinicians:model', this.get('_editor'));
+    return this.getRelationship('_editor');
   },
   getTeam() {
-    return Radio.request('entities', 'teams:model', this.get('_team'));
+    return this.getRelationship('_team');
   },
   getState() {
-    return Radio.request('entities', 'states:model', this.get('_state'));
+    return this.getRelationship('_state');
   },
   getProgram() {
-    if (!this.get('_program')) return;
-    return Radio.request('entities', 'programs:model', this.get('_program'));
+    return this.getRelationship('_program');
   },
   getForm() {
-    if (!this.get('_form')) return;
-    return Radio.request('entities', 'forms:model', this.get('_form'));
+    return this.getRelationship('_form');
   },
 });
 

--- a/src/js/entities-service/entities/files.js
+++ b/src/js/entities-service/entities/files.js
@@ -1,4 +1,3 @@
-import Radio from 'backbone.radio';
 import { get, first } from 'underscore';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -27,7 +26,8 @@ const _Model = BaseModel.extend({
       });
     },
     FileRemoved() {
-      const action = Radio.request('entities', 'actions:model', this.get('_action'));
+      const action = this.getAction();
+
       action.removeFile(this);
 
       this.destroy({ isDeleted: true });
@@ -35,11 +35,17 @@ const _Model = BaseModel.extend({
   },
   urlRoot() {
     if (this.isNew()) {
-      const actionId = this.get('_action');
+      const action = this.getAction();
 
-      return `/api/actions/${ actionId }/relationships/files?urls=upload`;
+      return `/api/actions/${ action.id }/relationships/files?urls=upload`;
     }
     return '/api/files';
+  },
+  getAction() {
+    return this.getRelationship('_action');
+  },
+  getPatient() {
+    return this.getRelationship('_patient');
   },
   fetchFile() {
     return this.fetch({
@@ -47,7 +53,8 @@ const _Model = BaseModel.extend({
     });
   },
   createUpload(fileName) {
-    const path = `patient/${ this.get('_patient') }/${ fileName }`;
+    const patient = this.getPatient();
+    const path = `patient/${ patient.id }/${ fileName }`;
     const promise = this.save({ path, _progress: 0 }, {}, { type: 'PUT' });
 
     return promise.catch((/* istanbul ignore next */{ responseData } = {}) => {

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -3,16 +3,8 @@ import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import JsonApiMixin from 'js/base/jsonapi-mixin';
 
 const TYPE = 'flows';
-const { parseRelationship } = JsonApiMixin;
-
-const _parseRelationship = function(relationship, key) {
-  if (!relationship || key === 'owner') return relationship;
-
-  return parseRelationship(relationship, key);
-};
 
 const _Model = BaseModel.extend({
   messages: {
@@ -125,14 +117,12 @@ const _Model = BaseModel.extend({
 
     return this.save(attrs, { relationships }, { wait: true });
   },
-  parseRelationship: _parseRelationship,
 });
 
 const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/flows',
   model: Model,
-  parseRelationship: _parseRelationship,
   save(attrs) {
     const saves = this.invoke('saveAll', attrs);
 

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -31,9 +31,7 @@ const _Model = BaseModel.extend({
     return Radio.request('entities', 'patients:model', this.get('_patient'));
   },
   getOwner() {
-    const owner = this.get('_owner');
-    const Owner = Store.get(owner.type);
-    return new Owner({ id: owner.id });
+    return this.getRelationship('_owner');
   },
   getAuthor() {
     return Radio.request('entities', 'clinicians:model', this.get('_author'));

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -12,7 +12,7 @@ const _Model = BaseModel.extend({
       this.set({ _owner: owner, ...attributes });
     },
     StateChanged({ state, attributes }) {
-      this.set({ _state: state.id, ...attributes });
+      this.set({ _state: state, ...attributes });
     },
     NameChanged({ attributes }) {
       this.set(attributes);
@@ -22,28 +22,31 @@ const _Model = BaseModel.extend({
     },
   },
   urlRoot() {
-    if (this.isNew()) return `/api/patients/${ this.get('_patient') }/relationships/flows`;
+    if (this.isNew()) {
+      const patient = this.getPatient();
+      return `/api/patients/${ patient.id }/relationships/flows`;
+    }
 
     return '/api/flows';
   },
   type: TYPE,
   getPatient() {
-    return Radio.request('entities', 'patients:model', this.get('_patient'));
+    return this.getRelationship('_patient');
   },
   getOwner() {
     return this.getRelationship('_owner');
   },
   getAuthor() {
-    return Radio.request('entities', 'clinicians:model', this.get('_author'));
+    return this.getRelationship('_author');
   },
   getState() {
-    return Radio.request('entities', 'states:model', this.get('_state'));
+    return this.getRelationship('_state');
   },
   getProgramFlow() {
-    return Radio.request('entities', 'programFlows:model', this.get('_program_flow'));
+    return this.getRelationship('_program_flow');
   },
   getProgram() {
-    return Radio.request('entities', 'programs:model', this.get('_program'));
+    return this.getRelationship('_program');
   },
   isDone() {
     const state = this.getState();
@@ -85,14 +88,14 @@ const _Model = BaseModel.extend({
     return false;
   },
   saveState(state) {
-    return this.save({ _state: state.id }, {
+    return this.save({ _state: state.getResource() }, {
       relationships: {
         state: this.toRelation(state),
       },
     });
   },
   saveOwner(owner) {
-    return this.save({ _owner: owner }, {
+    return this.save({ _owner: owner.getResource() }, {
       relationships: {
         owner: this.toRelation(owner),
       },
@@ -108,9 +111,9 @@ const _Model = BaseModel.extend({
     if (this.isNew()) attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
-      'state': this.toRelation(attrs._state, 'states'),
+      'state': this.toRelation(attrs._state),
       'owner': this.toRelation(attrs._owner),
-      'program-flow': this.toRelation(attrs._program_flow, 'program-flows'),
+      'program-flow': this.toRelation(attrs._program_flow),
     };
 
     return this.save(attrs, { relationships }, { wait: true });

--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -4,18 +4,10 @@ import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
 import { alphaSort } from 'js/utils/sorting';
-import JsonApiMixin from 'js/base/jsonapi-mixin';
 
 import { FORM_RESPONSE_STATUS } from 'js/static';
 
 const TYPE = 'form-responses';
-const { parseRelationship } = JsonApiMixin;
-
-const _parseRelationship = function(relationship, key) {
-  if (key === 'editor') return relationship;
-
-  return parseRelationship(relationship, key);
-};
 
 const _Model = BaseModel.extend({
   type: TYPE,
@@ -57,14 +49,12 @@ const _Model = BaseModel.extend({
 
     return editor.get('name') || `${ editor.get('first_name') } ${ editor.get('last_name') }`;
   },
-  parseRelationship: _parseRelationship,
 });
 
 const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/form-responses',
   model: Model,
-  parseRelationship: _parseRelationship,
   comparator(responseA, responseB) {
     return alphaSort('desc', responseA.get('updated_at'), responseB.get('updated_at'));
   },

--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -39,10 +39,7 @@ const _Model = BaseModel.extend({
   },
   getEditor() {
     // editor can be a clinician or patient
-    const editor = this.get('_editor');
-    const Editor = Store.get(editor.type);
-
-    return new Editor({ id: editor.id });
+    return this.getRelationship('_editor');
   },
   getEditorName() {
     const editor = this.getEditor();

--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -16,9 +16,9 @@ const _Model = BaseModel.extend({
     const attrs = this.attributes;
 
     const relationships = {
-      'form': this.toRelation(attrs._form, 'forms'),
-      'patient': this.toRelation(attrs._patient, 'patients'),
-      'action': this.toRelation(attrs._action, 'patient-actions'),
+      'form': this.toRelation(attrs._form),
+      'patient': this.toRelation(attrs._patient),
+      'action': this.toRelation(attrs._action),
     };
 
     return this.save(attrs, { relationships }, { wait: true });

--- a/src/js/entities-service/entities/patient-fields.js
+++ b/src/js/entities-service/entities/patient-fields.js
@@ -9,7 +9,11 @@ const TYPE = 'patient-fields';
 const _Model = BaseModel.extend({
   type: TYPE,
   url() {
-    return `/api/patients/${ this.get('_patient') }/fields/${ this.get('name') }`;
+    const patient = this.getPatient();
+    return `/api/patients/${ patient.id }/fields/${ this.get('name') }`;
+  },
+  getPatient() {
+    return this.getRelationship('_patient');
   },
   isNew() {
     // NOTE: This will treat the PATCH like a PUT
@@ -26,7 +30,7 @@ const _Model = BaseModel.extend({
     }
 
     const relationships = {
-      'patient': this.toRelation(attrs._patient, 'patients'),
+      'patient': this.toRelation(attrs._patient),
     };
 
     return this.save(attrs, { relationships }, { wait: true });

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -3,7 +3,6 @@ import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import JsonApiMixin from 'js/base/jsonapi-mixin';
 
 import trim from 'js/utils/formatting/trim';
 import collectionOf from 'js/utils/formatting/collection-of';
@@ -11,13 +10,6 @@ import collectionOf from 'js/utils/formatting/collection-of';
 import { ACTION_OUTREACH, STATE_STATUS, PROGRAM_BEHAVIORS } from 'js/static';
 
 const TYPE = 'program-actions';
-const { parseRelationship } = JsonApiMixin;
-
-const _parseRelationship = function(relationship, key) {
-  if (!relationship || key === 'owner') return relationship;
-
-  return parseRelationship(relationship, key);
-};
 
 const _Model = BaseModel.extend({
   urlRoot: '/api/program-actions',
@@ -112,7 +104,6 @@ const _Model = BaseModel.extend({
 
     return this.save(attrs, { relationships }, { wait: true });
   },
-  parseRelationship: _parseRelationship,
 });
 
 const Model = Store(_Model, TYPE);
@@ -126,7 +117,6 @@ const Collection = BaseCollection.extend({
     return '/api/program-actions';
   },
   model: Model,
-  parseRelationship: _parseRelationship,
   updateSequences() {
     const data = this.map((flowAction, sequence) => {
       flowAction.set({ sequence });

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -30,24 +30,33 @@ const _Model = BaseModel.extend({
     tags.remove(tag);
     return this.save({ tags: tags.map('text') });
   },
-  getAction({ patientId, flowId }) {
+  getProgramFlow() {
+    return this.getRelationship('_program_flow');
+  },
+  getProgram() {
+    return this.getRelationship('_program');
+  },
+  createAction({ patient, flow }) {
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
 
     const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));
 
-    return Radio.request('entities', 'actions:model', {
+    const attrs = {
       name: this.get('name'),
-      _flow: flowId,
-      _patient: patientId,
-      _state: defaultInitialState.id,
+      _state: defaultInitialState.getResource(),
       _owner: this.get('_owner') || {
         id: currentUser.id,
         type: 'clinicians',
       },
-      _program_action: this.id,
-    });
+      _program_action: this.getResource(),
+    };
+
+    if (patient) attrs._patient = patient.getResource();
+    if (flow) attrs._flow = flow.getResource();
+
+    return Radio.request('entities', 'actions:model', attrs);
   },
   enableAttachmentUploads() {
     this.save({ allowed_uploads: ['pdf'] });
@@ -56,20 +65,17 @@ const _Model = BaseModel.extend({
     this.save({ allowed_uploads: [] });
   },
   getOwner() {
-    const owner = this.get('_owner');
-    if (!owner) return;
-    return Radio.request('entities', 'teams:model', owner.id);
+    return this.getRelationship('_owner');
   },
   saveOwner(owner) {
-    owner = this.toRelation(owner);
-    return this.save({ _owner: owner.data }, {
-      relationships: { owner },
+    return this.save({ _owner: owner ? owner.getResource() : null }, {
+      relationships: {
+        owner: this.toRelation(owner),
+      },
     });
   },
   getForm() {
-    const formId = this.get('_form');
-    if (!formId) return;
-    return Radio.request('entities', 'forms:model', formId);
+    return this.getRelationship('_form');
   },
   hasOutreach() {
     return this.get('outreach') !== ACTION_OUTREACH.DISABLED;
@@ -96,10 +102,10 @@ const _Model = BaseModel.extend({
     attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
-      'owner': this.toRelation(attrs._owner, 'teams'),
-      'form': this.toRelation(attrs._form, 'forms'),
-      'program-flow': this.toRelation(attrs._program_flow, 'program-flows'),
-      'program': this.toRelation(attrs._program, 'programs'),
+      'owner': this.toRelation(attrs._owner),
+      'form': this.toRelation(attrs._form),
+      'program-flow': this.toRelation(attrs._program_flow),
+      'program': this.toRelation(attrs._program),
     };
 
     return this.save(attrs, { relationships }, { wait: true });

--- a/src/js/entities-service/entities/program-flows.js
+++ b/src/js/entities-service/entities/program-flows.js
@@ -3,7 +3,6 @@ import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import JsonApiMixin from 'js/base/jsonapi-mixin';
 
 import trim from 'js/utils/formatting/trim';
 import collectionOf from 'js/utils/formatting/collection-of';
@@ -12,13 +11,6 @@ import collectionOf from 'js/utils/formatting/collection-of';
 import { STATE_STATUS, PROGRAM_BEHAVIORS } from 'js/static';
 
 const TYPE = 'program-flows';
-const { parseRelationship } = JsonApiMixin;
-
-const _parseRelationship = function(relationship, key) {
-  if (!relationship || key === 'owner') return relationship;
-
-  return parseRelationship(relationship, key);
-};
 
 const _Model = BaseModel.extend({
   urlRoot() {
@@ -92,14 +84,12 @@ const _Model = BaseModel.extend({
 
     return !!visibleToTeamsList.find(team => team.id === currentUserTeam.id);
   },
-  parseRelationship: _parseRelationship,
 });
 
 const Model = Store(_Model, TYPE);
 const Collection = BaseCollection.extend({
   url: '/api/program-flows',
   model: Model,
-  parseRelationship: _parseRelationship,
   filterAddable() {
     const clone = this.clone();
 

--- a/src/js/entities-service/entities/program-flows.js
+++ b/src/js/entities-service/entities/program-flows.js
@@ -14,13 +14,19 @@ const TYPE = 'program-flows';
 
 const _Model = BaseModel.extend({
   urlRoot() {
-    if (this.isNew()) return `/api/programs/${ this.get('_program') }/relationships/flows`;
+    if (this.isNew()) {
+      const program = this.getProgram();
+      return `/api/programs/${ program.id }/relationships/flows`;
+    }
 
     return '/api/program-flows';
   },
   type: TYPE,
   validate({ name }) {
     if (!trim(name)) return 'Flow name required';
+  },
+  getProgram() {
+    return this.getRelationship('_program');
   },
   getTags() {
     return Radio.request('entities', 'tags:collection', collectionOf(this.get('tags'), 'text'));
@@ -36,38 +42,40 @@ const _Model = BaseModel.extend({
     return this.save({ tags: tags.map('text') });
   },
   getOwner() {
-    const owner = this.get('_owner');
-    if (!owner) return;
-    return Radio.request('entities', 'teams:model', owner.id);
+    return this.getRelationship('_owner');
   },
-  getFlow(patientId) {
+  createFlow(patient) {
     const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
 
     const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));
 
     const flow = Radio.request('entities', 'flows:model', {
-      _patient: patientId,
-      _program_flow: this.get('id'),
-      _state: defaultInitialState.id,
+      _patient: patient.getResource(),
+      _program_flow: this.getResource(),
+      _state: defaultInitialState.getResource(),
     });
 
     return flow;
   },
   saveOwner(owner) {
-    owner = this.toRelation(owner);
-    return this.save({ _owner: owner.data }, {
-      relationships: { owner },
+    return this.save({ _owner: owner ? owner.getResource() : null }, {
+      relationships: {
+        owner: this.toRelation(owner),
+      },
     });
   },
   saveAll(attrs) {
     attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
-      owner: this.toRelation(attrs._owner, 'teams'),
+      owner: this.toRelation(attrs._owner),
     };
 
     return this.save(attrs, { relationships }, { wait: true });
+  },
+  setActions(actions) {
+    this.set('_program_actions', actions.getResources());
   },
   getActions() {
     return Radio.request('entities', 'programActions:collection', this.get('_program_actions'), { flowId: this.id });

--- a/src/js/entities-service/entities/teams.js
+++ b/src/js/entities-service/entities/teams.js
@@ -9,9 +9,22 @@ const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/teams',
   getAssignableClinicians() {
-    const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
+    const clinicians = this.getClinicians();
 
     return clinicians.filterAssignable();
+  },
+  getClinicians() {
+    return Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
+  },
+  addClinician(clinician) {
+    const clinicians = this.getClinicians();
+    clinicians.add(clinician);
+    this.set('_clinicians', clinicians.getResources());
+  },
+  removeClinician(clinician) {
+    const clinicians = this.getClinicians();
+    clinicians.remove(clinician);
+    this.set('_clinicians', clinicians.getResources());
   },
 });
 

--- a/src/js/entities-service/entities/workspace-patients.js
+++ b/src/js/entities-service/entities/workspace-patients.js
@@ -11,8 +11,8 @@ const _Model = BaseModel.extend({
     const opts = { type: 'PUT' };
 
     const relationships = {
-      'workspace': this.toRelation(this.get('_workspace'), 'workspaces'),
-      'patient': this.toRelation(this.get('_patient'), 'patients'),
+      'workspace': this.toRelation(this.get('_workspace')),
+      'patient': this.toRelation(this.get('_patient')),
     };
 
     this.save(attrs, { relationships }, opts);

--- a/src/js/entities-service/entities/workspaces.js
+++ b/src/js/entities-service/entities/workspaces.js
@@ -1,4 +1,3 @@
-import { reject, union, pick } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -15,48 +14,46 @@ const _Model = BaseModel.extend({
   getForms() {
     return Radio.request('entities', 'forms:collection', this.get('_forms'));
   },
+  getClinicians() {
+    return Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
+  },
   getAssignableClinicians() {
-    const clinicians = Radio.request('entities', 'clinicians:collection', this.get('_clinicians'));
+    const clinicians = this.getClinicians();
 
     return clinicians.filterAssignable();
   },
   updateClinicians(clinicians) {
-    this.set('_clinicians', clinicians.map(m => pick(m, 'id', 'type')));
+    this.set('_clinicians', clinicians.getResources());
   },
   addClinician(clinician) {
     const url = `/api/workspaces/${ this.id }/relationships/clinicians`;
-    const workspaces = clinician.get('_workspaces');
+    clinician.addWorkspace(this);
 
-    clinician.set({ _workspaces: union(workspaces, [{ id: this.id }]) });
+    const clinicians = this.getClinicians();
+    clinicians.add(clinician);
 
-    this.set({ _clinicians: union(this.get('_clinicians'), [{ id: clinician.id }]) });
+    this.updateClinicians(clinicians);
 
     return this.sync('create', this, {
       url,
       data: JSON.stringify({
-        data: [{
-          id: clinician.id,
-          type: clinician.type,
-        }],
+        data: [clinician.getResource()],
       }),
     });
   },
   removeClinician(clinician) {
     const url = `/api/workspaces/${ this.id }/relationships/clinicians`;
+    clinician.removeWorkspace(this);
 
-    clinician.set({ _workspaces: reject(clinician.get('_workspaces'), { id: this.id }) });
+    const clinicians = this.getClinicians();
+    clinicians.remove(clinician);
 
-    this.set({
-      _clinicians: reject(this.get('_clinicians'), { id: clinician.id }),
-    });
+    this.updateClinicians(clinicians);
 
     return this.sync('delete', this, {
       url,
       data: JSON.stringify({
-        data: [{
-          id: clinician.id,
-          type: clinician.type,
-        }],
+        data: [clinician.getResource()],
       }),
     });
   },

--- a/src/js/entities-service/files.js
+++ b/src/js/entities-service/files.js
@@ -5,6 +5,7 @@ const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
     'files:model': 'getModel',
+    'files:collection': 'getCollection',
     'fetch:files:collection:byAction': 'fetchFilesByAction',
   },
   fetchFilesByAction(actionId) {

--- a/src/js/entities-service/workspace-patients.js
+++ b/src/js/entities-service/workspace-patients.js
@@ -16,9 +16,12 @@ const Entity = BaseEntity.extend({
   },
   getByPatient(patientId) {
     const currentWorkspace = Radio.request('workspace', 'current');
-    const workspaceId = currentWorkspace.id;
 
-    return new Model({ id: uuid(patientId, workspaceId), _patient: patientId, _workspace: workspaceId });
+    return new Model({
+      id: uuid(patientId, currentWorkspace.id),
+      _patient: { id: patientId, type: 'patients' },
+      _workspace: currentWorkspace.getResource(),
+    });
   },
 });
 

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -1,5 +1,6 @@
 import 'js/base/setup';
 
+import { get } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
@@ -36,8 +37,8 @@ const ActionFormApp = App.extend({
     const actionTags = form.getPrefillActionTag();
 
     return {
-      flowId: action.get('_flow'),
-      patientId: action.get('_patient'),
+      flowId: get(action.getFlow(), 'id'),
+      patientId: action.getPatient().id,
       submittedAt: isReport && `<=${ action.get('created_at') }`,
       actionId: !actionTags && action.id,
       actionTags,

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -273,8 +273,8 @@ export default App.extend({
     });
   },
   useLatestDraft(responseData) {
-    if (this.form) responseData._form = this.form.getResource();
-    if (this.patient) responseData._patient = this.patient.getResource();
+    responseData._form = this.form.getResource();
+    responseData._patient = this.patient.getResource();
     if (this.action) responseData._action = this.action.getResource();
 
     if (!this.latestResponse || this.latestResponse.get('status') !== FORM_RESPONSE_STATUS.DRAFT) return responseData;

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -132,7 +132,7 @@ export default App.extend({
   fetchField({ fieldName, requestId }) {
     const field = Radio.request('entities', 'patientFields:model', {
       name: fieldName,
-      _patient: this.patient.id,
+      _patient: this.patient.getResource(),
     });
 
     return field.fetch()
@@ -147,7 +147,7 @@ export default App.extend({
     const field = Radio.request('entities', 'patientFields:model', {
       name: fieldName,
       value,
-      _patient: this.patient.id,
+      _patient: this.patient.getResource(),
     });
 
     return field.saveAll()
@@ -201,17 +201,18 @@ export default App.extend({
       });
     });
   },
-  _getPrefillFilters(form, action, flowId) {
-    const patientId = action.get('_patient');
+  _getPrefillFilters(form, action, flow) {
+    const flowId = flow && flow.id;
+    const patientId = action.getPatient().id;
     const actionTags = form.getPrefillActionTag();
     const formId = !actionTags && form.getPrefillFormId();
     const submittedAt = form.isReport() && `<=${ action.get('created_at') }`;
 
     return { patientId, flowId, formId, actionTags, submittedAt };
   },
-  fetchLatestFormSubmission(flowId) {
+  fetchLatestFormSubmission(flow) {
     const isReadOnly = this.isReadOnly();
-    const filter = this._getPrefillFilters(this.form, this.action, flowId);
+    const filter = this._getPrefillFilters(this.form, this.action, flow);
 
     return Promise.all([
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
@@ -240,7 +241,7 @@ export default App.extend({
 
     if (!firstResponse && this.action) {
       if (this.action.hasTag('prefill-latest-response')) return this.fetchLatestFormSubmission();
-      if (this.action.hasTag('prefill-flow-response')) return this.fetchLatestFormSubmission(this.action.get('_flow'));
+      if (this.action.hasTag('prefill-flow-response')) return this.fetchLatestFormSubmission(this.action.getFlow());
     }
 
     return Promise.all([
@@ -272,6 +273,10 @@ export default App.extend({
     });
   },
   useLatestDraft(responseData) {
+    if (this.form) responseData._form = this.form.getResource();
+    if (this.patient) responseData._patient = this.patient.getResource();
+    if (this.action) responseData._action = this.action.getResource();
+
     if (!this.latestResponse || this.latestResponse.get('status') !== FORM_RESPONSE_STATUS.DRAFT) return responseData;
 
     return {
@@ -283,9 +288,6 @@ export default App.extend({
     const data = this.useLatestDraft({
       response: { data: this._draft },
       status: FORM_RESPONSE_STATUS.DRAFT,
-      _form: this.form,
-      _patient: this.patient,
-      _action: this.action,
     });
 
     const formResponse = Radio.request('entities', 'formResponses:model', data);
@@ -311,9 +313,6 @@ export default App.extend({
     const data = this.useLatestDraft({
       response,
       status: FORM_RESPONSE_STATUS.SUBMITTED,
-      _form: this.form,
-      _patient: this.patient,
-      _action: this.action,
     });
 
     const formResponse = Radio.request('entities', 'formResponses:model', data);

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -94,6 +94,7 @@ export default App.extend({
 
   onClose() {
     this.stopHeartbeat();
+    /* istanbul ignore next: resubscribing in tests causes test leaking */
     if (!_TEST_ && this.resources.length) this._subscribe();
   },
 

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -1,7 +1,6 @@
 import { each, map, values, isArray } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
-import Store from 'backbone.store';
 
 import App from 'js/base/app';
 
@@ -99,6 +98,8 @@ export default App.extend({
   },
 
   onMessage(event) {
+    let model;
+
     const channel = this.getChannel();
 
     const data = JSON.parse(event.data);
@@ -106,12 +107,11 @@ export default App.extend({
     if (data.name === 'pong') return;
 
     if (data.resource) {
-      const Resource = Store.get(data.resource.type);
-      const resource = new Resource({ id: data.resource.id });
-      resource.handleMessage(data);
+      model = Radio.request('entities', 'get:store', data.resource);
+      model.handleMessage(data);
     }
 
-    channel.trigger('message', data);
+    channel.trigger('message', data, model);
   },
 
   _getResources(resources) {

--- a/src/js/views/clinicians/clinician-modal/clinician-modal_views.js
+++ b/src/js/views/clinicians/clinician-modal/clinician-modal_views.js
@@ -107,19 +107,19 @@ const ClinicianModal = View.extend({
     });
 
     this.listenTo(roleComponent, 'change:role', role => {
-      this.model.set('_role', role.id);
+      this.model.setRole(role);
     });
 
     this.showChildView('role', roleComponent);
   },
   showTeam() {
     const teamComponent = new TeamComponent({
-      team: this.model.get('_team'),
+      team: this.model.getTeam(),
       className: 'modal__form-component',
     });
 
     this.listenTo(teamComponent, 'change:team', team => {
-      this.model.set('_team', team.id);
+      this.model.setTeam(team);
     });
 
     this.showChildView('team', teamComponent);

--- a/src/js/views/clinicians/clinicians-all_views.js
+++ b/src/js/views/clinicians/clinicians-all_views.js
@@ -88,7 +88,7 @@ const ItemView = View.extend({
   },
   showState() {
     const isActive = this.model.isActive();
-    const selectedId = this.model.get('enabled') ? 'enabled' : 'disabled';
+    const selectedId = this.model.isEnabled() ? 'enabled' : 'disabled';
 
     const stateComponent = new StateComponent({ isActive, selectedId, isCompact: true });
 
@@ -102,7 +102,7 @@ const ItemView = View.extend({
     const roleComponent = new RoleComponent({
       role: this.model.getRole(),
       isCompact: true,
-      state: { isDisabled: !this.model.get('enabled') },
+      state: { isDisabled: !this.model.isEnabled() },
     });
 
     this.listenTo(roleComponent, 'change:role', role => {
@@ -115,7 +115,7 @@ const ItemView = View.extend({
     const teamComponent = new TeamComponent({
       team: this.model.getTeam(),
       isCompact: true,
-      state: { isDisabled: !this.model.get('enabled') },
+      state: { isDisabled: !this.model.isEnabled() },
     });
 
     this.listenTo(teamComponent, 'change:team', team => {

--- a/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
+++ b/src/js/views/clinicians/sidebar/clinician-sidebar_views.js
@@ -176,7 +176,7 @@ const SidebarView = View.extend({
   },
   showState() {
     const isActive = this.model.isActive();
-    const selectedId = this.model.get('enabled') ? 'enabled' : 'disabled';
+    const selectedId = this.model.isEnabled() ? 'enabled' : 'disabled';
 
     const stateComponent = new StateComponent({ isActive, selectedId });
 
@@ -187,7 +187,7 @@ const SidebarView = View.extend({
     this.showChildView('state', stateComponent);
   },
   showRole() {
-    const isDisabled = !this.model.get('enabled');
+    const isDisabled = !this.model.isEnabled();
     const roleComponent = new RoleComponent({ role: this.model.getRole(), state: { isDisabled } });
 
     this.listenTo(roleComponent, 'change:role', role => {
@@ -197,8 +197,8 @@ const SidebarView = View.extend({
     this.showChildView('role', roleComponent);
   },
   showTeam() {
-    const isDisabled = !this.model.get('enabled');
-    const teamComponent = new TeamComponent({ team: this.model.get('_team'), state: { isDisabled } });
+    const isDisabled = !this.model.isEnabled();
+    const teamComponent = new TeamComponent({ team: this.model.getTeam(), state: { isDisabled } });
 
     this.listenTo(teamComponent, 'change:team', team => {
       this.model.saveTeam(team);
@@ -211,7 +211,7 @@ const SidebarView = View.extend({
       member: this.model,
       workspaces: Radio.request('bootstrap', 'workspaces'),
       droplistOptions: {
-        isDisabled: !this.model.get('enabled'),
+        isDisabled: !this.model.isEnabled(),
       },
     }));
 

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -35,7 +35,7 @@ const ContextTrailView = View.extend({
   },
   onClickBack() {
     Radio.request('history', 'go:back', () => {
-      if (this.action.get('_flow')) {
+      if (this.action.getFlow()) {
         this.routeToFlow();
         return;
       }
@@ -47,7 +47,7 @@ const ContextTrailView = View.extend({
     this.routeToPatient();
   },
   routeToFlow() {
-    Radio.trigger('event-router', 'flow', this.action.get('_flow'));
+    Radio.trigger('event-router', 'flow', this.action.getFlow().id);
   },
   routeToPatient() {
     Radio.trigger('event-router', 'patient:dashboard', this.patient.id);

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -91,7 +91,7 @@ const ActionItemView = View.extend({
     'click .js-no-click': 'prevent-row-click',
   },
   onClick() {
-    Radio.trigger('event-router', 'patient:action:archive', this.model.get('_patient'), this.model.id);
+    Radio.trigger('event-router', 'patient:action:archive', this.model.getPatient().id, this.model.id);
   },
   onRender() {
     this.canEdit = this.model.canEdit();
@@ -115,7 +115,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    const stateComponent = new StateComponent({ stateId: this.model.getState().id, isCompact: true });
 
     this.listenTo(stateComponent, 'change:state', state => {
       this.model.saveState(state);
@@ -211,7 +211,7 @@ const FlowItemView = View.extend({
       return;
     }
 
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    const stateComponent = new StateComponent({ stateId: this.model.getState().id, isCompact: true });
 
     this.listenTo(stateComponent, 'change:state', state => {
       this.model.saveState(state);

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -95,7 +95,7 @@ const ActionItemView = View.extend({
     'click .js-no-click': 'prevent-row-click',
   },
   onClick() {
-    Radio.trigger('event-router', 'patient:action', this.model.get('_patient'), this.model.id);
+    Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   onRender() {
     this.canEdit = this.model.canEdit();
@@ -119,7 +119,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    const stateComponent = new StateComponent({ stateId: this.model.getState().id, isCompact: true });
 
     this.listenTo(stateComponent, 'change:state', state => {
       this.model.saveState(state);

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -90,7 +90,7 @@ const HeaderView = View.extend({
 
     const stateComponent = new FlowStateComponent({
       flow: this.model,
-      stateId: this.model.get('_state'),
+      stateId: this.model.getState().id,
       isCompact: true,
     });
 
@@ -180,7 +180,7 @@ const ActionItemView = View.extend({
     'click .js-no-click': 'prevent-row-click',
   },
   onClick() {
-    Radio.trigger('event-router', 'flow:action', this.model.get('_flow'), this.model.id);
+    Radio.trigger('event-router', 'flow:action', this.model.getFlow().id, this.model.id);
   },
   onEditing(isEditing) {
     this.isEditing = isEditing;
@@ -241,7 +241,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    this.stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    this.stateComponent = new StateComponent({ stateId: this.model.getState().id, isCompact: true });
 
     this.listenTo(this.stateComponent, 'change:state', state => {
       this.model.saveState(state);

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -270,7 +270,7 @@ const DayItemView = View.extend({
     this.showChildView('check', checkComponent);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
+    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
   },
   onClickForm() {
     Radio.trigger('event-router', 'form:patientAction', this.model.id, this.model.getForm().id);
@@ -284,11 +284,11 @@ const DayItemView = View.extend({
     }
 
     if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action:archive', this.model.get('_patient'), this.model.id);
+      Radio.trigger('event-router', 'patient:action:archive', this.model.getPatient().id, this.model.id);
       return;
     }
 
-    Radio.trigger('event-router', 'patient:action', this.model.get('_patient'), this.model.id);
+    Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   showDetailsTooltip() {
     if (!this.model.get('details')) return;

--- a/src/js/views/patients/shared/components/state_component.cy.js
+++ b/src/js/views/patients/shared/components/state_component.cy.js
@@ -11,7 +11,7 @@ import StateComponent from './state_component';
 const states = new States({ data: getStates() }, { parse: true });
 const workspaces = new Workspaces({ data: getWorkspaces() }, { parse: true });
 
-workspaces.at(1).set('_states', [{ id: stateInProgress.id }]);
+workspaces.at(1).set('_states', [{ id: stateInProgress.id, type: 'states' }]);
 
 context('State Component', function() {
   specify('Display', function() {

--- a/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
@@ -220,7 +220,7 @@ const ActionView = View.extend({
     this.showChildView('details', new DetailsView({ model: this.clonedAction }));
   },
   showState() {
-    const stateComponent = new StateComponent({ stateId: this.model.get('_state') });
+    const stateComponent = new StateComponent({ stateId: this.model.getState().id });
 
     this.listenTo(stateComponent, 'change:state', state => {
       this.model.saveState(state);

--- a/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
@@ -206,23 +206,29 @@ const ActivityView = View.extend({
 
     return Templates[type];
   },
+  _getModelName(model) {
+    return model ? model.get('name') : null;
+  },
   templateContext() {
     const recipient = this.model.getRecipient();
     const editor = this.model.getEditor();
+    const editorTeam = editor && editor.getTeam();
     const clinician = this.model.getClinician();
     const program = this.model.getProgram();
     const form = this.model.getForm();
+    const team = this.model.getTeam();
+    const state = this.model.getState();
     const sourceI18n = `patients.sidebar.action.activityViews.${ this.model.get('source') }`;
 
     return {
       recipient: recipient ? `${ recipient.get('first_name') } ${ recipient.get('last_name') }` : null,
-      name: editor.get('name'),
-      team: editor.getTeam().get('name'),
-      to_clinician: clinician.get('name'),
-      to_team: this.model.getTeam().get('name'),
-      to_state: this.model.getState().get('name'),
-      program: program ? program.get('name') : null,
-      form: form ? form.get('name') : null,
+      name: this._getModelName(editor),
+      team: this._getModelName(editorTeam),
+      to_clinician: this._getModelName(clinician),
+      to_team: this._getModelName(team),
+      to_state: this._getModelName(state),
+      program: this._getModelName(program),
+      form: this._getModelName(form),
       getI18nSource(key) {
         return `${ sourceI18n }.${ key }`;
       },

--- a/src/js/views/patients/sidebar/flow/flow-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar-activity-views.js
@@ -51,19 +51,25 @@ const ActivityView = View.extend({
 
     return Templates[type];
   },
+  _getModelName(model) {
+    return model ? model.get('name') : null;
+  },
   templateContext() {
     const editor = this.model.getEditor();
+    const editorTeam = editor && editor.getTeam();
     const clinician = this.model.getClinician();
     const program = this.model.getProgram();
+    const team = this.model.getTeam();
+    const state = this.model.getState();
     const sourceI18n = `patients.sidebar.flow.activityViews.${ this.model.get('source') }`;
 
     return {
-      name: editor.get('name'),
-      team: editor.getTeam().get('name'),
-      program: (program) ? program.get('name') : null,
-      to_clinician: clinician.get('name'),
-      to_team: this.model.getTeam().get('name'),
-      to_state: this.model.getState().get('name'),
+      name: this._getModelName(editor),
+      team: this._getModelName(editorTeam),
+      to_clinician: this._getModelName(clinician),
+      to_team: this._getModelName(team),
+      to_state: this._getModelName(state),
+      program: this._getModelName(program),
       getI18nSource(key) {
         return `${ sourceI18n }.${ key }`;
       },

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -140,7 +140,7 @@ const SidebarView = View.extend({
 
     const stateComponent = new FlowStateComponent({
       flow: this.model,
-      stateId: this.model.get('_state'),
+      stateId: this.model.getState().id,
     });
 
     this.listenTo(stateComponent, 'change:state', state => {

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -74,14 +74,14 @@ const ActionItemView = View.extend({
     }
 
     if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action:archive', this.model.get('_patient'), this.model.id);
+      Radio.trigger('event-router', 'patient:action:archive', this.model.getPatient().id, this.model.id);
       return;
     }
 
-    Radio.trigger('event-router', 'patient:action', this.model.get('_patient'), this.model.id);
+    Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
+    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
   },
   onRender() {
     this.showForm();
@@ -126,7 +126,7 @@ const ActionItemView = View.extend({
       return;
     }
 
-    this.stateComponent = new StateComponent({ stateId: this.model.get('_state'), isCompact: true });
+    this.stateComponent = new StateComponent({ stateId: this.model.getState().id, isCompact: true });
 
     this.listenTo(this.stateComponent, 'change:state', state => {
       this.model.saveState(state);

--- a/src/js/views/patients/worklist/flow_views.js
+++ b/src/js/views/patients/worklist/flow_views.js
@@ -61,7 +61,7 @@ const FlowItemView = View.extend({
     Radio.trigger('event-router', 'flow', this.model.id);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.get('_patient'));
+    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
   },
   onRender() {
     const canEdit = this.canEdit;
@@ -103,7 +103,7 @@ const FlowItemView = View.extend({
     }
 
     const stateComponent = new FlowStateComponent({
-      stateId: this.model.get('_state'),
+      stateId: this.model.getState().id,
       isCompact: true,
     });
 

--- a/src/js/views/programs/program/flow/flow_views.js
+++ b/src/js/views/programs/program/flow/flow_views.js
@@ -148,10 +148,10 @@ const ActionItemView = View.extend({
   },
   onClick() {
     if (this.model.isNew()) {
-      Radio.trigger('event-router', 'programFlow:action:new', this.model.get('_program_flow'));
+      Radio.trigger('event-router', 'programFlow:action:new', this.model.getProgramFlow().id);
       return;
     }
-    Radio.trigger('event-router', 'programFlow:action', this.model.get('_program_flow'), this.model.id);
+    Radio.trigger('event-router', 'programFlow:action', this.model.getProgramFlow().id, this.model.id);
   },
   onClickForm() {
     const form = this.model.getForm();
@@ -191,7 +191,7 @@ const ActionItemView = View.extend({
   },
   showOwner() {
     const isDisabled = this.model.isNew();
-    const isFromFlow = !!this.model.get('_program_flow');
+    const isFromFlow = !!this.model.getProgramFlow();
     const ownerComponent = new OwnerComponent({ owner: this.model.getOwner(), isFromFlow, isCompact: true, state: { isDisabled } });
 
     this.listenTo(ownerComponent, 'change:owner', owner => {

--- a/src/js/views/programs/program/workflows/workflows_views.js
+++ b/src/js/views/programs/program/workflows/workflows_views.js
@@ -75,11 +75,11 @@ const ActionItemView = View.extend({
   },
   onClick() {
     if (this.model.isNew()) {
-      Radio.trigger('event-router', 'program:action:new', this.model.get('_program'));
+      Radio.trigger('event-router', 'program:action:new', this.model.getProgram().id);
       return;
     }
 
-    Radio.trigger('event-router', 'program:action', this.model.get('_program'), this.model.id);
+    Radio.trigger('event-router', 'program:action', this.model.getProgram().id, this.model.id);
   },
   onClickForm() {
     const form = this.model.getForm();
@@ -92,7 +92,7 @@ const ActionItemView = View.extend({
   },
   showBehavior() {
     const isDisabled = this.model.isNew();
-    const isFromFlow = !!this.model.get('_program_flow');
+    const isFromFlow = !!this.model.getProgramFlow();
     const behaviorComponent = new BehaviorComponent({
       isConditionalAvailable: isFromFlow,
       behavior: this.model.get('behavior'),
@@ -108,7 +108,7 @@ const ActionItemView = View.extend({
   },
   showOwner() {
     const isDisabled = this.model.isNew();
-    const isFromFlow = !!this.model.get('_program_flow');
+    const isFromFlow = !!this.model.getProgramFlow();
     const ownerComponent = new OwnerComponent({ owner: this.model.getOwner(), isFromFlow, isCompact: true, state: { isDisabled } });
 
     this.listenTo(ownerComponent, 'change:owner', owner => {
@@ -148,7 +148,7 @@ const FlowItemView = View.extend({
   },
   onClick() {
     if (this.model.isNew()) {
-      Radio.trigger('event-router', 'programFlow:new', this.model.get('_program'));
+      Radio.trigger('event-router', 'programFlow:new', this.model.getProgram().id);
       return;
     }
 

--- a/src/js/views/programs/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/programs/sidebar/action/action-sidebar_views.js
@@ -330,7 +330,7 @@ const SidebarView = View.extend({
   },
   showBehavior() {
     const isDisabled = this.action.isNew();
-    const isFromFlow = !!this.action.get('_program_flow');
+    const isFromFlow = !!this.action.getProgramFlow();
     const behaviorComponent = new BehaviorComponent({
       isConditionalAvailable: isFromFlow,
       behavior: this.action.get('behavior'),
@@ -345,7 +345,7 @@ const SidebarView = View.extend({
   },
   showOwner() {
     const isDisabled = this.action.isNew();
-    const isFromFlow = !!this.action.get('_program_flow');
+    const isFromFlow = !!this.action.getProgramFlow();
     const ownerComponent = new OwnerComponent({ owner: this.action.getOwner(), isFromFlow, state: { isDisabled } });
 
     this.listenTo(ownerComponent, 'change:owner', owner => {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -2485,7 +2485,7 @@ context('Patient Action Form', function() {
         patient: getRelationship(testPatient),
         owner: getRelationship(testCurrentClinician),
         state: getRelationship(stateInProgress),
-        form: getRelationship(testForm.id),
+        form: getRelationship(testForm),
       },
     });
 

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -5,6 +5,7 @@ import { getAction } from 'support/api/actions';
 import { getForm } from 'support/api/forms';
 import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
+import { getFormResponse } from 'support/api/form-responses';
 
 context('Formservice', function() {
   specify('display form with a response', function() {
@@ -213,7 +214,7 @@ context('Formservice', function() {
     cy
       .intercept('GET', '/api/actions/1/form', {
         statusCode: 200,
-        body: { data: {} },
+        body: { data: getForm() },
       })
       .as('routeFormModelByAction');
 
@@ -227,20 +228,21 @@ context('Formservice', function() {
     cy
       .intercept('GET', '/api/actions/1/form/fields', {
         statusCode: 200,
-        body: { data: {} },
+        body: { data: [] },
       })
       .as('routeActionFormFields');
 
     cy
       .intercept('GET', '/api/actions/1*', {
         statusCode: 200,
-        body: { data: {} },
+        body: { data: getAction() },
       })
       .as('routeAction');
 
     cy
       .intercept('GET', '/api/patients/**/form-responses/submitted*', {
-        statusCode: 204,
+        statusCode: 200,
+        body: { data: getFormResponse() },
       })
       .as('routeLatestFormSubmission');
 

--- a/test/integration/globals/default-route.js
+++ b/test/integration/globals/default-route.js
@@ -5,7 +5,7 @@ import { getErrors, getRelationship } from 'helpers/json-api';
 import { getCurrentClinician } from 'support/api/clinicians';
 import { roleReducedEmployee } from 'support/api/roles';
 
-context('patient page', function() {
+context('default routes', function() {
   specify('default route', function() {
     cy
       .routesForDefault()

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -11,6 +11,8 @@ import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { getProgram } from 'support/api/programs';
+import { getProgramAction } from 'support/api/program-actions';
+import { getProgramFlow } from 'support/api/program-flows';
 import { teamCoordinator, teamNurse, teamOther } from 'support/api/teams';
 import { stateTodo, stateInProgress, stateDone } from 'support/api/states';
 import { testForm } from 'support/api/forms';
@@ -22,26 +24,31 @@ import { ACTION_OUTREACH } from 'js/static';
 context('patient dashboard page', function() {
   const testPatient = getPatient();
 
-  function createActionPostRoute(id) {
+  function createActionPostRoute(name) {
+    const actionData = getAction({
+      attributes: {
+        name,
+        updated_at: testTs(),
+        outreach: 'disabled',
+        sharing: 'disabled',
+        due_time: null,
+      },
+      relationships: {
+        author: getRelationship(getCurrentClinician()),
+        state: getRelationship(stateTodo),
+      },
+    });
+
     cy
       .intercept('POST', `/api/patients/${ testPatient.id }/relationships/actions*`, {
         statusCode: 201,
         body: {
-          data: {
-            id,
-            attributes: {
-              updated_at: testTs(),
-              outreach: 'disabled',
-              sharing: 'disabled',
-              due_time: null,
-            },
-            relationships: {
-              author: getRelationship(getCurrentClinician()),
-            },
-          },
+          data: actionData,
         },
       })
       .as('routePostAction');
+
+    return actionData.id;
   }
 
   specify('action and flow list', function() {
@@ -456,7 +463,7 @@ context('patient dashboard page', function() {
     const testProgramIds = _.times(5, () => uuid());
 
     const testProgramActions = [
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'One of One',
           behavior: 'standard',
@@ -471,7 +478,7 @@ context('patient dashboard page', function() {
           teams: getRelationship([teamNurse]),
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'One of Two',
           behavior: 'standard',
@@ -485,7 +492,7 @@ context('patient dashboard page', function() {
           owner: getRelationship(null),
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'Two of Two',
           behavior: 'standard',
@@ -494,7 +501,7 @@ context('patient dashboard page', function() {
           days_until_due: null,
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'Should not show - unpublished',
           behavior: 'standard',
@@ -503,7 +510,7 @@ context('patient dashboard page', function() {
           days_until_due: null,
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'Should not show - archived',
           behavior: 'standard',
@@ -512,7 +519,7 @@ context('patient dashboard page', function() {
           days_until_due: null,
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'Should not show - automated behavior',
           behavior: 'automated',
@@ -521,7 +528,7 @@ context('patient dashboard page', function() {
           days_until_due: null,
         },
       }),
-      getAction({
+      getProgramAction({
         attributes: {
           name: 'Should not show - not visible to current user team',
           behavior: 'standard',
@@ -537,7 +544,7 @@ context('patient dashboard page', function() {
     ];
 
     const testProgramFlows = [
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: '1 Flow',
           behavior: 'standard',
@@ -551,7 +558,7 @@ context('patient dashboard page', function() {
           teams: getRelationship([teamNurse]),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: '2 Flow',
           behavior: 'standard',
@@ -562,7 +569,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[1], 'programs'),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: '3 Flow',
           behavior: 'standard',
@@ -573,7 +580,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[1], 'programs'),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: 'Should not show - unpublished',
           behavior: 'standard',
@@ -584,7 +591,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[1], 'programs'),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: 'Should not show - archived',
           behavior: 'standard',
@@ -595,7 +602,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[1], 'programs'),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: 'Should not show - automated behavior',
           behavior: 'automated',
@@ -606,7 +613,7 @@ context('patient dashboard page', function() {
           program: getRelationship(testProgramIds[1], 'programs'),
         },
       }),
-      getFlow({
+      getProgramFlow({
         attributes: {
           name: 'Should not show - not visible to current user team',
           behavior: 'standard',
@@ -798,7 +805,7 @@ context('patient dashboard page', function() {
       .get('.picklist')
       .should('not.contain', 'Should not show');
 
-    createActionPostRoute('test-1');
+    const testOne = createActionPostRoute('One of One');
 
     cy
       .get('.picklist')
@@ -821,7 +828,7 @@ context('patient dashboard page', function() {
 
     cy
       .url()
-      .should('contain', `patient/${ testPatient.id }/action/test-1`);
+      .should('contain', `patient/${ testPatient.id }/action/${ testOne }`);
 
     cy
       .get('.patient__list')
@@ -843,7 +850,7 @@ context('patient dashboard page', function() {
       .contains('Add')
       .click();
 
-    createActionPostRoute('test-2');
+    const testTwo = createActionPostRoute('One of Two');
 
     cy
       .get('.picklist')
@@ -866,7 +873,7 @@ context('patient dashboard page', function() {
 
     cy
       .url()
-      .should('contain', `patient/${ testPatient.id }/action/test-2`);
+      .should('contain', `patient/${ testPatient.id }/action/${ testTwo }`);
 
     cy
       .get('.patient__list')
@@ -888,7 +895,7 @@ context('patient dashboard page', function() {
       .contains('Add')
       .click();
 
-    createActionPostRoute('test-3');
+    const testThree = createActionPostRoute('Two of Two');
 
     cy
       .get('.picklist')
@@ -905,7 +912,7 @@ context('patient dashboard page', function() {
 
     cy
       .url()
-      .should('contain', `patient/${ testPatient.id }/action/test-3`);
+      .should('contain', `patient/${ testPatient.id }/action/${ testThree }`);
 
     cy
       .get('.patient__list')
@@ -917,14 +924,15 @@ context('patient dashboard page', function() {
       .find('.action-sidebar__name')
       .should('contain', 'Two of Two');
 
+    const testFlow = getFlow({
+      attributes: { updated_at: testTs() },
+    });
+
     cy
       .intercept('POST', `/api/patients/${ testPatient.id }/relationships/flows*`, {
         statusCode: 201,
         body: {
-          data: {
-            id: '1',
-            attributes: { updated_at: testTs() },
-          },
+          data: testFlow,
         },
       })
       .as('routePostFlow');
@@ -954,7 +962,7 @@ context('patient dashboard page', function() {
 
     cy
       .url()
-      .should('contain', 'flow/1');
+      .should('contain', `flow/${ testFlow.id }`);
 
     cy
       .get('.patient-flow__header')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -344,7 +344,7 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'CommentAdded',
-      author: getCurrentClinician(),
+      author: getCurrentClinician().id,
       resource: {
         type: 'patient-actions',
         id: testFlowAction.id,

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -3459,11 +3459,21 @@ context('worklist page', function() {
 
   specify('patient sidebar', function() {
     const testPatient = getPatient({
-      id: '1',
       attributes: {
         first_name: 'Test',
         last_name: 'Patient',
         sex: 'u',
+      },
+    });
+
+    const testFlow = getFlow({
+      attributes: {
+        name: 'Test Flow Item',
+      },
+      relationships: {
+        owner: getRelationship(teamCoordinator),
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
       },
     });
 
@@ -3476,17 +3486,7 @@ context('worklist page', function() {
       })
       .routeFlows(fx => {
         fx.data = [
-          getFlow({
-            id: '1',
-            attributes: {
-              name: 'Test Flow Item',
-            },
-            relationships: {
-              owner: getRelationship(teamCoordinator),
-              state: getRelationship(stateTodo),
-              patient: getRelationship(testPatient),
-            },
-          }),
+          testFlow,
         ];
 
         fx.included.push(testPatient);
@@ -3496,17 +3496,17 @@ context('worklist page', function() {
       .routeActions(fx => {
         fx.data = [
           getAction({
-            id: '1',
             relationships: {
               owner: getRelationship(teamCoordinator),
               state: getRelationship(stateTodo),
               patient: getRelationship(testPatient),
-              flow: getRelationship('1', 'flows'),
+              flow: getRelationship(testFlow),
             },
           }),
         ];
 
         fx.included.push(testPatient);
+        fx.included.push(testFlow);
 
         return fx;
       })
@@ -3573,7 +3573,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', 'patient/dashboard/1');
+      .should('contain', `patient/dashboard/${ testPatient.id }`);
 
     cy
       .get('.patient-sidebar')
@@ -3596,7 +3596,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', 'patient/dashboard/1');
+      .should('contain', `patient/dashboard/${ testPatient.id }`);
 
     cy
       .get('.patient-sidebar')

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -622,7 +622,20 @@ context('program action sidebar', function() {
     cy
       .get('.sidebar')
       .find('[data-owner-region]')
-      .contains('Nurse');
+      .contains('Nurse')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-clear')
+      .click();
+
+    cy
+      .wait('@routePatchAction')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.relationships.owner.data).to.be.null;
+      });
 
     cy
       .get('.sidebar')

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -29,6 +29,7 @@ context('program action sidebar', function() {
         fx.data = getProgramActions({
           relationships: {
             'program': getRelationship(testProgram),
+            'program-flow': getRelationship(),
           },
         });
 

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -400,7 +400,20 @@ context('program flow sidebar', function() {
     cy
       .get('@flowHeader')
       .find('[data-owner-region]')
-      .contains('NUR');
+      .contains('NUR')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-clear')
+      .click();
+
+    cy
+      .wait('@routePatchFlow')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.relationships.owner.data).to.be.null;
+      });
 
     cy
       .get('.sidebar__footer')


### PR DESCRIPTION
Shortcut Story ID: [sc-55079]

This is potentially the final step, but we should be able to apply changes mostly without test updates until things are fixed.

We need to look for `fooModel.get('_,...` `fooModel.set('_...` and `fooModel.set({ _...` and make sure we're handling resources `{ id, type }` and not just ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced relationship data structure to include both `id` and `type` for each item, improving clarity and detail in relationships.
	- Introduced new methods for retrieving resources and relationships, enhancing data encapsulation.
	- Added new methods for managing clinician relationships, improving the handling of team and role data.
	- Added a new method to the Backbone Collection extension for retrieving resources from models.
	- Integrated a new function for accessing the store based on resource types, improving data retrieval capabilities.

- **Bug Fixes**
	- Removed deprecated relationship parsing methods, streamlining the handling of relationships in the application.

- **Refactor**
	- Simplified model and collection definitions by eliminating custom relationship parsing logic, potentially improving performance and maintainability.
	- Updated method calls to utilize new encapsulated logic for accessing model properties, enhancing consistency across the codebase.
	- Transitioned from direct property access to method calls for retrieving model data, improving clarity and maintainability.
	- Enhanced the handling of actions and patient relationships by encapsulating logic for retrieving related entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->