### PR TITLE
Allow missing flows on worklists

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -8,6 +8,8 @@ import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 import { ACTION_OUTREACH, ACTION_SHARING } from 'js/static';
 
+import { addError } from 'js/datadog';
+
 const TYPE = 'patient-actions';
 
 const _Model = BaseModel.extend({
@@ -132,6 +134,12 @@ const _Model = BaseModel.extend({
   },
   isFlowDone() {
     const flow = this.getFlow();
+
+    if (flow && !flow.isCached()) {
+      addError(`Missing flow ${ flow.id } for action ${ this.id }`);
+      return true;
+    }
+
     return flow && flow.isDone();
   },
   isOverdue() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -850,12 +850,18 @@ context('worklist page', function() {
 
   specify('actions on a done-flow list', function() {
     const testFlow = getFlow({
-      id: '1',
       attributes: {
         name: 'Test Flow',
       },
       relationships: {
         state: getRelationship(stateDone),
+      },
+    });
+
+    const missingFlow = getFlow();
+    const actionMissingFlow = getAction({
+      relationships: {
+        flow: getRelationship(missingFlow),
       },
     });
 
@@ -868,11 +874,18 @@ context('worklist page', function() {
           },
         });
 
+        // Add flow relationship without including it
+        fx.data.push(actionMissingFlow);
+
         fx.included.push(testFlow);
 
         return fx;
       })
       .visit('/worklist/owned-by');
+
+    cy.window().then(win => {
+      cy.stub(win.console, 'error').as('consoleError');
+    });
 
     cy
       .wait('@routeActions')
@@ -884,6 +897,10 @@ context('worklist page', function() {
       .get('.worklist-list__meta')
       .find('button')
       .should('not.exist');
+
+    cy
+      .get('@consoleError')
+      .should('be.calledWith', `Missing flow ${ missingFlow.id } for action ${ actionMissingFlow.id }`);
   });
 
   specify('maximum list count reached', function() {


### PR DESCRIPTION
This will throw a relevant error if there’s an issue. Currently assuming missing flows are “done” as this is the more restrictive choice, plus I suspect it’s probably the more likely state

Shortcut Story ID: [sc-59466]

I think we should probably throw this commit on an FE hotfix branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error reporting by logging issues when expected data components are missing, leading to improved system stability.

- **Tests**
  - Expanded test scenarios for the worklist page to verify accurate total counts and filtering messages, including handling cases with a large number of actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->