### PR TITLE
Only add right margin if the worklist date filter element is not empty

### DIFF
--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -9,7 +9,7 @@
     <div class="flex flex-align-center w-100" data-filters-region></div>
     <div class="flex">
       <span class="worklist-list__count" data-count-region></span>
-      <span class="u-margin--r-16 u-text--nowrap" data-date-filter-region></span>
+      <span class="worklist-list__filter-date u-text--nowrap" data-date-filter-region></span>
       <span class="worklist-list__filter-sort" data-sort-region></span>
     </div>
   </div>

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -108,6 +108,10 @@
   white-space: nowrap;
 }
 
+.worklist-list__filter-date:not(:empty) {
+  margin-right: 16px;
+}
+
 .worklist-list__filter-sort .fa-arrow-down-arrow-up {
   margin-right: 8px;
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-60440]

When that element is empty, it was adding an additional `16px` of margin. Which made the spacing for the action/flow count not match across the different worklists.

For example:

<img width="360" alt="Screenshot 2025-03-25 at 11 47 32 AM" src="https://github.com/user-attachments/assets/e94dda9f-e9d5-40cc-8add-93c09c7a69de" />
<img width="642" alt="Screenshot 2025-03-25 at 11 47 23 AM" src="https://github.com/user-attachments/assets/7dcaeb6b-c37c-4608-9d46-b7a39c95adcf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual layout of the worklist’s date filter to achieve improved alignment.
  - Revised spacing to ensure a consistent and balanced appearance when filtering by date.
  - These adjustments enhance overall interface polish and improve the clarity of date filtering within the worklist view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->