### PR TITLE
Handle web socket notifications on patient dashboard & archive

### DIFF
--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -33,24 +33,15 @@ export default App.extend({
     this.showChildView('content', new ListView({ collection: this.collection }));
   },
   subscribe() {
-    const channel = Radio.channel('ws');
-
     const filters = {
       states: this.states,
       patient: this.patient.id,
     };
 
-    channel.request('subscribe', this.collection.models, {
+    Radio.request('ws', 'subscribe', this.collection.models, {
       filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
-
-    this.listenTo(channel, 'message', (data, model) => {
-      if (this.collection.get(model) || model.isFetching()) return;
-
-      model.fetch().then(() => {
-        this.collection.add(model);
-        Radio.request('ws', 'add', model);
-      });
-    });
+    Radio.request('ws', 'manage:add', this, this.collection, 'flows');
+    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions');
   },
 });

--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -7,13 +7,15 @@ import { LayoutView, ListView } from 'js/views/patients/patient/archive/archive_
 
 export default App.extend({
   onBeforeStart({ patient }) {
+    this.patient = patient;
     this.showView(new LayoutView({ model: patient }));
     this.getRegion('content').startPreloader();
   },
   beforeStart({ patient }) {
     const currentWorkspace = Radio.request('workspace', 'current');
-    const states = currentWorkspace.getStates();
-    const filter = { states: states.groupByDone().done.getFilterIds() };
+    this.states = currentWorkspace.getStates();
+
+    const filter = { states: this.states.groupByDone().done.getFilterIds() };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
@@ -22,6 +24,32 @@ export default App.extend({
   },
   onStart({ patient }, actions, flows) {
     this.collection = new Backbone.Collection([...actions.models, ...flows.models]);
+
+    this.subscribe();
+
     this.showChildView('content', new ListView({ collection: this.collection }));
+  },
+  subscribe() {
+    const channel = Radio.channel('ws');
+
+    const filter = {
+      states: this.states.groupByDone().done.getFilterIds(),
+      patient: this.patient.id,
+    };
+
+    channel.request('subscribe', this.collection.models, {
+      filters: { actions: filter, flows: filter },
+    });
+
+    this.listenTo(channel, 'message', (data, model) => {
+      if (this.collection.get(model) || model.isFetching()) return;
+
+      model.fetch().then(() => {
+        if (model.type === 'patient-actions' && model.getFlow()) return;
+
+        this.collection.add(model);
+        Radio.request('ws', 'add', model);
+      });
+    });
   },
 });

--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -1,5 +1,6 @@
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import { NIL as NIL_UUID } from 'uuid';
 
 import App from 'js/base/app';
 
@@ -32,21 +33,19 @@ export default App.extend({
   subscribe() {
     const channel = Radio.channel('ws');
 
-    const filter = {
+    const filters = {
       states: this.states.groupByDone().done.getFilterIds(),
       patient: this.patient.id,
     };
 
     channel.request('subscribe', this.collection.models, {
-      filters: { actions: filter, flows: filter },
+      filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
 
     this.listenTo(channel, 'message', (data, model) => {
       if (this.collection.get(model) || model.isFetching()) return;
 
       model.fetch().then(() => {
-        if (model.type === 'patient-actions' && model.getFlow()) return;
-
         this.collection.add(model);
         Radio.request('ws', 'add', model);
       });

--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -8,15 +8,17 @@ import { LayoutView, ListView } from 'js/views/patients/patient/archive/archive_
 
 export default App.extend({
   onBeforeStart({ patient }) {
+    const currentWorkspace = Radio.request('workspace', 'current');
+    const { done } = currentWorkspace.getStates().groupByDone();
+    this.states = done.getFilterIds();
+
     this.patient = patient;
+
     this.showView(new LayoutView({ model: patient }));
     this.getRegion('content').startPreloader();
   },
   beforeStart({ patient }) {
-    const currentWorkspace = Radio.request('workspace', 'current');
-    this.states = currentWorkspace.getStates();
-
-    const filter = { states: this.states.groupByDone().done.getFilterIds() };
+    const filter = { states: this.states };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
@@ -34,7 +36,7 @@ export default App.extend({
     const channel = Radio.channel('ws');
 
     const filters = {
-      states: this.states.groupByDone().done.getFilterIds(),
+      states: this.states,
       patient: this.patient.id,
     };
 

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -1,5 +1,6 @@
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import { NIL as NIL_UUID } from 'uuid';
 
 import App from 'js/base/app';
 
@@ -46,21 +47,19 @@ export default App.extend({
   subscribe() {
     const channel = Radio.channel('ws');
 
-    const filter = {
+    const filters = {
       states: this.states.groupByDone().notDone.getFilterIds(),
       patient: this.patient.id,
     };
 
     channel.request('subscribe', this.collection.models, {
-      filters: { actions: filter, flows: filter },
+      filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
 
     this.listenTo(channel, 'message', (data, model) => {
       if (this.collection.get(model) || model.isFetching()) return;
 
       model.fetch().then(() => {
-        if (model.type === 'patient-actions' && model.getFlow()) return;
-
         this.collection.add(model);
         Radio.request('ws', 'add', model);
       });

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -14,20 +14,24 @@ export default App.extend({
   },
 
   onBeforeStart({ patient }) {
+    const currentWorkspace = Radio.request('workspace', 'current');
+    const { notDone } = currentWorkspace.getStates().groupByDone();
+    this.states = notDone.getFilterIds();
+
     this.currentUser = Radio.request('bootstrap', 'currentUser');
     this.patient = patient;
+
     this.showView(new LayoutView({ model: patient }));
+
     if (!this.currentUser.can('work:own')) {
       this.getRegion('addWorkflow').empty();
     }
+
     this.getRegion('content').startPreloader();
   },
 
   beforeStart({ patient }) {
-    const currentWorkspace = Radio.request('workspace', 'current');
-    this.states = currentWorkspace.getStates();
-
-    const filter = { states: this.states.groupByDone().notDone.getFilterIds() };
+    const filter = { states: this.states };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
@@ -48,7 +52,7 @@ export default App.extend({
     const channel = Radio.channel('ws');
 
     const filters = {
-      states: this.states.groupByDone().notDone.getFilterIds(),
+      states: this.states,
       patient: this.patient.id,
     };
 

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -24,8 +24,9 @@ export default App.extend({
 
   beforeStart({ patient }) {
     const currentWorkspace = Radio.request('workspace', 'current');
-    const states = currentWorkspace.getStates();
-    const filter = { states: states.groupByDone().notDone.getFilterIds() };
+    this.states = currentWorkspace.getStates();
+
+    const filter = { states: this.states.groupByDone().notDone.getFilterIds() };
 
     return [
       Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId: patient.id, filter }),
@@ -36,9 +37,34 @@ export default App.extend({
   onStart(options, actions, flows) {
     this.collection = new Backbone.Collection([...actions.models, ...flows.models]);
 
+    this.subscribe();
+
     this.showChildView('content', new ListView({ collection: this.collection }));
 
     this.startAddWorkflow();
+  },
+  subscribe() {
+    const channel = Radio.channel('ws');
+
+    const filter = {
+      states: this.states.groupByDone().notDone.getFilterIds(),
+      patient: this.patient.id,
+    };
+
+    channel.request('subscribe', this.collection.models, {
+      filters: { actions: filter, flows: filter },
+    });
+
+    this.listenTo(channel, 'message', (data, model) => {
+      if (this.collection.get(model) || model.isFetching()) return;
+
+      model.fetch().then(() => {
+        if (model.type === 'patient-actions' && model.getFlow()) return;
+
+        this.collection.add(model);
+        Radio.request('ws', 'add', model);
+      });
+    });
   },
   startAddWorkflow() {
     if (!this.currentUser.can('work:own')) return;

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -49,25 +49,16 @@ export default App.extend({
     this.startAddWorkflow();
   },
   subscribe() {
-    const channel = Radio.channel('ws');
-
     const filters = {
       states: this.states,
       patient: this.patient.id,
     };
 
-    channel.request('subscribe', this.collection.models, {
+    Radio.request('ws', 'subscribe', this.collection.models, {
       filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
-
-    this.listenTo(channel, 'message', (data, model) => {
-      if (this.collection.get(model) || model.isFetching()) return;
-
-      model.fetch().then(() => {
-        this.collection.add(model);
-        Radio.request('ws', 'add', model);
-      });
-    });
+    Radio.request('ws', 'manage:add', this, this.collection, 'flows');
+    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions');
   },
   startAddWorkflow() {
     if (!this.currentUser.can('work:own')) return;

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -200,7 +200,7 @@ const FlowItemView = View.extend({
   modelEvents: {
     'change:_owner': 'render',
   },
-  behaviors: [RowBehavior],
+  behaviors: [RowBehavior, DoneBehavior],
   regions: {
     owner: '[data-owner-region]',
   },

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
 import { getRelationship, mergeJsonApi } from 'helpers/json-api';
+import formatDate from 'helpers/format-date';
 
 import { getAction } from 'support/api/actions';
 import { getFlow } from 'support/api/flows';
@@ -398,6 +399,384 @@ context('patient archive page', function() {
     cy
       .url()
       .should('contain', `patient-action/1/form/${ testForm.id }`);
+  });
+
+  specify('flow list - socket notifications', function() {
+    const testPatient = getPatient({
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const testSocketFlow = getFlow({
+      attributes: {
+        name: 'Test Flow - Subscribed on Page Load',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - Created Elsewhere',
+        updated_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewStateSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - State Updated to Match Current Filter',
+        updated_at: testTsSubtract(1),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [testSocketFlow];
+
+        return fx;
+      })
+      .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
+      .wait('@routePatient')
+      .wait('@routePatientFlows');
+
+    // state was set to be not done, which means it's removed from the list
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // wait for fade-out animation to completely finish
+    cy.tick(1000);
+
+    cy
+      .get('.patient__empty-list')
+      .should('contain', 'No Archive');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketFlow.type,
+        id: testNewSocketFlow.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewSocketFlow.id);
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Flow - Created Elsewhere');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewStateSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that flow
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewStateSocketFlow.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - State Updated to Match Current Filter');
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.patient__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+  });
+
+  specify('action list - socket notifications', function() {
+    const testPatient = getPatient({
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const testSocketAction = getAction({
+      attributes: {
+        name: 'Test Action - Subscribed on Page Load',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Created Elsewhere',
+        updated_at: testTsSubtract(3),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewStateSocketAction = getAction({
+      attributes: {
+        name: 'New Action - State Updated to Match Current Filter',
+        updated_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [testSocketAction];
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
+      .wait('@routePatient')
+      .wait('@routePatientActions');
+
+    // state was set to done, which means it's removed from the list
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // wait for fade-out animation to completely finish
+    cy.tick(1000);
+
+    cy
+      .get('.patient__empty-list')
+      .should('contain', 'No Archive');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewSocketAction.id);
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Action - Created Elsewhere');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewStateSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that flow
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewStateSocketAction.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - State Updated to Match Current Filter');
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.patient__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
   });
 
   specify('work with work:owned:manage permission', function() {

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -464,8 +464,12 @@ context('patient archive page', function() {
       .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientActions')
-      .wait('@routePatientFlows')
-      .wait(200); // for initial ws connection to be created
+      .wait('@routeWorkspacePatient')
+      .wait('@routePatientFlows');
+
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledOnce');
 
     // state was set to be not done, which means it's removed from the list
     cy.sendWs({
@@ -655,8 +659,11 @@ context('patient archive page', function() {
       .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientActions')
-      .wait('@routePatientFlows')
-      .wait(200); // for initial ws connection to be created
+      .wait('@routePatientFlows');
+
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledOnce');
 
     // state was set to done, which means it's removed from the list
     cy.sendWs({

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -463,7 +463,9 @@ context('patient archive page', function() {
       })
       .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
-      .wait('@routePatientFlows');
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows')
+      .wait(200); // for initial ws connection to be created
 
     // state was set to be not done, which means it's removed from the list
     cy.sendWs({
@@ -652,7 +654,9 @@ context('patient archive page', function() {
       })
       .visitOnClock(`/patient/archive/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
-      .wait('@routePatientActions');
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows')
+      .wait(200); // for initial ws connection to be created
 
     // state was set to done, which means it's removed from the list
     cy.sendWs({

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1055,7 +1055,8 @@ context('patient dashboard page', function() {
       .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientFlows')
-      .wait('@routePatientActions');
+      .wait('@routePatientActions')
+      .wait(200); // for initial ws connection to be created
 
     cy.sendWs({
       category: 'NameChanged',
@@ -1283,7 +1284,8 @@ context('patient dashboard page', function() {
       .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientFlows')
-      .wait('@routePatientActions');
+      .wait('@routePatientActions')
+      .wait(200); // for initial ws connection to be created
 
     cy.sendWs({
       category: 'NameChanged',

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -3,8 +3,9 @@ import dayjs from 'dayjs';
 import { v4 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
-import { testDate, testDateSubtract } from 'helpers/test-date';
+import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
 import { getRelationship, mergeJsonApi } from 'helpers/json-api';
+import formatDate from 'helpers/format-date';
 
 import { getAction } from 'support/api/actions';
 import { getFlow } from 'support/api/flows';
@@ -991,6 +992,571 @@ context('patient dashboard page', function() {
       .get('.sidebar')
       .find('.js-menu')
       .should('not.exist');
+  });
+
+  specify('flow list - socket notifications', function() {
+    const testSocketFlow = getFlow({
+      attributes: {
+        name: 'Test Flow - Subscribed on Page Load',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - Created Elsewhere',
+        updated_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewStateSocketFlow = getFlow({
+      attributes: {
+        name: 'New Flow - State Updated to Match Current Filter',
+        updated_at: testTsSubtract(1),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatient(fx => {
+        fx.data = mergeJsonApi(testPatient, {
+          relationships: {
+            workspaces: getRelationship(workspaceOne),
+          },
+        });
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [testSocketFlow];
+
+        return fx;
+      })
+      .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
+      .wait('@routePatient')
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.patient__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    // state was set to done, which means it's removed from the list
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateDone.type,
+          id: stateDone.id,
+        },
+      },
+    });
+
+    // wait for fade-out animation to completely finish
+    cy.tick(1000);
+
+    cy
+      .get('.patient__empty-list')
+      .should('contain', 'No Workflows');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketFlow.type,
+        id: testNewSocketFlow.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewSocketFlow.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - Created Elsewhere');
+
+    cy
+      .routeFlow(fx => {
+        fx.data = testNewStateSocketFlow;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that flow
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeFlow')
+      .its('request.url')
+      .should('contain', testNewStateSocketFlow.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Flow - State Updated to Match Current Filter');
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Name Via Websocket');
+  });
+
+  specify('action list - socket notifications', function() {
+    const currentClinician = getCurrentClinician();
+    const testSocketComment = getComment();
+    const testSocketFileId = uuid();
+
+    const testSocketAction = getAction({
+      attributes: {
+        name: 'Test Action - Subscribed on Page Load',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Created Elsewhere',
+        updated_at: testTsSubtract(3),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    const testNewStateSocketAction = getAction({
+      attributes: {
+        name: 'New Action - State Updated to Match Current Filter',
+        updated_at: testTsSubtract(2),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+        owner: getRelationship(teamCoordinator),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatient(fx => {
+        fx.data = mergeJsonApi(testPatient, {
+          relationships: {
+            workspaces: getRelationship(workspaceOne),
+          },
+        });
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [testSocketAction];
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
+      .wait('@routePatient')
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .as('firstRow')
+      .should('contain', 'New Name Via Websocket');
+
+    cy
+      .get('@firstRow')
+      .find('.patient__action-ts')
+      .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+
+    cy.sendWs({
+      category: 'DetailsChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          details: '',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-details-region]')
+      .should('be.empty');
+
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    cy.sendWs({
+      category: 'ActionDueChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          due_date: testDateAdd(1),
+          due_time: '07:00:00',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should($action => {
+        expect($action.find('[data-due-date-region]')).to.contain(formatDate(testDateAdd(1), 'SHORT'));
+        expect($action.find('[data-due-time-region]')).to.contain('7:00 AM');
+      });
+
+    cy.sendWs({
+      category: 'SharingUpdated',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          sharing: 'pending',
+          outreach: 'patient',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-share-from-square');
+
+    cy.sendWs({
+      category: 'CommentAdded',
+      author: currentClinician.id,
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        comment: {
+          type: testSocketComment.type,
+          id: testSocketComment.id,
+        },
+        attributes: {
+          message: 'New websocket comment.',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-comment')
+      .should('exist')
+      .next()
+      .should('contain', '1');
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        clinician: {
+          type: currentClinician.type,
+          id: currentClinician.id,
+        },
+        file: {
+          type: 'files',
+          id: testSocketFileId,
+        },
+        attributes: {
+          path: 'patients/1/HRA.pdf',
+          bucket: 'bucket_name',
+          urls: {
+            view: 'https://www.bucket_name.s3.amazonaws.com/patients/1/view/HRA.pdf',
+            download: 'https://www.bucket_name.s3.amazonaws.com/patients/1/download/HRA.pdf',
+          },
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.fa-paperclip')
+      .should('exist');
+
+    // state was set to done, which means it's removed from the list
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testSocketAction.type,
+        id: testSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateDone.type,
+          id: stateDone.id,
+        },
+      },
+    });
+
+    // wait for fade-out animation to completely finish
+    cy.tick(1000);
+
+    cy
+      .get('.patient__empty-list')
+      .should('contain', 'No Workflows');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewSocketAction.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - Created Elsewhere');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewStateSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that flow
+    cy.sendWs({
+      category: 'OwnerChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        owner: {
+          type: teamNurse.type,
+          id: teamNurse.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewStateSocketAction.id);
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - State Updated to Match Current Filter');
+
+    cy
+      .get('@firstRow')
+      .find('[data-owner-region]')
+      .should('contain', 'NU');
+
+    // ensures we subscribe correctly to models added to the worklist via ws
+    cy.sendWs({
+      category: 'NameChanged',
+      resource: {
+        type: testNewStateSocketAction.type,
+        id: testNewStateSocketAction.id,
+      },
+      payload: {
+        attributes: {
+          name: 'New Name Via Websocket',
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Name Via Websocket');
   });
 
   specify('non work:own clinician', function() {

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
@@ -1055,8 +1055,23 @@ context('patient dashboard page', function() {
       .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientFlows')
-      .wait('@routePatientActions')
-      .wait(200); // for initial ws connection to be created
+      .wait('@routePatientActions');
+
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledOnce');
+
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const states = [stateTodo.id, stateInProgress.id].join();
+        const patient = testPatient.id;
+        const { filters } = stub.getCall(0).args[0].data;
+        expect(filters).to.deep.equal({
+          actions: { states, patient, flow: NIL_UUID },
+          flows: { states, patient },
+        });
+      });
 
     cy.sendWs({
       category: 'NameChanged',
@@ -1284,8 +1299,11 @@ context('patient dashboard page', function() {
       .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routePatientFlows')
-      .wait('@routePatientActions')
-      .wait(200); // for initial ws connection to be created
+      .wait('@routePatientActions');
+
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledOnce');
 
     cy.sendWs({
       category: 'NameChanged',


### PR DESCRIPTION
Shortcut Story ID: [sc-59837]

- [x] Handle ws notifications on patient dashboard
- [x] Handle ws notifications on patient archive
- [x] Use `NIL_UUID` for action.flow filter
- [x] Manually test functionality/edge cases in local dev environment
- [x] Add dashboard cypress tests
- [x] Add archive cypress tests
- [x] Fix failing tests - web socket messages intermittently not coming through at beginning of test
- [x] Rebase branch & use new service request implemented in https://github.com/RoundingWell/care-ops-frontend/pull/1417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enabled real-time updates for patient data on the archive and dashboard, ensuring that changes to patient flows and actions are reflected live.
	- Improved the visual handling of completed items with smooth fade-out effects for a better user experience.
- **Tests**
	- Expanded test coverage to validate that real-time notifications update the UI consistently for both flows and actions.
	- Added new test specifications for socket notifications related to flows and actions in both the patient archive and dashboard contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->