### PR TITLE
Remove form-response POST retry

### DIFF
--- a/src/js/sw.js
+++ b/src/js/sw.js
@@ -80,17 +80,4 @@ if (self.location.hostname !== 'localhost') {
       ],
     }),
   );
-
-  const bgSyncPlugin = new BackgroundSyncPlugin('form-responses', {
-    maxRetentionTime: 24 * 60, // Retry for max of 24 Hours (specified in minutes)
-  });
-
-  // Retries POST requests to /api/form-responses when offline
-  registerRoute(
-    /\/api\/form-responses/,
-    new NetworkOnly({
-      plugins: [bgSyncPlugin],
-    }),
-    'POST',
-  );
 }


### PR DESCRIPTION
This is batching a bunch of `POST`s for form drafts, and the first one sent may “win” for the user.

This was added prior to form drafts and `PATCH`ing to the draft.  So while this is broken it’s also incomplete.  For now we can rely on the local cache of the form draft when offline.

Shortcut Story ID: [sc-58842]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Feature Removal**
	- Removed background sync functionality for form submissions
	- Eliminated offline retry mechanism for form responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->