### PR TITLE
Refactor form-response/latest to use newer endpoints

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -4,8 +4,6 @@ import store from 'store';
 
 import App from 'js/base/app';
 
-import { FORM_RESPONSE_STATUS } from 'js/static';
-
 import FormsService from 'js/services/forms';
 
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
@@ -51,12 +49,7 @@ export default App.extend({
     return [
       Radio.request('entities', 'fetch:patients:model', patientId),
       Radio.request('entities', 'fetch:forms:model', formId),
-      Radio.request('entities', 'fetch:formResponses:latest', {
-        patient: patientId,
-        form: formId,
-        status: FORM_RESPONSE_STATUS.ANY,
-        editor: this.currentUser.id,
-      }),
+      Radio.request('entities', 'fetch:formResponses:byMe', { patientId, formId }),
     ];
   },
   onBeforeStop() {

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -5,7 +5,6 @@ import store from 'store';
 import App from 'js/base/app';
 
 import intl from 'js/i18n';
-import { FORM_RESPONSE_STATUS } from 'js/static';
 
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
 import ActionSiderbarApp from 'js/apps/patients/sidebar/action-sidebar_app';
@@ -66,11 +65,7 @@ export default App.extend({
       Radio.request('entities', 'fetch:forms:byAction', this.patientActionId),
       Radio.request('entities', 'fetch:actions:withResponses', this.patientActionId),
       Radio.request('entities', 'fetch:patients:model:byAction', this.patientActionId),
-      Radio.request('entities', 'fetch:formResponses:latest', {
-        action: this.patientActionId,
-        status: FORM_RESPONSE_STATUS.ANY,
-        editor: this.currentUser.id,
-      }),
+      Radio.request('entities', 'fetch:formResponses:byMe', { actionId: this.patientActionId }),
     ];
   },
   onFail() {

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -10,6 +10,7 @@ const Entity = BaseEntity.extend({
     'fetch:formResponses:model': 'fetchFormResponse',
     'fetch:formResponses:latest': 'fetchLatestResponse',
     'fetch:formResponses:byMe': 'fetchByMe',
+    'fetch:formResponses:byPatient': 'fetchSubmittedByPatient',
   },
   fetchFormResponse(id, options) {
     if (!id) return new Model();
@@ -30,6 +31,14 @@ const Entity = BaseEntity.extend({
 
     return this.fetchOrEmpty('/api/clinicians/me/form-responses/latest', { filter });
   },
+  fetchSubmittedByPatient({ patientId, actionId, flowId, formId, actionTags, submittedAt }) {
+    const filter = {
+      ...(actionId && { actions: actionId }),
+      ...(flowId && { flows: flowId }),
+      ...(formId && { forms: formId }),
+      ...(actionTags && { action_tags: actionTags }),
+      ...(submittedAt && { submitted_at: submittedAt }),
+    };
 
     return this.fetchBy('/api/form-responses/latest', { data })
       .then(response => {

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -1,4 +1,3 @@
-import { reduce } from 'underscore';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/form-responses';
 
@@ -8,7 +7,6 @@ const Entity = BaseEntity.extend({
     'formResponses:model': 'getModel',
     'formResponses:collection': 'getCollection',
     'fetch:formResponses:model': 'fetchFormResponse',
-    'fetch:formResponses:latest': 'fetchLatestResponse',
     'fetch:formResponses:byMe': 'fetchByMe',
     'fetch:formResponses:byPatient': 'fetchSubmittedByPatient',
   },
@@ -17,12 +15,6 @@ const Entity = BaseEntity.extend({
 
     return this.fetchModel(id, options);
   },
-  fetchLatestResponse(filter) {
-    const data = reduce(filter, (filters, value, key) => {
-      if (!value) return filters;
-      filters.filter[key] = value;
-      return filters;
-    }, { filter: {} });
   fetchOrEmpty(url, data) {
     return this.fetchBy(url, { data }).then(response => response || new Model());
   },
@@ -40,11 +32,7 @@ const Entity = BaseEntity.extend({
       ...(submittedAt && { submitted_at: submittedAt }),
     };
 
-    return this.fetchBy('/api/form-responses/latest', { data })
-      .then(response => {
-        if (!response) return new Model();
-        return response;
-      });
+    return this.fetchOrEmpty(`/api/patients/${ patientId }/form-responses/submitted`, { filter });
   },
 });
 

--- a/src/js/entities-service/form-responses.js
+++ b/src/js/entities-service/form-responses.js
@@ -9,6 +9,7 @@ const Entity = BaseEntity.extend({
     'formResponses:collection': 'getCollection',
     'fetch:formResponses:model': 'fetchFormResponse',
     'fetch:formResponses:latest': 'fetchLatestResponse',
+    'fetch:formResponses:byMe': 'fetchByMe',
   },
   fetchFormResponse(id, options) {
     if (!id) return new Model();
@@ -21,6 +22,14 @@ const Entity = BaseEntity.extend({
       filters.filter[key] = value;
       return filters;
     }, { filter: {} });
+  fetchOrEmpty(url, data) {
+    return this.fetchBy(url, { data }).then(response => response || new Model());
+  },
+  fetchByMe({ actionId, patientId, formId }) {
+    const filter = actionId ? { action: actionId } : { patient: patientId, form: formId };
+
+    return this.fetchOrEmpty('/api/clinicians/me/form-responses/latest', { filter });
+  },
 
     return this.fetchBy('/api/form-responses/latest', { data })
       .then(response => {

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -7,8 +7,6 @@ import App from 'js/base/app';
 
 import 'js/entities-service';
 
-import { FORM_RESPONSE_STATUS } from 'js/static';
-
 const ActionFormApp = App.extend({
   beforeStart({ actionId }) {
     return [
@@ -21,7 +19,7 @@ const ActionFormApp = App.extend({
   onStart(opts, form, definition, data, action) {
     const filter = this._getPrefillFilters(form, action);
 
-    return Promise.resolve(Radio.request('entities', 'fetch:formResponses:latest', filter))
+    return Promise.resolve(Radio.request('entities', 'fetch:formResponses:byPatient', filter))
       .then(response => {
         parent.postMessage({ message: 'form:pdf', args: {
           definition,
@@ -34,27 +32,16 @@ const ActionFormApp = App.extend({
       });
   },
   _getPrefillFilters(form, action) {
-    const opts = {
-      status: FORM_RESPONSE_STATUS.SUBMITTED,
-      flow: action.get('_flow'),
-      patient: action.get('_patient'),
-    };
-
     const isReport = form.isReport();
+    const actionTags = form.getPrefillActionTag();
 
-    if (isReport) opts.submitted = `<=${ action.get('created_at') }`;
-
-    const prefillActionTag = form.getPrefillActionTag();
-
-    if (prefillActionTag) {
-      opts['action.tags'] = prefillActionTag;
-
-      return opts;
-    }
-
-    opts.action = action.id;
-
-    return opts;
+    return {
+      flowId: action.get('_flow'),
+      patientId: action.get('_patient'),
+      submittedAt: isReport && `<=${ action.get('created_at') }`,
+      actionId: !actionTags && action.id,
+      actionTags,
+    };
   },
 });
 

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -201,40 +201,22 @@ export default App.extend({
       });
     });
   },
-  _getPrefillFilters({ flowId, patientId }, form) {
-    const opts = {
-      status: FORM_RESPONSE_STATUS.SUBMITTED,
-      flow: flowId,
-      patient: patientId,
-    };
+  _getPrefillFilters(form, action, flowId) {
+    const patientId = action.get('_patient');
+    const actionTags = form.getPrefillActionTag();
+    const formId = !actionTags && form.getPrefillFormId();
+    const submittedAt = form.isReport() && `<=${ action.get('created_at') }`;
 
-    const isReport = form.isReport();
-
-    if (isReport) opts.submitted = `<=${ this.action.get('created_at') }`;
-
-    const prefillActionTag = form.getPrefillActionTag();
-
-    if (prefillActionTag) {
-      opts['action.tags'] = prefillActionTag;
-
-      return opts;
-    }
-
-    opts.form = form.getPrefillFormId();
-
-    return opts;
+    return { patientId, flowId, formId, actionTags, submittedAt };
   },
   fetchLatestFormSubmission(flowId) {
     const isReadOnly = this.isReadOnly();
-    const actionId = get(this.action, 'id');
-    const patientId = this.patient.id;
-
-    const filter = this._getPrefillFilters({ flowId, patientId }, this.form);
+    const filter = this._getPrefillFilters(this.form, this.action, flowId);
 
     return Promise.all([
       Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      Radio.request('entities', 'fetch:forms:data', actionId, patientId, this.form.id),
-      Radio.request('entities', 'fetch:formResponses:latest', filter),
+      Radio.request('entities', 'fetch:forms:data', this.action.id, this.patient.id, this.form.id),
+      Radio.request('entities', 'fetch:formResponses:byPatient', filter),
     ]).then(([definition, data, response]) => {
       this.channelRequest('send', 'fetch:form:data', {
         definition,

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -6,7 +6,6 @@ const ACTION_OUTREACH = {
 const FORM_RESPONSE_STATUS = {
   DRAFT: 'draft',
   SUBMITTED: 'submitted',
-  ANY: 'draft,submitted',
 };
 
 const ACTION_SHARING = {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -570,9 +570,8 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[patient]=${ testPatient.id }`)
-      .should('contain', `filter[form]=${ testForm.id }`)
-      .should('contain', `filter[flow]=${ testFlow.id }`);
+      .should('contain', `filter[forms]=${ testForm.id }`)
+      .should('contain', `filter[flows]=${ testFlow.id }`);
 
     cy
       .iframe()
@@ -661,9 +660,8 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[patient]=${ testPatient.id }`)
-      .should('contain', `filter[form]=${ testForm.id }`)
-      .should('not.contain', 'filter[flow]');
+      .should('contain', `filter[forms]=${ testForm.id }`)
+      .should('not.contain', 'filter[flows]');
 
     cy
       .iframe()
@@ -755,11 +753,10 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[patient]=${ testPatient.id }`)
-      .should('contain', 'filter[action.tags]=foo-tag')
-      .should('not.contain', 'filter[created]')
-      .should('not.contain', 'filter[flow]')
-      .should('not.contain', 'filter[form]');
+      .should('contain', 'filter[action_tags]=foo-tag')
+      .should('not.contain', 'filter[submitted_at]')
+      .should('not.contain', 'filter[flows]')
+      .should('not.contain', 'filter[forms]');
 
     cy
       .iframe()
@@ -2764,7 +2761,7 @@ context('Patient Action Form', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[submitted]=<=${ createdAt }`);
+      .should('contain', `filter[submitted_at]=<=${ createdAt }`);
   });
 
   specify('refresh stale form', function() {

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -107,6 +107,11 @@ context('Patient Action Form', function() {
       .routeFormActionFields()
       .routeActionActivity()
       .routePatientByAction()
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
+      })
       .visit(`/patient-action/${ testAction.id }/form/${ testForm.id }`)
       .wait('@routeFormByAction')
       .wait('@routeAction')
@@ -806,6 +811,11 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
+      })
       .routeActionActivity()
       .routePatientByAction()
       .visit(`/patient-action/${ testAction.id }/form/${ testForm.id }`)
@@ -943,6 +953,11 @@ context('Patient Action Form', function() {
         fx.data = testFormResponses[0];
 
         return fx;
+      })
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponses[0],
+        };
       })
       .routeActionActivity()
       .routePatientByAction(fx => {
@@ -1302,6 +1317,11 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
+      })
       .visit(`/patient-action/${ testAction.id }/form/${ testForm.id }`)
       .wait('@routeAction')
       .wait('@routeFormByAction')
@@ -1443,6 +1463,11 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
+      })
       .visit('/worklist/owned-by')
       .wait('@routeActions');
 
@@ -1577,6 +1602,7 @@ context('Patient Action Form', function() {
       })
       .routeFormDefinition()
       .routeFormResponse()
+      .routeLatestFormResponse()
       .routeFormActionFields()
       .visit(`/patient-action/${ testAction.id }/form/${ testForm.id }`)
       .wait('@routeAction')
@@ -2249,6 +2275,11 @@ context('Patient Action Form', function() {
 
         return fx;
       })
+      .routeLatestFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
+      })
       .routeFormDefinition()
       .routeFormActionFields()
       .routeActionActivity()
@@ -2824,22 +2855,29 @@ context('Patient Action Form', function() {
       .find('textarea[name="data[familyHistory]"]')
       .should('contain', 'Form draft work done in another tab.');
 
+    const submission = getFormResponse({
+      id: testFormResponseId,
+      attributes: {
+        status: FORM_RESPONSE_STATUS.SUBMITTED,
+        updated_at: testTs(),
+        response: {
+          data: {
+            familyHistory: 'Form work submitted in another tab.',
+          },
+        },
+      },
+    });
+
     cy
       .routeFormResponse(fx => {
-        fx.data = getFormResponse({
-          id: testFormResponseId,
-          attributes: {
-            status: FORM_RESPONSE_STATUS.SUBMITTED,
-            updated_at: testTs(),
-            response: {
-              data: {
-                familyHistory: 'Form work submitted in another tab.',
-              },
-            },
-          },
-        });
+        fx.data = submission;
 
         return fx;
+      })
+      .routeLatestFormResponse(() => {
+        return {
+          data: submission,
+        };
       });
 
     cy

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -204,10 +204,9 @@ context('Formservice', function() {
       .wait('@routeLatestFormSubmission')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[action.tags]=foo-tag')
-      .should('contain', `filter[flow]=${ testFlow.id }`)
-      .should('contain', `filter[patient]=${ testPatient.id }`)
-      .should('contain', `filter[submitted]=<=${ createdAt }`);
+      .should('contain', 'filter[action_tags]=foo-tag')
+      .should('contain', `filter[flows]=${ testFlow.id }`)
+      .should('contain', `filter[submitted_at]=<=${ createdAt }`);
   });
 
   specify('action formservice iframe makes correct api requests', function() {
@@ -240,7 +239,7 @@ context('Formservice', function() {
       .as('routeAction');
 
     cy
-      .intercept('GET', '/api/form-responses/latest?filter[status]=submitted', {
+      .intercept('GET', '/api/patients/**/form-responses/submitted*', {
         statusCode: 204,
       })
       .as('routeLatestFormSubmission');

--- a/test/support/api/form-responses.js
+++ b/test/support/api/form-responses.js
@@ -54,11 +54,10 @@ Cypress.Commands.add('routeLatestFormSubmission', (mutator = _.identity) => {
 });
 
 Cypress.Commands.add('routeLatestFormResponse', (mutator = _.identity) => {
-  const urlRegex = /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=draft).*$/;
   const body = mutator();
 
   cy
-    .intercept('GET', urlRegex, {
+    .intercept('GET', '/api/clinicians/me/form-responses/latest*', {
       statusCode: body ? 200 : 204,
       body,
     })

--- a/test/support/api/form-responses.js
+++ b/test/support/api/form-responses.js
@@ -44,10 +44,8 @@ Cypress.Commands.add('routeFormResponse', (mutator = _.identity) => {
 Cypress.Commands.add('routeLatestFormSubmission', (mutator = _.identity) => {
   const data = getFormResponse();
 
-  const urlRegex = /^\/api\/form-responses\/latest\?(?=.*filter\[status\]=submitted).*$/;
-
   cy
-    .intercept('GET', urlRegex, {
+    .intercept('GET', '/api/patients/**/form-responses/submitted*', {
       body: mutator({ data, included: [] }),
     })
     .as('routeLatestFormSubmission');


### PR DESCRIPTION
Shortcut Story ID: [sc-57621]

Now we're using clinicians/me/form-responses/latests for a latest response by the user
and patients/../form-responses/submitted for the use cases where we need a response from a different context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Streamlined fetching of form responses to focus on user-specific submissions.

- **Bug Fixes**
  - Enhanced integration tests to accurately reflect expected behaviors and improve error handling for form submissions.

- **Documentation**
  - Updated test cases and API request structures to align with new endpoint specifications and naming conventions.

- **Chores**
  - Removed unnecessary constants and simplified filter logic in various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->