### PR TITLE
Add an action name a-z default sort option to worklists

### DIFF
--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -62,6 +62,10 @@ const patientNameComparator = function(a, b) {
   return alphaSort(this.get('direction'), a.model.getPatient().getSortName(), b.model.getPatient().getSortName());
 };
 
+const actionNameComparator = function(a, b) {
+  return alphaSort(this.get('direction'), a.model.get('name'), b.model.get('name'));
+};
+
 const updatedAtComparator = function(a, b) {
   return alphaSort(this.get('direction'), a.model.get('updated_at'), b.model.get('updated_at'));
 };
@@ -81,6 +85,19 @@ const defaultSortOptions = [
     id: 'sortPatientDesc',
     text: i18n.sortPatientOptions.desc,
     comparator: patientNameComparator,
+  },
+  {
+    id: 'sortActionNameAsc',
+    text: i18n.sortActionOptions.asc,
+    entities: ['actions'],
+    direction: 'asc',
+    comparator: actionNameComparator,
+  },
+  {
+    id: 'sortActionNameDesc',
+    text: i18n.sortActionOptions.desc,
+    entities: ['actions'],
+    comparator: actionNameComparator,
   },
   {
     id: 'sortDueAsc',

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -681,6 +681,9 @@ careOptsFrontend:
             }
         noOwnerToggleView:
           noOwner: No Owner
+        sortActionOptions:
+          asc: 'Action: A - Z'
+          desc: 'Action: Z - A'
         sortCreatedOptions:
           asc: 'Added: Oldest - Newest'
           desc: 'Added: Newest - Oldest'
@@ -826,7 +829,7 @@ careOptsFrontend:
             headingOutreachText: Program Outreach Action
           menuView:
             delete: Delete Program Action
-            headingText: Program Action Menu  
+            headingText: Program Action Menu
           saveView:
             cancelBtn: Cancel
             saveBtn: Save

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2645,10 +2645,48 @@ context('worklist page', function() {
       .should('contain', 'Due Time Least Recent');
 
     cy
+      .get('.worklist-list__filter-sort')
+      .click()
+      .get('.picklist')
+      .contains('Action: A - Z')
+      .click();
+
+    cy
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
-      .contains('Due Date Most Recent')
+      .should('contain', 'Created Least Recent');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .should('contain', 'Updated Most Recent');
+
+    cy
+      .get('.worklist-list__filter-sort')
+      .click()
+      .get('.picklist')
+      .contains('Action: Z - A')
+      .click();
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .should('contain', 'Updated Most Recent');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .should('contain', 'Created Least Recent');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .contains('Updated Most Recent')
       .click()
       .wait('@routeAction');
 
@@ -2662,11 +2700,11 @@ context('worklist page', function() {
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
-      .contains('Due Date Most Recent');
+      .contains('Updated Most Recent');
 
     cy
       .get('.worklist-list__filter-sort')
-      .contains('Due: Later - Sooner');
+      .contains('Action: Z - A');
   });
 
   specify('action sorting - patient', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-57090]

Adds `Action: A - Z` & `Action: Z - A` sort options on the action versions of worklists, excluded from flow versions.

This is a default sort option shown for all environments/customers.
