### PR TITLE
Change the action message from `CommentAdded` => `ActionCommentAdded`

### DIFF
--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -35,7 +35,7 @@ const _Model = BaseModel.extend({
     SharingUpdated({ attributes }) {
       this.set(attributes);
     },
-    CommentAdded({ comment, attributes }, { author }) {
+    ActionCommentAdded({ comment, attributes }, { author }) {
       const commentModel = Radio.request('entities', 'comments:model', {
         id: comment.id,
         message: attributes.message,

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1407,7 +1407,7 @@ context('patient dashboard page', function() {
       .find('.fa-share-from-square');
 
     cy.sendWs({
-      category: 'CommentAdded',
+      category: 'ActionCommentAdded',
       author: currentClinician.id,
       resource: {
         type: testSocketAction.type,

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -339,7 +339,7 @@ context('patient flow page', function() {
       .should('contain', 'Response Saved');
 
     cy.sendWs({
-      category: 'CommentAdded',
+      category: 'ActionCommentAdded',
       author: getCurrentClinician().id,
       resource: {
         type: testFlowAction.type,
@@ -3007,7 +3007,7 @@ context('patient flow page', function() {
       .should('not.exist');
 
     cy.sendWs({
-      category: 'CommentAdded',
+      category: 'ActionCommentAdded',
       author: getCurrentClinician().id,
       resource: {
         type: testSocketAction.type,

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1349,7 +1349,7 @@ context('worklist page', function() {
       .find('.fa-share-from-square');
 
     cy.sendWs({
-      category: 'CommentAdded',
+      category: 'ActionCommentAdded',
       author: currentClinician.id,
       resource: {
         type: testSocketAction.type,


### PR DESCRIPTION
Shortcut Story ID: [sc-61014]

Coincides with this BE PR: https://github.com/RoundingWell/care-ops-backend/pull/9318

- [x] Change `CommentAdded` => `ActionCommentAdded`
- [x] Verify change works in local dev environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming of the comment addition event from "CommentAdded" to "ActionCommentAdded" throughout the application for consistency.

- **Tests**
  - Adjusted integration tests to use the new "ActionCommentAdded" event name when simulating comment additions via WebSocket notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->