### PR TITLE
Remove action from URL when action sidebar is closed 

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -16,6 +16,8 @@ import { LayoutView, ContextTrailView, HeaderView, ListView, SelectAllView } fro
 import { BulkEditButtonView, BulkEditActionsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
 import { AddButtonView, i18n } from 'js/views/patients/shared/add-workflow/add-workflow_views';
 
+const userActivityCh = Radio.channel('user-activity');
+
 export default SubRouterApp.extend({
   StateModel,
   routerAppName: 'FlowApp',
@@ -289,6 +291,10 @@ export default SubRouterApp.extend({
       'stop'() {
         this.setState('actionBeingEdited', null);
       },
+    });
+
+    this.listenTo(userActivityCh, 'close:actionSidebar', () => {
+      Radio.trigger('event-router', 'flow', this.flow.id);
     });
 
     this.startChildApp('action', { actionId });

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -10,6 +10,8 @@ import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
 
 import { LayoutView } from 'js/views/patients/patient/patient_views';
 
+const userActivityCh = Radio.channel('user-activity');
+
 export default SubRouterApp.extend({
   eventRoutes() {
     return {
@@ -71,6 +73,15 @@ export default SubRouterApp.extend({
       'fail'() {
         this.startCurrent('dashboard');
       },
+    });
+
+    this.listenTo(userActivityCh, 'close:actionSidebar', () => {
+      if (this.getCurrent()._name === 'archive') {
+        Radio.trigger('event-router', 'patient:archive', this.patient.id);
+        return;
+      }
+
+      Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
     });
 
     this.startChildApp('action', { actionId, patientId });

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -1,5 +1,6 @@
 import { bind } from 'underscore';
 import Backbone from 'backbone';
+import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'marionette';
 
@@ -67,6 +68,9 @@ const LayoutView = View.extend({
   },
   onAttach() {
     animSidebar(this.el);
+  },
+  onClose() {
+    Radio.trigger('user-activity', 'close:actionSidebar');
   },
 });
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -103,6 +103,27 @@ context('patient flow page', function() {
   });
 
   specify('patient flow action sidebar', function() {
+    const testFlowActions = [
+      getAction({
+        attributes: {
+          name: 'First Action',
+          sequence: 1,
+        },
+        relationships: {
+          flow: getRelationship(testFlow),
+        },
+      }),
+      getAction({
+        attributes: {
+          name: 'Second Action',
+          sequence: 2,
+        },
+        relationships: {
+          flow: getRelationship(testFlow),
+        },
+      }),
+    ];
+
     cy
       .routesForPatientAction()
       .routeFlow(fx => {
@@ -110,15 +131,19 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routeFlowActions()
+      .routeFlowActions(fx => {
+        fx.data = testFlowActions;
+
+        return fx;
+      })
       .routeAction(fx => {
-        fx.data = testAction;
+        fx.data = testFlowActions[0];
 
         return fx;
       })
       .routePatientByFlow()
       .routeActionActivity()
-      .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
+      .visit(`/flow/${ testFlow.id }/action/${ testFlowActions[0].id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
       .wait('@routeFlowActions');
@@ -126,7 +151,46 @@ context('patient flow page', function() {
     cy
       .get('.sidebar')
       .find('[data-action-region] .action-sidebar__name')
-      .should('contain', 'Test Action');
+      .should('contain', 'First Action');
+
+    cy.routeAction(fx => {
+      fx.data = testFlowActions[1];
+
+      return fx;
+    });
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .action-sidebar__name')
+      .should('contain', 'First Action');
+
+    cy
+      .get('.patient-flow__list')
+      .as('actionsList')
+      .find('.table-list__item')
+      .eq(1)
+      .find('.patient__action-name')
+      .click()
+      .wait('@routeAction');
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .action-sidebar__name')
+      .should('contain', 'Second Action');
+
+    cy
+      .url()
+      .should('contain', `/flow/${ testFlow.id }/action/${ testFlowActions[1].id }`);
+
+    cy
+      .get('.sidebar')
+      .find('.js-close')
+      .click();
+
+    cy
+      .url()
+      .should('not.contain', `/action/${ testFlowActions[1].id }`)
+      .should('contain', `/flow/${ testFlow.id }`);
   });
 
   specify('done patient flow action sidebar', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-54866]

When a user is on a flow page with the action sidebar open (`/flow/:id/action/:id`). And then closes the sidebar via the `.js-close` icon in the UI, the URL should be changed to `/flow/:id` with the `/action/:id` portion removed.

We don't want this to happen when the action sidebar is closed because the user clicked on a different flow action in the list (this closes the current action sidebar and opens a new sidebar for the selected action) or navigated away from the patient flow page.

We only want this functionality on the patient flow page. The action sidebar is used in several different pages/apps. Those other versions should not have this functionality added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user activity tracking with improved navigation when closing the action sidebar.
	- Added functionality to the sidebar to communicate user activity events upon closure.

- **Bug Fixes**
	- Expanded integration tests for the patient flow page, improving action management and error handling scenarios.
	- Verified correct display and functionality of the flow action sidebar.

- **Tests**
	- Introduced new action definitions and expanded tests for bulk editing and socket notifications.
	- Added tests for multi-selection functionality and progress bar accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->