### PR TITLE
Add name of clinician/patient to form response dropdown

### DIFF
--- a/src/js/entities-service/entities/form-responses.js
+++ b/src/js/entities-service/entities/form-responses.js
@@ -45,6 +45,18 @@ const _Model = BaseModel.extend({
   getFormData() {
     return omit(this.get('response'), 'data');
   },
+  getEditor() {
+    // editor can be a clinician or patient
+    const editor = this.get('_editor');
+    const Editor = Store.get(editor.type);
+
+    return new Editor({ id: editor.id });
+  },
+  getEditorName() {
+    const editor = this.getEditor();
+
+    return editor.get('name') || `${ editor.get('first_name') } ${ editor.get('last_name') }`;
+  },
   parseRelationship: _parseRelationship,
 });
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -111,6 +111,8 @@ careOptsFrontend:
           increaseWidth: Increase Width
           responseHistory: See Form Response History
           showActionSidebar: Show Action Sidebar
+        historyDroplistView:
+          nameText: '• By { name }'
         historyView:
           currentVersionButton: Back to Current Version
         lastUpdatedView:

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -405,12 +405,30 @@ const UpdateView = View.extend({
 });
 
 const HistoryDroplist = Droplist.extend({
-  viewOptions: {
-    className: 'button-filter',
-    template: hbs`{{far "clock-rotate-left"}}{{formatDateTime updated_at "AT_TIME"}}{{far "angle-down"}}`,
+  viewOptions() {
+    return {
+      className: 'button-filter',
+      template: hbs`
+        {{far "clock-rotate-left"}}{{formatDateTime updated_at "AT_TIME"}} {{formatMessage (intlGet "forms.form.formViews.historyDroplistView.nameText") name=name}}{{far "angle-down"}}
+      `,
+      templateContext() {
+        return {
+          name: this.model.getEditorName(),
+        };
+      },
+    };
   },
-  picklistOptions: {
-    itemTemplate: hbs`{{formatDateTime updated_at "AT_TIME"}}`,
+  picklistOptions() {
+    return {
+      itemTemplate: hbs`
+        {{formatDateTime updated_at "AT_TIME"}}&nbsp;{{formatMessage (intlGet "forms.form.formViews.historyDroplistView.nameText") name=name}}
+      `,
+      itemTemplateContext() {
+        return {
+          name: this.model.getEditorName(),
+        };
+      },
+    };
   },
 });
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import dayjs from 'dayjs';
 import { v4 as uuid } from 'uuid';
 
@@ -834,10 +833,19 @@ context('Patient Action Form', function() {
   });
 
   specify('submitting the form', function() {
+    const testUpdatedAt = testTs();
+
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Testin',
+        last_name: 'Mctester',
+      },
+    });
+
     const testFormResponses = [
       getFormResponse({
         attributes: {
-          updated_at: testTs(),
+          updated_at: testUpdatedAt,
           status: FORM_RESPONSE_STATUS.SUBMITTED,
           response: {
             data: {
@@ -849,19 +857,27 @@ context('Patient Action Form', function() {
       }),
       getFormResponse({
         attributes: {
-          updated_at: testTs(),
+          updated_at: testUpdatedAt,
+          status: FORM_RESPONSE_STATUS.SUBMITTED,
+          response: {
+            data: {
+              familyHistory: 'Here is some typing by a patient',
+              storyTime: 'Once upon a time...',
+            },
+          },
+        },
+        relationships: {
+          editor: getRelationship(testPatient),
+        },
+      }),
+      getFormResponse({
+        attributes: {
+          updated_at: testUpdatedAt,
           status: FORM_RESPONSE_STATUS.SUBMITTED,
           response: { data: { fields: { foo: 'bar' } } },
         },
       }),
     ];
-
-    const testPatient = getPatient({
-      attributes: {
-        first_name: 'Testin',
-        last_name: 'Mctester',
-      },
-    });
 
     const testAction = getAction({
       relationships: {
@@ -1057,18 +1073,33 @@ context('Patient Action Form', function() {
     cy
       .get('@metaRegion')
       .find('.button-filter')
+      .should('contain', formatDate(testUpdatedAt, 'AT_TIME'))
+      .should('contain', 'By Clinician McTester')
       .click();
 
     cy
       .get('.picklist')
       .find('.js-picklist-item')
-      .should('have.length', 2)
+      .should('have.length', 3);
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .eq(1)
+      .should('contain', formatDate(testUpdatedAt, 'AT_TIME'))
+      .should('contain', 'By Testin Mctester');
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
       .last()
+      .should('contain', formatDate(testUpdatedAt, 'AT_TIME'))
+      .should('contain', 'By Clinician McTester')
       .click();
 
     cy
       .get('iframe')
-      .should('have.attr', 'src', `/formapp/${ testFormResponses[1].id }`);
+      .should('have.attr', 'src', `/formapp/${ testFormResponses[2].id }`);
 
     cy
       .get('@metaRegion')


### PR DESCRIPTION
Shortcut Story ID: [sc-54545]

Info retrieved from the `form-response.relationships.editor` relationship. Supports an editor with a type of `clinicians` or `patients`.

![Screenshot 2024-10-03 at 4 51 01 PM](https://github.com/user-attachments/assets/783ea347-7443-4755-b77e-10923778502e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced methods to retrieve and format editor information in form responses.
  - Added localization support for displaying historical actions related to forms.

- **Improvements**
  - Enhanced dropdowns to dynamically show editor names and updated times.
  - Improved form submission logic and error handling for better user experience.
  - Expanded local storage management and dynamic form pre-filling capabilities.
  - Enhanced integration of form widgets to display patient information effectively.

- **Tests**
  - Expanded test coverage for various form scenarios, ensuring robustness and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->