### PR TITLE
Pass models array to ws service

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -238,12 +238,12 @@ export default App.extend(extend({
     model.destroy();
   },
   addSubscriptions() {
-    Radio.request('ws', 'add', this.comments);
+    Radio.request('ws', 'add', this.comments.models);
   },
   removeSubscriptions() {
     // for when sidebar is closed before comments api request is finished
     if (!this.comments) return;
 
-    Radio.request('ws', 'unsubscribe', this.comments);
+    Radio.request('ws', 'unsubscribe', this.comments.models);
   },
 }, SidebarMixin));


### PR DESCRIPTION
Service now supports a pojo, a model or an array of pojos or models, but not a collection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of comment subscriptions in the sidebar application.
	- Enhanced specificity in data management for WebSocket events related to comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->