### PR TITLE
Update top padding css for action sidebar sharing state element

### DIFF
--- a/src/js/views/patients/sidebar/action/action-sidebar.scss
+++ b/src/js/views/patients/sidebar/action/action-sidebar.scss
@@ -11,7 +11,7 @@
 
 .action-sidebar__sharing-state {
   border: 1px solid #FFF;
-  padding: 8px 16px;
+  padding: 4px 16px 8px;
 
   .icon {
     font-size: 16px;


### PR DESCRIPTION
Shortcut Story ID: [sc-56617]

Before: 

<img width="279" alt="Screenshot 2024-11-07 at 11 40 27 AM" src="https://github.com/user-attachments/assets/816553fa-2bd7-477c-af5e-6881337ab5fb">

After:

<img width="276" alt="Screenshot 2024-11-07 at 11 42 23 AM" src="https://github.com/user-attachments/assets/c078c453-bc73-4fce-992b-5cdd219ecd61">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the padding for the action sidebar component, enhancing the layout by reducing the top padding for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->