### PR TITLE
Handle attachments web socket notifications on patient flow page

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -48,6 +48,7 @@ export default App.extend(extend({
       'change:_owner': this.onChangeOwner,
       'destroy': this.stop,
       'add:comment': this.onCommentAdded,
+      'add:attachment': this.onAttachmentAdded,
     });
 
     this.showChildView('heading', new HeadingView({ model: this.action }));
@@ -76,6 +77,9 @@ export default App.extend(extend({
   },
   onCommentAdded(model) {
     this.activityCollection.add(model);
+  },
+  onAttachmentAdded(model) {
+    this.attachments.add(model);
   },
   onStart(options, activity, comments, attachments) {
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -53,6 +53,19 @@ const _Model = BaseModel.extend({
 
       this.trigger('add:comment', commentModel);
     },
+    AttachmentAdded({ file, attributes }) {
+      const attachmentModel = Radio.request('entities', 'files:model', {
+        id: file.id,
+        path: attributes.path,
+        created_at: dayjs.utc().format(),
+        _action: this.id,
+        _patient: this.getPatient().id,
+        _view: attributes.view,
+        _download: attributes.download,
+      });
+
+      this.trigger('add:attachment', attachmentModel);
+    },
     ResourceDeleted() {
       this.destroy({ isDeleted: true });
     },

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -64,6 +64,9 @@ const _Model = BaseModel.extend({
         _download: attributes.download,
       });
 
+      const newFilesRelationship = [...this.get('_files'), { id: file.id, type: 'files' }];
+      this.set({ _files: newFilesRelationship });
+
       this.trigger('add:attachment', attachmentModel);
     },
     ResourceDeleted() {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -108,6 +108,7 @@ context('patient flow page', function() {
 
   specify('patient flow action sidebar', function() {
     const testCommentId = uuid();
+    const testOtherFileId = uuid();
 
     const testPatient = getPatient({
       attributes: {
@@ -141,6 +142,7 @@ context('patient flow page', function() {
         'form': getRelationship(testForm),
         'patient': getRelationship(testPatient),
         'program-action': getRelationship(testProgramAction),
+        'files': getRelationship([{ id: testOtherFileId }], 'files'),
       },
     });
 
@@ -169,6 +171,23 @@ context('patient flow page', function() {
       })
       .routePatientByFlow(fx => {
         fx.data = testPatient;
+
+        return fx;
+      })
+      .routeActionFiles(fx => {
+        fx.data = [
+          {
+            id: testOtherFileId,
+            attributes: {
+              path: `patients/${ testPatient.id }/Other_file.pdf`,
+              created_at: testTsSubtract(1),
+            },
+            meta: {
+              view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/Other_File.pdf`,
+              download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/Other_File.pdf`,
+            },
+          },
+        ];
 
         return fx;
       })
@@ -417,7 +436,7 @@ context('patient flow page', function() {
         },
         file: {
           type: 'files',
-          id: '70294032-539b-4dc0-93df-9e4ff2eee8c1',
+          id: uuid(),
         },
         attributes: {
           path: `patients/${ testPatient.id }/HRA.pdf`,
@@ -431,7 +450,7 @@ context('patient flow page', function() {
       .get('[data-attachments-files-region]')
       .children()
       .as('attachmentItems')
-      .should('have.length', 1)
+      .should('have.length', 2)
       .first()
       .contains('HRA.pdf');
 
@@ -2829,6 +2848,30 @@ context('patient flow page', function() {
       .get('@flowSidebar')
       .find('[data-state-region]')
       .should('contain', 'Done');
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        file: {
+          type: 'files',
+          id: uuid(),
+        },
+        attributes: {
+          path: 'patients/1/HRA.pdf',
+          view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
+          download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .fa-paperclip')
+      .should('exist');
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -119,6 +119,12 @@ context('patient flow page', function() {
       },
     });
 
+    const testProgramAction = getProgramAction({
+      attributes: {
+        allowed_uploads: ['pdf'],
+      },
+    });
+
     const testFlowAction = getAction({
       attributes: {
         name: 'Test Action',
@@ -126,18 +132,25 @@ context('patient flow page', function() {
         outreach: 'disabled',
         sharing: 'disabled',
         updated_at: testTsSubtract(1),
+        allowed_uploads: ['pdf'],
       },
       relationships: {
-        flow: getRelationship(testFlow),
-        state: getRelationship(stateTodo),
-        owner: getRelationship(teamNurse),
-        form: getRelationship(testForm),
-        patient: getRelationship(testPatient),
+        'flow': getRelationship(testFlow),
+        'state': getRelationship(stateTodo),
+        'owner': getRelationship(teamNurse),
+        'form': getRelationship(testForm),
+        'patient': getRelationship(testPatient),
+        'program-action': getRelationship(testProgramAction),
       },
     });
 
     cy
       .routesForPatientAction()
+      .routeSettings(fx => {
+        fx.data.push({ id: 'upload_attachments', attributes: { value: true } });
+
+        return fx;
+      })
       .routeFlow(fx => {
         fx.data = mergeJsonApi(testFlow, {
           relationships: {
@@ -149,6 +162,8 @@ context('patient flow page', function() {
       })
       .routeFlowActions(fx => {
         fx.data = [testFlowAction];
+
+        fx.included.push(testProgramAction);
 
         return fx;
       })
@@ -388,6 +403,37 @@ context('patient flow page', function() {
       .get('[data-activity-region]')
       .find('.comment__item')
       .should('have.length', 3);
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: 'patient-actions',
+        id: testFlowAction.id,
+      },
+      payload: {
+        clinician: {
+          type: 'clinicians',
+          id: '95014c50-2401-4d95-83e1-4a39fb928c90',
+        },
+        file: {
+          type: 'files',
+          id: '70294032-539b-4dc0-93df-9e4ff2eee8c1',
+        },
+        attributes: {
+          path: `patients/${ testPatient.id }/HRA.pdf`,
+          view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/HRA.pdf`,
+          download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA.pdf`,
+        },
+      },
+    });
+
+    cy
+      .get('[data-attachments-files-region]')
+      .children()
+      .as('attachmentItems')
+      .should('have.length', 1)
+      .first()
+      .contains('HRA.pdf');
 
     cy.sendWs({
       category: 'ResourceDeleted',


### PR DESCRIPTION
Shortcut Story ID: [sc-###]

In this PR, these are being handled only in the action sidebar on the patient flow page.

Coinciding with the backend PR: https://github.com/RoundingWell/care-ops-backend/pull/8787.

- [x]  Support `AttachmentAdded` notifications
- [ ]  Support `FileReplaced` notifications
- [ ]  Support `FileRemoved` notifications