### PR TITLE
Support websocket workspace

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -1,4 +1,4 @@
-import { bind, invoke, get } from 'underscore';
+import { bind, get } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
@@ -98,7 +98,7 @@ export default SubRouterApp.extend({
     this.stopChildApp('actionSidebar');
   },
   subscribe() {
-    Radio.request('ws', 'subscribe', invoke([this.flow, ...this.actions.models], 'getResource'));
+    Radio.request('ws', 'subscribe', [this.flow, ...this.actions.models]);
   },
   _setFlowProgress() {
     const complete = this.actions.filter(action => action.isDone()).length;

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -55,12 +55,6 @@ export default Backbone.Model.extend(extend({
       return key !== 'id' && /^[^_]/.test(key);
     });
   },
-  getResource() {
-    return {
-      id: this.id,
-      type: this.type,
-    };
-  },
   toJSONApi(attributes = this.attributes) {
     return {
       id: this.id,

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -5,6 +5,7 @@ import WSService from './ws';
 
 let service;
 const clientKey = 'clientKey';
+const workspace = 'workspaceId';
 
 Cypress.Commands.add('startService', () => {
   const startSpy = cy.spy().as('startService');
@@ -21,6 +22,7 @@ Cypress.Commands.add('startService', () => {
 context('WS Service', function() {
   beforeEach(function() {
     Radio.reply('bootstrap', 'currentUser', { clientKey });
+    Radio.reply('workspace', 'current', { id: workspace });
     Radio.reply('auth', 'getToken', () => 'token');
     const url = 'ws://cypress-websocket/ws';
     cy.mockWs(url);
@@ -31,6 +33,7 @@ context('WS Service', function() {
     service.destroy();
     Radio.stopReplying('auth', 'getToken');
     Radio.stopReplying('bootstrap', 'currentUser');
+    Radio.stopReplying('workspace', 'current');
   });
 
   specify('ws url not configured', function() {
@@ -93,7 +96,8 @@ context('WS Service', function() {
       data: {
         name: 'Subscribe',
         data: {
-          clientKey: 'clientKey',
+          clientKey,
+          workspace,
           resources: [closedTest],
         },
       },
@@ -182,42 +186,42 @@ context('WS Service', function() {
 
         channel.request('subscribe', new TestModel({ id: 'foo', foo: true }));
       })
-      .should('deep.equal', { clientKey, resources: [notifications[0]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[0]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('add', notifications[1], { shouldPersist: true });
       })
-      .should('deep.equal', { clientKey, resources: [notifications[0], notifications[1]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[0], notifications[1]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('subscribe', notifications[2]);
       })
-      .should('deep.equal', { clientKey, resources: [notifications[2], notifications[1]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[2], notifications[1]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('unsubscribe', notifications[1]);
       })
-      .should('deep.equal', { clientKey, resources: [notifications[2]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[2]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('subscribe', [notifications[3]], { shouldPersist: true });
       })
-      .should('deep.equal', { clientKey, resources: [notifications[3]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[3]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('add', [notifications[0], notifications[1]]);
       })
-      .should('deep.equal', { clientKey, resources: [notifications[3], notifications[0], notifications[1]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[3], notifications[0], notifications[1]] });
 
     cy
       .interceptWs('Subscribe', () => {
         channel.request('unsubscribe', [notifications[3]]);
       })
-      .should('deep.equal', { clientKey, resources: [notifications[0], notifications[1]] });
+      .should('deep.equal', { clientKey, workspace, resources: [notifications[0], notifications[1]] });
   });
 });

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -8,9 +8,9 @@ const clientKey = 'clientKey';
 const workspace = 'workspaceId';
 
 Cypress.Commands.add('startService', () => {
-  const startSpy = cy.spy().as('startService');
+  const startStub = cy.stub().as('startService');
 
-  service.on('start', startSpy);
+  service.on('start', startStub);
 
   // Return a promise that resolves when the service starts
   return new Cypress.Promise(resolve => {
@@ -48,41 +48,45 @@ context('WS Service', function() {
   });
 
   specify('Constructing the websocket', function() {
-    service.start();
+    const testNotConnected = { name: 'SendTest', data: 'NOTCONNECTED' };
 
-    cy
-      .interceptWs('SendTest').as('sendTest');
+    service.start();
 
     service.on('start', () => {
       const channel = Radio.channel('ws');
 
       service.ws.readyState = WebSocket.CONNECTING;
-      channel.request('send', { name: 'SendTest', data: 'NOTCONNECTED' });
+      channel.request('send', testNotConnected);
     });
 
     cy
-      .get('@sendTest')
-      .should('equal', 'NOTCONNECTED');
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testNotConnected);
   });
 
   specify('Connecting the websocket', function() {
     const channel = Radio.channel('ws');
+    const testConnecting = { name: 'SendTest', data: 'CONNECTING' };
+    const testOpen = { name: 'SendTest', data: 'OPEN' };
 
     cy
-      .startService()
-      .interceptWs('SendTest', () => {
-        channel.request('send', { name: 'SendTest', data: 'CONNECTING' });
-      })
-      .should('equal', 'CONNECTING')
+      .wrap(service)
       .then(() => {
-        expect(service.isRunning()).to.be.true;
+        expect(service.isRunning()).to.be.false;
+        channel.request('send', testConnecting);
       });
 
     cy
-      .interceptWs('SendTest', () => {
-        channel.request('send', { name: 'SendTest', data: 'OPEN' });
-      })
-      .should('equal', 'OPEN');
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testConnecting)
+      .then(() => {
+        expect(service.isRunning()).to.be.true;
+        channel.request('send', testOpen);
+      });
+
+    cy
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testOpen);
   });
 
   specify('Restarting a closed socket', function() {
@@ -161,11 +165,11 @@ context('WS Service', function() {
     service.HEART_BEAT_INTERVAL = 10;
 
     cy
-      .startService()
-      .wait(10);
+      .startService();
 
     cy
-      .interceptWs('ping')
+      .get('@wsHandleMessage')
+      .should('be.calledWith', { name: 'ping' })
       .sendWs({ name: 'pong' });
   });
 
@@ -177,51 +181,61 @@ context('WS Service', function() {
       { id: 'foo4', type: 'bar4' },
     ];
 
+    function testData(resources) {
+      return {
+        name: 'Subscribe',
+        data: {
+          clientKey,
+          workspace,
+          resources,
+        },
+      };
+    }
+
     const channel = Radio.channel('ws');
 
-    cy
-      .startService()
-      .interceptWs('Subscribe', () => {
-        const TestModel = Backbone.Model.extend({ type: 'bar' });
+    const TestModel = Backbone.Model.extend({ type: 'bar' });
 
-        channel.request('subscribe', new TestModel({ id: 'foo', foo: true }));
-      })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[0]] });
+    channel.request('subscribe', new TestModel({ id: 'foo', foo: true }));
 
     cy
-      .interceptWs('Subscribe', () => {
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[0]]))
+
+      .then(() => {
         channel.request('add', notifications[1], { shouldPersist: true });
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[0], notifications[1]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[0], notifications[1]]))
 
-    cy
-      .interceptWs('Subscribe', () => {
+      .then(() => {
         channel.request('subscribe', notifications[2]);
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[2], notifications[1]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[2], notifications[1]]))
 
-    cy
-      .interceptWs('Subscribe', () => {
+      .then(() => {
         channel.request('unsubscribe', notifications[1]);
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[2]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[2]]))
 
-    cy
-      .interceptWs('Subscribe', () => {
+      .then(() => {
         channel.request('subscribe', [notifications[3]], { shouldPersist: true });
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[3]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[3]]))
 
-    cy
-      .interceptWs('Subscribe', () => {
+      .then(() => {
         channel.request('add', [notifications[0], notifications[1]]);
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[3], notifications[0], notifications[1]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[3], notifications[0], notifications[1]]))
 
-    cy
-      .interceptWs('Subscribe', () => {
+      .then(() => {
         channel.request('unsubscribe', [notifications[3]]);
       })
-      .should('deep.equal', { clientKey, workspace, resources: [notifications[0], notifications[1]] });
+      .get('@wsHandleMessage')
+      .should('be.calledWith', testData([notifications[0], notifications[1]]));
   });
 });

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -93,7 +93,6 @@ context('WS Service', function() {
     const channel = Radio.channel('ws');
 
     const closedTest = { id: 'foo', type: 'bar' };
-    const addTest = { id: 'foo2', type: 'bar2' };
 
     const notification = {
       state: {},
@@ -125,19 +124,6 @@ context('WS Service', function() {
       .then(spy => {
         const secondCall = spy.getCall(1);
         expect(secondCall.args[0]).to.deep.equal(notification);
-      })
-      .then(() => {
-        channel.request('add', addTest);
-        service.ws.close();
-      });
-
-    cy
-      .get('@startService')
-      .should('be.calledThrice')
-      .then(spy => {
-        const thirdCall = spy.getCall(2);
-        notification.data.data.resources.push(addTest);
-        expect(thirdCall.args[0]).to.deep.equal(notification);
       });
   });
 

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -74,7 +74,7 @@ export default App.extend({
   },
 
   onOpen(data) {
-    this.sendData(data);
+    if (data) this.sendData(data);
     this.startHeartbeat();
   },
 

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -36,11 +36,13 @@ export default App.extend({
 
   _subscribe() {
     const currentUser = Radio.request('bootstrap', 'currentUser');
+    const currentWorkspace = Radio.request('workspace', 'current');
 
     this.send({
       name: 'Subscribe',
       data: {
         clientKey: currentUser.clientKey,
+        workspace: currentWorkspace.id,
         resources: this.resources.toJSON(),
       },
     });

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -95,7 +95,7 @@ export default App.extend({
 
   onClose() {
     this.stopHeartbeat();
-    if (this.resources.length) this._subscribe();
+    if (!_TEST_ && this.resources.length) this._subscribe();
   },
 
   onMessage(event) {

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2678,18 +2678,21 @@ context('patient flow page', function() {
       .visitOnClock(`/flow/${ testSocketFlow.id }`, { now: testTs() })
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
-      .wait('@routeFlowActions')
-      .interceptWs('Subscribe')
-      .its('resources')
-      .should('deep.equal', [
-        getRelationship(testSocketFlow).data,
-        getRelationship(testSocketAction).data,
-      ]);
+      .wait('@routeFlowActions');
 
     cy
       .get('[data-header-region]')
       .click('top')
       .tick(300);
+
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        expect(stub.getCall(0).args[0].data.resources).to.deep.equal([
+          getRelationship(testSocketFlow).data,
+          getRelationship(testSocketAction).data,
+        ]);
+      });
 
     cy.sendWs({
       category: 'NameChanged',

--- a/test/support/websockets.js
+++ b/test/support/websockets.js
@@ -4,16 +4,7 @@ import { Server, WebSocket as MockedWebSocket } from 'mock-socket';
 let socketReady;
 let mockServer;
 
-const messageHandlers = {};
-
-const handleMessages = message => {
-  const { name, data } = JSON.parse(message);
-  if (messageHandlers[name]) {
-    messageHandlers[name](data);
-  }
-};
-
-const getServer = url => {
+const getServer = (url, messageHandler) => {
   return new Cypress.Promise(resolve => {
     if (mockServer) {
       mockServer.close();
@@ -22,8 +13,8 @@ const getServer = url => {
     mockServer = new Server(url, { mock: true });
 
     mockServer.on('connection', socket => {
-      socket.on('message', function(message) {
-        if (message) handleMessages(message);
+      socket.on('message', message => {
+        messageHandler(JSON.parse(message));
       });
     });
 
@@ -38,7 +29,9 @@ Cypress.Commands.add('mockWs', url => {
     win.WebSocket = MockedWebSocket;
   });
 
-  socketReady = getServer(url);
+  const messageHandler = cy.stub().as('wsHandleMessage');
+
+  socketReady = getServer(url, messageHandler);
 
   cy.on('test:after:run', () => {
     cy.log('ws: Stopping Mock Server');
@@ -58,14 +51,5 @@ Cypress.Commands.add('errorWs', () => {
   cy.wrap(socketReady).then(() => {
     cy.log('ws: Sending error');
     mockServer.simulate('error');
-  });
-});
-
-Cypress.Commands.add('interceptWs', (name, callback) => {
-  cy.wrap(socketReady).then(() => {
-    return new Cypress.Promise(resolve => {
-      messageHandlers[name] = resolve;
-      if (callback) callback();
-    });
   });
 });

--- a/test/support/websockets.js
+++ b/test/support/websockets.js
@@ -4,10 +4,6 @@ import { Server, WebSocket as MockedWebSocket } from 'mock-socket';
 let socketReady;
 let mockServer;
 
-const sendMessage = (socket, message) => {
-  socket.send(JSON.stringify(message));
-};
-
 const messageHandlers = {};
 
 const handleMessages = message => {
@@ -17,7 +13,7 @@ const handleMessages = message => {
   }
 };
 
-const getServer = (url, connectionResponseData) => {
+const getServer = url => {
   return new Cypress.Promise(resolve => {
     if (mockServer) {
       mockServer.close();
@@ -26,10 +22,6 @@ const getServer = (url, connectionResponseData) => {
     mockServer = new Server(url, { mock: true });
 
     mockServer.on('connection', socket => {
-      if (connectionResponseData) {
-        sendMessage(socket, connectionResponseData);
-      }
-
       socket.on('message', function(message) {
         if (message) handleMessages(message);
       });
@@ -39,14 +31,14 @@ const getServer = (url, connectionResponseData) => {
   });
 };
 
-Cypress.Commands.add('mockWs', (url, { connectionResponseMessage } = {}) => {
+Cypress.Commands.add('mockWs', url => {
   cy.log('ws: Mocking WebSocket');
 
   cy.on('window:before:load', win => {
     win.WebSocket = MockedWebSocket;
   });
 
-  socketReady = getServer(url, connectionResponseMessage);
+  socketReady = getServer(url);
 
   cy.on('test:after:run', () => {
     cy.log('ws: Stopping Mock Server');


### PR DESCRIPTION
Shortcut Story ID: [sc-58278]

For the moment at least all websocket subscriptions.. similar to api requests can by default pass the current workspace.

We might run into issue in the future where we want to monitor across workspace, but we'll tackle that when we get there as it will likely coincide with changes to how we interact with the API as well.  (ie: get a notification from a different workspace.. make a request on that different workspace)

In addition to this is a bit of cleanup of unused features or flake-related issues

* I had added `getResource` to model in order to make it easier to feed the subscription service `{ id: type }` but later we just made the subscription service support an array of models so it's no longer needed.
* I removed the `connectionResponseMessage` from the mock websocket server as it was never used and likely never will be
* I removed wsIntercept for a stub for any handler.  wsIntercept was difficullt to manage timing wise.  Removing it uncovered issues for more consistent tests.
* websockets were closing at the end of the tests causing the app to resubscribe which that message did overlap tests causing some bleed into the new stub
* similarly we were sending an empty subscribe in the tests because `onOpen` sometimes passed data and sometimes didn't depending on timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Improved WebSocket service handling and connection management
  - Enhanced resource subscription logic

- **Refactor**
  - Simplified WebSocket message processing in testing environment
  - Streamlined WebSocket notification handling
  - Removed deprecated resource retrieval method

- **Tests**
  - Updated WebSocket testing support
  - Improved test assertions for WebSocket interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->