### PR TITLE
Add model.getResource

### DIFF
--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -48,6 +48,12 @@ export default Backbone.Model.extend(extend({
       return key !== 'id' && /^[^_]/.test(key);
     });
   },
+  getResource() {
+    return {
+      id: this.id,
+      type: this.type,
+    };
+  },
   toJSONApi(attributes = this.attributes) {
     return {
       id: this.id,


### PR DESCRIPTION
Called in the flow app subscribe:
https://github.com/RoundingWell/care-ops-frontend/blob/develop/src/js/apps/patients/patient/flow/flow_app.js#L84

This was originally in the websocket work, but I pulled it when I forgot it was used.. hard to tell it isn't in a `invoke`

We aren't testing the subscribe request specifics which is why this went under the radar.. so the first time we actually tested it was in the wild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method, `getResource`, to enhance model capabilities by providing easy access to the model's identifying information. 

- **Bug Fixes**
	- No bug fixes were included in this release. 

- **Documentation**
	- Updated documentation to reflect the addition of the `getResource` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->