### PR TITLE
Subscribe/unsubscribe to each comment in action sidebar

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -61,6 +61,8 @@ export default App.extend(extend({
     if (flow) this.stopListening(flow);
     this.stopListening(this.action);
     this.action.trigger('editing', false);
+
+    this.removeSubscriptions();
   },
   beforeStart() {
     return [
@@ -76,14 +78,20 @@ export default App.extend(extend({
   },
   onCommentAdded(model) {
     this.activityCollection.add(model);
+    this.comments.add(model);
+
+    Radio.request('ws', 'add', model);
   },
   onStart(options, activity, comments, attachments) {
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);
+    this.comments = comments;
     this.attachments = attachments;
 
     this.showActivity();
     this.showNewCommentForm();
     this.showAttachments();
+
+    this.addSubscriptions();
   },
   showContent() {
     const sidebarView = new SidebarView({ model: this.action });
@@ -185,7 +193,12 @@ export default App.extend(extend({
   },
   onPostNewComment({ model }) {
     model.set({ created_at: dayjs.utc().format() }).save();
+
     this.activityCollection.add(model);
+    this.comments.add(model);
+
+    Radio.request('ws', 'add', model);
+
     this.showNewCommentForm();
   },
   onCancelNewComment() {
@@ -224,5 +237,13 @@ export default App.extend(extend({
   onRemoveAttachment(model) {
     model.destroy();
   },
+  addSubscriptions() {
+    Radio.request('ws', 'add', this.comments);
+  },
+  removeSubscriptions() {
+    // for when sidebar is closed before comments api request is finished
+    if (!this.comments) return;
 
+    Radio.request('ws', 'unsubscribe', this.comments);
+  },
 }, SidebarMixin));

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -330,7 +330,7 @@ context('patient flow page', function() {
       .find('.comment__item')
       .last()
       .as('socketComment')
-      .should('contain', formatDate(testTs(), 'AT_TIME'))
+      .should('contain', formatDate(dayjs.utc().format(), 'AT_TIME'))
       .should('contain', 'Clinician McTester')
       .should('contain', 'New websocket comment.');
 

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -160,15 +160,15 @@ context('reduced schedule page', function() {
       .find('.js-patient-sidebar-button')
       .click()
       .wait('@routePatient');
-  
+
     cy
       .get('.worklist-patient-sidebar')
       .should('contain', 'First Last');
-  
+
     cy
       .get('.worklist-patient-sidebar .js-close')
       .click();
-  
+
     cy
       .get('.worklist-patient-sidebar')
       .should('not.exist');


### PR DESCRIPTION
Shortcut Story ID: [sc-57310]

Should subscribe to all comments when the action sidebar is opened. And should also subscribe to an individual comment when one is added via websocket or manual user action.

Subscriptions should be removed when the action sidebar is closed.