### PR TITLE
Small cleanup in worklist `'socket notifications'` test

### DIFF
--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1138,15 +1138,6 @@ context('worklist page', function() {
       },
     });
 
-    const testDoneStateFlow = getFlow({
-      attributes: {
-        name: 'Test Flow - Has State Not In Current Filters',
-      },
-      relationships: {
-        state: getRelationship(stateDone),
-      },
-    });
-
     const testSocketAction = getAction({
       attributes: {
         name: 'Test Action - Subscribed on Page Load',
@@ -1198,20 +1189,6 @@ context('worklist page', function() {
       relationships: {
         state: getRelationship(stateTodo),
         flow: getRelationship(testFlow),
-        owner: getRelationship(currentClinician),
-        patient: getRelationship(testPatient1),
-      },
-    });
-
-    const testNewFlowStateSocketAction = getAction({
-      attributes: {
-        name: 'New Action - Flow State Does Not Match Current Filters',
-        updated_at: testTs(),
-        created_at: testTs(),
-      },
-      relationships: {
-        state: getRelationship(stateTodo),
-        flow: getRelationship(testDoneStateFlow),
         owner: getRelationship(currentClinician),
         patient: getRelationship(testPatient1),
       },
@@ -1554,15 +1531,6 @@ context('worklist page', function() {
     cy
       .get('@firstRow')
       .should('contain', 'New Action - Owner Updated to Match Current Worklist Filter');
-
-    cy
-      .routeAction(fx => {
-        fx.data = testNewFlowStateSocketAction;
-
-        fx.included.push(testDoneStateFlow);
-
-        return fx;
-      });
   });
 
   specify('actions on a done-flow list', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-60286]

This code should have been removed in this PR: https://github.com/RoundingWell/care-ops-frontend/pull/1402/files#diff-54d3e412e8691c70c8fcd99fa1dfdbf93e1d79ce872dde135e6c0ab9e37c374b. But I missed it originally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Streamlined integration testing setup by removing redundant flow and action definitions to promote efficiency and maintainability, with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->