### PR TITLE
Create an `isValue()` handlebars helper

### DIFF
--- a/src/js/base/helpers.cy.js
+++ b/src/js/base/helpers.cy.js
@@ -124,4 +124,41 @@ context('Handlebars helpers', function() {
       .find('.test-default-html')
       .should('contain', 'No Phone Available');
   });
+
+  specify('isValue', function() {
+    const IsValueView = View.extend({
+      template: hbs`
+        {{#if (isValue 'string' 'string')}}
+          <div class="test-true-value">Should show</div>
+        {{/if}}
+        {{#if (isValue 'not-equal-string' 'string')}}
+          <div class="test-false-value">Should not show</div>
+        {{/if}}
+        {{#if (isValue null 'string')}}
+          <div class="test-null-value">Should not show</div>
+        {{/if}}
+      `,
+    });
+
+    cy
+      .mount(() => {
+        return new IsValueView();
+      })
+      .as('root');
+
+    cy
+      .get('@root')
+      .find('.test-true-value')
+      .should('exist');
+
+    cy
+      .get('@root')
+      .find('.test-false-value')
+      .should('not.exist');
+
+    cy
+      .get('@root')
+      .find('.test-null-value')
+      .should('not.exist');
+  });
 });

--- a/src/js/base/helpers.js
+++ b/src/js/base/helpers.js
@@ -34,6 +34,9 @@ const helpers = {
 
     return new Handlebars.SafeString(formattedPhone);
   },
+  isValue(data, value) {
+    return data === value;
+  },
 };
 
 Handlebars.registerHelper(helpers);


### PR DESCRIPTION
Shortcut Story ID: [sc-59145]

Does a simple check of: `'string' === 'string'`. Matches the handlebars helper we have in the forms app.

So we can do something like this in widgets:

```js
{
  "template": "{{#if (isValue status 'active')}}Active{{else}}Inactive{{/if}}",
  "display_name": "Workspace Status"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new evaluation mechanism to improve conditional content rendering, ensuring that UI elements appear or hide based on specific value comparisons.

- **Tests**
  - Added tests to verify that the conditional rendering behaves as expected under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->