### PR TITLE
Keep 24px top spacing for loading animation in form modal

### DIFF
--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -334,15 +334,17 @@ const Router = Backbone.Router.extend({
 });
 
 function startFormApp() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const isModal = urlParams.get('modal');
+
   $('#root').append(`
-    <div class="loader__bar js-progress-bar">
+    <div class="loader__bar${ isModal ? ' u-margin--t-24' : '' } js-progress-bar">
       <div class="loader__bar-progress--loop"></div>
     </div>
     <div class="loader__text js-loading">${ intl.regions.preload.loading }</div>
   `);
 
-  const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.get('modal')) $('body').addClass('is-modal');
+  if (isModal) $('body').addClass('is-modal');
 
   router = new Router();
   Backbone.history.start({ pushState: true });

--- a/src/scss/formapp-core.scss
+++ b/src/scss/formapp-core.scss
@@ -1,6 +1,7 @@
 @forward 'core/fonts';
 @forward 'core/text';
 @forward 'core/typography';
+@forward 'core/space';
 
 body {
   padding: 24px;


### PR DESCRIPTION
Shortcut Story ID: [sc-61035]

In https://github.com/RoundingWell/care-ops-frontend/pull/1425 we removed the top/bottom padding for forms that are rendered in a modal. But we lost the top spacing for the loader animation.

This PR adds a 24px margin to the loader animation only when it's being shown for a form in a modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and maintainability of form loading by optimizing how URL parameters are handled.
- **Style**
  - Enhanced style modularity by including additional spacing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->