### PR TITLE
Add passing options to app.restart

### DIFF
--- a/src/js/base/app.js
+++ b/src/js/base/app.js
@@ -1,9 +1,19 @@
-import { bind, isArray, noop, uniqueId } from 'underscore';
+import { bind, isArray, noop, uniqueId, extend } from 'underscore';
 import { App } from 'marionette.toolkit';
 
 import handleErrors from 'js/utils/handle-errors';
 
 export default App.extend({
+  // TODO: Move this to marionette.toolkit
+  restart(options) {
+    const state = this.getState().attributes;
+
+    this._isRestarting = true;
+    this.stop().start(extend({ state }, options));
+    this._isRestarting = false;
+
+    return this;
+  },
   triggerStart(options) {
     this._isLoading = true;
 


### PR DESCRIPTION
Shortcut Story ID: [sc-55890]

`restart` didn't  pass `options` but maybe it should?  otherwise we need to set state here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `restart` method in the application, allowing users to seamlessly restart the app while preserving the current state.
  
- **Bug Fixes**
	- Improved WebSocket service tests to ensure better handling of socket closure and state changes, enhancing overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->