### PR TITLE
Delete action routing and error handling

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -2,7 +2,7 @@ import { bind, invoke, get } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
-import intl, { renderTemplate } from 'js/i18n';
+import { renderTemplate } from 'js/i18n';
 import handleErrors from 'js/utils/handle-errors';
 
 import SubRouterApp from 'js/base/subrouterapp';
@@ -15,9 +15,9 @@ import FlowSiderbarApp from 'js/apps/patients/sidebar/flow-sidebar_app';
 import ActionSiderbarApp from 'js/apps/patients/sidebar/action-sidebar_app';
 
 
-import { LayoutView, ContextTrailView, HeaderView, ListView, SelectAllView } from 'js/views/patients/patient/flow/flow_views';
+import { LayoutView, ContextTrailView, HeaderView, ListView, SelectAllView, i18n } from 'js/views/patients/patient/flow/flow_views';
 import { BulkEditButtonView, BulkEditActionsSuccessTemplate, BulkDeleteActionsSuccessTemplate } from 'js/views/patients/shared/bulk-edit/bulk-edit_views';
-import { AddButtonView, i18n } from 'js/views/patients/shared/add-workflow/add-workflow_views';
+import { AddButtonView } from 'js/views/patients/shared/add-workflow/add-workflow_views';
 
 export default SubRouterApp.extend({
   StateModel,
@@ -208,7 +208,7 @@ export default SubRouterApp.extend({
             this.getState().clearSelected();
           })
           .catch(() => {
-            Radio.request('alert', 'show:error', intl.patients.worklist.worklistApp.bulkEditFailure);
+            Radio.request('alert', 'show:error', i18n.bulkEditFailure);
             this.getState().clearSelected();
             this.restart({ flowId: this.flow.id, currentRoute: this.currentRoute });
           });
@@ -301,6 +301,11 @@ export default SubRouterApp.extend({
     sidebarApp.stop();
 
     const action = Radio.request('entities', 'actions:model', actionId);
+
+    if (!action.isCached()) {
+      Radio.request('alert', 'show:error', i18n.actionNotFound);
+      return;
+    }
 
     Radio.request('sidebar', 'start', sidebarApp, { action });
 

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -58,7 +58,7 @@ export default SubRouterApp.extend({
         return;
       }
 
-      Radio.request('alert', 'show:error', intl.actionNotFound);
+      this.showActionNotFound();
       this.stop();
       Radio.trigger('event-router', 'patient:dashboard', patientId);
       return;
@@ -84,6 +84,10 @@ export default SubRouterApp.extend({
     delete this.action;
   },
 
+  showActionNotFound() {
+    Radio.request('alert', 'show:error', intl.actionNotFound);
+  },
+
   startList(list) {
     if (this._list === list) return;
 
@@ -106,6 +110,11 @@ export default SubRouterApp.extend({
     const sidebarApp = this.getChildApp('actionSidebar');
 
     sidebarApp.stop();
+
+    if (!this.action.isCached()) {
+      this.showActionNotFound();
+      return;
+    }
 
     Radio.request('sidebar', 'start', sidebarApp, { action: this.action });
 

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -46,7 +46,7 @@ export default App.extend(extend({
 
     this.listenTo(action, {
       'change:_owner': this.onChangeOwner,
-      'destroy': this.stop,
+      'destroy': this.onDestroy,
       'add:comment': this.onCommentAdded,
     });
 
@@ -125,12 +125,12 @@ export default App.extend(extend({
   },
   onDelete() {
     this.action.destroy({ wait: true })
-      .then(() => {
-        this.stop();
-      })
       .catch(({ responseData }) => {
         Radio.request('alert', 'show:apiError', responseData);
       });
+  },
+  onDestroy() {
+    this.triggerMethod('close', this);
   },
   showForm() {
     if (!this.action.getForm() && !this.action.hasSharing()) return;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -255,6 +255,9 @@ careOptsFrontend:
           newAction: New Action
           actionLoading: Loading...
       flowViews:
+        actionNotFound: The Action you requested does not exist.
+        addActionHeadingText: Add Action
+        bulkEditFailure: Something went wrong. Please try again.
         contextBackBtn: Back to List
         emptyView: No Actions
       patientViews:

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -6,6 +6,7 @@ import { View, CollectionView } from 'marionette';
 import 'scss/modules/progress-bar.scss';
 import 'scss/modules/table-list.scss';
 
+import intl from 'js/i18n';
 import PreloadRegion from 'js/regions/preload_region';
 
 import { CheckComponent, StateComponent, OwnerComponent, DueComponent, TimeComponent, FormButton, DetailsTooltip } from 'js/views/patients/shared/actions_views';
@@ -17,6 +18,8 @@ import ActionItemTemplate from './action-item.hbs';
 
 import '../patient.scss';
 import './patient-flow.scss';
+
+export const i18n = intl.patients.patient.flowViews;
 
 const ContextTrailView = View.extend({
   initialize() {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -693,8 +693,9 @@ context('patient flow page', function() {
 
     cy
       .get('.alert-box')
-      .should('contain', 'Insufficient permissions to delete action');
-
+      .should('contain', 'Insufficient permissions to delete action')
+      .find('.js-dismiss')
+      .click();
 
     cy
       .intercept('DELETE', `/api/actions/${ testListAction.id }`, {
@@ -719,6 +720,16 @@ context('patient flow page', function() {
       .get('@actionsList')
       .find('.table-list__item')
       .should('have.length', 2);
+
+    cy
+      .url()
+      .should('not.contain', '/action/');
+
+    cy.go('back');
+
+    cy
+      .get('.alert-box')
+      .should('contain', 'The Action you requested does not exist');
   });
 
   specify('add action', function() {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -678,6 +678,37 @@ context('action sidebar', function() {
     cy
       .get('.sidebar')
       .should('not.exist');
+
+    cy.go('back');
+
+    cy
+      .intercept('DELETE', `/api/actions/${ testAction.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routeDeleteFlowAction');
+
+    cy
+      .get('.sidebar')
+      .find('.js-menu')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .contains('Delete Action')
+      .click()
+      .wait('@routeDeleteFlowAction');
+
+    cy
+      .url()
+      .should('not.contain', '/action/');
+
+    cy.go('back');
+
+    cy
+      .get('.alert-box')
+      .should('contain', 'The Action you requested does not exist');
   });
 
   specify('action attachments', function() {
@@ -1979,7 +2010,7 @@ context('action sidebar', function() {
       })
       .routeFlowActions(fx => {
         fx.data = [testAction];
-          
+
         return fx;
       })
       .routePatientByFlow()


### PR DESCRIPTION
This does two things.
When a action is deleted we should close the sidebar so the default routing can be handled. Also if routed to an action that is no longer cached we should alert the user the action is no longer available.

Shortcut Story ID: [sc-57747]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced improved error handling for actions not found, enhancing user notifications.
	- Added internationalization support for patient flow views and various components.
	- Implemented a new method for centralized error alerts related to actions.

- **Bug Fixes**
	- Enhanced state management for action deletions and user notifications in the sidebar.

- **Tests**
	- Expanded test coverage for action deletion and real-time updates in the patient flow and sidebar functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->