### PR TITLE
Add fields request to reduced schedule

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -98,7 +98,8 @@ export default App.extend({
   },
   beforeStart() {
     const filter = this.getState().getEntityFilter();
-    return Radio.request('entities', 'fetch:actions:collection', { data: { filter } });
+    const fields = { flows: ['name', 'state'] };
+    return Radio.request('entities', 'fetch:actions:collection', { data: { filter, fields } });
   },
   onStart(options, collection) {
     this.collection = collection;

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -101,7 +101,8 @@ context('reduced schedule page', function() {
       .itsUrl()
       .its('search')
       .should('contain', `filter[clinicians]=${ currentClinician.id }`)
-      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`);
+      .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
+      .should('contain', 'fields[flows]=name,state');
 
     cy
       .url()


### PR DESCRIPTION
When we added fields to the schedule, it looks like we missed doing it on the reduced schedule.. not the end of the world, but it used to fail silently.. now it doesn’t

Shortcut Story ID: [sc-58838]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data retrieval for patient schedule actions by specifying which flow fields to include in the request.

- **Tests**
	- Updated integration test to verify new URL query parameters for flow fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->