### PR TITLE
Update `marionette.toolkit` package & remove `app.restart()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8626,9 +8626,9 @@
       }
     },
     "node_modules/marionette.toolkit": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/marionette.toolkit/-/marionette.toolkit-6.2.0.tgz",
-      "integrity": "sha512-BFD36EAL1Vqh0uczRoesNvwb97uw6G9mjaiIAgA1ZTtAR4jmcXA11kvgXayYyhLeBIlsXS3F893XohRxomOlHw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/marionette.toolkit/-/marionette.toolkit-6.3.0.tgz",
+      "integrity": "sha512-a34OVGLRk2C0EvxWr3HECEXKjqJ94F542xFp2hJtsNuUqNflexlzIZ9FCNTIt9I/zthnfomLNAu/ksIJ3KzMBw==",
       "license": "MIT",
       "peerDependencies": {
         "backbone": "^1.3.3",

--- a/src/js/base/app.js
+++ b/src/js/base/app.js
@@ -1,19 +1,9 @@
-import { bind, isArray, noop, uniqueId, extend } from 'underscore';
+import { bind, isArray, noop, uniqueId } from 'underscore';
 import { App } from 'marionette.toolkit';
 
 import handleErrors from 'js/utils/handle-errors';
 
 export default App.extend({
-  // TODO: Move this to marionette.toolkit
-  restart(options) {
-    const state = this.getState().attributes;
-
-    this._isRestarting = true;
-    this.stop().start(extend({ state }, options));
-    this._isRestarting = false;
-
-    return this;
-  },
   triggerStart(options) {
     this._isLoading = true;
 


### PR DESCRIPTION
Shortcut Story ID: [sc-55912]

The ability to pass an options object to `app.restart()` was added to the FE codebase here: https://github.com/RoundingWell/care-ops-frontend/pull/1338.

We've now added that directly to the `marionette.toolkit` package: https://github.com/RoundingWellOS/marionette.toolkit/pull/276.

So we can update `marionette.toolkit` to the latest version and remove that code from the FE codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `restart` method to streamline application functionality.
  
- **Chores**
	- Cleaned up unused imports related to the `restart` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->