### PR TITLE
Refactor clinician fixture data & `getClinician()` helper function in tests

### DIFF
--- a/src/js/views/patients/shared/components/owner_component.cy.js
+++ b/src/js/views/patients/shared/components/owner_component.cy.js
@@ -183,7 +183,7 @@ context('Owner Component', function() {
   });
 
   specify('Current User is not in workspaces', function() {
-    const notInWorkspace = getClinician({ id: '12345', attributes: { name: 'Not in Workspace' } });
+    const notInWorkspace = getClinician({ attributes: { name: 'Not in Workspace' } });
     const owner = new Clinician({ data: notInWorkspace }, { parse: true });
 
     Radio.reply('bootstrap', 'currentUser', () => {
@@ -295,7 +295,6 @@ context('Owner Component', function() {
 
   specify('currentUser can work:team:manage', function() {
     const employee = getClinician({
-      id: '45678',
       attributes: { name: 'Employee' },
       relationships: {
         role: getRelationship(roleTeamEmployee),

--- a/test/fixtures/test/clinicians.json
+++ b/test/fixtures/test/clinicians.json
@@ -1,62 +1,62 @@
 [
   {
-    "id": "11111",
+    "id": "a0ca7e32-c41e-4055-bdbe-6671b3e78153",
     "name": "Clinician McTester",
     "email": "clinician.mctester@rwell.com",
     "enabled": true,
     "last_active_at": "2021-10-18T04:25:22.961Z"
   },
   {
-    "id": "22222",
+    "id": "6b9481c0-4922-4f3f-8cab-dbf5e82eba62",
     "name": "Jenna Botsford",
     "email": "Zoey.Lubowitz@hotmail.com",
     "enabled": true,
     "last_active_at": "2023-03-04T13:05:19.232Z"
   },
   {
-    "id": "33333",
+    "id": "b43f2feb-5e69-4b00-95d7-9191cc692619",
     "name": "Sherman Dicki",
     "email": "Michel_Predovic@yahoo.com",
     "enabled": true,
     "last_active_at": "2023-03-02T08:23:02.730Z"
   },
   {
-    "id": "44444",
+    "id": "6f4dffc3-07b3-44a8-ae23-dbb3c77521cc",
     "name": "Ernest Jacobs",
     "email": "Macey_Gerhold@gmail.com",
     "enabled": true,
     "last_active_at": "2023-03-02T08:01:20.624Z"
   },
   {
-    "id": "55555",
+    "id": "4fc6ea41-8c8f-426d-a692-112a215a209e",
     "name": "Michele Dickens",
     "email": "Yasmeen.Macejkovic95@gmail.com",
     "enabled": true,
     "last_active_at": "2023-03-01T04:34:46.111Z"
   },
   {
-    "id": "66666",
+    "id": "f58123ff-2a72-4c2d-ae16-e31876f62051",
     "name": "Clark Runolfsdottir",
     "email": "Imani96@hotmail.com",
     "enabled": true,
     "last_active_at": "2023-02-28T04:14:10.211Z"
   },
   {
-    "id": "77777",
+    "id": "45227b11-f144-4306-8d62-7b1af117c4fb",
     "name": "Loren Hodkiewicz",
     "email": "Olin_Romaguera@gmail.com",
     "enabled": true,
     "last_active_at": "2023-03-05T00:29:39.379Z"
   },
   {
-    "id": "88888",
+    "id": "195fadfb-d250-4bb5-b684-47fbbd9f64fa",
     "name": "Percy",
     "email": "Jamison46@hotmail.com",
     "enabled": true,
     "last_active_at": "2023-02-26T23:24:09.337Z"
   },
   {
-    "id": "99999",
+    "id": "494694e6-ea28-41b2-9134-dd90fdf02e2c",
     "name": "Traci Batz",
     "email": "Ward_Shields@hotmail.com",
     "enabled": true,

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 import { getErrors, getRelationship } from 'helpers/json-api';
 
 import stateColors from 'helpers/state-colors';
@@ -10,7 +8,6 @@ import { workspaceOne } from 'support/api/workspaces';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 
 const testClinician = getClinician({
-  id: uuid(),
   attributes: {
     name: 'Test Clinician',
     email: 'test.clinician@roundingwell.com',
@@ -339,7 +336,6 @@ context('clinician sidebar', function() {
 
   specify('incomplete clinician', function() {
     const incompleteClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Test Clinician',
         email: 'test.clinician@roundingwell.com',
@@ -368,7 +364,6 @@ context('clinician sidebar', function() {
 
   specify('never active clinician', function() {
     const inactiveClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Test Clinician',
         email: 'test.clinician@roundingwell.com',

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 import formatDate from 'helpers/format-date';
 import { testTs } from 'helpers/test-timestamp';
 import { getRelationship } from 'helpers/json-api';
@@ -13,7 +11,6 @@ context('clinicians list', function() {
   specify('display clinicians list', function() {
     const testClinicians = [
       getClinician({
-        id: uuid(),
         attributes: {
           name: 'Aaron Aaronson',
           last_active_at: testTs(),
@@ -24,7 +21,6 @@ context('clinicians list', function() {
         },
       }),
       getClinician({
-        id: uuid(),
         attributes: {
           name: 'Baron Baronson',
           last_active_at: null,
@@ -204,7 +200,6 @@ context('clinicians list', function() {
       .routeClinicians(fx => {
         fx.data = [
           getClinician({
-            id: uuid(),
             attributes: {
               name: 'Aaron Aaronson',
             },
@@ -214,7 +209,6 @@ context('clinicians list', function() {
             },
           }),
           getClinician({
-            id: uuid(),
             attributes: {
               name: 'Baron Baronson',
             },

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -2297,7 +2297,7 @@ context('Patient Action Form', function() {
       },
     });
 
-    const otherClinician = getClinician({ id: uuid() });
+    const otherClinician = getClinician();
 
     const testPatient = getPatient();
 
@@ -2465,7 +2465,6 @@ context('Patient Action Form', function() {
     });
 
     const nonTeamClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import { v5 as uuid } from 'uuid';
 
 import { getRelationship, getErrors } from 'helpers/json-api';
 
@@ -14,7 +14,7 @@ const testPatient = getPatient();
 
 function getTestPatientField(name, value) {
   return getPatientField({
-    id: uuidv5(`resource:field:${ name }`, testPatient.id),
+    id: uuid(`resource:field:${ name }`, testPatient.id),
     attributes: { name, value },
   });
 }
@@ -49,7 +49,6 @@ context('Noncontext Form', function() {
         fx.data = [
           currentClinician,
           getClinician({
-            id: uuidv4(),
             attributes: {
               name: 'Team Member',
             },
@@ -58,7 +57,6 @@ context('Noncontext Form', function() {
             },
           }),
           getClinician({
-            id: uuidv4(),
             attributes: {
               name: 'Non Team Member',
             },
@@ -441,7 +439,7 @@ context('Noncontext Form', function() {
       .wait('@routePatchPatientFieldFoo')
       .its('request.body.data')
       .then(data => {
-        expect(data.id).to.equal(uuidv5('resource:field:foo', testPatient.id));
+        expect(data.id).to.equal(uuid('resource:field:foo', testPatient.id));
         expect(data.attributes.name).to.equal('foo');
         expect(data.attributes.value).to.deep.equal(['one', 'two']);
       })
@@ -459,7 +457,7 @@ context('Noncontext Form', function() {
       .click()
       .wait('@routePatchPatientFieldBar')
       .its('request.body.data.id')
-      .should('equal', uuidv5('resource:field:bar', testPatient.id))
+      .should('equal', uuid('resource:field:bar', testPatient.id))
       .wait(100);
 
     cy
@@ -474,7 +472,7 @@ context('Noncontext Form', function() {
       .click()
       .wait('@routePatchPatientFieldBazinga')
       .its('request.body.data.id')
-      .should('equal', uuidv5('resource:field:bazinga', testPatient.id))
+      .should('equal', uuid('resource:field:bazinga', testPatient.id))
       .wait(100);
 
     cy

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -588,7 +588,6 @@ context('App Nav', function() {
     const testNewPatientId = uuid();
 
     const testClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Test Clinician',
         email: 'test.clinician@roundingwell.com',

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
@@ -962,7 +961,6 @@ context('patient archive page', function() {
 
   specify('work with work:team:manage permission', function() {
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1646,7 +1646,6 @@ context('patient dashboard page', function() {
       })
       .routeCurrentClinician(fx => {
         fx.data = getCurrentClinician({
-          id: uuid(),
           attributes: {
             enabled: true,
           },
@@ -1788,7 +1787,6 @@ context('patient dashboard page', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1190,7 +1190,6 @@ context('patient flow page', function() {
   specify('flow owner assignment', function() {
     const currentClinician = getCurrentClinician();
     const otherClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Other Clinician',
       },
@@ -1440,7 +1439,6 @@ context('patient flow page', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },
@@ -2554,7 +2552,6 @@ context('patient flow page', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },
@@ -2640,7 +2637,7 @@ context('patient flow page', function() {
     const testSocketFileId = uuid();
     const testComment = getComment();
 
-    const testClinician = getClinician({ id: uuid() });
+    const testClinician = getClinician();
 
     const testSocketFlow = getFlow({
       attributes: {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -29,7 +29,6 @@ context('action sidebar', function() {
 
     const currentClinician = getCurrentClinician();
     const testClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Another Clinician',
       },
@@ -1255,7 +1254,7 @@ context('action sidebar', function() {
               message: 'Message from Someone Else',
             },
             relationships: {
-              clinician: getRelationship(getClinician({ id: uuid() })),
+              clinician: getRelationship(getClinician()),
             },
           }),
         ];
@@ -2054,7 +2053,6 @@ context('action sidebar', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },
@@ -2169,7 +2167,7 @@ context('action sidebar', function() {
         name: 'Not authored by Current User',
       },
       relationships: {
-        author: getRelationship(getClinician({ id: uuid() })),
+        author: getRelationship(getClinician()),
         state: getRelationship(stateInProgress),
         owner: getRelationship(teamCoordinator),
       },
@@ -2238,7 +2236,7 @@ context('action sidebar', function() {
       },
     });
 
-    const otherClinician = getClinician({ id: uuid() });
+    const otherClinician = getClinician();
 
     const testFlow = getFlow({
       relationships: {
@@ -2339,7 +2337,6 @@ context('action sidebar', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/sidebar/flow-sidebar.js
+++ b/test/integration/patients/sidebar/flow-sidebar.js
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { getRelationship, getErrors } from 'helpers/json-api';
 
@@ -148,7 +146,6 @@ context('flow sidebar', function() {
         fx.data = [
           currentClinician,
           getClinician({
-            id: uuid(),
             relationships: {
               team: getRelationship(teamCoordinator),
             },
@@ -676,7 +673,6 @@ context('flow sidebar', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -1,5 +1,3 @@
-import { v4 as uuid } from 'uuid';
-
 import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDateAdd } from 'helpers/test-date';
@@ -1334,7 +1332,6 @@ context('Worklist bulk editing', function() {
     });
 
     const nonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -425,7 +425,6 @@ context('schedule page', function() {
     const testTime = dayjs(testDate()).hour(12).valueOf();
 
     const testClinician = getClinician({
-      id: uuidv4(),
       attributes: { name: 'Test Clinician' },
       relationships: {
         team: getRelationship(teamNurse),
@@ -1718,7 +1717,6 @@ context('schedule page', function() {
     });
 
     const testNonTeamMemberClincian = getClinician({
-      id: uuidv4(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1820,7 +1820,6 @@ context('worklist page', function() {
     const testCurrentClinician = getCurrentClinician({ relationships });
 
     const testClinician = getClinician({
-      id: uuid(),
       attributes: { name: 'Test Clinician' },
       relationships,
     });
@@ -1831,22 +1830,18 @@ context('worklist page', function() {
           testCurrentClinician,
           testClinician,
           getClinician({
-            id: uuid(),
             attributes: { name: 'C Clinician' },
             relationships,
           }),
           getClinician({
-            id: uuid(),
             attributes: { name: 'A Clinician' },
             relationships,
           }),
           getClinician({
-            id: uuid(),
             attributes: { name: 'B Clinician' },
             relationships,
           }),
           getClinician({
-            id: uuid(),
             attributes: { name: 'Admin Clinician' },
             relationships: {
               team: getRelationship(teamCoordinator),
@@ -1969,7 +1964,6 @@ context('worklist page', function() {
     const testClinicians = [
       getCurrentClinician({ relationships }),
       getClinician({
-        id: uuid(),
         attributes: { name: 'Test Clinician' },
         relationships: {
           team: getRelationship(teamCoordinator),
@@ -1977,17 +1971,14 @@ context('worklist page', function() {
         },
       }),
       getClinician({
-        id: uuid(),
         attributes: { name: 'C Clinician' },
         relationships,
       }),
       getClinician({
-        id: uuid(),
         attributes: { name: 'A Clinician' },
         relationships,
       }),
       getClinician({
-        id: uuid(),
         attributes: { name: 'B Clinician' },
         relationships,
       }),
@@ -4503,7 +4494,7 @@ context('worklist page', function() {
           name: 'Different Owner',
         },
         relationships: {
-          owner: getRelationship(getClinician({ id: uuid() })),
+          owner: getRelationship(getClinician()),
           state: getRelationship(stateTodo),
         },
       },
@@ -4691,7 +4682,6 @@ context('worklist page', function() {
     });
 
     const testTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Team Member',
       },
@@ -4701,7 +4691,6 @@ context('worklist page', function() {
     });
 
     const testNonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },
@@ -4816,7 +4805,6 @@ context('worklist page', function() {
     });
 
     const testNonTeamMemberClinician = getClinician({
-      id: uuid(),
       attributes: {
         name: 'Non Team Member',
       },

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -1,4 +1,6 @@
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
+
 import { testTs } from 'helpers/test-timestamp';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
@@ -28,7 +30,7 @@ export function getCurrentClinician(data, { depth = 0 } = {}) {
 function getFixture(data) {
   if (!data) return _.sample(fxClinicians);
 
-  if (!data.id) throw new Error('Clinician id must be specified for overriding getClinician');
+  if (!data.id) data = _.extend({ id: uuid() }, data);
 
   return _.find(fxClinicians, { id: data.id }) || _.extend({}, _.sample(fxClinicians), { id: data.id });
 }


### PR DESCRIPTION
Shortcut Story ID: [sc-54617]

Two overarching changes to the tests:

1. Use hardcoded uuids in the clinician json fixture file.
2. Make it so `getClinician()` no longer requires that an `id` be sent with the data. It will automatically generate a `id: uuid()` if it's not included. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified test data setup by removing explicit ID assignments for clinicians in multiple test suites. Tests now rely on default or internally generated IDs.
  - Updated clinician fixture data to use UUIDs instead of numeric string IDs.
  - Improved test data helpers to automatically generate UUIDs for clinicians when not provided, reducing manual setup.
  - No changes to application logic or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->