### PR TITLE
Show comment count on action list items

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
       "circle-xmark",
       "clock",
       "clock-rotate-left",
+      "comment",
       "download",
       "ellipsis",
       "file-lines",

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -201,6 +201,7 @@ export default App.extend(extend({
     model.set({ created_at: dayjs.utc().format() });
 
     model.save().then(() => {
+      this.action.addComment(model);
       Radio.request('ws', 'add', model);
     });
 

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -174,12 +174,17 @@ export default App.extend(extend({
     this.action.save({ sharing: ACTION_SHARING.PENDING });
   },
   showActivity() {
-    this.showContentView('activity', new ActivitiesView({
+    const activitiesView = new ActivitiesView({
       collection: this.activityCollection,
       model: this.action,
-    }));
+    });
     const createdEvent = this.activityCollection.find({ event_type: 'ActionCreated' });
 
+    this.listenTo(activitiesView, {
+      'remove:comment': this.onRemoveComment,
+    });
+
+    this.showContentView('activity', activitiesView);
     this.showFooterView('timestamps', new TimestampsView({ model: this.action, createdEvent }));
   },
   showNewCommentForm() {
@@ -212,6 +217,11 @@ export default App.extend(extend({
   },
   onCancelNewComment() {
     this.showNewCommentForm();
+  },
+  onRemoveComment(model) {
+    this.action.removeComment(model);
+
+    Radio.request('ws', 'unsubscribe', model);
   },
   showAttachments() {
     const canUploadAttachments = !!Radio.request('settings', 'get', 'upload_attachments') && this.action.hasAllowedUploads();

--- a/src/js/entities-service/comments.js
+++ b/src/js/entities-service/comments.js
@@ -5,6 +5,7 @@ const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
     'comments:model': 'getModel',
+    'comments:collection': 'getCollection',
     'fetch:comments:collection:byAction': 'fetchCommentsByAction',
   },
   fetchCommentsByAction(actionId) {

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -247,7 +247,12 @@ const _Model = BaseModel.extend({
 
     return this.save(attrs, { relationships }, { wait: true });
   },
+  addComment(comment) {
+    const comments = this.getComments();
+    comments.add(comment);
 
+    this.set({ _comments: comments.getResources() });
+  },
   addFile(file) {
     const files = this.getFiles();
     files.add(file);

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -81,6 +81,9 @@ const _Model = BaseModel.extend({
   getFormResponses() {
     return Radio.request('entities', 'formResponses:collection', this.get('_form_responses'));
   },
+  getComments() {
+    return Radio.request('entities', 'comments:collection', this.get('_comments'));
+  },
   getFiles() {
     return Radio.request('entities', 'files:collection', this.get('_files'));
   },
@@ -148,6 +151,9 @@ const _Model = BaseModel.extend({
   },
   hasSharing() {
     return this.get('sharing') !== ACTION_SHARING.DISABLED;
+  },
+  commentCount() {
+    return this.getComments().length;
   },
   hasAttachments() {
     return !!this.getFiles().length;

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -253,6 +253,12 @@ const _Model = BaseModel.extend({
 
     this.set({ _comments: comments.getResources() });
   },
+  removeComment(comment) {
+    const comments = this.getComments();
+    comments.remove(comment);
+
+    this.set({ _comments: comments.getResources() });
+  },
   addFile(file) {
     const files = this.getFiles();
     files.add(file);

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -42,6 +42,8 @@ const _Model = BaseModel.extend({
         _clinician: { id: author, type: 'clinicians' },
       });
 
+      this.addComment(commentModel);
+
       this.trigger('ws:add:comment', commentModel);
     },
     AttachmentAdded({ file, attributes }) {

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -40,6 +40,7 @@ const _Model = BaseModel.extend({
         created_at: dayjs.utc().format(),
         edited_at: null,
         _clinician: { id: author, type: 'clinicians' },
+        _action: this.getResource(),
       });
 
       this.addComment(commentModel);

--- a/src/js/entities-service/entities/comments.js
+++ b/src/js/entities-service/entities/comments.js
@@ -14,6 +14,10 @@ const _Model = BaseModel.extend({
       this.set({ edited_at: dayjs.utc().format(), ...attributes });
     },
     CommentRemoved() {
+      const action = this.getAction();
+
+      action.removeComment(this);
+
       this.destroy({ isDeleted: true });
     },
   },

--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -12,10 +12,10 @@
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   {{#if hasAttachments}}
-    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
   {{/if}}
   {{#if commentCount}}
-    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8">{{far "comment"}}<span class="patient__action-display-icon-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
   {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>{{~ remove_whitespace ~}}
 </td>

--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -11,6 +11,11 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
-  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}
+    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+  {{/if}}
+  {{#if commentCount}}
+    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+  {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>{{~ remove_whitespace ~}}
 </td>

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -84,6 +84,7 @@ const ActionItemView = View.extend({
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
       hasAttachments: this.model.hasAttachments(),
+      commentCount: this.model.commentCount(),
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -14,6 +14,11 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
-  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}
+    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+  {{/if}}
+  {{#if commentCount}}
+    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+  {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -15,10 +15,10 @@
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   {{#if hasAttachments}}
-    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
   {{/if}}
   {{#if commentCount}}
-    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8">{{far "comment"}}<span class="patient__action-display-icon-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
   {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -88,6 +88,7 @@ const ActionItemView = View.extend({
     return {
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
       hasAttachments: this.model.hasAttachments(),
+      commentCount: this.model.commentCount(),
     };
   },
   triggers: {

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -15,6 +15,11 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
-  {{#if hasAttachments}}<span class="patient__action-attachment">{{far "paperclip"}}</span>{{/if}}{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}
+    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+  {{/if}}
+  {{#if commentCount}}
+    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+  {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -16,10 +16,10 @@
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}
   {{#if hasAttachments}}
-    <span class="patient__action-attachment u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
   {{/if}}
   {{#if commentCount}}
-    <span class="patient__action-comment u-margin--l-8">{{far "comment"}}<span class="patient__action-comment-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+    <span class="patient__action-display-icon u-margin--l-8">{{far "comment"}}<span class="patient__action-display-icon-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
   {{/if}}
   <span class="patient__action-ts">{{formatDateTime updated_at "TIME_OR_DAY"}}</span>
 </td>

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -163,6 +163,7 @@ const ActionItemView = View.extend({
       hasForm: this.model.getForm(),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
       hasAttachments: this.model.hasAttachments(),
+      commentCount: this.model.commentCount(),
     };
   },
   tagName: 'tr',

--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -82,7 +82,7 @@
 
 .patient-flow__meta {
   padding-left: 8px;
-  width: 510px;
+  width: 562px;
 }
 
 .patient-flow__actions {

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -145,7 +145,7 @@
 
 .patient__action-attachment,
 .patient__action-comment {
-  color: #999;
+  color: $black-60;
   display: inline-block;
   vertical-align: middle;
   width: 16px;

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -140,14 +140,22 @@
 }
 
 .patient__list-meta {
-  width: 510px;
+  width: 562px;
 }
 
-.patient__action-attachment {
+.patient__action-attachment,
+.patient__action-comment {
   color: #999;
   display: inline-block;
-  margin-left: 8px;
   vertical-align: middle;
+  width: 16px;
+}
+
+.patient__action-comment-text {
+  font-size: 12px;
+  font-weight: 600;
+  margin-left: 2px;
+  vertical-align: top;
 }
 
 .patient__flow-icon .icon {

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -143,15 +143,14 @@
   width: 562px;
 }
 
-.patient__action-attachment,
-.patient__action-comment {
+.patient__action-display-icon {
   color: $black-60;
   display: inline-block;
   vertical-align: middle;
   width: 16px;
 }
 
-.patient__action-comment-text {
+.patient__action-display-icon-text {
   font-size: 12px;
   font-weight: 600;
   margin-left: 2px;

--- a/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
@@ -173,6 +173,7 @@ const CommentView = View.extend({
     this.render();
   },
   onDeleteComment() {
+    this.triggerMethod('remove:comment', this.model);
     this.model.destroy();
   },
 });
@@ -247,6 +248,9 @@ const ActivitiesView = CollectionView.extend({
   childViewContainer: '[data-activities-region]',
   childView(model) {
     return (model.type === 'events') ? ActivityView : CommentView;
+  },
+  childViewTriggers: {
+    'remove:comment': 'remove:comment',
   },
   viewFilter({ model }) {
     if (model.get('event_type') === 'ActionCreated' && model.get('source') === 'system') return false;

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -25,7 +25,12 @@
     <span data-due-time-region></span>{{~ remove_whitespace ~}}
   </span>{{~ remove_whitespace ~}}
   <span class="table-list__meta" data-form-region></span>{{~ remove_whitespace ~}}&#8203;
-  {{#if hasAttachments}}<span class="worklist-list__display-icon u-margin--l-8">{{far "paperclip"}}</span>{{/if}}&#8203;{{~ remove_whitespace ~}}
+  {{#if hasAttachments}}
+    <span class="worklist-list__display-icon u-margin--l-8 u-margin--r-8">{{far "paperclip"}}</span>{{~ remove_whitespace ~}}
+  {{/if}}
+  {{#if commentCount}}
+    <span class="worklist-list__display-icon u-margin--l-8">{{far "comment"}}<span class="worklist-list__display-icon-text">{{commentCount}}</span></span>{{~ remove_whitespace ~}}
+  {{/if}}
 </td>
 <td class="table-list__cell worklist-list__action-ts w-10">{{formatDateTime created_at "TIME_OR_DAY"}}&#8203;</td>
 <td class="table-list__cell worklist-list__action-ts w-10">{{formatDateTime updated_at "TIME_OR_DAY"}}&#8203;</td>

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -47,6 +47,7 @@ const ActionItemView = View.extend({
       owner: this.model.getOwner().get('name'),
       icon: this.model.hasOutreach() ? 'share-from-square' : 'file-lines',
       hasAttachments: this.model.hasAttachments(),
+      commentCount: this.model.commentCount(),
     };
   },
   initialize({ state }) {

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -24,7 +24,7 @@
 }
 
 .worklist-list__display-icon {
-  color: #999;
+  color: $black-60;
   display: inline-block;
   vertical-align: middle;
   width: 16px;

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -30,6 +30,13 @@
   width: 16px;
 }
 
+.worklist-list__display-icon-text {
+  font-size: 12px;
+  font-weight: 600;
+  margin-left: 2px;
+  vertical-align: top;
+}
+
 .work-list__item:hover {
   .fa-square {
     color: $black-20;
@@ -73,22 +80,22 @@
 
 .worklist-list__item-name,
 .worklist-list__name-header {
-  width: 22%;
+  width: 17%;
 }
 
 .worklist-list__meta {
   text-overflow: inherit;
-  width: 43%;
+  width: 48%;
 }
 
 .worklist-list__action-meta-header {
   padding-left: 40px;
-  width: 43%;
+  width: 48%;
 }
 
 .worklist-list__flow-meta-header {
   padding-left: 20px;
-  width: 43%;
+  width: 48%;
 }
 
 .worklist-list__count {

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
@@ -14,6 +13,7 @@ import { stateDone, stateInProgress, stateTodo } from 'support/api/states';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
+import { getComment } from 'support/api/comments';
 
 context('patient archive page', function() {
   const currentClinican = getCurrentClinician({
@@ -57,7 +57,7 @@ context('patient archive page', function() {
               state: getRelationship(stateDone),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
-              comments: getRelationship([{ id: uuid() }], 'files'),
+              comments: getRelationship(getComment()),
             },
           }),
           getAction({

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -57,7 +57,7 @@ context('patient archive page', function() {
               state: getRelationship(stateDone),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
-              comments: getRelationship(getComment()),
+              comments: getRelationship([getComment()]),
             },
           }),
           getAction({

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { v4 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
@@ -56,6 +57,7 @@ context('patient archive page', function() {
               state: getRelationship(stateDone),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
+              comments: getRelationship([{ id: uuid() }], 'files'),
             },
           }),
           getAction({
@@ -224,6 +226,13 @@ context('patient archive page', function() {
 
     cy
       .get('.patient__list')
+      .find('.table-list__item')
+      .eq(2)
+      .find('.fa-comment')
+      .should('not.exist');
+
+    cy
+      .get('.patient__list')
       .should('contain', 'Second In List')
       .find('.patient__flow-icon');
 
@@ -371,6 +380,14 @@ context('patient archive page', function() {
       .first()
       .find('.fa-paperclip')
       .should('exist');
+
+    cy
+      .get('.table-list__item')
+      .first()
+      .find('.fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
 
     cy
       .get('.table-list__item')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -18,6 +18,7 @@ import { stateTodo, stateInProgress, stateDone } from 'support/api/states';
 import { testForm } from 'support/api/forms';
 import { workspaceOne } from 'support/api/workspaces';
 import { roleEmployee, roleAdmin, roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
+import { getComment } from 'support/api/comments';
 
 import { ACTION_OUTREACH } from 'js/static';
 
@@ -69,7 +70,7 @@ context('patient dashboard page', function() {
         state: getRelationship(stateTodo),
         form: getRelationship(testForm),
         files: getRelationship([{ id: '1' }], 'files'),
-        comments: getRelationship([{ id: uuid() }], 'comments'),
+        comments: getRelationship(getComment()),
       },
     });
 

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -69,6 +69,7 @@ context('patient dashboard page', function() {
         state: getRelationship(stateTodo),
         form: getRelationship(testForm),
         files: getRelationship([{ id: '1' }], 'files'),
+        comments: getRelationship([{ id: uuid() }], 'comments'),
       },
     });
 
@@ -408,12 +409,20 @@ context('patient dashboard page', function() {
 
     cy
       .get('.table-list__item')
-      .first()
-      .next()
-      .next()
+      .eq(2)
       .find('[data-form-region]')
-      .should('be.empty')
+      .should('be.empty');
+
+    cy
+      .get('.table-list__item')
+      .eq(2)
       .find('.fa-paperclip')
+      .should('not.exist');
+
+    cy
+      .get('.table-list__item')
+      .eq(2)
+      .find('.fa-comment')
       .should('not.exist');
 
     // dirty hack to make sure the form button isn't offscreen
@@ -433,6 +442,14 @@ context('patient dashboard page', function() {
       .first()
       .find('.fa-paperclip')
       .should('exist');
+
+    cy
+      .get('.table-list__item')
+      .first()
+      .find('.fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
 
     cy
       .routeFormByAction()

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -70,7 +70,7 @@ context('patient dashboard page', function() {
         state: getRelationship(stateTodo),
         form: getRelationship(testForm),
         files: getRelationship([{ id: '1' }], 'files'),
-        comments: getRelationship(getComment()),
+        comments: getRelationship([getComment()]),
       },
     });
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -3016,6 +3016,20 @@ context('patient flow page', function() {
       .should('contain', '1');
 
     cy.sendWs({
+      category: 'CommentRemoved',
+      resource: {
+        type: 'comments',
+        id: testCommentId,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .fa-comment')
+      .should('not.exist');
+
+    cy.sendWs({
       category: 'ResourceDeleted',
       resource: {
         type: 'patient-actions',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -619,7 +619,7 @@ context('patient flow page', function() {
               owner: getRelationship(teamNurse),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
-              comments: getRelationship(getComment()),
+              comments: getRelationship([getComment()]),
             },
           }),
           testListAction,

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -210,7 +210,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'NameChanged',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -241,7 +241,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'DetailsChanged',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -265,7 +265,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'DetailsChanged',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -283,7 +283,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ActionDurationChanged',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -306,7 +306,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'SharingUpdated',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -326,7 +326,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'SharingUpdated',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -347,7 +347,7 @@ context('patient flow page', function() {
       category: 'CommentAdded',
       author: getCurrentClinician().id,
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -428,7 +428,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'AttachmentAdded',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {
@@ -528,7 +528,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ResourceDeleted',
       resource: {
-        type: 'patient-actions',
+        type: testFlowAction.type,
         id: testFlowAction.id,
       },
       payload: {},
@@ -1113,12 +1113,12 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ResourceCreated',
       resource: {
-        type: 'flows',
+        type: testFlow.type,
         id: testFlow.id,
       },
       payload: {
         resource: {
-          type: 'patient-actions',
+          type: otherAction.type,
           id: otherAction.id,
         },
       },
@@ -2638,6 +2638,8 @@ context('patient flow page', function() {
     const testSocketFileId = uuid();
     const testComment = getComment();
 
+    const testClinician = getClinician({ id: uuid() });
+
     const testSocketFlow = getFlow({
       attributes: {
         name: 'Flow Test',
@@ -2708,7 +2710,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'NameChanged',
       resource: {
-        type: 'flows',
+        type: testSocketFlow.type,
         id: testSocketFlow.id,
       },
       payload: {
@@ -2739,7 +2741,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'DetailsChanged',
       resource: {
-        type: 'flows',
+        type: testSocketFlow.type,
         id: testSocketFlow.id,
       },
       payload: {
@@ -2762,7 +2764,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'NameChanged',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
@@ -2790,7 +2792,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'DetailsChanged',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
@@ -2808,7 +2810,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ActionDueChanged',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
@@ -2835,7 +2837,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'SharingUpdated',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
@@ -2858,12 +2860,12 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'OwnerChanged',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
         owner: {
-          type: 'teams',
+          type: teamCoordinator.type,
           id: teamCoordinator.id,
         },
       },
@@ -2872,12 +2874,12 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'OwnerChanged',
       resource: {
-        type: 'flows',
+        type: testSocketFlow.type,
         id: testSocketFlow.id,
       },
       payload: {
         owner: {
-          type: 'teams',
+          type: teamCoordinator.type,
           id: teamCoordinator.id,
         },
       },
@@ -2900,12 +2902,12 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'StateChanged',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
         state: {
-          type: 'states',
+          type: stateDone.type,
           id: stateDone.id,
         },
       },
@@ -2918,12 +2920,12 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'StateChanged',
       resource: {
-        type: 'flows',
+        type: testSocketFlow.type,
         id: testSocketFlow.id,
       },
       payload: {
         state: {
-          type: 'states',
+          type: stateDone.type,
           id: stateDone.id,
         },
       },
@@ -2949,13 +2951,13 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'AttachmentAdded',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
         clinician: {
-          type: 'clinicians',
-          id: uuid(),
+          type: testClinician.type,
+          id: testClinician.id,
         },
         file: {
           type: 'files',
@@ -2995,7 +2997,7 @@ context('patient flow page', function() {
       category: 'CommentAdded',
       author: getCurrentClinician().id,
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {
@@ -3033,7 +3035,7 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ResourceDeleted',
       resource: {
-        type: 'patient-actions',
+        type: testSocketAction.type,
         id: testSocketAction.id,
       },
       payload: {},

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2635,6 +2635,7 @@ context('patient flow page', function() {
 
   specify('socket notifications', function() {
     const testSocketFileId = uuid();
+    const testCommentId = uuid();
 
     const testSocketFlow = getFlow({
       attributes: {
@@ -2662,6 +2663,8 @@ context('patient flow page', function() {
         state: getRelationship(stateTodo),
         owner: getRelationship(teamOther),
         form: getRelationship(testForm),
+        files: getRelationship([], 'files'),
+        comments: getRelationship([], 'comments'),
       },
     });
 
@@ -2986,6 +2989,31 @@ context('patient flow page', function() {
       .get('.patient-flow__list')
       .find('.table-list__item .fa-paperclip')
       .should('not.exist');
+
+    cy.sendWs({
+      category: 'CommentAdded',
+      author: getCurrentClinician().id,
+      resource: {
+        type: 'patient-actions',
+        id: testSocketAction.id,
+      },
+      payload: {
+        comment: {
+          type: 'comments',
+          id: testCommentId,
+        },
+        attributes: {
+          message: 'New websocket comment.',
+        },
+      },
+    });
+
+    cy
+      .get('.patient-flow__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -618,6 +618,7 @@ context('patient flow page', function() {
               owner: getRelationship(teamNurse),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
+              comments: getRelationship([{ id: uuid() }], 'comments'),
             },
           }),
           testListAction,
@@ -684,6 +685,8 @@ context('patient flow page', function() {
         expect($action.find('[data-due-date-region] .is-overdue')).to.exist;
         expect($action.find('[data-form-region]')).not.to.be.empty;
         expect($action.find('.fa-paperclip')).to.exist;
+        expect($action.find('.fa-comment')).to.exist;
+        expect($action.find('.fa-comment').next()).to.contain('1');
       });
 
     cy
@@ -695,6 +698,7 @@ context('patient flow page', function() {
         expect($action.find('.fa-circle-dot')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('OT');
         expect($action.find('.fa-paperclip')).to.not.exist;
+        expect($action.find('.fa-comment')).to.not.exist;
       });
 
     cy

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -108,9 +108,9 @@ context('patient flow page', function() {
   });
 
   specify('patient flow action sidebar', function() {
-    const testCommentId = uuid();
     const testFileId = uuid();
     const testOtherFileId = uuid();
+    const testComment = getComment();
 
     const testPatient = getPatient({
       attributes: {
@@ -352,8 +352,8 @@ context('patient flow page', function() {
       },
       payload: {
         comment: {
-          type: 'comments',
-          id: testCommentId,
+          type: testComment.type,
+          id: testComment.id,
         },
         attributes: {
           message: 'New websocket comment.',
@@ -378,8 +378,8 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'CommentEdited',
       resource: {
-        type: 'comments',
-        id: testCommentId,
+        type: testComment.type,
+        id: testComment.id,
       },
       payload: {
         attributes: {
@@ -396,8 +396,8 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'CommentEdited',
       resource: {
-        type: 'comments',
-        id: testCommentId,
+        type: testComment.type,
+        id: testComment.id,
       },
       payload: {
         attributes: {
@@ -414,8 +414,8 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'CommentRemoved',
       resource: {
-        type: 'comments',
-        id: testCommentId,
+        type: testComment.type,
+        id: testComment.id,
       },
       payload: {},
     });
@@ -2636,7 +2636,7 @@ context('patient flow page', function() {
 
   specify('socket notifications', function() {
     const testSocketFileId = uuid();
-    const testCommentId = uuid();
+    const testComment = getComment();
 
     const testSocketFlow = getFlow({
       attributes: {
@@ -3000,8 +3000,8 @@ context('patient flow page', function() {
       },
       payload: {
         comment: {
-          type: 'comments',
-          id: testCommentId,
+          type: testComment.type,
+          id: testComment.id,
         },
         attributes: {
           message: 'New websocket comment.',
@@ -3019,8 +3019,8 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'CommentRemoved',
       resource: {
-        type: 'comments',
-        id: testCommentId,
+        type: testComment.type,
+        id: testComment.id,
       },
       payload: {},
     });

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -18,6 +18,7 @@ import { stateInProgress, stateDone, stateTodo } from 'support/api/states';
 import { teamCoordinator, teamNurse, teamOther } from 'support/api/teams';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { workspaceOne } from 'support/api/workspaces';
+import { getComment } from 'support/api/comments';
 
 const tomorrow = testDateAdd(1);
 
@@ -618,7 +619,7 @@ context('patient flow page', function() {
               owner: getRelationship(teamNurse),
               form: getRelationship(testForm),
               files: getRelationship([{ id: '1' }], 'files'),
-              comments: getRelationship([{ id: uuid() }], 'comments'),
+              comments: getRelationship(getComment()),
             },
           }),
           testListAction,
@@ -2663,8 +2664,8 @@ context('patient flow page', function() {
         state: getRelationship(stateTodo),
         owner: getRelationship(teamOther),
         form: getRelationship(testForm),
-        files: getRelationship([], 'files'),
-        comments: getRelationship([], 'comments'),
+        files: getRelationship([]),
+        comments: getRelationship([]),
       },
     });
 

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1517,11 +1517,35 @@ context('action sidebar', function() {
 
   specify('action comments - show/hide icon in action list items', function() {
     const testPatient = getPatient();
+
+    const testComments = [
+      getComment({
+        attributes: {
+          edited_at: null,
+          created_at: testTsSubtract(1),
+          message: 'Test comment to be deleted.',
+        },
+        relationships: {
+          clinician: getRelationship(getCurrentClinician()),
+        },
+      }),
+      getComment({
+        attributes: {
+          edited_at: null,
+          created_at: testTsSubtract(2),
+          message: 'Another test comment to be deleted.',
+        },
+        relationships: {
+          clinician: getRelationship(getCurrentClinician()),
+        },
+      }),
+    ];
+
     const testAction = getAction({
       relationships: {
         patient: getRelationship(testPatient),
         state: getRelationship(stateTodo),
-        comments: getRelationship([], 'comments'),
+        comments: getRelationship(testComments),
       },
     });
 
@@ -1553,7 +1577,7 @@ context('action sidebar', function() {
         return fx;
       })
       .routeActionComments(fx => {
-        fx.data = [];
+        fx.data = testComments;
 
         return fx;
       })
@@ -1564,6 +1588,61 @@ context('action sidebar', function() {
       .wait('@routeActionFiles');
 
     cy
+      .intercept('DELETE', '/api/comments/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routeDeleteComment');
+
+    cy
+      .get('[data-activity-region]')
+      .find('.comment__item')
+      .first()
+      .find('.js-edit')
+      .click();
+
+    cy
+      .get('[data-activity-region]')
+      .find('.js-delete')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click()
+      .wait('@routeDeleteComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy
+      .get('[data-activity-region]')
+      .find('.comment__item')
+      .first()
+      .find('.js-edit')
+      .click();
+
+    cy
+      .get('[data-activity-region]')
+      .find('.js-delete')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click()
+      .wait('@routeDeleteComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('not.exist');
+
+    cy
       .get('.patient__list')
       .find('.table-list__item .fa-comment')
       .should('not.exist');
@@ -1571,7 +1650,7 @@ context('action sidebar', function() {
     cy
       .get('.sidebar')
       .find('[data-comment-region]')
-      .as('commentRegion')
+      .as('postCommentRegion')
       .find('.js-input')
       .type('Test comment');
 
@@ -1583,7 +1662,7 @@ context('action sidebar', function() {
       .as('routePostComment');
 
     cy
-      .get('@commentRegion')
+      .get('@postCommentRegion')
       .find('.js-post')
       .click()
       .wait('@routePostComment');
@@ -1596,14 +1675,12 @@ context('action sidebar', function() {
       .should('contain', '1');
 
     cy
-      .get('.sidebar')
-      .find('[data-comment-region]')
-      .as('commentRegion')
+      .get('@postCommentRegion')
       .find('.js-input')
       .type('Another test comment');
 
     cy
-      .get('@commentRegion')
+      .get('@postCommentRegion')
       .find('.js-post')
       .click()
       .wait('@routePostComment');

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1522,7 +1522,7 @@ context('action sidebar', function() {
       relationships: {
         patient: getRelationship(testPatient),
         state: getRelationship(stateTodo),
-        comments: getRelationship([], 'comments'),
+        comments: getRelationship([]),
       },
     });
 

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1515,6 +1515,107 @@ context('action sidebar', function() {
       .should('contain', 'more comment');
   });
 
+  specify('action comments - show/hide icon in action list items', function() {
+    const testPatient = getPatient();
+    const testAction = getAction({
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateTodo),
+        comments: getRelationship([], 'comments'),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [testAction];
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      })
+      .routeActionFiles(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeActionComments(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .visit(`/patient/${ testPatient.id }/action/${ testAction.id }`)
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows')
+      .wait('@routeAction')
+      .wait('@routeActionFiles');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('not.exist');
+
+    cy
+      .get('.sidebar')
+      .find('[data-comment-region]')
+      .as('commentRegion')
+      .find('.js-input')
+      .type('Test comment');
+
+    cy
+      .intercept('POST', '/api/actions/*/relationships/comments', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routePostComment');
+
+    cy
+      .get('@commentRegion')
+      .find('.js-post')
+      .click()
+      .wait('@routePostComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy
+      .get('.sidebar')
+      .find('[data-comment-region]')
+      .as('commentRegion')
+      .find('.js-input')
+      .type('Another test comment');
+
+    cy
+      .get('@commentRegion')
+      .find('.js-post')
+      .click()
+      .wait('@routePostComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '2');
+  });
+
   specify('display action from program action', function() {
     const testProgram = getProgram({
       attributes: {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1518,34 +1518,11 @@ context('action sidebar', function() {
   specify('action comments - show/hide icon in action list items', function() {
     const testPatient = getPatient();
 
-    const testComments = [
-      getComment({
-        attributes: {
-          edited_at: null,
-          created_at: testTsSubtract(1),
-          message: 'Test comment to be deleted.',
-        },
-        relationships: {
-          clinician: getRelationship(getCurrentClinician()),
-        },
-      }),
-      getComment({
-        attributes: {
-          edited_at: null,
-          created_at: testTsSubtract(2),
-          message: 'Another test comment to be deleted.',
-        },
-        relationships: {
-          clinician: getRelationship(getCurrentClinician()),
-        },
-      }),
-    ];
-
     const testAction = getAction({
       relationships: {
         patient: getRelationship(testPatient),
         state: getRelationship(stateTodo),
-        comments: getRelationship(testComments),
+        comments: getRelationship([], 'comments'),
       },
     });
 
@@ -1577,7 +1554,7 @@ context('action sidebar', function() {
         return fx;
       })
       .routeActionComments(fx => {
-        fx.data = testComments;
+        fx.data = [];
 
         return fx;
       })
@@ -1586,6 +1563,78 @@ context('action sidebar', function() {
       .wait('@routePatientFlows')
       .wait('@routeAction')
       .wait('@routeActionFiles');
+
+    cy
+      .get('.sidebar')
+      .find('[data-comment-region]')
+      .as('postCommentRegion')
+      .find('.js-input')
+      .type('Test comment');
+
+    cy
+      .intercept('POST', '/api/actions/*/relationships/comments', {
+        statusCode: 201,
+        body: {
+          data: {
+            type: 'comments',
+            id: uuid(),
+            attributes: {
+              message: 'Test comment',
+              edited_at: null,
+              created_at: testTs(),
+            },
+          },
+        },
+      })
+      .as('routePostComment');
+
+    cy
+      .get('@postCommentRegion')
+      .find('.js-post')
+      .click()
+      .wait('@routePostComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy
+      .get('@postCommentRegion')
+      .find('.js-input')
+      .type('Another test comment');
+
+    cy
+      .intercept('POST', '/api/actions/*/relationships/comments', {
+        statusCode: 201,
+        body: {
+          data: {
+            type: 'comments',
+            id: uuid(),
+            attributes: {
+              message: 'Another test comment',
+              edited_at: null,
+              created_at: testTs(),
+            },
+          },
+        },
+      })
+      .as('routePostComment');
+
+    cy
+      .get('@postCommentRegion')
+      .find('.js-post')
+      .click()
+      .wait('@routePostComment');
+
+    cy
+      .get('.patient__list')
+      .find('.table-list__item .fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '2');
 
     cy
       .intercept('DELETE', '/api/comments/*', {
@@ -1641,56 +1690,6 @@ context('action sidebar', function() {
       .get('.patient__list')
       .find('.table-list__item .fa-comment')
       .should('not.exist');
-
-    cy
-      .get('.patient__list')
-      .find('.table-list__item .fa-comment')
-      .should('not.exist');
-
-    cy
-      .get('.sidebar')
-      .find('[data-comment-region]')
-      .as('postCommentRegion')
-      .find('.js-input')
-      .type('Test comment');
-
-    cy
-      .intercept('POST', '/api/actions/*/relationships/comments', {
-        statusCode: 204,
-        body: {},
-      })
-      .as('routePostComment');
-
-    cy
-      .get('@postCommentRegion')
-      .find('.js-post')
-      .click()
-      .wait('@routePostComment');
-
-    cy
-      .get('.patient__list')
-      .find('.table-list__item .fa-comment')
-      .should('exist')
-      .next()
-      .should('contain', '1');
-
-    cy
-      .get('@postCommentRegion')
-      .find('.js-input')
-      .type('Another test comment');
-
-    cy
-      .get('@postCommentRegion')
-      .find('.js-post')
-      .click()
-      .wait('@routePostComment');
-
-    cy
-      .get('.patient__list')
-      .find('.table-list__item .fa-comment')
-      .should('exist')
-      .next()
-      .should('contain', '2');
   });
 
   specify('display action from program action', function() {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -1575,15 +1575,13 @@ context('action sidebar', function() {
       .intercept('POST', '/api/actions/*/relationships/comments', {
         statusCode: 201,
         body: {
-          data: {
-            type: 'comments',
-            id: uuid(),
+          data: getComment({
             attributes: {
               message: 'Test comment',
               edited_at: null,
               created_at: testTs(),
             },
-          },
+          }),
         },
       })
       .as('routePostComment');
@@ -1610,15 +1608,13 @@ context('action sidebar', function() {
       .intercept('POST', '/api/actions/*/relationships/comments', {
         statusCode: 201,
         body: {
-          data: {
-            type: 'comments',
-            id: uuid(),
+          data: getComment({
             attributes: {
               message: 'Another test comment',
               edited_at: null,
               created_at: testTs(),
             },
-          },
+          }),
         },
       })
       .as('routePostComment');

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { NIL as NIL_UUID } from 'uuid';
+import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { ACTION_OUTREACH } from 'js/static';
 
@@ -389,6 +389,7 @@ context('worklist page', function() {
           files: getRelationship([{ id: '1' }], 'files'),
           owner: getRelationship(teamCoordinator),
           patient: getRelationship(testPatient1),
+          comments: getRelationship([{ id: uuid() }], 'comments'),
         },
       }),
       getAction({
@@ -758,6 +759,18 @@ context('worklist page', function() {
     cy
       .get('@secondRow')
       .find('.fa-paperclip')
+      .should('not.exist');
+
+    cy
+      .get('@firstRow')
+      .find('.fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy
+      .get('@secondRow')
+      .find('.fa-comment')
       .should('not.exist');
 
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -390,7 +390,7 @@ context('worklist page', function() {
           files: getRelationship([{ id: '1' }], 'files'),
           owner: getRelationship(teamCoordinator),
           patient: getRelationship(testPatient1),
-          comments: getRelationship(getComment()),
+          comments: getRelationship([getComment()]),
         },
       }),
       getAction({

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
+import { NIL as NIL_UUID } from 'uuid';
 
 import { ACTION_OUTREACH } from 'js/static';
 
@@ -20,6 +20,7 @@ import { roleAdmin, roleEmployee, roleNoFilterEmployee, roleTeamEmployee } from 
 import { teamCoordinator, teamNurse } from 'support/api/teams';
 import { workspaceOne } from 'support/api/workspaces';
 import { testForm } from 'support/api/forms';
+import { getComment } from 'support/api/comments';
 
 const testPatient1 = getPatient({
   id: '1',
@@ -389,7 +390,7 @@ context('worklist page', function() {
           files: getRelationship([{ id: '1' }], 'files'),
           owner: getRelationship(teamCoordinator),
           patient: getRelationship(testPatient1),
-          comments: getRelationship([{ id: uuid() }], 'comments'),
+          comments: getRelationship(getComment()),
         },
       }),
       getAction({


### PR DESCRIPTION
Shortcut Story ID: [sc-58537]

This is based on the `action.relationships.comments` array. The Icon is shown if `length > 0` and hidden if `length === 0`.

The visibility of the icon and it's count will change when an action's comments change via manual user action in the UI or via websocket nofitications.

Comment icon is shown or incremented when a comment is added. And hidden or decremented when a comment is deleted.

Pages where icon is added:

* Worklist
* Patient flow
* Patient dashboard
* Patient archive

Screenshot example of new icon:

<img width="517" alt="Screenshot 2025-01-23 at 5 26 39 PM" src="https://github.com/user-attachments/assets/03abdbc2-660b-4bf6-bc62-41654acc83a7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced comment management across multiple views, with real-time updates for added and removed comments.
  - New comment icon and count display have been integrated to provide clear visual feedback on actions.

- **Style**
  - Improved spacing and layout adjustments for attachments and comment icons across patient, dashboard, worklist, and sidebar views.

- **Tests**
  - Updated integration tests to validate the proper display and behavior of comments and associated icons.
  - Added new tests to ensure comment icons reflect the correct state in action lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->