### PR TITLE
Modify `ResourceCreated` socket notification handling

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -88,7 +88,6 @@ export default SubRouterApp.extend({
 
     this.listenTo(this.flow, {
       'change:_owner': this.onFlowChangeOwner,
-      'message': this.onFlowMessage,
     });
 
     this.startRoute(currentRoute);
@@ -98,7 +97,16 @@ export default SubRouterApp.extend({
     this.stopChildApp('actionSidebar');
   },
   subscribe() {
-    Radio.request('ws', 'subscribe', [this.flow, ...this.actions.models]);
+    const channel = Radio.channel('ws');
+    const filters = { actions: { flow: this.flow.id } };
+
+    channel.request('subscribe', [this.flow, ...this.actions.models], { filters });
+
+    this.listenTo(channel, 'message', ({ category }, model) => {
+      if (category !== 'ResourceCreated') return;
+
+      model.fetch().then(bind(this._addAction, this));
+    });
   },
   _setFlowProgress() {
     const complete = this.actions.filter(action => action.isDone()).length;
@@ -110,7 +118,7 @@ export default SubRouterApp.extend({
     this.actions.add(action);
     this.editableCollection.add(action);
 
-    this.subscribe();
+    Radio.request('ws', 'add', action);
 
     this._setFlowProgress();
   },
@@ -119,13 +127,6 @@ export default SubRouterApp.extend({
   },
   onActionDestroy() {
     this._setFlowProgress();
-  },
-  onFlowMessage({ category, payload }) {
-    if (category !== 'ResourceCreated') return;
-    const { resource } = payload;
-
-    const fetchAction = Radio.request('entities', 'fetch:actions:model', resource.id);
-    fetchAction.then(bind(this._addAction, this));
   },
   onFlowChangeOwner(flow, _owner) {
     if (_owner.type === 'teams') return;

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -160,9 +160,8 @@ export default App.extend({
 
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
-    this.listenTo(channel, 'message', ({ category, resource, payload }) => {
-      const modelResource = category === 'ResourceCreated' ? payload.resource : resource;
-      const model = Radio.request('entities', 'get:store', modelResource);
+    this.listenTo(channel, 'message', ({ resource }) => {
+      const model = Radio.request('entities', 'get:store', resource);
 
       if (this.collection.get(model) || model.isFetching()) return;
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -27,6 +27,9 @@ context('patient flow page', function() {
     attributes: {
       name: 'Test Flow',
     },
+    relationships: {
+      state: getRelationship(stateTodo),
+    },
   });
 
   const testAction = getAction({
@@ -156,18 +159,14 @@ context('patient flow page', function() {
         return fx;
       })
       .routeFlow(fx => {
-        fx.data = mergeJsonApi(testFlow, {
-          relationships: {
-            state: getRelationship(stateTodo),
-          },
-        });
+        fx.data = testFlow;
 
         return fx;
       })
       .routeFlowActions(fx => {
         fx.data = [testFlowAction];
 
-        fx.included.push(testProgramAction);
+        fx.included.push(testProgramAction, testFlow);
 
         return fx;
       })
@@ -1099,7 +1098,8 @@ context('patient flow page', function() {
         name: 'Socket Action',
       },
       relationships: {
-        'flow': getRelationship(testFlow),
+        flow: getRelationship(testFlow),
+        state: getRelationship(stateTodo),
       },
     });
 
@@ -1113,13 +1113,24 @@ context('patient flow page', function() {
     cy.sendWs({
       category: 'ResourceCreated',
       resource: {
-        type: testFlow.type,
-        id: testFlow.id,
+        type: otherAction.type,
+        id: otherAction.id,
+      },
+      payload: {},
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that action
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: otherAction.type,
+        id: otherAction.id,
       },
       payload: {
-        resource: {
-          type: otherAction.type,
-          id: otherAction.id,
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
         },
       },
     });
@@ -1134,6 +1145,12 @@ context('patient flow page', function() {
       .find('.is-selected')
       .next()
       .contains('Socket Action');
+
+    cy
+      .get('[data-content-region]')
+      .find('.is-selected')
+      .next()
+      .find('[data-state-region] .fa-circle-dot');
   });
 
   specify('failed flow', function() {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -460,15 +460,10 @@ context('worklist page', function() {
     cy.sendWs({
       category: 'ResourceCreated',
       resource: {
-        type: testPatient1.type,
-        id: testPatient1.id,
+        type: testNewSocketFlow.type,
+        id: testNewSocketFlow.id,
       },
-      payload: {
-        resource: {
-          type: testNewSocketFlow.type,
-          id: testNewSocketFlow.id,
-        },
-      },
+      payload: {},
     });
 
     // a notification that is sent for a resource we are currently fetching
@@ -1444,15 +1439,10 @@ context('worklist page', function() {
     cy.sendWs({
       category: 'ResourceCreated',
       resource: {
-        type: testFlow.type,
-        id: testFlow.id,
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
       },
-      payload: {
-        resource: {
-          type: testNewSocketAction.type,
-          id: testNewSocketAction.id,
-        },
-      },
+      payload: {},
     });
 
     // a notification that is sent for a resource we are currently fetching


### PR DESCRIPTION
Shortcut Story ID: [sc-59992] [sc-59950]

`ResourceCreated` socket messages now have an empty `payload`. And the flow/action data is in the `resource` object. A change made in this BE PR: https://github.com/RoundingWell/care-ops-backend/pull/9167/files.

This PR also updates the flow page subscription to use a `filters.actions.flow` filter. And some flow page app code needed to be re-worked a result of that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the real-time update mechanism on patient flows and worklist views for smoother and more reliable notifications.
	- Simplified WebSocket message handling and improved the structure of resource updates.
- **Tests**
	- Updated validations to ensure resource updates and state changes are accurately handled, improving overall system reliability.
	- Adjusted test cases to reflect changes in WebSocket message structures and relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->