### PR TITLE
Update tooltip text content in worklist/schedule titles

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -294,7 +294,7 @@ careOptsFrontend:
         emptyView:
           noScheduledActions: No Scheduled Actions
         scheduleTitleView:
-          tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team). States included are To Do and In Progress.
+          tooltip: Schedule Worklist displays all Actions with a due date for you (or someone else on your team).
         tableHeaderView:
           actionHeader: State, Action
           dueDateHeader: Due Date
@@ -630,20 +630,20 @@ careOptsFrontend:
         actionEmptyView: No Actions
         actionListTooltips: |
           {title, select,
-            owned_by {This worklist includes Actions with the Owner set to you (or someone else on your team). States included are To Do and In Progress.}
-            shared_by {This worklist includes Actions with the Owner set to { team } and { team } users. States included are To Do and In Progress.}
-            new_past_day {Actions added in the last 24 hours. States include To Do and In Progress.}
-            updated_past_three_days {Actions updated in the last 3 days. States include To Do and In Progress.}
+            owned_by {This worklist includes Actions with the Owner set to you (or someone else on your team).}
+            shared_by {This worklist includes Actions with the Owner set to { team } and { team } users.}
+            new_past_day {Actions added in the last 24 hours.}
+            updated_past_three_days {Actions updated in the last 3 days.}
             done_last_thirty_days {Actions completed in the last 30 days.}
           }
       flowViews:
         flowEmptyView: No Flows
         flowListTooltips: |
           {title, select,
-            owned_by {This worklist includes Flows with the Owner set to you (or someone else on your team). States included are To Do and In Progress.}
-            shared_by {This worklist includes Flows with the Owner set to { team } and { team } users. States included are To Do and In Progress.}
-            new_past_day {Flows added in the last 24 hours. States include To Do and In Progress.}
-            updated_past_three_days {Flows updated in the last 3 days. States include To Do and In Progress.}
+            owned_by {This worklist includes Flows with the Owner set to you (or someone else on your team).}
+            shared_by {This worklist includes Flows with the Owner set to { team } and { team } users.}
+            new_past_day {Flows added in the last 24 hours.}
+            updated_past_three_days {Flows updated in the last 3 days.}
             done_last_thirty_days {Flows completed in the last 30 days.}
           }
       tableHeaderTemplate:


### PR DESCRIPTION
Shortcut Story ID: [sc-60307]

Since users can now select multiple states via the filters sidebar, we can remove the text about what states are included in the lists.

<img width="325" alt="Screenshot 2025-03-24 at 12 59 22 PM" src="https://github.com/user-attachments/assets/a230289c-e125-45da-91dc-d8529b4b0d96" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified tooltip text to reduce verbosity while maintaining essential information in schedule views and action lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->