### PR TITLE
Allow for customizing the wrapper template of any widget

### DIFF
--- a/src/js/views/forms/form/widgets/form-widgets.scss
+++ b/src/js/views/forms/form/widgets/form-widgets.scss
@@ -8,5 +8,9 @@
   .form-widgets__section {
     margin-bottom: 8px;
     padding: 0 8px;
+
+    &:empty {
+      display: none;
+    }
   }
 }

--- a/src/js/views/patients/widgets/README.md
+++ b/src/js/views/patients/widgets/README.md
@@ -70,6 +70,47 @@ The `values` of the widget inform the backend as to what data to provide to the 
 }
 ```
 
+---
+
+## Customizing the Wrapper Template
+
+By default, all widgets will use the following template to "wrap" the contents from a widget:
+
+```hbs
+{{~#if definition.display_name}}<div class="widgets__heading">{{ definition.display_name }}</div>{{/if~}}
+<div class="widgets__item" data-content-region></div>
+```
+
+You can override this in `definition.wrapperTemplate` as long as you **include** a `<div data-content-region>` element. This region is where the widget’s main content (from `template`) will render.
+
+Below is an example of a more advanced wrapper template:
+
+```json
+{
+  "id": "<uuid>",
+  "type": "widgets",
+  "attributes": {
+    "category": "widget",
+    "slug": "template",
+    "name": "Custom Wrapper Example",
+    "definition": {
+      "template": "<div>{{ someValue }}</div>",
+      "display_name": "My Custom Wrapper",
+      "wrapperTemplate": "{{#if someValue}}{{#if definition.display_name}}<h2>{{ definition.display_name }}</h2>{{/if}}<div data-content-region></div></div>{{else}}If no content this widget should be display:none{{/if}}"
+    },
+    "values": {
+      "someValue": "@patient.someValue"
+    }
+  }
+}
+```
+
+#### Notes on Custom Wrapper Usage
+
+- **`<div data-content-region>`**: This is required. If you remove or rename it, the widget's main content will not render. However, any remaining wrapper HTML will still appear.
+- **Conditional Rendering**: The above example shows how you might conditionally display content based on the existence of `someValue`. If `someValue` is not set or returned from the backend, the template will render different HTML.
+- **Hiding the widget** if the template renders "" it should apply `display:none`
+
 ## Hardcoded Widgets
 
 * dob

--- a/src/js/views/patients/widgets/widgets.js
+++ b/src/js/views/patients/widgets/widgets.js
@@ -1,4 +1,4 @@
-import { extend, isFunction, find } from 'underscore';
+import { extend, isFunction, find, get } from 'underscore';
 import Radio from 'backbone.radio';
 import { View } from 'marionette';
 import dayjs from 'dayjs';
@@ -9,11 +9,23 @@ import Handlebars from 'handlebars/dist/cjs/handlebars';
 
 import './widgets.scss';
 
+function getWrapperTemplate(definition) {
+  const template = get(definition, 'wrapperTemplate');
+
+  if (!template) return;
+
+  return { wrapperTemplate: Handlebars.compile(template) };
+}
+
 // NOTE: widget is a view or view definition
 export function buildWidget(widget, patient, widgetModel, options) {
-  if (isFunction(widget)) return new widget(extend({ model: patient, slug: widgetModel.get('slug') }, options, widgetModel.get('definition')));
+  const definition = widgetModel.get('definition');
 
-  return new View(extend({ model: patient }, options, widgetModel.get('definition'), widget));
+  const wrapperTemplate = getWrapperTemplate(definition);
+
+  if (isFunction(widget)) return new widget(extend({ model: patient, slug: widgetModel.get('slug') }, options, definition, wrapperTemplate));
+
+  return new View(extend({ model: patient }, options, definition, wrapperTemplate, widget));
 }
 
 // NOTE: These widgets are documented in ./README.md

--- a/src/js/views/patients/widgets/widgets_views.js
+++ b/src/js/views/patients/widgets/widgets_views.js
@@ -10,15 +10,28 @@ const WidgetView = View.extend({
   className() {
     return this.getOption('itemClassName');
   },
+  getTemplate() {
+    return this.contentWidget.getOption('wrapperTemplate') || this.template;
+  },
   template: hbs`{{#if definition.display_name}}<div class="widgets__heading">{{ definition.display_name }}</div>{{/if}}<div class="widgets__item" data-content-region></div>`,
-  regions: {
+  ui: {
     content: '[data-content-region]',
   },
-  onRender() {
+  initialize() {
     const widget = this.getOption('widget');
     const patient = this.getOption('patient');
-
-    this.showChildView('content', buildWidget(widget, patient, this.model));
+    this.contentWidget = buildWidget(widget, patient, this.model);
+  },
+  serializeData() {
+    return {
+      ...this.model.attributes,
+      ...this.contentWidget.values,
+    };
+  },
+  onRender() {
+    if (this.ui.content.length === 0) return;
+    this.addRegion('content', { el: this.ui.content });
+    this.showChildView('content', this.contentWidget);
   },
 });
 

--- a/src/scss/domain/patient-sidebar.scss
+++ b/src/scss/domain/patient-sidebar.scss
@@ -4,6 +4,10 @@
   max-width: 256px;
   overflow: hidden;
 
+  &:empty {
+    display: none;
+  }
+
   &:last-of-type {
     padding-bottom: 32px;
   }

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -82,6 +82,8 @@ context('patient sidebar', function() {
                 'patientSSNIdentifier',
                 'hbsWidget',
                 'hbsEmptyWidget',
+                'hbsNoRegionWidget',
+                'hbsEmptyTemplateWidget',
               ],
             },
           },
@@ -175,6 +177,24 @@ context('patient sidebar', function() {
             },
             values: {
               emptyField: '@patient.emptyField',
+            },
+          }),
+          addWidget({
+            slug: 'hbsNoRegionWidget',
+            category: 'widget',
+            definition: {
+              template: 'Content that will not appear because the region is missing',
+              // Missing <div data-content-region> on purpose
+              wrapperTemplate: '<div class="no-region-wrapper">No region defined</div>',
+            },
+          }),
+          addWidget({
+            slug: 'hbsEmptyTemplateWidget',
+            category: 'widget',
+            definition: {
+              template: 'Should be display:none',
+              // Missing <div data-content-region> on purpose
+              wrapperTemplate: '{{#if foo}}not foo{{/if}}',
             },
           }),
         ]);
@@ -279,6 +299,14 @@ context('patient sidebar', function() {
       .next()
       .find('.widgets-value')
       .hasBeforeContent('–');
+
+    cy
+      .get('@patientSidebar')
+      .find('.no-region-wrapper')
+      .should('contain', 'No region defined')
+      .parent()
+      .next('.patient-sidebar__section')
+      .should('have.css', 'display', 'none');
 
     cy
       .get('@patientSidebar')


### PR DESCRIPTION
Adds `definition.wrapperTemplate` that is passed the widget attributes and the widget values.

Returning “” from the wrapperTemplate should `display:none` the widget

Shortcut Story ID: [sc-58659]

I think the readme modifications should cover the change, but this should allow any handlebars logic with any requested widget data to determine if the widget should show or if something entirely different should show based on the data... this should work for any widget.  I've only tested simple cases so far, but I'm pretty sure it works for all the use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced widget configuration with optional template support to improve customization and conditional content rendering.
	- Introduced sidebar widgets that handle scenarios where a content region is not defined or where content is conditionally displayed.
- **Style**
	- Updated styles to hide empty sections in forms and patient sidebars, resulting in a cleaner layout.
- **Documentation**
	- Expanded instructions for widget template customization with clear examples and usage guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->