### PR TITLE
Update deprecated filters on action/flow list api requests

### DIFF
--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -13,7 +13,7 @@ export default App.extend({
   beforeStart({ patient }) {
     const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
-    const filter = { state: states.groupByDone().done.getFilterIds() };
+    const filter = { states: states.groupByDone().done.getFilterIds() };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -25,7 +25,7 @@ export default App.extend({
   beforeStart({ patient }) {
     const currentWorkspace = Radio.request('workspace', 'current');
     const states = currentWorkspace.getStates();
-    const filter = { state: states.groupByDone().notDone.getFilterIds() };
+    const filter = { states: states.groupByDone().notDone.getFilterIds() };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),

--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_state.js
@@ -50,8 +50,8 @@ export default Backbone.Model.extend({
   },
   getEntityStatesFilter() {
     return {
-      'state': this.get('states').join() || NIL_UUID,
-      'flow.state': this.get('flowStates').join() || NIL_UUID,
+      states: this.get('states').join() || NIL_UUID,
+      flow_states: this.get('flowStates').join() || NIL_UUID,
     };
   },
   getOwner() {
@@ -67,7 +67,7 @@ export default Backbone.Model.extend({
   },
   getEntityFilter() {
     const filters = {
-      clinician: this.currentClinician.id,
+      clinicians: this.currentClinician.id,
     };
 
     extend(filters, this.getEntityStatesFilter());

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -101,8 +101,8 @@ const StateModel = Backbone.Model.extend({
   },
   getEntityStatesFilter() {
     return {
-      'state': this.get('states').join() || NIL_UUID,
-      'flow.state': this.get('flowStates').join() || NIL_UUID,
+      states: this.get('states').join() || NIL_UUID,
+      flow_states: this.get('flowStates').join() || NIL_UUID,
     };
   },
   getOwner() {
@@ -113,7 +113,7 @@ const StateModel = Backbone.Model.extend({
   getEntityOwnerFilter() {
     const clinician = this.get('clinicianId');
 
-    return { clinician };
+    return { clinicians: clinician };
   },
   getEntityCustomFilter() {
     const filtersState = this.get('customFilters');

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -152,11 +152,11 @@ const StateModel = Backbone.Model.extend({
   getEntityStatesFilter() {
     const state = this.get('states').join() || NIL_UUID;
 
-    if (this.isFlowType()) return { state };
+    if (this.isFlowType()) return { states: state };
 
     return {
-      state,
-      'flow.state': this.get('flowStates').join() || NIL_UUID,
+      states: state,
+      flow_states: this.get('flowStates').join() || NIL_UUID,
     };
   },
   isOwnerTeam() {
@@ -179,12 +179,12 @@ const StateModel = Backbone.Model.extend({
       const noOwner = this.get('noOwner');
       const canFilterClinicians = this.currentClinician.can('app:worklist:clinician_filter');
 
-      if (noOwner || !canFilterClinicians) return { team, clinician: NIL_UUID };
+      if (noOwner || !canFilterClinicians) return { teams: team, clinicians: NIL_UUID };
 
-      return { team };
+      return { teams: team };
     }
 
-    return { clinician };
+    return { clinicians: clinician };
   },
   getEntityCustomFilter() {
     const filtersState = this.get('customFilters');

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -147,7 +147,7 @@ context('patient archive page', function() {
       .wait('@routePatientActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=55555,66666,77777');
+      .should('contain', 'filter[states]=55555,66666,77777');
 
     // Filters only done id 55555
     cy

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -166,7 +166,7 @@ context('patient dashboard page', function() {
       .wait('@routePatientActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[states]=22222,33333');
 
     // Filters out done id 55555
     cy

--- a/test/integration/patients/sidebar/filter-sidebar.js
+++ b/test/integration/patients/sidebar/filter-sidebar.js
@@ -95,8 +95,8 @@ context('filter sidebar', function() {
       .itsUrl()
       .its('search')
       .should('contain', 'filter[@insurance]=Medicare')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .get('.worklist-list__toggle')
@@ -293,8 +293,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[state]=${ stateTodo.id }`);
+      .should('contain', `filter[states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[states]=${ stateTodo.id }`);
 
     cy
       .get('@filtersSidebar')
@@ -318,8 +318,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[flow.state]=${ stateTodo.id }`);
+      .should('contain', `filter[flow_states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[flow_states]=${ stateTodo.id }`);
 
     cy
       .get('.list-page__filters')
@@ -358,7 +358,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ NIL_UUID }`);
+      .should('contain', `filter[states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -397,7 +397,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ NIL_UUID }`);
+      .should('contain', `filter[flow_states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -436,7 +436,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateInProgress.id }`);
 
     cy
       .get('.list-page__filters')
@@ -473,8 +473,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .get('.list-page__filters')
@@ -568,7 +568,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateDone.id },${ stateUnableToComplete.id }`);
+      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id }`);
 
     cy
       .get('.list-page__filters')
@@ -611,7 +611,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateUnableToComplete.id }`);
+      .should('contain', `filter[states]=${ stateUnableToComplete.id }`);
 
     cy
       .get('.list-page__filters')
@@ -648,7 +648,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateDone.id },${ stateUnableToComplete.id }`);
+      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id }`);
 
     cy
       .get('.list-page__filters')
@@ -730,10 +730,10 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=11111')
+      .should('contain', 'filter[clinicians]=11111')
       .should('contain', 'filter[@insurance]=Medicare')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .get('.list-page__filters')
@@ -894,8 +894,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[state]=${ stateTodo.id }`);
+      .should('contain', `filter[states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[states]=${ stateTodo.id }`);
 
     cy
       .get('.list-page__filters')
@@ -922,8 +922,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[flow.state]=${ stateTodo.id }`);
+      .should('contain', `filter[flow_states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[flow_states]=${ stateTodo.id }`);
 
     cy
       .get('.list-page__filters')
@@ -950,7 +950,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ NIL_UUID }`);
+      .should('contain', `filter[states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -977,7 +977,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ NIL_UUID }`);
+      .should('contain', `filter[flow_states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -1025,8 +1025,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`)
       .should('not.contain', 'filter[@insurance]');
 
     cy
@@ -1155,10 +1155,10 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[clinician]=${ currentClinician.id }`)
+      .should('contain', `filter[clinicians]=${ currentClinician.id }`)
       .should('contain', 'filter[@insurance]=Medicare')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .get('.list-page__filters')
@@ -1320,8 +1320,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[state]=${ stateTodo.id }`);
+      .should('contain', `filter[states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[states]=${ stateTodo.id }`);
 
     cy
       .get('.list-page__filters')
@@ -1348,8 +1348,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ stateInProgress.id }`)
-      .should('not.contain', `filter[flow.state]=${ stateTodo.id }`);
+      .should('contain', `filter[flow_states]=${ stateInProgress.id }`)
+      .should('not.contain', `filter[flow_states]=${ stateTodo.id }`);
 
     cy
       .get('.list-page__filters')
@@ -1376,7 +1376,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ NIL_UUID }`);
+      .should('contain', `filter[states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -1403,7 +1403,7 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[flow.state]=${ NIL_UUID }`);
+      .should('contain', `filter[flow_states]=${ NIL_UUID }`);
 
     cy
       .get('.list-page__filters')
@@ -1451,8 +1451,8 @@ context('filter sidebar', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`)
-      .should('contain', `filter[flow.state]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', `filter[flow_states]=${ stateTodo.id },${ stateInProgress.id }`)
       .should('not.contain', 'filter[@insurance]');
 
     cy

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -100,8 +100,8 @@ context('reduced schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[clinician]=${ currentClinician.id }`)
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[clinicians]=${ currentClinician.id }`)
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .url()
@@ -558,7 +558,7 @@ context('reduced schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`);
 
     cy
       .intercept('GET', '/api/actions?*', {
@@ -584,7 +584,7 @@ context('reduced schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateInProgress.id }`);
 
     cy
       .routeActions();
@@ -598,6 +598,6 @@ context('reduced schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[state]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`);
   });
 });

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -462,8 +462,8 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[clinicians]=11111')
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .get('[data-owner-filter-region]')
@@ -491,7 +491,7 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=test-id');
+      .should('contain', 'filter[clinicians]=test-id');
 
     cy
       .get('[data-date-filter-region]')
@@ -1850,7 +1850,7 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .intercept('GET', '/api/actions?*', {
@@ -1876,7 +1876,7 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=33333');
+      .should('contain', 'filter[states]=33333');
 
     cy
       .routeActions();
@@ -1890,6 +1890,6 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[states]=22222,33333');
   });
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -329,7 +329,7 @@ context('worklist page', function() {
       .itsUrl()
       .its('search')
       .should('contain', `filter[updated_at]=${ dayjs(testDate()).startOf('day').subtract(30, 'days').format() }`)
-      .should('contain', 'filter[state]=55555,66666,77777');
+      .should('contain', 'filter[states]=55555,66666,77777');
 
     cy
       .intercept('PATCH', '/api/flows/*', {
@@ -1094,8 +1094,8 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[clinicians]=11111')
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .get('[data-owner-filter-region]')
@@ -1129,8 +1129,8 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=test-clinician')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[clinicians]=test-clinician')
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .get('.list-page__title')
@@ -1152,8 +1152,8 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=11111')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[clinicians]=11111')
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .get('.list-page__title')
@@ -1180,7 +1180,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=test-clinician');
+      .should('contain', 'filter[clinicians]=test-clinician');
   });
 
   specify('owner filtering', function() {
@@ -1248,7 +1248,7 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[team]=${ teamCoordinator.id }`);
+      .should('contain', `filter[teams]=${ teamCoordinator.id }`);
 
     cy
       .get('[data-owner-filter-region]')
@@ -1265,7 +1265,7 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[clinician]=1');
+      .should('contain', 'filter[clinicians]=1');
 
     cy
       .get('[data-owner-toggle-region]')
@@ -1299,8 +1299,8 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[clinician]=${ NIL_UUID }`)
-      .should('contain', 'filter[team]=22222');
+      .should('contain', `filter[clinicians]=${ NIL_UUID }`)
+      .should('contain', 'filter[teams]=22222');
 
     cy
       .get('[data-owner-toggle-region]')
@@ -1312,8 +1312,8 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('not.contain', `filter[clinician]=${ NIL_UUID }`)
-      .should('contain', 'filter[team]=22222');
+      .should('not.contain', `filter[clinicians]=${ NIL_UUID }`)
+      .should('contain', 'filter[teams]=22222');
   });
 
   // TODO: Move to component tests
@@ -1959,7 +1959,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[clinician]=${ NIL_UUID }`);
+      .should('contain', `filter[clinicians]=${ NIL_UUID }`);
 
     cy
       .get('[data-owner-filter-region]')
@@ -4162,7 +4162,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[states]=22222,33333');
 
     cy
       .intercept('GET', '/api/actions?*', {
@@ -4188,7 +4188,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=33333');
+      .should('contain', 'filter[states]=33333');
 
     cy
       .routeActions();
@@ -4202,6 +4202,6 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'filter[state]=22222,33333');
+      .should('contain', 'filter[states]=22222,33333');
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-58220]

Updates:

- `api/actions` (worklists, schedule, reduced schedule):
  - `filter[flow.state]` => `filter[flow_states]`
  - `filter[state]` => `filter[states]`
  - `filter[team]` => `filter[teams]`
  - `filter[clinician]` => `filter[clinicians]`
  
- `api/flows` (worklists):
  - `filter[state]` => `filter[states]`
  - `filter[team]` => `filter[teams]`
  - `filter[clinician]` => `filter[clinicians]`

- `/api/patients/:id/relationships/actions` (patient dashboard/archive):
  - `filter[state]` => `filter[states]`

- `/api/patients/:id/relationships/flows` (patient dashboard/archive):
  - `filter[state]` => `filter[states]`