### PR TITLE
Add worklist subscription and filters

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -154,20 +154,9 @@ export default App.extend({
 
     this.showList();
   },
-  _getWsFetchOptions(filterKey) {
-    if (filterKey === 'flows') return {};
-
-    return {
-      data: {
-        fields: { flows: ['name', 'state'] },
-        include: ['program-action.program', 'flow.program-flow.program'].join(),
-      },
-    };
-  },
   subscribe() {
     const channel = Radio.channel('ws');
     const filterKey = this.getState().getType();
-    const flowStates = this.getState('flowStates');
 
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
@@ -177,16 +166,37 @@ export default App.extend({
 
       if (this.collection.get(model) || model.isFetching()) return;
 
-      const options = this._getWsFetchOptions(filterKey);
+      if (filterKey === 'flows') {
+        this._fetchFlow(model);
 
-      model.fetch(options).then(() => {
-        // notifications do not fully filter our action flow_states
-        if (filterKey === 'actions' && !flowStates.includes(model.getFlow().getState().id)) return;
+        return;
+      }
 
-        this.collection.add(model);
+      this._fetchAction(model);
 
-        channel.request('add', model);
-      });
+      return;
+    });
+  },
+  _fetchFlow(model) {
+    const fetchFlow = Radio.request('entities', 'fetch:flows:model', model.id);
+
+    fetchFlow.then(() => {
+      this.collection.add(model);
+
+      Radio.request('ws', 'add', model);
+    });
+  },
+  _fetchAction(model) {
+    const flowStates = this.getState('flowStates');
+
+    const fetchAction = Radio.request('entities', 'fetch:actions:model', model.id);
+
+    fetchAction.then(() => {
+      if (!flowStates.includes(model.getFlow().getState().id)) return;
+
+      this.collection.add(model);
+
+      Radio.request('ws', 'add', model);
     });
   },
   // NOTE: Shows views dependent on getState().getType()

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -154,6 +154,16 @@ export default App.extend({
 
     this.showList();
   },
+  _getWsFetchOptions(filterKey) {
+    if (filterKey === 'flows') return {};
+
+    return {
+      data: {
+        fields: { flows: ['name', 'state'] },
+        include: ['program-action.program', 'flow.program-flow.program'].join(),
+      },
+    };
+  },
   subscribe() {
     const channel = Radio.channel('ws');
     const filterKey = this.getState().getType();
@@ -167,7 +177,9 @@ export default App.extend({
 
       if (this.collection.get(model) || model.isFetching()) return;
 
-      model.fetch().then(() => {
+      const options = this._getWsFetchOptions(filterKey);
+
+      model.fetch(options).then(() => {
         // notifications do not fully filter our action flow_states
         if (filterKey === 'actions' && !flowStates.includes(model.getFlow().getState().id)) return;
 

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -157,6 +157,7 @@ export default App.extend({
   subscribe() {
     const channel = Radio.channel('ws');
     const filterKey = this.getState().getType();
+    const flowStates = this.getState('flowStates');
 
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
@@ -164,6 +165,9 @@ export default App.extend({
       if (this.collection.get(model)) return;
 
       model.fetch().then(() => {
+        // notifications do not fully filter our action flow_states
+        if (filterKey === 'actions' && !flowStates.includes(model.getFlow().getState().id)) return;
+
         this.collection.add(model);
       });
     });

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -162,8 +162,6 @@ export default App.extend({
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
     this.listenTo(channel, 'message', ({ category, resource, payload }) => {
-      if (!category) return;
-
       const modelResource = category === 'ResourceCreated' ? payload.resource : resource;
       const model = Radio.request('entities', 'get:store', modelResource);
 

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -162,7 +162,7 @@ export default App.extend({
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
     this.listenTo(channel, 'message', (message, model) => {
-      if (this.collection.get(model)) return;
+      if (this.collection.get(model) || model.isFetching()) return;
 
       model.fetch().then(() => {
         // notifications do not fully filter our action flow_states

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -161,7 +161,12 @@ export default App.extend({
 
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
-    this.listenTo(channel, 'message', (message, model) => {
+    this.listenTo(channel, 'message', ({ category, resource, payload }) => {
+      if (!category) return;
+
+      const modelResource = category === 'ResourceCreated' ? payload.resource : resource;
+      const model = Radio.request('entities', 'get:store', modelResource);
+
       if (this.collection.get(model) || model.isFetching()) return;
 
       model.fetch().then(() => {
@@ -169,6 +174,8 @@ export default App.extend({
         if (filterKey === 'actions' && !flowStates.includes(model.getFlow().getState().id)) return;
 
         this.collection.add(model);
+
+        channel.request('add', model);
       });
     });
   },

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -126,9 +126,10 @@ export default App.extend({
   },
   beforeStart() {
     const listType = this.getState().getType();
+    this.filters = this.getState().getEntityFilter();
 
     const data = {
-      filter: this.getState().getEntityFilter(),
+      filter: this.filters,
       include: this.sortOptions.getInclude(),
     };
 
@@ -143,6 +144,8 @@ export default App.extend({
     this.filteredCollection = collection.clone();
     this.editableCollection = collection.clone();
 
+    this.subscribe();
+
     this.listenTo(this.filteredCollection, 'reset', this.showCountView);
     this.showCountView();
 
@@ -150,6 +153,20 @@ export default App.extend({
     this.toggleBulkSelect();
 
     this.showList();
+  },
+  subscribe() {
+    const channel = Radio.channel('ws');
+    const filterKey = this.getState().getType();
+
+    channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
+
+    this.listenTo(channel, 'message', (message, model) => {
+      if (this.collection.get(model)) return;
+
+      model.fetch().then(() => {
+        this.collection.add(model);
+      });
+    });
   },
   // NOTE: Shows views dependent on getState().getType()
   showTypeViews() {
@@ -210,7 +227,7 @@ export default App.extend({
     const filtersState = this.getFiltersState();
 
     const sidebarApp = this.getChildApp('filtersSidebar');
-    
+
     Radio.request('sidebar', 'start', sidebarApp, { filtersState });
   },
   toggleBulkSelect() {

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -1,4 +1,4 @@
-import { extend, isEmpty, isFunction, pick, reduce, result } from 'underscore';
+import { each, extend, isEmpty, isFunction, pick, reduce, result } from 'underscore';
 import Backbone from 'backbone';
 import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
@@ -41,6 +41,8 @@ export default Backbone.Model.extend(extend({
     // Resolve with entity if successful
     return fetcher.then(response => {
       this._isFetching = false;
+
+      each(this._notifications, this._handleMessage, this);
 
       if (!response || response.ok) return this;
 
@@ -105,12 +107,30 @@ export default Backbone.Model.extend(extend({
 
     return isFunction(messages[category]) ? messages[category] : this[messages[category]];
   },
-  handleMessage({ category, resource, author, payload }) {
-    payload.attributes = extend({}, payload.attributes, { updated_at: dayjs.utc().format() });
+  queueMessage(data) {
+    const category = data.category;
 
+    if (!this._notifications) {
+      this._notifications = { [category]: data };
+      return;
+    }
+
+    this._notifications[category] = data;
+  },
+  _handleMessage({ category, resource, author, payload }) {
     const handler = this._getMessageHandler(category);
     if (handler) handler.call(this, payload, { category, resource, author });
 
     this.trigger('message', { category, resource, author, payload });
+  },
+  handleMessage({ category, resource, author, payload }) {
+    payload.attributes = extend({}, payload.attributes, { updated_at: dayjs.utc().format() });
+
+    if (this.isFetching()) {
+      this.queueMessage({ category, resource, author, payload });
+      return;
+    }
+
+    this._handleMessage({ category, resource, author, payload });
   },
 }, JsonApiMixin));

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -39,15 +39,21 @@ export default Backbone.Model.extend(extend({
     this._isFetching = true;
 
     // Resolve with entity if successful
-    return fetcher.then(response => {
-      this._isFetching = false;
+    return fetcher
+      .then(response => {
+        this._isFetching = false;
 
-      each(this._notifications, this._handleMessage, this);
+        each(this._notifications, this._handleMessage, this);
 
-      if (!response || response.ok) return this;
+        if (!response || response.ok) return this;
 
-      return response;
-    });
+        return response;
+      })
+      .catch(error => {
+        this._isFetching = false;
+
+        throw error;
+      });
   },
   isFetching() {
     return this._isFetching;

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -36,12 +36,19 @@ export default Backbone.Model.extend(extend({
     // Model fetches default to aborting.
     const fetcher = Backbone.Model.prototype.fetch.call(this, extend({ abort: true }, options));
 
+    this._isFetching = true;
+
     // Resolve with entity if successful
     return fetcher.then(response => {
+      this._isFetching = false;
+
       if (!response || response.ok) return this;
 
       return response;
     });
+  },
+  isFetching() {
+    return this._isFetching;
   },
   parse(response) {
     /* istanbul ignore if */

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -17,7 +17,12 @@ const Entity = BaseEntity.extend({
       'program-action.program',
       'flow.program-flow.program',
     ].join();
-    return this.fetchModel(id, { data: { include } });
+
+    const fields = {
+      flows: ['name', 'state'],
+    };
+
+    return this.fetchModel(id, { data: { include, fields } });
   },
   fetchActionWithResponses(id) {
     const data = {

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -103,6 +103,9 @@ export default App.extend({
   },
 
   onMessage(event) {
+    /* istanbul ignore next: Can't test this bref functionality in node websockets */
+    if (!event.data) return;
+
     let model;
 
     const channel = this.getChannel();

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -112,7 +112,7 @@ export default App.extend({
 
     const data = JSON.parse(event.data);
 
-    if (data.name === 'pong') return;
+    if (!data.category || data.name === 'pong') return;
 
     if (data.resource) {
       model = Radio.request('entities', 'get:store', data.resource);

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -37,13 +37,17 @@ export default App.extend({
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const currentWorkspace = Radio.request('workspace', 'current');
 
+    const data = {
+      clientKey: currentUser.clientKey,
+      workspace: currentWorkspace.id,
+      resources: this.resources.toJSON(),
+    };
+
+    if (this.filters) data.filters = this.filters;
+
     this.send({
       name: 'Subscribe',
-      data: {
-        clientKey: currentUser.clientKey,
-        workspace: currentWorkspace.id,
-        resources: this.resources.toJSON(),
-      },
+      data,
     });
   },
 
@@ -121,8 +125,10 @@ export default App.extend({
     return map(resources, ({ id, type }) => ({ id, type }));
   },
 
-  subscribe(resources, { shouldPersist } = {}) {
+  // TODO: We likely want to support a more reboust way of maintaining filters
+  subscribe(resources, { shouldPersist, filters } = {}) {
     resources = this._getResources(resources);
+    this.filters = filters;
 
     if (shouldPersist) {
       each(resources, ({ id, type }) => {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { NIL as NIL_UUID } from 'uuid';
+import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { ACTION_OUTREACH } from 'js/static';
 
@@ -301,6 +301,289 @@ context('worklist page', function() {
       .contains('Flows')
       .click()
       .wait('@routeFlows');
+  });
+
+  specify('flow list - socket notifications', function() {
+    const currentClinician = getCurrentClinician();
+
+    const testSocketFlow = getFlow({
+      attributes: {
+        name: 'Test Flow - Subscribed on Page Load',
+        updated_at: testTsSubtract(4),
+        created_at: testTsSubtract(4),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - Created Elsewhere',
+        updated_at: testTsSubtract(3),
+        created_at: testTsSubtract(3),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewStateSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - State Updated to Match Current Worklist Filter',
+        updated_at: testTsSubtract(2),
+        created_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewOwnerSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - Owner Updated to Match Current Worklist Filter',
+        updated_at: testTsSubtract(1),
+        created_at: testTsSubtract(1),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    localStorage.setItem(`owned-by_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'owned-by',
+      listType: 'flows',
+      flowsSortId: 'sortCreatedDesc',
+      clinicianId: currentClinician.id,
+      states: [stateTodo, stateInProgress],
+      customFilters: {},
+    }));
+
+    cy
+      .routesForPatientAction()
+      .routeFlows(fx => {
+        fx.data = [testSocketFlow];
+
+        fx.included.push(testPatient1);
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient1;
+
+        return fx;
+      })
+      .routeActions()
+      .routeFlow()
+      .routeFlowActions()
+      .routePatientByFlow()
+      .visitOnClock('/worklist/owned-by', { now: testTs() })
+      .wait('@routeFlows');
+
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.worklist-list__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-dot');
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: teamCoordinator.type,
+          id: teamCoordinator.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'CO');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testPatient1.type,
+        id: testPatient1.id,
+      },
+      payload: {
+        resource: {
+          type: testNewSocketFlow.type,
+          id: testNewSocketFlow.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that flow
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewSocketFlow.type,
+        id: testNewSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewSocketFlow.id)
+      .should('not.contain', 'fields[flows]=name,state')
+      .should('not.contain', 'include=program-action.program%2Cflow.program-flow.program');
+
+    cy
+      .get('[data-count-region]')
+      .should('contain', '2 Flows');
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - Created Elsewhere');
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-dot');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewSocketFlow.type,
+        id: testNewSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateDone.type,
+          id: stateDone.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-check');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewStateSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateTodo.type,
+          id: stateTodo.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewStateSocketFlow.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - State Updated to Match Current Worklist Filter');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewOwnerSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewOwnerSocketFlow.type,
+        id: testNewOwnerSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: currentClinician.type,
+          id: currentClinician.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewOwnerSocketFlow.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - Owner Updated to Match Current Worklist Filter');
   });
 
   specify('done flow list', function() {
@@ -846,6 +1129,478 @@ context('worklist page', function() {
 
     cy
       .go('back');
+  });
+
+  specify('action list - socket notifications', function() {
+    const currentClinician = getCurrentClinician();
+    const testComment = getComment();
+    const testSocketFileId = uuid();
+
+    const testFlow = getFlow({
+      attributes: {
+        name: 'Test Flow',
+      },
+      relationships: {
+        state: getRelationship(stateInProgress),
+      },
+    });
+
+    const testDoneStateFlow = getFlow({
+      attributes: {
+        name: 'Test Flow - Has State Not In Current Filters',
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+      },
+    });
+
+    const testSocketAction = getAction({
+      attributes: {
+        name: 'Test Action - Subscribed on Page Load',
+        updated_at: testTsSubtract(4),
+        created_at: testTsSubtract(4),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testFlow),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Created Elsewhere',
+        updated_at: testTsSubtract(3),
+        created_at: testTsSubtract(3),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testFlow),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewStateSocketAction = getAction({
+      attributes: {
+        name: 'New Action - State Updated to Match Current Worklist Filter',
+        updated_at: testTsSubtract(2),
+        created_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testFlow),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewOwnerSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Owner Updated to Match Current Worklist Filter',
+        updated_at: testTsSubtract(1),
+        created_at: testTsSubtract(1),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testFlow),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    const testNewFlowStateSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Flow State Does Not Match Current Filters',
+        updated_at: testTs(),
+        created_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testDoneStateFlow),
+        owner: getRelationship(currentClinician),
+        patient: getRelationship(testPatient1),
+      },
+    });
+
+    localStorage.setItem(`owned-by_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'owned-by',
+      listType: 'actions',
+      actionsSortId: 'sortCreatedDesc',
+      clinicianId: currentClinician.id,
+      states: [stateTodo.id, stateInProgress.id],
+      flowStates: [stateTodo.id, stateInProgress.id],
+      customFilters: {},
+    }));
+
+    cy
+      .routesForPatientAction()
+      .routeActions(fx => {
+        fx.data = [testSocketAction];
+
+        fx.included.push(testPatient1, testFlow);
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient1;
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testSocketAction;
+
+        return fx;
+      })
+      .routeFormByAction()
+      .routeFormDefinition()
+      .routeLatestFormResponse()
+      .visitOnClock('/worklist/owned-by', { now: testTs() })
+      .wait('@routeActions');
+
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.worklist-list__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+
+    cy.sendWs({
+      category: 'DetailsChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          details: '',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-details-region]')
+      .should('be.empty');
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-dot');
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: teamCoordinator.type,
+          id: teamCoordinator.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'CO');
+
+    cy.sendWs({
+      category: 'ActionDueChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          due_date: testDateAdd(1),
+          due_time: '07:00:00',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should($action => {
+        expect($action.find('[data-due-date-region]')).to.contain(formatDate(testDateAdd(1), 'SHORT'));
+        expect($action.find('[data-due-time-region]')).to.contain('7:00 AM');
+      });
+
+    cy.sendWs({
+      category: 'SharingUpdated',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          sharing: 'pending',
+          outreach: 'patient',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-share-from-square');
+
+    cy.sendWs({
+      category: 'CommentAdded',
+      author: currentClinician.id,
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        comment: {
+          type: testComment.type,
+          id: testComment.id,
+        },
+        attributes: {
+          message: 'New websocket comment.',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        clinician: {
+          type: currentClinician.type,
+          id: currentClinician.id,
+        },
+        file: {
+          type: 'files',
+          id: testSocketFileId,
+        },
+        attributes: {
+          path: 'patients/1/HRA.pdf',
+          bucket: 'bucket_name',
+          urls: {
+            view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
+            download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
+          },
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-paperclip')
+      .should('exist');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testFlow.type,
+        id: testFlow.id,
+      },
+      payload: {
+        resource: {
+          type: testNewSocketAction.type,
+          id: testNewSocketAction.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that action
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewSocketAction.id)
+      .should('contain', 'fields[flows]=name,state')
+      .should('contain', 'include=program-action.program%2Cflow.program-flow.program');
+
+    cy
+      .get('[data-count-region]')
+      .should('contain', '2 Actions');
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - Created Elsewhere');
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-dot');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateDone.type,
+          id: stateDone.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-state-region] .fa-circle-check');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewStateSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateTodo.type,
+          id: stateTodo.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewStateSocketAction.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - State Updated to Match Current Worklist Filter');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewOwnerSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewOwnerSocketAction.type,
+        id: testNewOwnerSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: currentClinician.type,
+          id: currentClinician.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewOwnerSocketAction.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - Owner Updated to Match Current Worklist Filter');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewFlowStateSocketAction;
+
+        fx.included.push(testDoneStateFlow);
+
+        return fx;
+      });
+
+    // should not be added to collection, flow state is not in current worklist filters
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewFlowStateSocketAction.type,
+        id: testNewFlowStateSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: currentClinician.type,
+          id: currentClinician.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewFlowStateSocketAction.id);
+
+    cy
+      .get('[data-count-region]')
+      .should('contain', '4 Actions');
   });
 
   specify('actions on a done-flow list', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-59124]

So to implement the filters messages we have to grab a model from the store.. rather than copy this pattern to a bunch of places I moved it to the entities channel.

Then I looked at other places where this pattern existed and changed it to `Model.getRelationship` which will coincide eventually with simplify the various relationships once https://github.com/RoundingWell/care-ops-frontend/pull/1320 is complete.

For not the filters implementation on the ws service is overly simplistic, but I don't know what kind of filter maintenance we're going to run into yet or if it's always a simple replace.

But I'm opening this as a draft as I think I need to real-world test the socket filters before adding tests in cypress etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the patient worklist with real-time notifications that immediately reflect updates for flows and actions.
  - Introduced improved filtering for a more accurate and responsive display of data.
  - Streamlined subscription mechanism to accommodate filters during WebSocket communications.

- **Bug Fixes**
  - Strengthened error handling during live data communications, reducing the risk of processing incomplete updates.

- **Tests**
  - Added automated tests to ensure that real-time notifications trigger the correct UI updates for patient worklist changes.
  - Implemented specifications for socket notifications related to flows and actions to verify UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->