### PR TITLE
Remove top/bottom padding for forms rendered inside modals

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -340,6 +340,10 @@ function startFormApp() {
     </div>
     <div class="loader__text js-loading">${ intl.regions.preload.loading }</div>
   `);
+
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('modal')) $('body').addClass('is-modal');
+
   router = new Router();
   Backbone.history.start({ pushState: true });
 }

--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -97,7 +97,7 @@ const IframeFormView = View.extend({
 
     return 'modal__form-iframe';
   },
-  template: hbs`<iframe src="/formapp/"></iframe>`,
+  template: hbs`<iframe src="/formapp/?modal=1"></iframe>`,
 });
 
 export {

--- a/src/scss/formapp-core.scss
+++ b/src/scss/formapp-core.scss
@@ -4,4 +4,8 @@
 
 body {
   padding: 24px;
+
+  &.is-modal {
+    padding: 0 24px;
+  }
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-61035] [sc-60670]




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The form app now automatically detects when it is opened in a modal and adjusts its appearance accordingly.
- **Style**
	- Improved layout for modal views by updating padding when displayed in a modal window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->