### PR TITLE
Restart closed websocket if still subscribed

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -1,5 +1,5 @@
 import Backbone from 'backbone';
-import { contains, extend, keys, reduce, size } from 'underscore';
+import { contains, extend, keys, reduce, size, union } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import dayjs from 'dayjs';
@@ -250,7 +250,7 @@ const _Model = BaseModel.extend({
     return !!size(programAction.get('allowed_uploads'));
   },
   addFile(resource) {
-    const newFilesRelationship = [...this.get('_files'), { id: resource.id, type: 'files' }];
+    const newFilesRelationship = union(this.get('_files'), [{ id: resource.id, type: 'files' }]);
 
     this.set({ _files: newFilesRelationship });
   },

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -7,8 +7,13 @@ let service;
 const clientKey = 'clientKey';
 
 Cypress.Commands.add('startService', () => {
+  const startSpy = cy.spy().as('startService');
+
+  service.on('start', startSpy);
+
+  // Return a promise that resolves when the service starts
   return new Cypress.Promise(resolve => {
-    service.on('start', resolve);
+    service.once('start', resolve);
     service.start();
   });
 });
@@ -80,16 +85,26 @@ context('WS Service', function() {
   specify('Restarting a closed socket', function() {
     const channel = Radio.channel('ws');
 
-    const closedTest = { name: 'SendTest', data: 'CLOSED' };
+    const closedTest = { id: 'foo', type: 'bar' };
+    const addTest = { id: 'foo2', type: 'bar2' };
+
+    const notification = {
+      state: {},
+      data: {
+        name: 'Subscribe',
+        data: {
+          clientKey: 'clientKey',
+          resources: [closedTest],
+        },
+      },
+    };
 
     cy
       .startService()
       .then(() => {
-        cy.stub(service, 'start').as('start');
-
         return new Cypress.Promise(resolve => {
           service.ws.addEventListener('close', () => {
-            channel.request('send', closedTest);
+            channel.request('subscribe', closedTest);
             resolve();
           });
           service.ws.close();
@@ -97,9 +112,25 @@ context('WS Service', function() {
       });
 
     cy
-      .get('@start')
-      .should('have.been.calledOnce')
-      .and('have.been.calledWith', { state: {}, data: closedTest });
+      .get('@startService')
+      .should('be.calledTwice')
+      .then(spy => {
+        const secondCall = spy.getCall(1);
+        expect(secondCall.args[0]).to.deep.equal(notification);
+      })
+      .then(() => {
+        channel.request('add', addTest);
+        service.ws.close();
+      });
+
+    cy
+      .get('@startService')
+      .should('be.calledThrice')
+      .then(spy => {
+        const thirdCall = spy.getCall(2);
+        notification.data.data.resources.push(addTest);
+        expect(thirdCall.args[0]).to.deep.equal(notification);
+      });
   });
 
   specify('Message handling', function() {

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -93,6 +93,7 @@ export default App.extend({
 
   onClose() {
     this.stopHeartbeat();
+    if (this.resources.length) this._subscribe();
   },
 
   onMessage(event) {


### PR DESCRIPTION
Shortcut Story ID: [sc-58128]

This doesn't really account for lost connection.. ie: it won't retry until the connection is restored.  but that's probably a pretty edgy-case where the connection is lost.. and regained without the user changing the context at any point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved WebSocket service connection handling to maintain subscriptions when resources are available after connection closure.
  
- **Tests**
	- Enhanced WebSocket service test suite to more precisely track service start events and resource management.
  
- **New Features**
	- Updated file handling logic to prevent duplicates in the file resource array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->