### PR TITLE
Remove check for action's parent flow state after fetching it on web socket notification

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -160,42 +160,14 @@ export default App.extend({
 
     channel.request('subscribe', this.collection.models, { filters: { [filterKey]: this.filters } });
 
-    this.listenTo(channel, 'message', ({ resource }) => {
-      const model = Radio.request('entities', 'get:store', resource);
-
+    this.listenTo(channel, 'message', (data, model) => {
       if (this.collection.get(model) || model.isFetching()) return;
 
-      if (filterKey === 'flows') {
-        this._fetchFlow(model);
+      model.fetch().then(() => {
+        this.collection.add(model);
 
-        return;
-      }
-
-      this._fetchAction(model);
-
-      return;
-    });
-  },
-  _fetchFlow(model) {
-    const fetchFlow = Radio.request('entities', 'fetch:flows:model', model.id);
-
-    fetchFlow.then(() => {
-      this.collection.add(model);
-
-      Radio.request('ws', 'add', model);
-    });
-  },
-  _fetchAction(model) {
-    const flowStates = this.getState('flowStates');
-
-    const fetchAction = Radio.request('entities', 'fetch:actions:model', model.id);
-
-    fetchAction.then(() => {
-      if (!flowStates.includes(model.getFlow().getState().id)) return;
-
-      this.collection.add(model);
-
-      Radio.request('ws', 'add', model);
+        Radio.request('ws', 'add', model);
+      });
     });
   },
   // NOTE: Shows views dependent on getState().getType()

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -18,11 +18,7 @@ const Entity = BaseEntity.extend({
       'flow.program-flow.program',
     ].join();
 
-    const fields = {
-      flows: ['name', 'state'],
-    };
-
-    return this.fetchModel(id, { data: { include, fields } });
+    return this.fetchModel(id, { data: { include } });
   },
   fetchActionWithResponses(id) {
     const data = {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -485,9 +485,7 @@ context('worklist page', function() {
     cy
       .wait('@routeFlow')
       .its('request.url')
-      .should('contain', testNewSocketFlow.id)
-      .should('not.contain', 'fields[flows]=name,state')
-      .should('not.contain', 'include=program-action.program%2Cflow.program-flow.program');
+      .should('contain', testNewSocketFlow.id);
 
     cy
       .get('[data-count-region]')
@@ -1464,9 +1462,7 @@ context('worklist page', function() {
     cy
       .wait('@routeAction')
       .its('request.url')
-      .should('contain', testNewSocketAction.id)
-      .should('contain', 'fields[flows]=name,state')
-      .should('contain', 'include=program-action.program%2Cflow.program-flow.program');
+      .should('contain', testNewSocketAction.id);
 
     cy
       .get('[data-count-region]')
@@ -1567,30 +1563,6 @@ context('worklist page', function() {
 
         return fx;
       });
-
-    // should not be added to collection, flow state is not in current worklist filters
-    cy.sendWs({
-      category: 'OwnerChanged',
-      resource: {
-        type: testNewFlowStateSocketAction.type,
-        id: testNewFlowStateSocketAction.id,
-      },
-      payload: {
-        owner: {
-          type: currentClinician.type,
-          id: currentClinician.id,
-        },
-      },
-    });
-
-    cy
-      .wait('@routeAction')
-      .its('request.url')
-      .should('contain', testNewFlowStateSocketAction.id);
-
-    cy
-      .get('[data-count-region]')
-      .should('contain', '4 Actions');
   });
 
   specify('actions on a done-flow list', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-60112]

After fetching an action that we recieved via websockets, we were checking it's parent flow state to ensure it matches the current worklist filters. But that's not needed, the BE does it on their end.

So I removed that `if ()` check. Which also allows us to simplify the code around fetching action/flow models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the patient worklist data retrieval by unifying fetch operations, resulting in more consistent and reliable updates.
  
- **Tests**
  - Removed outdated validation scenarios for real-time notifications to align with the current functionality, simplifying WebSocket handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->