### PR TITLE
Use uuids for roles & states fixtures

### DIFF
--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "22222",
+    "id": "85c42103-e014-4482-8392-dc9aab215a02",
     "name": "admin",
     "label": "Admin",
     "description": "Full permissions",
@@ -20,7 +20,7 @@
     ]
   },
   {
-    "id": "11111",
+    "id": "44da594f-1460-4fbe-b2d6-75731658cfdc",
     "name": "manager",
     "label": "Manager",
     "description": "Able to manage clinicians, patients, programs, and view dashboards",
@@ -40,7 +40,7 @@
     ]
   },
   {
-    "id": "33333",
+    "id": "2606b628-86a9-4be2-830e-b0f541422e6d",
     "name": "employee",
     "label": "Employee",
     "description": "Able to access workspace only",
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "id": "44444",
+    "id": "34984bfd-e370-496c-87c7-0e728893a7d2",
     "name": "restricted_employee",
     "label": "Restricted Employee",
     "description": "Able to access reduced workspace",
@@ -69,14 +69,14 @@
     ]
   },
   {
-    "id": "55555",
+    "id": "70c30b67-6e7d-47f6-a1fe-8bfe0f7a149a",
     "name": "patient",
     "label": "Patient",
     "description": "Limited access for outreach",
     "permissions": []
   },
   {
-    "id": "66666",
+    "id": "110eb40e-4a09-4969-8f93-869ced70c856",
     "name": "restricted__filter_employee",
     "label": "Restricted Filter Employee",
     "description": "Remove clinicians from worklist filters",
@@ -88,7 +88,7 @@
     ]
   },
   {
-    "id": "77777",
+    "id": "7244daae-5396-4fb1-b28d-7f3acc537682",
     "name": "liason_employee",
     "label": "Liason Employee",
     "description": "Can only manage work owned by their team or team members.",

--- a/test/fixtures/test/roles.json
+++ b/test/fixtures/test/roles.json
@@ -89,8 +89,8 @@
   },
   {
     "id": "7244daae-5396-4fb1-b28d-7f3acc537682",
-    "name": "liason_employee",
-    "label": "Liason Employee",
+    "name": "liaison_employee",
+    "label": "Liaison Employee",
     "description": "Can only manage work owned by their team or team members.",
     "permissions": [
       "app:schedule:clinician_filter",

--- a/test/fixtures/test/states.json
+++ b/test/fixtures/test/states.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "22222",
+    "id": "123bbe66-db12-4994-9e69-4c51c938827b",
     "name": "To Do",
     "sequence": 100,
     "status": "queued",
@@ -11,7 +11,7 @@
     }
   },
   {
-    "id": "33333",
+    "id": "ae773a40-1e54-4967-9686-52c4fc2245a3",
     "name": "In Progress",
     "sequence": 200,
     "status": "started",
@@ -22,7 +22,7 @@
     }
   },
   {
-    "id": "55555",
+    "id": "e40ecab6-9069-4553-88b3-202e8d1e7fbf",
     "name": "Done",
     "sequence": 300,
     "status": "done",
@@ -33,7 +33,7 @@
     }
   },
   {
-    "id": "66666",
+    "id": "2a70a785-a3dd-43b0-93ed-355c320f0fef",
     "name": "Unable to Complete",
     "sequence": 400,
     "status": "done",
@@ -44,7 +44,7 @@
     }
   },
   {
-    "id": "77777",
+    "id": "4738aece-e6a6-4ee3-9c4b-713dc0031f30",
     "name": "THMG Transfered",
     "sequence": 400,
     "status": "done",
@@ -55,7 +55,7 @@
     }
   },
   {
-    "id": "88888",
+    "id": "0a520cc9-a745-4f63-af63-03261c16948b",
     "name": "Evernorth",
     "sequence": 500,
     "status": "done",

--- a/test/fixtures/test/states.json
+++ b/test/fixtures/test/states.json
@@ -49,8 +49,8 @@
   },
   {
     "id": "4738aece-e6a6-4ee3-9c4b-713dc0031f30",
-    "name": "THMG Transfered",
-    "slug": "thmg-transfered",
+    "name": "THMG Transferred",
+    "slug": "thmg-transferred",
     "sequence": 400,
     "status": "done",
     "options": {

--- a/test/fixtures/test/states.json
+++ b/test/fixtures/test/states.json
@@ -2,6 +2,7 @@
   {
     "id": "123bbe66-db12-4994-9e69-4c51c938827b",
     "name": "To Do",
+    "slug": "to-do",
     "sequence": 100,
     "status": "queued",
     "options": {
@@ -13,6 +14,7 @@
   {
     "id": "ae773a40-1e54-4967-9686-52c4fc2245a3",
     "name": "In Progress",
+    "slug": "in-progress",
     "sequence": 200,
     "status": "started",
     "options": {
@@ -24,6 +26,7 @@
   {
     "id": "e40ecab6-9069-4553-88b3-202e8d1e7fbf",
     "name": "Done",
+    "slug": "done",
     "sequence": 300,
     "status": "done",
     "options": {
@@ -35,6 +38,7 @@
   {
     "id": "2a70a785-a3dd-43b0-93ed-355c320f0fef",
     "name": "Unable to Complete",
+    "slug": "unable-to-complete",
     "sequence": 400,
     "status": "done",
     "options": {
@@ -46,6 +50,7 @@
   {
     "id": "4738aece-e6a6-4ee3-9c4b-713dc0031f30",
     "name": "THMG Transfered",
+    "slug": "thmg-transfered",
     "sequence": 400,
     "status": "done",
     "options": {
@@ -57,6 +62,7 @@
   {
     "id": "0a520cc9-a745-4f63-af63-03261c16948b",
     "name": "Evernorth",
+    "slug": "evernorth",
     "sequence": 500,
     "status": "done",
     "options": {

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -11,7 +11,7 @@ import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
 import { workspaceOne } from 'support/api/workspaces';
 import { testForm } from 'support/api/forms';
-import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransfered } from 'support/api/states';
+import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransferred } from 'support/api/states';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
@@ -146,7 +146,7 @@ context('patient archive page', function() {
       .wait('@routePatientActions')
       .itsUrl()
       .its('search')
-      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id },${ stateThmgTransfered.id }`);
+      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id },${ stateThmgTransferred.id }`);
 
     // Filters only done id 55555
     cy

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -14,7 +14,7 @@ import { getPatient } from 'support/api/patients';
 import { getPatientField } from 'support/api/patient-fields';
 import { getFlow, getFlows } from 'support/api/flows';
 import { getCurrentClinician, getClinician } from 'support/api/clinicians';
-import { stateTodo, stateInProgress, stateDone, stateUnableToComplete, stateThmgTransfered } from 'support/api/states';
+import { stateTodo, stateInProgress, stateDone, stateUnableToComplete, stateThmgTransferred } from 'support/api/states';
 import { getWidget } from 'support/api/widgets';
 import { roleAdmin, roleEmployee, roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
@@ -650,7 +650,7 @@ context('worklist page', function() {
       .itsUrl()
       .its('search')
       .should('contain', `filter[updated_at]=${ dayjs(testDate()).startOf('day').subtract(30, 'days').format() }`)
-      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id },${ stateThmgTransfered.id }`);
+      .should('contain', `filter[states]=${ stateDone.id },${ stateUnableToComplete.id },${ stateThmgTransferred.id }`);
 
     cy
       .intercept('PATCH', '/api/flows/*', {

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -7,7 +7,7 @@ import fxActions from 'fixtures/collections/actions';
 import { getClinician } from './clinicians';
 import { getFlow } from './flows';
 import { getPatient, getPatients } from './patients';
-import { getState } from './states';
+import { getState, stateInProgress } from './states';
 import { getTeam } from './teams';
 import { getProgramAction } from './program-actions';
 import { programOne } from './programs';
@@ -47,7 +47,7 @@ export function getActions({ attributes, relationships, meta } = {}, { sample = 
 Cypress.Commands.add('routeAction', (mutator = _.identity) => {
   const data = getAction({
     relationships: {
-      state: getRelationship('33333', 'states'),
+      state: getRelationship(stateInProgress),
     },
   });
 

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -10,7 +10,7 @@ import { getPatient, getPatients } from './patients';
 import { getProgramActions } from './program-actions';
 import { getProgramFlow } from './program-flows';
 import { getProgram, programOne } from './programs';
-import { getState } from './states';
+import { getState, stateInProgress } from './states';
 import { getTeam } from './teams';
 
 const TYPE = 'flows';
@@ -56,7 +56,7 @@ Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
 
   const data = getFlow({
     relationships: {
-      'state': getRelationship('33333', 'states'),
+      'state': getRelationship(stateInProgress),
       'program': getRelationship(program),
       'program-flow': getRelationship(programFlow),
     },

--- a/test/support/api/roles.js
+++ b/test/support/api/roles.js
@@ -15,12 +15,18 @@ export function getRoles() {
 
 const roles = getRoles();
 
-export const roleAdmin = _.find(roles, { id: '22222' });
-export const roleManager = _.find(roles, { id: '11111' });
-export const roleEmployee = _.find(roles, { id: '33333' });
-export const roleReducedEmployee = _.find(roles, { id: '44444' });
-export const roleNoFilterEmployee = _.find(roles, { id: '66666' });
-export const roleTeamEmployee = _.find(roles, { id: '77777' });
+function getRoleByName(name) {
+  return _.find(roles, role => {
+    return role.attributes.name === name;
+  });
+}
+
+export const roleAdmin = getRoleByName('admin');
+export const roleManager = getRoleByName('manager');
+export const roleEmployee = getRoleByName('employee');
+export const roleReducedEmployee = getRoleByName('restricted_employee');
+export const roleNoFilterEmployee = getRoleByName('restricted__filter_employee');
+export const roleTeamEmployee = getRoleByName('liason_employee');
 
 Cypress.Commands.add('routeRoles', (mutator = _.identity) => {
   const data = getResource(fxTestRoles, TYPE);

--- a/test/support/api/roles.js
+++ b/test/support/api/roles.js
@@ -26,7 +26,7 @@ export const roleManager = getRoleByName('manager');
 export const roleEmployee = getRoleByName('employee');
 export const roleReducedEmployee = getRoleByName('restricted_employee');
 export const roleNoFilterEmployee = getRoleByName('restricted__filter_employee');
-export const roleTeamEmployee = getRoleByName('liason_employee');
+export const roleTeamEmployee = getRoleByName('liaison_employee');
 
 Cypress.Commands.add('routeRoles', (mutator = _.identity) => {
   const data = getResource(fxTestRoles, TYPE);

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -15,17 +15,17 @@ export function getState() {
 
 const states = getStates();
 
-function getStateByName(name) {
+function getStateBySlug(slug) {
   return _.find(states, state => {
-    return state.attributes.name === name;
+    return state.attributes.slug === slug;
   });
 }
 
-export const stateTodo = getStateByName('To Do');
-export const stateInProgress = getStateByName('In Progress');
-export const stateDone = getStateByName('Done');
-export const stateUnableToComplete = getStateByName('Unable to Complete');
-export const stateThmgTransfered = getStateByName('THMG Transfered');
+export const stateTodo = getStateBySlug('to-do');
+export const stateInProgress = getStateBySlug('in-progress');
+export const stateDone = getStateBySlug('done');
+export const stateUnableToComplete = getStateBySlug('unable-to-complete');
+export const stateThmgTransfered = getStateBySlug('thmg-transfered');
 
 Cypress.Commands.add('routeStates', (mutator = _.identity) => {
   const data = getStates();

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -25,7 +25,7 @@ export const stateTodo = getStateBySlug('to-do');
 export const stateInProgress = getStateBySlug('in-progress');
 export const stateDone = getStateBySlug('done');
 export const stateUnableToComplete = getStateBySlug('unable-to-complete');
-export const stateThmgTransfered = getStateBySlug('thmg-transfered');
+export const stateThmgTransferred = getStateBySlug('thmg-transferred');
 
 Cypress.Commands.add('routeStates', (mutator = _.identity) => {
   const data = getStates();

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -15,12 +15,17 @@ export function getState() {
 
 const states = getStates();
 
-// Exporting one of each state.status
-export const stateTodo = _.find(states, { id: '22222' });
-export const stateInProgress = _.find(states, { id: '33333' });
-export const stateDone = _.find(states, { id: '55555' });
-export const stateUnableToComplete = _.find(states, { id: '66666' });
-export const stateThmgTransfered = _.find(states, { id: '77777' });
+function getStateByName(name) {
+  return _.find(states, state => {
+    return state.attributes.name === name;
+  });
+}
+
+export const stateTodo = getStateByName('To Do');
+export const stateInProgress = getStateByName('In Progress');
+export const stateDone = getStateByName('Done');
+export const stateUnableToComplete = getStateByName('Unable to Complete');
+export const stateThmgTransfered = getStateByName('THMG Transfered');
 
 Cypress.Commands.add('routeStates', (mutator = _.identity) => {
   const data = getStates();


### PR DESCRIPTION
Shortcut Story ID: [sc-61215]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated test data to use UUIDs instead of numeric string IDs for roles and states.
  - Added a "slug" field to each state in test data.
  - Corrected spelling errors in role and state names for consistency.
  - Changed test logic to reference roles and states by name or slug instead of hardcoded IDs for improved reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->