### PR TITLE
Move patient-field id to construction

### DIFF
--- a/src/js/entities-service/entities/patient-fields.js
+++ b/src/js/entities-service/entities/patient-fields.js
@@ -1,5 +1,4 @@
 import { extend } from 'underscore';
-import { v5 as uuid } from 'uuid';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
@@ -15,22 +14,12 @@ const _Model = BaseModel.extend({
   getPatient() {
     return this.getRelationship('_patient');
   },
-  isNew() {
-    // NOTE: This will treat the PATCH like a PUT
-    // We won't always have an ID, but never need to POST
-    return false;
-  },
   saveAll(attrs) {
     attrs = extend({}, this.attributes, attrs);
-    const patient = this.toRelation(attrs._patient);
 
-    // NOTE: sets the id instead of attrs.id due to how backbone's save works
-    /* istanbul ignore next: Currently not saving new fields, but would be important if we do */
-    if (!attrs.id) {
-      this.set({ id: uuid(`resource:field:${ attrs.name.toLowerCase() }`, patient.id) });
-    }
-
-    const relationships = { patient };
+    const relationships = {
+      patient: this.toRelation(attrs._patient),
+    };
 
     return this.save(attrs, { relationships }, { wait: true });
   },

--- a/src/js/entities-service/patient-fields.js
+++ b/src/js/entities-service/patient-fields.js
@@ -1,11 +1,18 @@
+import { extend } from 'underscore';
+import { v5 as uuid } from 'uuid';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/patient-fields';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
-    'patientFields:model': 'getModel',
+    'patientFields:model': 'getPatientField',
     'patientFields:collection': 'getCollection',
+  },
+  getPatientField(attrs) {
+    const id = uuid(`resource:field:${ attrs.name.toLowerCase() }`, attrs._patient.id);
+
+    return this.getModel(extend({ id }, attrs));
   },
 });
 

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -301,6 +301,10 @@ context('Noncontext Form', function() {
         body: { data: getTestPatientField('bar', ['one', 'two']) },
       })
       .as('routePatchPatientFieldFoo')
+      .intercept('PATCH', `/api/patients/${ testPatient.id }/fields/bazinga`, {
+        body: { data: getTestPatientField('bazinga', ['one', 'two']) },
+      })
+      .as('routePatchPatientFieldBazinga')
       .intercept('PATCH', `/api/patients/${ testPatient.id }/fields/bar`, {
         statusCode: 400,
         body: { errors },
@@ -359,6 +363,19 @@ context('Noncontext Form', function() {
                 updateField('bar', ['one', 'two'])
                   .catch(value => {
                     data.opts = ['error1', 'error2'];
+                  });
+              `,
+            },
+            {
+              label: 'Test Create Field',
+              action: 'custom',
+              key: 'test5',
+              type: 'button',
+              input: true,
+              custom: `
+                updateField('bazinga', ['one', 'two'])
+                  .then(value => {
+                    data.opts = value;
                   });
               `,
             },
@@ -473,6 +490,16 @@ context('Noncontext Form', function() {
       .wait('@routePatchPatientFieldBar')
       .its('request.body.data.id')
       .should('equal', uuid('resource:field:bar', testPatient.id))
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Create Field')
+      .click()
+      .wait('@routePatchPatientFieldBazinga')
+      .its('request.body.data.id')
+      .should('equal', uuid('resource:field:bazinga', testPatient.id))
       .wait(100);
 
     cy


### PR DESCRIPTION
We had added an id accomodation for saving new patient fields prior to having a method for it.  Fields later changed to v5 uuids and a stable id, so it makes more sense to construct them with the eventual id, so that backbone.store caches the correct model

Shortcut Story ID: [sc-58951]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced patient record management with more reliable patient field updates, ensuring improved data consistency for a smoother experience.

- **Refactor**
  - Streamlined the processing of patient field updates by simplifying the underlying logic, resulting in more efficient operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->