### PR TITLE
When a new comment is created, add web socket subscription after api request finishes

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -198,12 +198,14 @@ export default App.extend(extend({
     });
   },
   onPostNewComment({ model }) {
-    model.set({ created_at: dayjs.utc().format() }).save();
+    model.set({ created_at: dayjs.utc().format() });
+
+    model.save().then(() => {
+      Radio.request('ws', 'add', model);
+    });
 
     this.activityCollection.add(model);
     this.comments.add(model);
-
-    Radio.request('ws', 'add', model);
 
     this.showNewCommentForm();
   },


### PR DESCRIPTION
Shortcut Story ID: [sc-58035]

This handles an edge case situation where a user creates a comment in one tab and then edits it in another. In that scenario, the comment's `id` in the web socket notification would be `undefined` if we don't wait for the api request to come back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved comment submission reliability by ensuring WebSocket notifications are sent only after successful comment save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->