### PR TITLE
On `AttachmentAdded` ws notification, do not set `_patient` for new file model

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -55,7 +55,6 @@ const _Model = BaseModel.extend({
         path: attributes.path,
         created_at: dayjs.utc().format(),
         _actions: [this.getResource()],
-        _patient: this.getPatient().getResource(),
         _view: attributes.urls.view,
         _download: attributes.urls.download,
       });


### PR DESCRIPTION
Shortcut Story ID: [sc-60292]

That `getPatient().getResource()` is causing datadog errors and it's not necessary to include it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated attachment data processing by removing patient-related details from attachments. Core attachment properties remain unchanged, ensuring streamlined handling of attachment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->