### PR TITLE
Change `updated_at` attribute when action/flow model is updated via web socket

### DIFF
--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -1,5 +1,6 @@
 import { extend, isEmpty, isFunction, pick, reduce, result } from 'underscore';
 import Backbone from 'backbone';
+import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Model.extend(extend({
@@ -84,6 +85,8 @@ export default Backbone.Model.extend(extend({
     return isFunction(messages[category]) ? messages[category] : this[messages[category]];
   },
   handleMessage({ category, payload }) {
+    payload.attributes = extend({}, payload.attributes, { updated_at: dayjs.utc().format() });
+
     const handler = this._getMessageHandler(category);
     if (handler) handler.call(this, payload);
 

--- a/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
@@ -264,6 +264,9 @@ const TimestampsView = View.extend({
       createdAt: this.getOption('createdEvent').get('date'),
     };
   },
+  modelEvents: {
+    'change:updated_at': 'render',
+  },
 });
 
 export {

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -76,6 +76,7 @@ const LayoutView = View.extend({
   modelEvents: {
     'change:_state': 'showOwner',
     'change:_owner': 'showFlow',
+    'change:updated_at': 'showTimestamps',
   },
   onAttach() {
     animSidebar(this.el);

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import dayjs from 'dayjs';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
@@ -121,6 +122,7 @@ context('patient flow page', function() {
         duration: 10,
         outreach: 'disabled',
         sharing: 'disabled',
+        updated_at: testTsSubtract(1),
       },
       relationships: {
         flow: getRelationship(testFlow),
@@ -189,6 +191,13 @@ context('patient flow page', function() {
       .get('.sidebar')
       .find('[data-action-region] .action-sidebar__name')
       .should('contain', 'New Websocket Name');
+
+    cy
+      .get('.sidebar')
+      .find('.sidebar__footer')
+      .contains('Updated')
+      .next()
+      .should('contain', formatDate(dayjs.utc().format(), 'AT_TIME'));
 
     cy
       .get('.sidebar')
@@ -2344,6 +2353,7 @@ context('patient flow page', function() {
     const testSocketFlow = getFlow({
       attributes: {
         name: 'Flow Test',
+        updated_at: testTsSubtract(1),
       },
       relationships: {
         state: getRelationship(stateInProgress),
@@ -2358,6 +2368,7 @@ context('patient flow page', function() {
         due_time: '06:00:00',
         outreach: 'disabled',
         sharing: 'disabled',
+        updated_at: testTsSubtract(1),
       },
       relationships: {
         flow: getRelationship(testSocketFlow),
@@ -2383,6 +2394,7 @@ context('patient flow page', function() {
         return fx;
       })
       .routeActionActivity()
+      .routeFlowActivity()
       .visit(`/flow/${ testSocketFlow.id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -2393,6 +2405,10 @@ context('patient flow page', function() {
         getRelationship(testSocketFlow).data,
         getRelationship(testSocketAction).data,
       ]);
+
+    cy
+      .get('[data-header-region]')
+      .click('top');
 
     cy.sendWs({
       category: 'NameChanged',
@@ -2411,6 +2427,18 @@ context('patient flow page', function() {
       .get('[data-header-region]')
       .find('.patient-flow__name')
       .contains('New Flow Name');
+
+    cy
+      .get('.app-frame__sidebar')
+      .find('.sidebar__footer')
+      .contains('Updated')
+      .next()
+      .should('contain', formatDate(dayjs.utc().format(), 'AT_TIME'));
+
+    cy
+      .get('.app-frame__sidebar')
+      .find('.js-close')
+      .click();
 
     cy.sendWs({
       category: 'DetailsChanged',
@@ -2447,6 +2475,11 @@ context('patient flow page', function() {
       .get('.patient-flow__list')
       .find('.table-list__item .patient__action-name')
       .contains('New Action Name');
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .patient__action-ts')
+      .should('contain', formatDate(dayjs.utc().format(), 'TIME_OR_DAY'));
 
     cy.sendWs({
       category: 'ActionDueChanged',


### PR DESCRIPTION
Shortcut Story ID: [sc-56745]

When we receive a web socket notification of any kind for a flow or action, its `updated_at` attribute will now be updated to the current date-time.

This change is applied on the base model level. But will only be put to use on the patient flow page since that's the only place we currently subscribe to web socket notifications.

On the patient flow page, that is displayed in these UI locations:

1. Each flow action list item.
2. Footer section of action sidebar.
3. Footer section of flow sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced message handling to include a timestamp (`updated_at`) for better tracking.
	- Introduced real-time updates in the UI for timestamp changes, improving responsiveness.

- **Bug Fixes**
	- Improved integration tests to ensure accurate display of updated timestamps and real-time changes in the patient flow management system.

- **Documentation**
	- Updated test cases to validate the new timestamp functionality and websocket event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->