### PR TITLE
Use uuids for team fixtures

### DIFF
--- a/test/fixtures/test/events-actions.json
+++ b/test/fixtures/test/events-actions.json
@@ -1,14 +1,8 @@
 [
   {
-    "id": "11111",
+    "id": "108cbc05-a26f-4f8e-91ed-13662ba4d322",
     "date": "2019-07-06T17:45:25.360Z",
     "event_type": "ActionCreated",
-    "source": "system",
-    "_relationships": {
-      "editor": {
-        "id": "11111",
-        "type": "clinicians"
-      }
-    }
+    "source": "system"
   }
 ]

--- a/test/fixtures/test/events-flows.json
+++ b/test/fixtures/test/events-flows.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "11111",
+    "id": "52bfe62b-b891-47a7-9d43-24480f34b6cf",
     "date": "2019-09-09T23:02:56.723Z",
     "event_type": "FlowCreated",
     "source": "system"

--- a/test/fixtures/test/form-fields.json
+++ b/test/fixtures/test/form-fields.json
@@ -1,5 +1,5 @@
 {
-  "id": "1",
+  "id": "1117b10d-9ae2-49f1-b8ce-de43f47b31dc",
   "patient": {
     "first_name": "John",
     "last_name": "Doe"

--- a/test/fixtures/test/teams.json
+++ b/test/fixtures/test/teams.json
@@ -1,36 +1,36 @@
 [
   {
-    "id": "11111",
+    "id": "91604f78-918f-46bf-acd2-90c0adbc99e8",
     "name": "Coordinator",
     "abbr": "CO"
   },
   {
-    "id": "22222",
+    "id": "03a7a545-63fa-4d26-a6d0-3ccd601721c3",
     "name": "Nurse",
     "abbr": "NUR"
   },
   {
-    "id": "33333",
+    "id": "70e94c4f-d046-429a-8a34-53a78848886c",
     "name": "Pharmacist",
     "abbr": "PHM"
   },
   {
-    "id": "44444",
+    "id": "8f970589-ac01-4568-a540-8eb5b029f00c",
     "name": "Physician",
     "abbr": "PHS"
   },
   {
-    "id": "55555",
+    "id": "5f5c1f5e-79b8-4a67-b052-8a63f04f1b8e",
     "name": "Specialist",
     "abbr": "SPC"
   },
   {
-    "id": "66666",
+    "id": "10929fe8-cbeb-4991-840f-47a5750451fa",
     "name": "Supervisor",
     "abbr": "SUP"
   },
   {
-    "id": "77777",
+    "id": "ff1c5515-ed13-443b-a632-b1bfb2ee1fd6",
     "name": "Other",
     "abbr": "OT"
   }

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -65,7 +65,7 @@ context('dashboard', function() {
 
     cy
       .url()
-      .should('not.contain', 'dashboards/1')
+      .should('not.contain', `dashboards/${ testUuid }`)
       .should('contain', 'dashboards');
 
     cy

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -104,7 +104,7 @@ context('Noncontext Form', function() {
               tableView: true,
               dataSrc: 'custom',
               data: {
-                custom: `values = getClinicians({ teamId: ${ teamCoordinator.id } });`,
+                custom: `values = getClinicians({ teamId: "${ teamCoordinator.id }" });`,
               },
               template: '<span>{{ item.name }}</span>',
               refreshOn: 'data',

--- a/test/support/api/teams.js
+++ b/test/support/api/teams.js
@@ -10,7 +10,7 @@ const TYPE = 'teams';
 function getFixture(data) {
   if (!data) return _.sample(fxTestTeams);
 
-  if (data.name) return _.find(fxTestTeams, { name: data.name });
+  if (data.abbr) return _.find(fxTestTeams, { abbr: data.abbr });
 
   if (!data.id) data.id = _.sample(fxTestTeams).id;
 
@@ -50,9 +50,9 @@ export function getTeams({ attributes, relationships, meta } = {}, { depth = 0 }
 }
 
 // Exporting only teams needed for testing variance
-export const teamCoordinator = getTeamResource({ name: 'Coordinator' });
-export const teamNurse = getTeamResource({ name: 'Nurse' });
-export const teamOther = getTeamResource({ name: 'Other' });
+export const teamCoordinator = getTeamResource({ abbr: 'CO' });
+export const teamNurse = getTeamResource({ abbr: 'NUR' });
+export const teamOther = getTeamResource({ abbr: 'OT' });
 
 Cypress.Commands.add('routeTeams', (mutator = _.identity) => {
   const data = getTeams();

--- a/test/support/api/teams.js
+++ b/test/support/api/teams.js
@@ -10,6 +10,8 @@ const TYPE = 'teams';
 function getFixture(data) {
   if (!data) return _.sample(fxTestTeams);
 
+  if (data.name) return _.find(fxTestTeams, { name: data.name });
+
   if (!data.id) data.id = _.sample(fxTestTeams).id;
 
   return _.find(fxTestTeams, { id: data.id }) || _.extend({}, _.sample(fxTestTeams), { id: data.id });
@@ -38,19 +40,19 @@ export function getTeam(data, { depth = 0 } = {}) {
 export function getTeams({ attributes, relationships, meta } = {}, { depth = 0 } = {}) {
   if (depth + 1 > 2) return [];
 
-  const clinicians = _.map(fxTestTeams, fxTeam => {
+  const teams = _.map(fxTestTeams, fxTeam => {
     const resource = getTeam(fxTeam, { depth });
 
     return mergeJsonApi(resource, { attributes, relationships, meta });
   });
 
-  return clinicians;
+  return teams;
 }
 
 // Exporting only teams needed for testing variance
-export const teamCoordinator = getTeamResource({ id: '11111' });
-export const teamNurse = getTeamResource({ id: '22222' });
-export const teamOther = getTeamResource({ id: '77777' });
+export const teamCoordinator = getTeamResource({ name: 'Coordinator' });
+export const teamNurse = getTeamResource({ name: 'Nurse' });
+export const teamOther = getTeamResource({ name: 'Other' });
 
 Cypress.Commands.add('routeTeams', (mutator = _.identity) => {
   const data = getTeams();


### PR DESCRIPTION
Shortcut Story ID: [sc-61276]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated team identifiers in test data to use UUIDs instead of numeric strings.
	- Improved test utilities to support team lookup by abbreviation as well as by identifier.
	- Adjusted test constants to use abbreviation-based lookup for teams.
	- Fixed form data source to correctly pass team identifiers as strings.
	- Removed editor relationship data from event action test fixtures.
	- Enhanced test assertions to dynamically verify dashboard URLs using UUIDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->