### PR TITLE
Handle attachments web socket notifications on patient flow page

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -48,6 +48,7 @@ export default App.extend(extend({
       'change:_owner': this.onChangeOwner,
       'destroy': this.onDestroy,
       'add:comment': this.onCommentAdded,
+      'add:attachment': this.onAttachmentAdded,
     });
 
     this.showChildView('heading', new HeadingView({ model: this.action }));
@@ -79,6 +80,11 @@ export default App.extend(extend({
   onCommentAdded(model) {
     this.activityCollection.add(model);
     this.comments.add(model);
+
+    Radio.request('ws', 'add', model);
+  },
+  onAttachmentAdded(model) {
+    this.attachments.add(model);
 
     Radio.request('ws', 'add', model);
   },
@@ -230,6 +236,8 @@ export default App.extend(extend({
     });
     attachment.upload(file);
 
+    Radio.request('ws', 'add', file);
+
     this.listenTo(attachment, 'upload:failed', () => {
       Radio.request('alert', 'show:error', intl.patients.sidebar.actionSidebarApp.uploadError);
     });
@@ -238,12 +246,12 @@ export default App.extend(extend({
     model.destroy();
   },
   addSubscriptions() {
-    Radio.request('ws', 'add', this.comments.models);
+    Radio.request('ws', 'add', [...this.comments.models, ...this.attachments.models]);
   },
   removeSubscriptions() {
     // for when sidebar is closed before comments api request is finished
-    if (!this.comments) return;
+    if (!this.comments || !this.attachments) return;
 
-    Radio.request('ws', 'unsubscribe', this.comments.models);
+    Radio.request('ws', 'unsubscribe', [...this.comments.models, ...this.attachments.models]);
   },
 }, SidebarMixin));

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -251,8 +251,8 @@ export default App.extend(extend({
     Radio.request('ws', 'add', [...this.comments.models, ...this.attachments.models]);
   },
   removeSubscriptions() {
-    // for when sidebar is closed before comments api request is finished
-    if (!this.comments || !this.attachments) return;
+    // for when the sidebar is closed prior to beforeStart being able to finish
+    if (!this.isRunning()) return;
 
     Radio.request('ws', 'unsubscribe', [...this.comments.models, ...this.attachments.models]);
   },

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -244,6 +244,8 @@ export default App.extend(extend({
   },
   onRemoveAttachment(model) {
     model.destroy();
+
+    Radio.request('ws', 'unsubscribe', model);
   },
   addSubscriptions() {
     Radio.request('ws', 'add', [...this.comments.models, ...this.attachments.models]);

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -236,7 +236,7 @@ export default App.extend(extend({
     });
     attachment.upload(file);
 
-    Radio.request('ws', 'add', file);
+    Radio.request('ws', 'add', attachment);
 
     this.listenTo(attachment, 'upload:failed', () => {
       Radio.request('alert', 'show:error', intl.patients.sidebar.actionSidebarApp.uploadError);

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -47,8 +47,8 @@ export default App.extend(extend({
     this.listenTo(action, {
       'change:_owner': this.onChangeOwner,
       'destroy': this.onDestroy,
-      'add:comment': this.onCommentAdded,
-      'add:attachment': this.onAttachmentAdded,
+      'ws:add:comment': this.onWsAddComment,
+      'ws:add:attachment': this.onWsAddAttachment,
     });
 
     this.showChildView('heading', new HeadingView({ model: this.action }));
@@ -77,13 +77,13 @@ export default App.extend(extend({
     /* istanbul ignore else : Covers edge case when owner changes prior to beforeStart */
     if (this.isRunning()) this.showAttachments();
   },
-  onCommentAdded(model) {
+  onWsAddComment(model) {
     this.activityCollection.add(model);
     this.comments.add(model);
 
     Radio.request('ws', 'add', model);
   },
-  onAttachmentAdded(model) {
+  onWsAddAttachment(model) {
     this.attachments.add(model);
 
     Radio.request('ws', 'add', model);

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -5,6 +5,7 @@ import JsonApiMixin from './jsonapi-mixin';
 
 export default Backbone.Model.extend(extend({
   destroy(options) {
+    // isDeleted means the model is already deleted from the db
     if (options && options.isDeleted) {
       this.stopListening();
       this.trigger('destroy', this, this.collection, options);
@@ -90,8 +91,9 @@ export default Backbone.Model.extend(extend({
 
     return isFunction(messages[category]) ? messages[category] : this[messages[category]];
   },
-  handleMessage({ category, author, payload }) {
+  handleMessage({ category, resource, author, payload }) {
     payload.attributes = extend({}, payload.attributes, { updated_at: dayjs.utc().format() });
+    payload.resource = resource;
     payload.author = author;
 
     const handler = this._getMessageHandler(category);

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -53,6 +53,22 @@ const _Model = BaseModel.extend({
 
       this.trigger('add:comment', commentModel);
     },
+    AttachmentAdded({ file, attributes }) {
+      const attachmentModel = Radio.request('entities', 'files:model', {
+        id: file.id,
+        path: attributes.path,
+        created_at: dayjs.utc().format(),
+        _action: this.id,
+        _patient: this.getPatient().id,
+        _view: attributes.urls.view,
+        _download: attributes.urls.download,
+      });
+
+      const newFilesRelationship = [...this.get('_files'), { id: file.id, type: 'files' }];
+      this.set({ _files: newFilesRelationship });
+
+      this.trigger('add:attachment', attachmentModel);
+    },
     ResourceDeleted() {
       this.destroy({ isDeleted: true });
     },

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -51,7 +51,7 @@ const _Model = BaseModel.extend({
         _clinician: author,
       });
 
-      this.trigger('add:comment', commentModel);
+      this.trigger('ws:add:comment', commentModel);
     },
     AttachmentAdded({ file, attributes }) {
       const attachmentModel = Radio.request('entities', 'files:model', {
@@ -67,7 +67,7 @@ const _Model = BaseModel.extend({
       const newFilesRelationship = [...this.get('_files'), { id: file.id, type: 'files' }];
       this.set({ _files: newFilesRelationship });
 
-      this.trigger('add:attachment', attachmentModel);
+      this.trigger('ws:add:attachment', attachmentModel);
     },
     ResourceDeleted() {
       this.destroy({ isDeleted: true });

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -250,6 +250,14 @@ const _Model = BaseModel.extend({
 
     return !!size(programAction.get('allowed_uploads'));
   },
+  removeAttachment(resource) {
+    const files = this.get('_files');
+    const newFilesRelationship = files.filter(file => {
+      return file.id !== resource.id;
+    });
+
+    this.set({ _files: newFilesRelationship });
+  },
   parseRelationship: _parseRelationship,
 });
 

--- a/src/js/entities-service/entities/files.js
+++ b/src/js/entities-service/entities/files.js
@@ -1,3 +1,4 @@
+import Radio from 'backbone.radio';
 import { get, first } from 'underscore';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
@@ -24,6 +25,12 @@ const _Model = BaseModel.extend({
         _view: attributes.urls.view,
         _download: attributes.urls.download,
       });
+    },
+    FileRemoved({ resource }) {
+      const action = Radio.request('entities', 'actions:model', this.get('_action'));
+      action.removeAttachment(resource);
+
+      this.destroy({ isDeleted: true });
     },
   },
   urlRoot() {

--- a/src/js/entities-service/entities/files.js
+++ b/src/js/entities-service/entities/files.js
@@ -17,6 +17,15 @@ const _Model = BaseModel.extend({
     _progress: 0,
   },
   type: TYPE,
+  messages: {
+    FileReplaced({ attributes }) {
+      this.set({
+        path: attributes.path,
+        _view: attributes.urls.view,
+        _download: attributes.urls.download,
+      });
+    },
+  },
   urlRoot() {
     if (this.isNew()) {
       const actionId = this.get('_action');

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -108,6 +108,7 @@ context('patient flow page', function() {
 
   specify('patient flow action sidebar', function() {
     const testCommentId = uuid();
+    const testOtherFileId = uuid();
 
     const testPatient = getPatient({
       attributes: {
@@ -119,6 +120,12 @@ context('patient flow page', function() {
       },
     });
 
+    const testProgramAction = getProgramAction({
+      attributes: {
+        allowed_uploads: ['pdf'],
+      },
+    });
+
     const testFlowAction = getAction({
       attributes: {
         name: 'Test Action',
@@ -126,18 +133,26 @@ context('patient flow page', function() {
         outreach: 'disabled',
         sharing: 'disabled',
         updated_at: testTsSubtract(1),
+        allowed_uploads: ['pdf'],
       },
       relationships: {
-        flow: getRelationship(testFlow),
-        state: getRelationship(stateTodo),
-        owner: getRelationship(teamNurse),
-        form: getRelationship(testForm),
-        patient: getRelationship(testPatient),
+        'flow': getRelationship(testFlow),
+        'state': getRelationship(stateTodo),
+        'owner': getRelationship(teamNurse),
+        'form': getRelationship(testForm),
+        'patient': getRelationship(testPatient),
+        'program-action': getRelationship(testProgramAction),
+        'files': getRelationship([{ id: testOtherFileId }], 'files'),
       },
     });
 
     cy
       .routesForPatientAction()
+      .routeSettings(fx => {
+        fx.data.push({ id: 'upload_attachments', attributes: { value: true } });
+
+        return fx;
+      })
       .routeFlow(fx => {
         fx.data = mergeJsonApi(testFlow, {
           relationships: {
@@ -150,10 +165,29 @@ context('patient flow page', function() {
       .routeFlowActions(fx => {
         fx.data = [testFlowAction];
 
+        fx.included.push(testProgramAction);
+
         return fx;
       })
       .routePatientByFlow(fx => {
         fx.data = testPatient;
+
+        return fx;
+      })
+      .routeActionFiles(fx => {
+        fx.data = [
+          {
+            id: testOtherFileId,
+            attributes: {
+              path: `patients/${ testPatient.id }/Other_file.pdf`,
+              created_at: testTsSubtract(1),
+            },
+            meta: {
+              view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/Other_File.pdf`,
+              download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/Other_File.pdf`,
+            },
+          },
+        ];
 
         return fx;
       })
@@ -388,6 +422,40 @@ context('patient flow page', function() {
       .get('[data-activity-region]')
       .find('.comment__item')
       .should('have.length', 3);
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: 'patient-actions',
+        id: testFlowAction.id,
+      },
+      payload: {
+        clinician: {
+          type: 'clinicians',
+          id: uuid(),
+        },
+        file: {
+          type: 'files',
+          id: uuid(),
+        },
+        attributes: {
+          path: `patients/${ testPatient.id }/HRA.pdf`,
+          bucket: 'bucket_name',
+          urls: {
+            view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/HRA.pdf`,
+            download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA.pdf`,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('[data-attachments-files-region]')
+      .children()
+      .as('attachmentItems')
+      .should('have.length', 2)
+      .first()
+      .contains('HRA.pdf');
 
     cy.sendWs({
       category: 'ResourceDeleted',
@@ -2794,6 +2862,37 @@ context('patient flow page', function() {
       .get('@flowSidebar')
       .find('[data-state-region]')
       .should('contain', 'Done');
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        clinician: {
+          type: 'clinicians',
+          id: uuid(),
+        },
+        file: {
+          type: 'files',
+          id: uuid(),
+        },
+        attributes: {
+          path: 'patients/1/HRA.pdf',
+          bucket: 'bucket_name',
+          urls: {
+            view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
+            download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
+          },
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .fa-paperclip')
+      .should('exist');
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -108,6 +108,7 @@ context('patient flow page', function() {
 
   specify('patient flow action sidebar', function() {
     const testCommentId = uuid();
+    const testFileId = uuid();
     const testOtherFileId = uuid();
 
     const testPatient = getPatient({
@@ -436,7 +437,7 @@ context('patient flow page', function() {
         },
         file: {
           type: 'files',
-          id: uuid(),
+          id: testFileId,
         },
         attributes: {
           path: `patients/${ testPatient.id }/HRA.pdf`,
@@ -453,9 +454,56 @@ context('patient flow page', function() {
       .get('[data-attachments-files-region]')
       .children()
       .as('attachmentItems')
-      .should('have.length', 2)
+      .should('have.length', 2);
+
+    cy
+      .get('@attachmentItems')
       .first()
-      .contains('HRA.pdf');
+      .as('attachmentItem')
+      .contains('HRA.pdf')
+      .should('have.attr', 'href')
+      .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/HRA.pdf`);
+
+    cy
+      .get('@attachmentItem')
+      .contains('Download')
+      .should('have.attr', 'href')
+      .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA.pdf`);
+
+    cy.sendWs({
+      category: 'FileReplaced',
+      resource: {
+        type: 'files',
+        id: testFileId,
+      },
+      payload: {
+        attributes: {
+          path: `patients/${ testPatient.id }/HRA_v2.pdf`,
+          bucket: 'bucket_name',
+          urls: {
+            view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/HRA_v2.pdf`,
+            download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA_v2.pdf`,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('[data-attachments-files-region]')
+      .children()
+      .should('have.length', 2);
+
+    cy
+      .get('@attachmentItem')
+      .contains('HRA_v2.pdf')
+      .should('have.attr', 'href')
+      .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/HRA_v2.pdf`);
+
+    cy
+      .get('@attachmentItem')
+      .contains('Download')
+      .should('have.attr', 'href')
+      .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA_v2.pdf`);
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -506,6 +506,25 @@ context('patient flow page', function() {
       .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA_v2.pdf`);
 
     cy.sendWs({
+      category: 'FileRemoved',
+      resource: {
+        type: 'files',
+        id: testFileId,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('[data-attachments-files-region]')
+      .children()
+      .should('have.length', 1);
+
+    cy
+      .get('@attachmentItems')
+      .contains('HRA_v2.pdf')
+      .should('not.exist');
+
+    cy.sendWs({
       category: 'ResourceDeleted',
       resource: {
         type: 'patient-actions',
@@ -2608,6 +2627,8 @@ context('patient flow page', function() {
   });
 
   specify('socket notifications', function() {
+    const testSocketFileId = uuid();
+
     const testSocketFlow = getFlow({
       attributes: {
         name: 'Flow Test',
@@ -2924,7 +2945,7 @@ context('patient flow page', function() {
         },
         file: {
           type: 'files',
-          id: uuid(),
+          id: testSocketFileId,
         },
         attributes: {
           path: 'patients/1/HRA.pdf',
@@ -2941,6 +2962,20 @@ context('patient flow page', function() {
       .get('.patient-flow__list')
       .find('.table-list__item .fa-paperclip')
       .should('exist');
+
+    cy.sendWs({
+      category: 'FileRemoved',
+      resource: {
+        type: 'files',
+        id: testSocketFileId,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .fa-paperclip')
+      .should('not.exist');
 
     cy.sendWs({
       category: 'ResourceDeleted',


### PR DESCRIPTION
Shortcut Story ID: [sc-56327] [sc-57309]

In this PR, these are being handled only in the action sidebar on the patient flow page.

Coinciding with the backend PR: https://github.com/RoundingWell/care-ops-backend/pull/8787.

- [x]  Support `AttachmentAdded` notifications
- [x]  Support `FileReplaced` notifications
- [x]  Support `FileRemoved` notifications
- [x] Show paperclip icon in action list items when file is added/removed via websocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced WebSocket communication for comments and attachments
  - Improved file management functionality with real-time updates

- **Bug Fixes**
  - Refined event handling for adding and removing attachments
  - Updated message processing for better resource tracking

- **Improvements**
  - Streamlined integration of WebSocket notifications
  - Added support for file replacement and removal operations

- **Testing**
  - Expanded test coverage for patient flow and file attachment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->