### PR TITLE
Add workos POC implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@fortawesome/pro-solid-svg-icons": "^6.1.0",
         "@fortawesome/pro-thin-svg-icons": "^6.4.0",
         "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
+        "@workos-inc/authkit-js": "^0.5.1",
         "animejs": "^3.2.1",
         "backbone": "^1.4.0",
         "backbone.eventrouter": "^1.0.1",
@@ -3582,6 +3583,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@workos-inc/authkit-js": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.5.1.tgz",
+      "integrity": "sha512-BOYrBiiINPmbkep+YGTsaJ8PiC8qtVCzZ3uN383TR9dRB/l77hEdO02EezQS5QWgMm02x503hLKdmacwWOwsMg==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "@fortawesome/pro-solid-svg-icons": "^6.1.0",
     "@fortawesome/pro-thin-svg-icons": "^6.4.0",
     "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
+    "@workos-inc/authkit-js": "^0.5.1",
     "animejs": "^3.2.1",
     "backbone": "^1.4.0",
     "backbone.eventrouter": "^1.0.1",

--- a/public/appconfig.json
+++ b/public/appconfig.json
@@ -28,6 +28,7 @@
   },
   "-workos": {
     "clientId": "client_01J7M1FVZZMHM6KTVTN5ZKRME1",
+    "rwClientId": "",
     "createClientOptions": {}
   },
   "datadog": {

--- a/public/appconfig.json
+++ b/public/appconfig.json
@@ -14,7 +14,7 @@
     "cacheLocation": "localstorage",
     "useRefreshTokens": true
   },
-  "kinde2": {
+  "-kinde": {
     "createParams": {
       "audience": "care-ops-backend",
       "client_id": "af4a982eafc845fc9df2e185b42d9ea6",
@@ -25,6 +25,10 @@
       "default": "conn_52f40d20db634985917ed7445d3167d0",
       "roundingwell": "conn_52f40d20db634985917ed7445d3167d0"
     }
+  },
+  "-workos": {
+    "clientId": "client_01J7M1FVZZMHM6KTVTN5ZKRME1",
+    "createClientOptions": {}
   },
   "datadog": {
     "clientToken": "pubdf015273e710a5a7b64bd5c80f126b9a",

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -3,6 +3,7 @@ import Radio from 'backbone.radio';
 import * as auth0 from './auth/auth0';
 import * as none from './auth/none';
 import * as kinde from './auth/kinde';
+import * as workos from './auth/workos';
 
 import 'scss/app-root.scss';
 
@@ -16,6 +17,7 @@ function getAuthAgent() {
   // These should be ordered by priority lowest to highest
   if (auth0.should()) authAgent = auth0;
   if (kinde.should()) authAgent = kinde;
+  if (workos.should()) authAgent = workos;
 
   return authAgent;
 }

--- a/src/js/auth/workos.js
+++ b/src/js/auth/workos.js
@@ -6,7 +6,7 @@ import { workosConfig as config, appConfig } from 'js/config';
 
 import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
 
-import { PATH_ROOT, PATH_AUTHD, PATH_LOGIN, PATH_LOGOUT } from './config';
+import { PATH_ROOT, PATH_RWELL, PATH_AUTHD, PATH_LOGIN, PATH_LOGOUT } from './config';
 
 let authkit;
 let token;
@@ -37,7 +37,6 @@ function replaceState(state) {
   window.history.replaceState({}, document.title, state);
 }
 
-
 function logout() {
   window.location = PATH_LOGOUT;
 }
@@ -65,6 +64,18 @@ function login(state = PATH_ROOT) {
   loginPromptView.render();
 }
 
+// If considered RW and rwClientId is set
+function getClientId(pathName) {
+  const { clientId, rwClientId } = config;
+
+  // RWell specific login
+  if (rwClientId && (pathName === PATH_RWELL || localStorage.getItem(PATH_RWELL))) {
+    return rwClientId;
+  }
+
+  return clientId;
+}
+
 async function createAuthkit(success, pathName) {
   const createClientOptions = {
     redirectUri: location.origin + PATH_AUTHD,
@@ -76,13 +87,18 @@ async function createAuthkit(success, pathName) {
 
       if (state === PATH_LOGIN) state = PATH_ROOT;
 
+      if (state === PATH_RWELL) {
+        state = PATH_ROOT;
+        localStorage.setItem(PATH_RWELL, 1);
+      }
+
       replaceState(state);
 
       success();
     },
   };
 
-  return createClient(config.clientId, extend(createClientOptions, config.createClientOptions));
+  return createClient(getClientId(pathName), extend(createClientOptions, config.createClientOptions));
 }
 
 /*

--- a/src/js/auth/workos.js
+++ b/src/js/auth/workos.js
@@ -1,0 +1,121 @@
+import { extend, isEmpty } from 'underscore';
+
+import { createClient } from '@workos-inc/authkit-js';
+
+import { workosConfig as config, appConfig } from 'js/config';
+
+import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
+
+import { PATH_ROOT, PATH_AUTHD, PATH_LOGIN, PATH_LOGOUT } from './config';
+
+let authkit;
+let token;
+
+function should() {
+  return !isEmpty(config);
+}
+
+function setToken(tokenString) {
+  token = tokenString;
+}
+
+function getToken() {
+  if (token) return token;
+  if (!authkit || !navigator.onLine) return;
+
+  return authkit
+    .getAccessToken()
+    .catch(() => {
+      logout();
+    });
+}
+
+/*
+ * Modifies the current history state
+ */
+function replaceState(state) {
+  window.history.replaceState({}, document.title, state);
+}
+
+
+function logout() {
+  window.location = PATH_LOGOUT;
+}
+
+function login(state = PATH_ROOT) {
+  // iframe buster
+  if (top !== self) {
+    top.location = PATH_LOGIN;
+    return;
+  }
+
+  if (appConfig.disableLoginPrompt) {
+    authkit.signIn({ state });
+    return;
+  }
+
+  replaceState(PATH_LOGIN);
+
+  const loginPromptView = new LoginPromptView();
+
+  loginPromptView.on('click:login', ()=> {
+    authkit.signIn({ state });
+  });
+
+  loginPromptView.render();
+}
+
+async function createAuthkit(success, pathName) {
+  const createClientOptions = {
+    redirectUri: location.origin + PATH_AUTHD,
+    onRedirectCallback: ({ user, state }) => {
+      if (!user) {
+        login(state);
+        return;
+      }
+
+      if (state === PATH_LOGIN) state = PATH_ROOT;
+
+      replaceState(state);
+
+      success();
+    },
+  };
+
+  return createClient(config.clientId, extend(createClientOptions, config.createClientOptions));
+}
+
+/*
+ * Requests authorization
+ * And authenticates authorization if redirected to PATH_AUTHD
+ */
+
+async function auth(success) {
+  // NOTE: Set path before await create to avoid redirect replaceState changing the value
+  const pathName = location.pathname;
+
+  authkit = await createAuthkit(success, pathName);
+
+  if (pathName === PATH_AUTHD) return;
+
+  if (pathName === PATH_LOGOUT) {
+    token = null;
+    authkit.signOut();
+    return;
+  }
+
+  if (!await authkit.getUser()) {
+    login(pathName);
+    return;
+  }
+
+  success();
+}
+
+export {
+  auth,
+  logout,
+  setToken,
+  getToken,
+  should,
+};

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -2,6 +2,7 @@ import { extend } from 'underscore';
 
 const auth0Config = {};
 const kindeConfig = {};
+const workosConfig = {};
 const datadogConfig = {};
 const appConfig = {};
 const versions = {};
@@ -22,6 +23,7 @@ function fetchConfig(success, isForm) {
     .then(config => {
       extend(auth0Config, config.auth0);
       extend(kindeConfig, config.kinde);
+      extend(workosConfig, config.workos);
       extend(datadogConfig, config.datadog);
       extend(appConfig, config.app);
       extend(versions, config.versions);
@@ -39,6 +41,7 @@ export {
   auth0Config,
   fetchConfig,
   kindeConfig,
+  workosConfig,
   datadogConfig,
   appConfig,
   versions,


### PR DESCRIPTION
Replaces #1323   Based on #1324

Shortcut Story ID: [sc-55351]

I don't have client ids in here or setup yet for dev.

I'm still not sure how we're going to implement our internal google connection, but I'm assuming the only option is separate clients.. but then I really don't know how the API will differentiate between if the token is internal or the orgs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated WorkOS authentication library for enhanced user authentication.
	- Added a new configuration for WorkOS client settings.
	- Introduced a module for managing WorkOS authentication processes.
	- Enhanced authentication logic to support multiple providers, including WorkOS.

- **Bug Fixes**
	- Improved handling of application state during login and logout processes.

- **Documentation**
	- Updated configuration files to include new authentication settings.

- **Refactor**
	- Streamlined authentication logic across multiple providers for better modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->