### PR TITLE
Normalize api query between the list and single action/flow gets

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -125,19 +125,25 @@ export default App.extend({
     this.showView();
   },
   beforeStart() {
-    const listType = this.getState().getType();
+    const isFlowType = this.getState().isFlowType();
+    const entityRequest = isFlowType ? 'fetch:flows:collection' : 'fetch:actions:collection';
+
+    const includes = ['patient', ...this.sortOptions.getInclude()];
+    const fields = { patients: ['first_name', 'last_name', 'patient-fields'] };
     this.filters = this.getState().getEntityFilter();
 
-    const data = {
-      filter: this.filters,
-      include: this.sortOptions.getInclude(),
-    };
-
-    if (listType === 'actions') {
-      data.fields = { flows: ['name', 'state'] };
+    if (!isFlowType) {
+      fields.flows = ['name', 'state'];
+      includes.push('flow');
     }
 
-    return Radio.request('entities', `fetch:${ listType }:collection`, { data });
+    this.query = {
+      filter: this.filters,
+      fields,
+      include: includes.join(','),
+    };
+
+    return Radio.request('entities', entityRequest, { data: this.query });
   },
   onStart(options, collection) {
     this.collection = collection;
@@ -156,20 +162,11 @@ export default App.extend({
   },
   subscribe() {
     const isFlowType = this.getState().isFlowType();
+    const entityType = isFlowType ? 'flows' : 'patient-actions';
+    const filterType = isFlowType ? 'flows' : 'actions';
 
-    if (isFlowType) {
-      Radio.request('ws', 'subscribe', this.collection.models, { filters: { flows: this.filters } });
-      Radio.request('ws', 'manage:add', this, this.collection, 'flows', { fields: { patients: ['first_name', 'last_name'] } });
-      return;
-    }
-
-    const fields = {
-      patients: ['first_name', 'last_name'],
-      flows: ['name', 'state'],
-    };
-
-    Radio.request('ws', 'subscribe', this.collection.models, { filters: { actions: this.filters } });
-    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions', { fields });
+    Radio.request('ws', 'subscribe', this.collection.models, { filters: { [filterType]: this.filters } });
+    Radio.request('ws', 'manage:add', this, this.collection, entityType, this.query);
   },
   // NOTE: Shows views dependent on getState().getType()
   showTypeViews() {

--- a/src/js/apps/patients/worklist/worklist_sort.js
+++ b/src/js/apps/patients/worklist/worklist_sort.js
@@ -54,7 +54,7 @@ const SortOptions = Backbone.Collection.extend({
 
     return map(uniq(fieldNames), fieldName => {
       return `patient.patient-fields.${ fieldName }`;
-    }).join(',');
+    });
   },
 });
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -2736,7 +2736,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'include=patient.patient-fields.foo');
+      .should('contain', 'include=patient,patient.patient-fields.foo');
 
     cy
       .get('.worklist-list__toggle')
@@ -3573,7 +3573,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'include=patient.patient-fields.foo');
+      .should('contain', 'include=patient,patient.patient-fields.foo');
 
     cy
       .get('.worklist-list__filter-sort')


### PR DESCRIPTION
Previously we were relying on default API settings on the action/flow list GETs.  fields only worked with includes, but they were auto-applied includes.

If we’re explicit, then it is the same request for the list and the request we need to make to add a newly notified entity.

This is much cleaner and clearer than before.  So after this is released for a cycle we can likely safely remove the defaults for the action/flow lists.  @DrechslerDerek 

Shortcut Story ID: [sc-60405]

I'd like to get this into the release so I needed 👀 while Nick is out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the worklist page’s data retrieval to provide more efficient and consistent information handling.
  - Adjusted the sorting logic to ensure field parameters are represented in a unified format.

- **Tests**
  - Updated URL parameter validations to align with the refined data and sorting logic for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->