### PR TITLE
Update action name in sidebar when the action's `model.name` changes

### DIFF
--- a/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
@@ -16,6 +16,10 @@ import ActionDetailsTemplate from './action-details.hbs';
 
 import './action-sidebar.scss';
 
+const NameView = View.extend({
+  template: hbs`<div class="action-sidebar__name">{{ name }}</div>`,
+});
+
 const SaveView = View.extend({
   className: 'u-margin--t-8 sidebar__save',
   template: hbs`
@@ -106,7 +110,7 @@ const ActionView = View.extend({
     'cancel': 'cancel',
   },
   template: hbs`
-    <div class="action-sidebar__name">{{ name }}</div>
+    <div data-name-region></div>
     <div class="u-margin--t-8" data-details-region></div>
     <div data-save-region></div>
     <div class="flex u-margin--t-16"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.actionSidebarActionViews.actionView.stateLabel }}</h4><div class="flex-grow" data-state-region></div></div>
@@ -130,12 +134,16 @@ const ActionView = View.extend({
     duration: '[data-duration-region]',
   },
   modelEvents: {
+    'change:name': 'onChangeName',
     'change:details': 'onChangeDetails',
     'change:_state': 'onChangeActionState',
     'change:_owner': 'onChangeOwner',
     'change:due_date': 'onChangeDue',
     'change:due_time': 'onChangeDue',
     'change:duration': 'onChangeDuration',
+  },
+  onChangeName() {
+    this.showName();
   },
   onChangeDetails() {
     if (this.isEditingDetails) return;
@@ -172,6 +180,7 @@ const ActionView = View.extend({
     this.clonedAction = this.model.clone();
   },
   onRender() {
+    this.showName();
     this.showEditForm();
     this.showState();
     this.showOwner();
@@ -184,6 +193,9 @@ const ActionView = View.extend({
   },
   onCancel() {
     this.showEditForm();
+  },
+  showName() {
+    this.showChildView('name', new NameView({ model: this.model }));
   },
   showEditForm() {
     this.cloneAction();

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -153,6 +153,22 @@ context('patient flow page', function() {
       .find('[data-action-region] .action-sidebar__name')
       .should('contain', 'Test Action');
 
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: 'patient-actions',
+        id: testFlowAction.id,
+      },
+      payload: {
+        name: 'New Websocket Name',
+      },
+    });
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .action-sidebar__name')
+      .should('contain', 'New Websocket Name');
+
     cy
       .get('.sidebar')
       .find('[data-details-region] .js-input')


### PR DESCRIPTION
Shortcut Story ID: [sc-56480]

This should have been included in: https://github.com/RoundingWell/care-ops-frontend/pull/1345. So the name in the action sidebar updates on a `NameChanged` websocket notification.

This will likely only happen because of an eval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `NameView` for displaying patient names, enhancing modularity in the UI.
  - Improved handling of WebSocket notifications for real-time updates on patient actions and flows.

- **Bug Fixes**
  - Enhanced integration tests to ensure UI correctly reflects changes from WebSocket messages, improving reliability.

- **Tests**
  - Expanded test cases to cover various patient action updates and user role permissions, ensuring robust interaction with the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->