### PR TITLE
Use `action.created_at` for `[submitted]` form response request filter

### DIFF
--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -42,7 +42,7 @@ const ActionFormApp = App.extend({
 
     const isReport = form.isReport();
 
-    if (isReport) opts.submitted = `<=${ action.get('submitted_at') }`;
+    if (isReport) opts.submitted = `<=${ action.get('created_at') }`;
 
     const prefillActionTag = form.getPrefillActionTag();
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -210,7 +210,7 @@ export default App.extend({
 
     const isReport = form.isReport();
 
-    if (isReport) opts.submitted = `<=${ this.action.get('submitted_at') }`;
+    if (isReport) opts.submitted = `<=${ this.action.get('created_at') }`;
 
     const prefillActionTag = form.getPrefillActionTag();
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -2459,12 +2459,12 @@ context('Patient Action Form', function() {
   });
 
   specify('report form', function() {
-    const submittedAt = testTs();
+    const createdAt = testTs();
     cy
       .routeAction(fx => {
         fx.data = getAction({
           attributes: {
-            submitted_at: submittedAt,
+            created_at: createdAt,
             tags: ['prefill-latest-response'],
           },
         });
@@ -2491,7 +2491,7 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[submitted]=<=${ submittedAt }`);
+      .should('contain', `filter[submitted]=<=${ createdAt }`);
   });
 
   specify('refresh stale form', function() {

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -156,7 +156,7 @@ context('Formservice', function() {
   });
 
   specify('action formservice latest response from action tags', function() {
-    const submittedAt = testTs();
+    const createdAt = testTs();
 
     cy
       .routeFormByAction(_.identity, 'BBBBB')
@@ -167,7 +167,7 @@ context('Formservice', function() {
         fx.data = getAction({
           id: '1',
           attributes: {
-            submitted_at: submittedAt,
+            created_at: createdAt,
             tags: ['prefill-latest-response'],
           },
           relationships: {
@@ -189,7 +189,7 @@ context('Formservice', function() {
       .should('contain', 'filter[action.tags]=foo-tag')
       .should('contain', 'filter[flow]=1')
       .should('contain', 'filter[patient]=1')
-      .should('contain', `filter[submitted]=<=${ submittedAt }`);
+      .should('contain', `filter[submitted]=<=${ createdAt }`);
   });
 
   specify('action formservice iframe makes correct api requests', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-55090]

Original PR was incorrectly using `action.submitted_at`: https://github.com/RoundingWell/care-ops-frontend/pull/1316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the logic for determining submission timestamps for reports, now using the creation date instead of the submission date.
  
- **Bug Fixes**
	- Adjusted test cases to reflect the change in timestamp terminology from "submitted" to "created," ensuring accurate validation of form submissions.

- **Refactor**
	- Renamed variables related to timestamps for consistency across the application and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->