### PR TITLE
Set a height of `36px` on `.list-page__filters`

### DIFF
--- a/src/js/views/patients/sidebar/filters/filters-sidebar.scss
+++ b/src/js/views/patients/sidebar/filters/filters-sidebar.scss
@@ -2,4 +2,5 @@
   color: color(blue);
   margin-right: 16px;
   padding: 0;
+  vertical-align: baseline;
 }

--- a/src/scss/modules/buttons.scss
+++ b/src/scss/modules/buttons.scss
@@ -228,7 +228,6 @@
 
   border-color: transparent;
   color: $black-60;
-  line-height: normal;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Shortcut Story ID: [sc-60431]

To stop layout from shifting when bulk edit button visibility is toggled on worklists & schedule.

Screengrab of the layout shifting, which this PR fixes:

https://github.com/user-attachments/assets/ad6233ec-bbfe-4e98-94f0-bf65e73f373d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the filter panel styling for clearer element alignment.
  - Adjusted button text styling by removing a fixed line height, enhancing layout consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->