### PR TITLE
Move local change cached to save

### DIFF
--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -74,16 +74,11 @@ export default Backbone.Model.extend(extend({
       data: JSON.stringify({ data }),
     }, opts);
 
-    return Backbone.Model.prototype.save.call(this, attrs, opts);
-  },
-  set() {
-    const isValid = Backbone.Model.prototype.set.apply(this, arguments);
+    const savePromise = Backbone.Model.prototype.save.call(this, attrs, opts);
 
-    if (!isValid) return false;
-
-    this.attributes.__cached_ts = dayjs.utc().format();
-
-    return this;
+    return savePromise.then(() => {
+      this.attributes.__cached_ts = dayjs.utc().format();
+    });
   },
   isCached() {
     return this.has('__cached_ts');


### PR DESCRIPTION
`set` doesn’t work because recalling a model from the backbone.store also calls `set`.

Plus we’re really interested in changing the cache when we’re marking changed made to the server.

Shortcut Story ID: [sc-55592]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced save functionality now returns a promise, ensuring better handling of save operations.
	- Introduced a `__cached_ts` attribute that updates only after a successful save, providing accurate timestamp tracking.

- **Bug Fixes**
	- Improved control flow during save operations to prevent potential issues with previous implementations.
	- Removed the outdated `set` method, streamlining the model's functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->