### PR TITLE
Handle `FlowProgressChanged` ws notifications for flows in lists

### DIFF
--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -20,6 +20,9 @@ const _Model = BaseModel.extend({
     DetailsChanged({ attributes }) {
       this.set(attributes);
     },
+    FlowProgressChanged({ attributes }) {
+      this.set({ _progress: attributes.progress });
+    },
     ResourceDeleted() {
       this.destroy({ isDeleted: true });
     },

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -442,6 +442,12 @@ context('patient archive page', function() {
         patient: getRelationship(testPatient),
         owner: getRelationship(teamCoordinator),
       },
+      meta: {
+        progress: {
+          complete: 0,
+          total: 2,
+        },
+      },
     });
 
     cy
@@ -594,6 +600,28 @@ context('patient archive page', function() {
       .get('@firstRow')
       .find('.patient__action-ts')
       .should('contain', formatDate(testTs(), 'TIME_OR_DAY'));
+
+    cy.sendWs({
+      category: 'FlowProgressChanged',
+      resource: {
+        type: testNewStateSocketFlow.type,
+        id: testNewStateSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          progress: {
+            complete: 1,
+            total: 3,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.patient__flow-progress')
+      .should('have.value', 1)
+      .should('have.attr', 'max', 3);
 
     cy.sendWs({
       category: 'ResourceDeleted',

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1005,6 +1005,12 @@ context('patient dashboard page', function() {
         patient: getRelationship(testPatient),
         owner: getRelationship(teamCoordinator),
       },
+      meta: {
+        progress: {
+          complete: 0,
+          total: 2,
+        },
+      },
     });
 
     const testNewSocketFlow = getFlow({
@@ -1116,6 +1122,28 @@ context('patient dashboard page', function() {
       .get('@firstRow')
       .find('[data-owner-region]')
       .should('contain', 'NU');
+
+    cy.sendWs({
+      category: 'FlowProgressChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          progress: {
+            complete: 1,
+            total: 3,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.patient__flow-progress')
+      .should('have.value', 1)
+      .should('have.attr', 'max', 3);
 
     // state was set to done, which means it's removed from the list
     cy.sendWs({

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -317,6 +317,12 @@ context('worklist page', function() {
         owner: getRelationship(currentClinician),
         patient: getRelationship(testPatient1),
       },
+      meta: {
+        progress: {
+          complete: 0,
+          total: 2,
+        },
+      },
     });
 
     const testNewSocketFlow = getFlow({
@@ -449,6 +455,28 @@ context('worklist page', function() {
       .get('@firstRow')
       .find('[data-owner-region]')
       .should('contain', 'CO');
+
+    cy.sendWs({
+      category: 'FlowProgressChanged',
+      resource: {
+        type: testSocketFlow.type,
+        id: testSocketFlow.id,
+      },
+      payload: {
+        attributes: {
+          progress: {
+            complete: 1,
+            total: 3,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('@firstRow')
+      .find('.worklist-list__flow-progress')
+      .should('have.value', 1)
+      .should('have.attr', 'max', 3);
 
     cy
       .routeFlow(fx => {


### PR DESCRIPTION
Shortcut Story ID: [sc-61108]

A flow's progress is calculated as `child actions completed / total child actions = flow progress %`. So this calculation can change if a child action's state changes or if a child action is created or deleted.

Corresponding BE PR: https://github.com/RoundingWell/care-ops-backend/pull/9338.

- [x] Handle `FlowProgressChanged` ws notifications
- [x] Add cypress tests
- [x] Test in local dev environment