### PR TITLE
Handle comments web socket notifications on patient flow page

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -47,6 +47,7 @@ export default App.extend(extend({
     this.listenTo(action, {
       'change:_owner': this.onChangeOwner,
       'destroy': this.stop,
+      'add:comment': this.onCommentAdded,
     });
 
     this.showChildView('heading', new HeadingView({ model: this.action }));
@@ -72,6 +73,9 @@ export default App.extend(extend({
     this.setAccess();
     /* istanbul ignore else : Covers edge case when owner changes prior to beforeStart */
     if (this.isRunning()) this.showAttachments();
+  },
+  onCommentAdded(model) {
+    this.activityCollection.add(model);
   },
   onStart(options, activity, comments, attachments) {
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -90,12 +90,13 @@ export default Backbone.Model.extend(extend({
 
     return isFunction(messages[category]) ? messages[category] : this[messages[category]];
   },
-  handleMessage({ category, payload }) {
+  handleMessage({ category, author, payload }) {
     payload.attributes = extend({}, payload.attributes, { updated_at: dayjs.utc().format() });
+    payload.author = author;
 
     const handler = this._getMessageHandler(category);
     if (handler) handler.call(this, payload);
 
-    this.trigger('message', { category, payload });
+    this.trigger('message', { category, author, payload });
   },
 }, JsonApiMixin));

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -42,6 +42,17 @@ const _Model = BaseModel.extend({
     SharingUpdated({ attributes }) {
       this.set(attributes);
     },
+    CommentAdded({ author, comment, attributes }) {
+      const commentModel = Radio.request('entities', 'comments:model', {
+        id: comment.id,
+        message: attributes.message,
+        created_at: dayjs.utc().format(),
+        edited_at: null,
+        _clinician: author,
+      });
+
+      this.trigger('add:comment', commentModel);
+    },
     ResourceDeleted() {
       this.destroy({ isDeleted: true });
     },

--- a/src/js/entities-service/entities/comments.js
+++ b/src/js/entities-service/entities/comments.js
@@ -2,6 +2,7 @@ import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
+import dayjs from 'dayjs';
 
 import trim from 'js/utils/formatting/trim';
 
@@ -9,6 +10,11 @@ const TYPE = 'comments';
 
 const _Model = BaseModel.extend({
   type: TYPE,
+  messages: {
+    CommentEdited({ attributes }) {
+      this.set({ edited_at: dayjs.utc().format(), ...attributes });
+    },
+  },
   urlRoot() {
     if (this.isNew()) return `/api/actions/${ this.get('_action') }/relationships/comments`;
 

--- a/src/js/entities-service/entities/comments.js
+++ b/src/js/entities-service/entities/comments.js
@@ -14,6 +14,9 @@ const _Model = BaseModel.extend({
     CommentEdited({ attributes }) {
       this.set({ edited_at: dayjs.utc().format(), ...attributes });
     },
+    CommentRemoved() {
+      this.destroy({ isDeleted: true });
+    },
   },
   urlRoot() {
     if (this.isNew()) return `/api/actions/${ this.get('_action') }/relationships/comments`;

--- a/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
@@ -121,6 +121,9 @@ const CommentView = View.extend({
   regions: {
     comment: '[data-comment-activity-region]',
   },
+  modelEvents: {
+    'change:message': 'render',
+  },
   template: hbs`
     <div data-comment-activity-region>
       <div class="comment__item">

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -326,8 +326,7 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
-      .find('[data-activity-region]')
+      .get('[data-activity-region]')
       .find('.comment__item')
       .last()
       .as('socketComment')
@@ -375,6 +374,20 @@ context('patient flow page', function() {
       .get('@socketComment')
       .should('contain', 'Edited websocket comment v2.')
       .should('contain', '(Edited)');
+
+    cy.sendWs({
+      category: 'CommentRemoved',
+      resource: {
+        type: 'comments',
+        id: testCommentId,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('[data-activity-region]')
+      .find('.comment__item')
+      .should('have.length', 3);
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
+import { v4 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
@@ -133,8 +134,20 @@ context('patient flow page', function() {
       },
     });
 
+    const testClinician = getClinician({
+      id: '22222',
+      attributes: {
+        name: 'Test Clinician',
+      },
+    });
+
     cy
       .routesForPatientAction()
+      .routeWorkspaceClinicians(fx => {
+        fx.data[1] = testClinician;
+
+        return fx;
+      })
       .routeFlow(fx => {
         fx.data = mergeJsonApi(testFlow, {
           relationships: {
@@ -303,6 +316,33 @@ context('patient flow page', function() {
       .find('[data-form-sharing-region]')
       .find('.action-sidebar__sharing-state')
       .should('contain', 'Response Saved');
+
+    cy.sendWs({
+      category: 'CommentAdded',
+      author: testClinician.id,
+      resource: {
+        type: 'patient-actions',
+        id: testFlowAction.id,
+      },
+      payload: {
+        comment: {
+          type: 'comments',
+          id: uuid(),
+        },
+        attributes: {
+          message: 'New websocket comment.',
+        },
+      },
+    });
+
+    cy
+      .get('.sidebar')
+      .find('[data-activity-region]')
+      .find('.comment__item')
+      .last()
+      .should('contain', formatDate(testTs(), 'AT_TIME'))
+      .should('contain', 'Test Clinician')
+      .should('contain', 'New websocket comment.');
 
     cy.sendWs({
       category: 'ResourceDeleted',
@@ -2015,12 +2055,12 @@ context('patient flow page', function() {
     cy
       .get('.alert-box')
       .should('contain', 'Something went wrong. Please try again.');
-      
+
     cy
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
       .wait('@routeFlowActions');
-    
+
     cy
       .get('.app-frame__content')
       .find('.table-list__item')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -107,6 +107,8 @@ context('patient flow page', function() {
   });
 
   specify('patient flow action sidebar', function() {
+    const testCommentId = uuid();
+
     const testPatient = getPatient({
       attributes: {
         first_name: 'Test',
@@ -134,20 +136,8 @@ context('patient flow page', function() {
       },
     });
 
-    const testClinician = getClinician({
-      id: '22222',
-      attributes: {
-        name: 'Test Clinician',
-      },
-    });
-
     cy
       .routesForPatientAction()
-      .routeWorkspaceClinicians(fx => {
-        fx.data[1] = testClinician;
-
-        return fx;
-      })
       .routeFlow(fx => {
         fx.data = mergeJsonApi(testFlow, {
           relationships: {
@@ -319,7 +309,7 @@ context('patient flow page', function() {
 
     cy.sendWs({
       category: 'CommentAdded',
-      author: testClinician.id,
+      author: getCurrentClinician(),
       resource: {
         type: 'patient-actions',
         id: testFlowAction.id,
@@ -327,7 +317,7 @@ context('patient flow page', function() {
       payload: {
         comment: {
           type: 'comments',
-          id: uuid(),
+          id: testCommentId,
         },
         attributes: {
           message: 'New websocket comment.',
@@ -340,9 +330,51 @@ context('patient flow page', function() {
       .find('[data-activity-region]')
       .find('.comment__item')
       .last()
+      .as('socketComment')
       .should('contain', formatDate(testTs(), 'AT_TIME'))
-      .should('contain', 'Test Clinician')
+      .should('contain', 'Clinician McTester')
       .should('contain', 'New websocket comment.');
+
+    cy
+      .get('@socketComment')
+      .find('.js-edit')
+      .click();
+
+    cy.sendWs({
+      category: 'CommentEdited',
+      resource: {
+        type: 'comments',
+        id: testCommentId,
+      },
+      payload: {
+        attributes: {
+          message: 'Edited websocket comment v1.',
+        },
+      },
+    });
+
+    cy
+      .get('@socketComment')
+      .should('contain', 'Edited websocket comment v1.')
+      .should('contain', '(Edited)');
+
+    cy.sendWs({
+      category: 'CommentEdited',
+      resource: {
+        type: 'comments',
+        id: testCommentId,
+      },
+      payload: {
+        attributes: {
+          message: 'Edited websocket comment v2.',
+        },
+      },
+    });
+
+    cy
+      .get('@socketComment')
+      .should('contain', 'Edited websocket comment v2.')
+      .should('contain', '(Edited)');
 
     cy.sendWs({
       category: 'ResourceDeleted',


### PR DESCRIPTION
Shortcut Story ID: [sc-56328] [sc-57310]

In this PR, these are being handled only in the action sidebar on the patient flow page.

Coinciding with the backend PR: https://github.com/RoundingWell/care-ops-backend/pull/8796.

- [x] Support `CommentedAdded` notifications
- [x] Support `CommentEdited` notifications
- [x] Support `CommentRemoved` notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for adding, editing, and removing comments within the patient flow.
	- New event listeners for real-time updates in the comment and timestamp views.
	- Added support for attachments with error handling during uploads.

- **Bug Fixes**
	- Improved handling of comment timestamps and attachment uploads.

- **Tests**
	- Expanded test cases for comments, including adding, editing, and removing scenarios in the patient flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->