### PR TITLE
Fix css alignment of header section in modals

### DIFF
--- a/src/js/views/globals/modal/modal.hbs
+++ b/src/js/views/globals/modal/modal.hbs
@@ -1,7 +1,7 @@
 <div class="modal__header {{ headerClass }}" data-header-region>
   {{#if headerIcon}}<span class="modal__header-icon">{{fa headerIconType headerIcon}}</span>{{/if}}
   <div class="flex-grow">{{ headingText }}</div>
-  <button class="button--icon js-close">{{far "xmark"}}</button>
+  <button class="button--icon flex flex-align-center js-close">{{far "xmark"}}</button>
 </div>
 
 <div class="modal__body" data-body-region>

--- a/src/scss/modules/modals.scss
+++ b/src/scss/modules/modals.scss
@@ -32,6 +32,7 @@
 }
 
 .modal__header {
+  align-items: center;
   color: $black-20;
   display: flex;
   font-size: 24px;


### PR DESCRIPTION
Shortcut Story ID: [sc-60224]

Fixes misalignment of icons, header title, and close `X` icon.

Examples:

- Add clinician modal ([screenshot](https://github.com/user-attachments/assets/96086cac-daf7-4a1f-88e4-c8800c51f0a2))
- Add patient modal ([screenshot](https://github.com/user-attachments/assets/c439276c-280f-453c-93b6-c4c397c15c0b))




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the modal close button with enhanced flexbox styling for improved alignment.
  - Adjusted the modal header layout to center its elements for a more balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->