### PR TITLE
Support read only & report forms on the patient sidebar

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -192,6 +192,8 @@ careOptsFrontend:
         modalView:
           cancelText: Cancel
           submitText: Save
+        viewOnlyForm:
+          doneText: Done
     patientModal:
       patientModalTemplate:
         addPatient: Add Patient

--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -53,7 +53,7 @@ export default App.extend({
     const formService = new FormsService({ patient, form });
     const bodyView = new IframeFormView({ model: form, size });
 
-    if (form.isReadOnly() || form.isReport()) {
+    if (form.isReadOnly()) {
       this.showViewOnlyForm(formService, bodyView, formName);
       return;
     }

--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -1,6 +1,8 @@
 import Radio from 'backbone.radio';
 import App from 'js/base/app';
 
+import intl from 'js/i18n';
+
 import FormsService from 'js/services/forms';
 
 import { ModalView, SidebarModalView, SmallModalView, IframeFormView } from 'js/views/globals/modal/modal_views';
@@ -49,11 +51,17 @@ export default App.extend({
   },
   showForm(patient, formName, form, size) {
     const formService = new FormsService({ patient, form });
+    const bodyView = new IframeFormView({ model: form, size });
+
+    if (form.isReadOnly() || form.isReport()) {
+      this.showViewOnlyForm(formService, bodyView, formName);
+      return;
+    }
 
     const modal = this.showModal({
       headingText: formName,
       headerIcon: 'square-poll-horizontal',
-      bodyView: new IframeFormView({ model: form, size }),
+      bodyView,
       onBeforeDestroy() {
         formService.destroy();
       },
@@ -78,5 +86,17 @@ export default App.extend({
     });
 
     return modal;
+  },
+  showViewOnlyForm(formService, bodyView, formName) {
+    this.showModal({
+      headingText: formName,
+      submitText: intl.globals.modal.modalViews.viewOnlyForm.doneText,
+      cancelText: false,
+      headerIcon: 'square-poll-horizontal',
+      bodyView,
+      onBeforeDestroy() {
+        formService.destroy();
+      },
+    });
   },
 });

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -44,6 +44,22 @@ context('patient sidebar', function() {
       },
     });
 
+    const testReadOnlyForm = getForm({
+      attributes: {
+        options: {
+          read_only: true,
+        },
+      },
+    });
+
+    const testReportForm = getForm({
+      attributes: {
+        options: {
+          is_report: true,
+        },
+      },
+    });
+
     cy
       .routesForPatientDashboard()
       .routeFormDefinition()
@@ -76,6 +92,8 @@ context('patient sidebar', function() {
                 'divider',
                 'formWidget',
                 'formModalWidget',
+                'readOnlyFormModalWidget',
+                'reportFormModalWidget',
                 'formModalWidgetSmall',
                 'formModalWidgetLarge',
                 'patientMRNIdentifier',
@@ -111,6 +129,26 @@ context('patient sidebar', function() {
               display_name: 'Modal Form',
               form_id: testScriptReducerForm.id,
               form_name: 'Test Modal Form',
+              is_modal: true,
+            },
+          }),
+          addWidget({
+            slug: 'readOnlyFormModalWidget',
+            category: 'formWidget',
+            definition: {
+              display_name: 'Modal Read Only Form',
+              form_id: testReadOnlyForm.id,
+              form_name: 'Test Modal Read Only Form',
+              is_modal: true,
+            },
+          }),
+          addWidget({
+            slug: 'reportFormModalWidget',
+            category: 'formWidget',
+            definition: {
+              display_name: 'Modal Report Form',
+              form_id: testReportForm.id,
+              form_name: 'Test Modal Report Form',
               is_modal: true,
             },
           }),
@@ -274,6 +312,16 @@ context('patient sidebar', function() {
       .should('contain', 'Test Modal Form')
       .parents('.patient-sidebar__section')
       .next()
+      .should('contain', 'Modal Read Only Form')
+      .find('.widgets__form-widget')
+      .should('contain', 'Test Modal Read Only Form')
+      .parents('.patient-sidebar__section')
+      .next()
+      .should('contain', 'Modal Report Form')
+      .find('.widgets__form-widget')
+      .should('contain', 'Test Modal Report Form')
+      .parents('.patient-sidebar__section')
+      .next()
       .find('.widgets__form-widget')
       .should('contain', 'Test Modal Form Small')
       .parents('.patient-sidebar__section')
@@ -385,6 +433,76 @@ context('patient sidebar', function() {
     cy
       .get('.modal')
       .should('not.exist');
+
+    cy
+      .routeForm(fx => {
+        fx.data = testReadOnlyForm;
+
+        return fx;
+      });
+
+    cy
+      .get('.patient-sidebar')
+      .find('.widgets__form-widget')
+      .contains('Test Modal Read Only Form')
+      .click()
+      .wait('@routeForm');
+
+    cy
+      .get('@iframe')
+      .find('[name="data[fields.foo]"]')
+      .should('be.disabled');
+
+    cy
+      .get('.modal')
+      .find('.modal__footer-actions .js-close')
+      .should('not.exist');
+
+    cy
+      .get('.modal')
+      .find('.modal__footer-actions .js-submit')
+      .should('contain', 'Done');
+
+    cy
+      .get('.modal')
+      .find('.js-close')
+      .first()
+      .click();
+
+    cy
+      .routeForm(fx => {
+        fx.data = testReportForm;
+
+        return fx;
+      });
+
+    cy
+      .get('.patient-sidebar')
+      .find('.widgets__form-widget')
+      .contains('Test Modal Report Form')
+      .click()
+      .wait('@routeForm');
+
+    cy
+      .get('@iframe')
+      .find('[name="data[fields.foo]"]')
+      .should('be.disabled');
+
+    cy
+      .get('.modal')
+      .find('.modal__footer-actions .js-close')
+      .should('not.exist');
+
+    cy
+      .get('.modal')
+      .find('.modal__footer-actions .js-submit')
+      .should('contain', 'Done');
+
+    cy
+      .get('.modal')
+      .find('.js-close')
+      .first()
+      .click();
 
     cy
       .get('@patientSidebar')

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -57,11 +57,17 @@ context('patient sidebar', function() {
       .routeFormDefinition()
       .routeLatestFormResponse()
       .routeFormFields()
+      .routeForm()
       .routeForm(fx => {
         fx.data = testScriptReducerForm;
 
         return fx;
-      })
+      }, testScriptReducerForm.id)
+      .routeForm(fx => {
+        fx.data = testReadOnlyForm;
+
+        return fx;
+      }, testReadOnlyForm.id)
       .routeWidgetValues(fx => {
         fx.values = {
           sex: 'f',
@@ -246,7 +252,7 @@ context('patient sidebar', function() {
       .wait('@routeWidgets');
 
     cy
-      .wait('@routeForm')
+      .wait(`@routeForm${ testScriptReducerForm.id }`)
       .itsUrl()
       .its('pathname')
       .should('contain', testScriptReducerForm.id);
@@ -416,12 +422,13 @@ context('patient sidebar', function() {
       .find('.widgets__form-widget')
       .contains('Test Modal Read Only Form')
       .click()
-      .wait('@routeForm');
+      .wait(`@routeForm${ testReadOnlyForm.id }`)
+      .wait('@routeFormDefinition');
 
     cy
-      .get('@iframe')
-      .find('[name="data[fields.foo]"]')
-      .should('be.disabled');
+      .iframe()
+      .as('iframe')
+      .find('.formio-editor-read-only-content');
 
     cy
       .get('.modal')

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -52,14 +52,6 @@ context('patient sidebar', function() {
       },
     });
 
-    const testReportForm = getForm({
-      attributes: {
-        options: {
-          is_report: true,
-        },
-      },
-    });
-
     cy
       .routesForPatientDashboard()
       .routeFormDefinition()
@@ -139,16 +131,6 @@ context('patient sidebar', function() {
               display_name: 'Modal Read Only Form',
               form_id: testReadOnlyForm.id,
               form_name: 'Test Modal Read Only Form',
-              is_modal: true,
-            },
-          }),
-          addWidget({
-            slug: 'reportFormModalWidget',
-            category: 'formWidget',
-            definition: {
-              display_name: 'Modal Report Form',
-              form_id: testReportForm.id,
-              form_name: 'Test Modal Report Form',
               is_modal: true,
             },
           }),
@@ -317,11 +299,6 @@ context('patient sidebar', function() {
       .should('contain', 'Test Modal Read Only Form')
       .parents('.patient-sidebar__section')
       .next()
-      .should('contain', 'Modal Report Form')
-      .find('.widgets__form-widget')
-      .should('contain', 'Test Modal Report Form')
-      .parents('.patient-sidebar__section')
-      .next()
       .find('.widgets__form-widget')
       .should('contain', 'Test Modal Form Small')
       .parents('.patient-sidebar__section')
@@ -435,51 +412,9 @@ context('patient sidebar', function() {
       .should('not.exist');
 
     cy
-      .routeForm(fx => {
-        fx.data = testReadOnlyForm;
-
-        return fx;
-      });
-
-    cy
       .get('.patient-sidebar')
       .find('.widgets__form-widget')
       .contains('Test Modal Read Only Form')
-      .click()
-      .wait('@routeForm');
-
-    cy
-      .get('@iframe')
-      .find('[name="data[fields.foo]"]')
-      .should('be.disabled');
-
-    cy
-      .get('.modal')
-      .find('.modal__footer-actions .js-close')
-      .should('not.exist');
-
-    cy
-      .get('.modal')
-      .find('.modal__footer-actions .js-submit')
-      .should('contain', 'Done');
-
-    cy
-      .get('.modal')
-      .find('.js-close')
-      .first()
-      .click();
-
-    cy
-      .routeForm(fx => {
-        fx.data = testReportForm;
-
-        return fx;
-      });
-
-    cy
-      .get('.patient-sidebar')
-      .find('.widgets__form-widget')
-      .contains('Test Modal Report Form')
       .click()
       .wait('@routeForm');
 

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
 import { getResource, mergeJsonApi } from 'helpers/json-api';
 
 import fxTestForms from 'fixtures/collections/forms';
@@ -13,6 +14,8 @@ export const testForm = getResource(_.extend(fxTestForms[0], {
 }), TYPE);
 
 export function getForm(data) {
+  data = _.extend({ id: uuid() }, data);
+
   return mergeJsonApi(testForm, data);
 }
 
@@ -31,14 +34,14 @@ Cypress.Commands.add('routeForms', (mutator = _.identity) => {
     .as('routeForms');
 });
 
-Cypress.Commands.add('routeForm', (mutator = _.identity) => {
+Cypress.Commands.add('routeForm', (mutator = _.identity, id = '') => {
   const data = getForm();
 
   cy
-    .intercept('GET', '/api/forms/*', {
+    .intercept('GET', `/api/forms/${ id }*`, {
       body: mutator({ data, included: [] }),
     })
-    .as('routeForm');
+    .as(`routeForm${ id }`);
 });
 
 Cypress.Commands.add('routeFormByAction', (mutator = _.identity) => {


### PR DESCRIPTION
Shortcut Story ID: [sc-60600]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a view-only modal form with a clear "Done" action, providing a distinct, non-editable interface for users.
	- Enhanced patient sidebar functionality with a new read-only form and associated modal widgets.

- **Tests**
	- Expanded testing to validate that the view-only and report forms display correctly with disabled inputs and appropriate footer actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->