### PR TITLE
Add Websocket client key

### DIFF
--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -71,6 +71,10 @@ async function buildFetcher(url, options = {}) {
   const currentWorkspace = Radio.request('workspace', 'current');
   if (currentWorkspace) options.headers.Workspace = currentWorkspace.id;
 
+  // Attach Client ID
+  const currentUser = Radio.request('bootstrap', 'currentUser');
+  if (currentUser) options.headers['Client-Key'] = currentUser.clientKey;
+
   return registerFetcher(baseUrl, fetch(url, options), controller);
 }
 

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -1,6 +1,5 @@
 import { extend, isEmpty, isFunction, pick, reduce, result } from 'underscore';
 import Backbone from 'backbone';
-import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Model.extend(extend({
@@ -74,11 +73,7 @@ export default Backbone.Model.extend(extend({
       data: JSON.stringify({ data }),
     }, opts);
 
-    const savePromise = Backbone.Model.prototype.save.call(this, attrs, opts);
-
-    return savePromise.then(() => {
-      this.attributes.__cached_ts = dayjs.utc().format();
-    });
+    return Backbone.Model.prototype.save.call(this, attrs, opts);
   },
   isCached() {
     return this.has('__cached_ts');
@@ -88,10 +83,7 @@ export default Backbone.Model.extend(extend({
 
     return isFunction(messages[category]) ? messages[category] : this[messages[category]];
   },
-  handleMessage({ category, timestamp, payload }) {
-    // Ignores messages that may be from recent local events
-    if (dayjs(this.get('__cached_ts')).add(10, 'seconds').isAfter(timestamp)) return;
-
+  handleMessage({ category, payload }) {
     const handler = this._getMessageHandler(category);
     if (handler) handler.call(this, payload);
 

--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -1,4 +1,5 @@
 import { setUser } from 'js/datadog';
+import { v4 as uuid } from 'uuid';
 import Radio from 'backbone.radio';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/clinicians';
@@ -17,6 +18,7 @@ const Entity = BaseEntity.extend({
     return this.fetchBy('/api/clinicians/me')
       .then(currentUser => {
         setUser(currentUser.pick('id', 'name', 'email'));
+        currentUser.clientKey = uuid();
         return currentUser;
       });
   },

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -34,7 +34,15 @@ export default App.extend({
   },
 
   _subscribe() {
-    this.send({ name: 'Subscribe', data: { resources: this.resources.toJSON() } });
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+
+    this.send({
+      name: 'Subscribe',
+      data: {
+        clientKey: currentUser.clientKey,
+        resources: this.resources.toJSON(),
+      },
+    });
   },
 
   send(data) {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2210,12 +2210,11 @@ context('patient flow page', function() {
       .wait('@routePatientByFlow')
       .wait('@routeFlowActions')
       .interceptWs('Subscribe')
-      .should('deep.equal', {
-        resources: [
-          getRelationship(testSocketFlow).data,
-          getRelationship(testSocketAction).data,
-        ],
-      });
+      .its('resources')
+      .should('deep.equal', [
+        getRelationship(testSocketFlow).data,
+        getRelationship(testSocketAction).data,
+      ]);
 
     cy
       .get('.patient-flow__progress')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import { testTs, testTsSubtract, testTsAdd } from 'helpers/test-timestamp';
+import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getErrors, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
@@ -670,22 +670,6 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'ActionCreated',
-      timestamp: testTs(),
-      resource: {
-        type: 'flows',
-        id: testFlow.id,
-      },
-      payload: {
-        action: {
-          type: 'patient-actions',
-          id: conditionalAction.id,
-        },
-      },
-    });
-
-    cy.sendWs({
-      category: 'ActionCreated',
-      timestamp: testTsAdd(300),
       resource: {
         type: 'flows',
         id: testFlow.id,
@@ -2239,7 +2223,6 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'OwnerChanged',
-      timestamp: testTsAdd(300),
       resource: {
         type: 'patient-actions',
         id: testSocketAction.id,
@@ -2254,7 +2237,6 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'OwnerChanged',
-      timestamp: testTsAdd(300),
       resource: {
         type: 'flows',
         id: testSocketFlow.id,
@@ -2267,28 +2249,12 @@ context('patient flow page', function() {
       },
     });
 
-    cy.sendWs({
-      category: 'StateChanged',
-      timestamp: testTsSubtract(30000),
-      resource: {
-        type: 'patient-actions',
-        id: testSocketAction.id,
-      },
-      payload: {
-        state: {
-          type: 'states',
-          id: stateDone.id,
-        },
-      },
-    });
-
     cy
       .get('.patient-flow__progress')
       .should('have.value', 0);
 
     cy.sendWs({
       category: 'StateChanged',
-      timestamp: testTsAdd(100),
       resource: {
         type: 'patient-actions',
         id: testSocketAction.id,
@@ -2307,7 +2273,6 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'StateChanged',
-      timestamp: testTsAdd(300),
       resource: {
         type: 'flows',
         id: testSocketFlow.id,


### PR DESCRIPTION
Shortcut Story ID: [sc-55726]

I think this is the ideal setup.  FE creates a token for the fetch header at the bootstrap of the current client.  This will make this value specific to the tab.  (although a hard-refresh will reset this token.. not a problem?  We could store it in a sessionCache if needed @DrechslerDerek)

I used `X-Client-Key` as `X-` indicates a custom header and no standard or proposed HTTP seemed to match what we're doing exactly that I could find.  And this is a per-client key.

Then we `Subscribe` with `data.clientKey` to match so that we're only pushed messages that _aren't_ related to the clientKey.  Then each client can treat all pushed messages as relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced request headers to include user-specific identification for improved tracking and authorization.
	- Added unique client key generation for current users to enhance identification.

- **Bug Fixes**
	- Simplified handling of WebSocket messages by removing unnecessary timestamp parameters, streamlining message structure.

- **Tests**
	- Updated WebSocket service tests to include client key in responses and adjusted assertions for consistency with the new structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->