### PR TITLE
Use `line-height: normal` for `.list__title-filter-button`

### DIFF
--- a/src/js/views/patients/shared/list.scss
+++ b/src/js/views/patients/shared/list.scss
@@ -3,7 +3,6 @@
   align-items: center;
   color: color(light_blue);
   display: flex;
-  line-height: 1;
   margin-left: 8px;
 
   .icon.fa-angle-down {


### PR DESCRIPTION
Shortcut Story ID: [sc-55237]

To stop bottom of text being cut off because of the `overflow: hidden` property, for example:

<img width="518" alt="Screenshot 2025-03-25 at 11 17 27 AM" src="https://github.com/user-attachments/assets/6b488f16-182b-4c6f-8ccc-794960dde087" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the vertical spacing for button text in the patient list view, resulting in a subtly updated look for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->