### PR TITLE
Rename ActionCreated message for resource

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -104,10 +104,10 @@ export default SubRouterApp.extend({
     this._setFlowProgress();
   },
   onFlowMessage({ category, payload }) {
-    if (category !== 'ActionCreated') return;
-    const { action } = payload;
+    if (category !== 'ResourceCreated') return;
+    const { resource } = payload;
 
-    const fetchAction = Radio.request('entities', 'fetch:actions:model', action.id);
+    const fetchAction = Radio.request('entities', 'fetch:actions:model', resource.id);
     fetchAction.then(bind(this._addAction, this));
   },
   onFlowChangeOwner(flow, _owner) {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -669,13 +669,13 @@ context('patient flow page', function() {
       });
 
     cy.sendWs({
-      category: 'ActionCreated',
+      category: 'ResourceCreated',
       resource: {
         type: 'flows',
         id: testFlow.id,
       },
       payload: {
-        action: {
+        resource: {
           type: 'patient-actions',
           id: otherAction.id,
         },


### PR DESCRIPTION
Shortcut Story ID: [sc-56044]

What I don't like about this is that we're not checking if there's a resource create for a different type..
But supporting a future unknown `ResourceCreated` likely requires awkward tests or istabul ignores, and the worst case situations is that a action fetch is done returning a 410 until we start handling the new create

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated event handling to respond to resource creation instead of action creation, enhancing the application's ability to process flow messages.

- **Bug Fixes**
	- Improved error handling for action updates and deletions, ensuring users receive appropriate error messages.

- **Tests**
	- Expanded integration tests for patient actions, flow progress, bulk editing, and permission checks, ensuring comprehensive validation of functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->