### PR TITLE
Handle `ResourceDeleted` websocket notification for actions on patient flow page

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -43,7 +43,11 @@ export default App.extend(extend({
     this.action.trigger('editing', true);
     const flow = this.action.getFlow();
     if (flow) this.listenTo(flow, 'change:_state', this.setAccess);
-    this.listenTo(action, 'change:_owner', this.onChangeOwner);
+
+    this.listenTo(action, {
+      'change:_owner': this.onChangeOwner,
+      'destroy': this.stop,
+    });
 
     this.showChildView('heading', new HeadingView({ model: this.action }));
     this.showContent();

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -5,6 +5,12 @@ import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Model.extend(extend({
   destroy(options) {
+    if (options && options.isDeleted) {
+      this.stopListening();
+      this.trigger('destroy', this, this.collection, options);
+      return;
+    }
+
     if (this.isNew()) {
       Backbone.Model.prototype.destroy.call(this, options);
       return Promise.resolve(options);

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -42,6 +42,9 @@ const _Model = BaseModel.extend({
     SharingUpdated({ attributes }) {
       this.set(attributes);
     },
+    ResourceDeleted() {
+      this.destroy({ isDeleted: true });
+    },
   },
   urlRoot() {
     if (this.isNew()) {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -303,6 +303,19 @@ context('patient flow page', function() {
       .find('[data-form-sharing-region]')
       .find('.action-sidebar__sharing-state')
       .should('contain', 'Response Saved');
+
+    cy.sendWs({
+      category: 'ResourceDeleted',
+      resource: {
+        type: 'patient-actions',
+        id: testFlowAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('.sidebar')
+      .should('not.exist');
   });
 
   specify('done patient flow action sidebar', function() {
@@ -2620,5 +2633,18 @@ context('patient flow page', function() {
       .get('@flowSidebar')
       .find('[data-state-region]')
       .should('contain', 'Done');
+
+    cy.sendWs({
+      category: 'ResourceDeleted',
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('.patient-flow__empty-list')
+      .contains('No Actions');
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-56332]

When this happens, we want to remove the action from the list via `destroy()` and close the action sidebar if it's open.

We added some code to the base model `destroy()` method to stop the `DELETE` api request in this scenario.