### PR TITLE
Add `target="_blank"` to attachment download button link

### DIFF
--- a/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-attachments-views.js
@@ -26,10 +26,10 @@ const AttachmentView = View.extend({
   downloadTemplate: hbs`
     <a class="action-sidebar__attachment-filename" target="_blank" href="{{_view}}">{{filename}}</a>
     <div class="flex">
-      <a class="action-sidebar__attachment-action flex-grow" href="{{_download}}" download>
+      <a class="action-sidebar__attachment-action flex-grow" target="_blank" href="{{_download}}" download>
         {{far "download"}} <span>{{ @intl.patients.sidebar.action.actionSidebarAttachmentsViews.attachmentView.downloadText }}</span>
       </a>
-     {{#if canRemoveAttachments}}
+      {{#if canRemoveAttachments}}
         <a class="action-sidebar__attachment-action js-remove">
           {{far "trash-can"}} <span>{{ @intl.patients.sidebar.action.actionSidebarAttachmentsViews.attachmentView.removeText }}</span>
         </a>

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -810,6 +810,11 @@ context('action sidebar', function() {
 
     cy
       .get('@attachmentDownload')
+      .should('have.attr', 'target')
+      .and('contain', '_blank');
+
+    cy
+      .get('@attachmentDownload')
       .should('have.attr', 'download');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-58472]

To open download in new browser tab. Opening in current tab breaks the action sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced attachment download functionality to open downloads in a new tab
	- Added test coverage to verify new download link behavior

- **Tests**
	- Updated integration test to validate attachment download link opens in a new tab

<!-- end of auto-generated comment: release notes by coderabbit.ai -->