### PR TITLE
Sass deprecation warning fixes

### DIFF
--- a/src/js/components/datepicker/datepicker.scss
+++ b/src/js/components/datepicker/datepicker.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 .datepicker {
   font-size: 12px;
   user-select: none;

--- a/src/scss/core/_base.scss
+++ b/src/scss/core/_base.scss
@@ -1,3 +1,5 @@
+@use '../provider-variables' as *;
+
 body {
   background-color: $white;
   overflow-x: hidden;

--- a/src/scss/core/_scrollbar.scss
+++ b/src/scss/core/_scrollbar.scss
@@ -1,3 +1,5 @@
+@use '../provider-variables' as *;
+
 ::-webkit-scrollbar {
   appearance: none;
 }

--- a/src/scss/core/_text.scss
+++ b/src/scss/core/_text.scss
@@ -1,6 +1,8 @@
 // Text alignment
 // -----------------------------------------------------------
 
+@use '../provider-variables' as *;
+
 .u-text-align--center { text-align: center !important; }
 .u-text-align--left { text-align: left !important; }
 .u-text-align--right { text-align: right !important; }

--- a/src/scss/core/_typography.scss
+++ b/src/scss/core/_typography.scss
@@ -1,6 +1,8 @@
 // Typography
 // -----------------------------------------------------------
 
+@use '../provider-variables' as *;
+
 body {
   color: $black-20;
   font-family: ProximaSoft, 'Droid Sans', 'helvetica neue', arial, sans-serif;

--- a/src/scss/formapp-core.scss
+++ b/src/scss/formapp-core.scss
@@ -1,6 +1,6 @@
-@import 'core/fonts';
-@import 'core/text';
-@import 'core/typography';
+@forward 'core/fonts';
+@forward 'core/text';
+@forward 'core/typography';
 
 body {
   padding: 24px;

--- a/src/scss/outreach-core.scss
+++ b/src/scss/outreach-core.scss
@@ -1,11 +1,11 @@
 // Core Styles
 // These are the core styles shared between mobile and desktop
-@import 'core/reset';
-@import 'core/flex';
-@import 'core/fonts';
-@import 'core/icon';
-@import 'core/layout';
-@import 'core/scrollbar';
-@import 'core/space';
-@import 'core/text';
-@import 'core/typography';
+@forward 'core/reset';
+@forward 'core/flex';
+@forward 'core/fonts';
+@forward 'core/icon';
+@forward 'core/layout';
+@forward 'core/scrollbar';
+@forward 'core/space';
+@forward 'core/text';
+@forward 'core/typography';

--- a/src/scss/provider-core.scss
+++ b/src/scss/provider-core.scss
@@ -1,12 +1,12 @@
 // Core Styles
 // These are the core styles shared between mobile and desktop
-@import 'core/reset';
-@import 'core/base';
-@import 'core/flex';
-@import 'core/fonts';
-@import 'core/icon';
-@import 'core/layout';
-@import 'core/scrollbar';
-@import 'core/space';
-@import 'core/text';
-@import 'core/typography';
+@forward 'core/reset';
+@forward 'core/base';
+@forward 'core/flex';
+@forward 'core/fonts';
+@forward 'core/icon';
+@forward 'core/layout';
+@forward 'core/scrollbar';
+@forward 'core/space';
+@forward 'core/text';
+@forward 'core/typography';

--- a/src/scss/provider-variables.scss
+++ b/src/scss/provider-variables.scss
@@ -2,12 +2,14 @@
 //   Colors
 // *************************************
 
+@use 'sass:map';
+
 // -------------------------------------
 //   Main Colors
 // -------------------------------------
 
 @function color($color, $tone: 'base') {
-  @return map-get(map-get($colors, $color), $tone);
+  @return map.get(map.get($colors, $color), $tone);
 }
 
 $colors: (

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,7 +34,6 @@ const css = {
       api: 'legacy',
       additionalData: `
         @use 'sass:math';
-        @use 'sass:color';
         @import 'src/scss/provider-variables.scss';
       `,
     },

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,7 +33,7 @@ const css = {
       // remove this when we switch sass to use modern js api
       api: 'legacy',
       additionalData: `
-        @import 'src/scss/provider-variables.scss';
+        @use 'src/scss/provider-variables.scss' as *;
       `,
     },
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,7 +33,6 @@ const css = {
       // remove this when we switch sass to use modern js api
       api: 'legacy',
       additionalData: `
-        @use 'sass:math';
         @import 'src/scss/provider-variables.scss';
       `,
     },


### PR DESCRIPTION
Shortcut Story ID: [sc-57510]

Original PR is: https://github.com/RoundingWell/care-ops-frontend/pull/1379. I messed up a rebase so it was recreated it in this PR. There's some discussion in that PR that will be carried over here.

Main deprecation updates:

- Switch from deprecated `map-get()` to `map.get()`.
- Switch from using deprecated `@import`'s to `@use` & `@forward` instead.
  - More info on the deprecation [here](https://sass-lang.com/blog/import-is-deprecated/).