### PR TITLE
Use the QuickSight AWS SDK to load dashboard iframe content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@fortawesome/pro-thin-svg-icons": "^6.4.0",
         "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
         "@workos-inc/authkit-js": "^0.10.1",
+        "amazon-quicksight-embedding-sdk": "^2.10.0",
         "animejs": "^3.2.1",
         "backbone": "^1.4.0",
         "backbone.eventrouter": "^1.0.1",
@@ -3878,6 +3879,30 @@
       "dependencies": {
         "css.escape": "^1.5.0",
         "platform": "1.3.3"
+      }
+    },
+    "node_modules/amazon-quicksight-embedding-sdk": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/amazon-quicksight-embedding-sdk/-/amazon-quicksight-embedding-sdk-2.10.0.tgz",
+      "integrity": "sha512-cYS1yjVMJFu8JqKGEk9v3meZI7SfbVIrJpeK1DIUVWyl/YpqMvcop8pCzMtTjuZ1XWF/z5G/I98VzadXrMQ66A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "punycode": "^2.1.1",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/amazon-quicksight-embedding-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/animejs": {
@@ -9863,7 +9888,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
     "@fortawesome/pro-thin-svg-icons": "^6.4.0",
     "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
     "@workos-inc/authkit-js": "^0.10.1",
+    "amazon-quicksight-embedding-sdk": "^2.10.0",
     "animejs": "^3.2.1",
     "backbone": "^1.4.0",
     "backbone.eventrouter": "^1.0.1",

--- a/src/js/views/dashboards/dashboard_views.js
+++ b/src/js/views/dashboards/dashboard_views.js
@@ -1,5 +1,6 @@
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
+import * as QuicksightEmbedding from 'amazon-quicksight-embedding-sdk';
 
 import { View } from 'marionette';
 
@@ -25,7 +26,20 @@ const ContextTrailView = View.extend({
 
 const IframeView = View.extend({
   className: 'flex-grow',
-  template: hbs`<iframe src="{{ embed_url }}"></iframe>`,
+  template: hbs`<div class="js-dashboard-container"></div>`,
+  ui: {
+    dashboardContainer: '.js-dashboard-container',
+  },
+  onRender() {
+    QuicksightEmbedding.createEmbeddingContext().then((embeddingContext => {
+      embeddingContext.embedDashboard({
+        url: this.model.get('embed_url'),
+        container: this.el,
+        height: '100%',
+        width: '100%',
+      });
+    }));
+  },
 });
 
 const LayoutView = View.extend({

--- a/src/js/views/dashboards/dashboard_views.js
+++ b/src/js/views/dashboards/dashboard_views.js
@@ -26,11 +26,8 @@ const ContextTrailView = View.extend({
 
 const IframeView = View.extend({
   className: 'flex-grow',
-  template: hbs`<div class="js-dashboard-container"></div>`,
-  ui: {
-    dashboardContainer: '.js-dashboard-container',
-  },
-  onRender() {
+  template: false,
+  initialize() {
     QuicksightEmbedding.createEmbeddingContext().then((embeddingContext => {
       embeddingContext.embedDashboard({
         url: this.model.get('embed_url'),

--- a/test/fixtures/config/dashboards.js
+++ b/test/fixtures/config/dashboards.js
@@ -1,10 +1,13 @@
 import faker from '@roundingwellos/faker';
 
 export default () => {
+  const id = faker.datatype.uuid();
+
   return {
-    id: faker.datatype.uuid(),
+    id,
     name: faker.name.title(),
     description: faker.lorem.sentences(),
-    embed_url: faker.internet.url(),
+    embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ id }?identityprovider=quicksight`,
   };
 };
+

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -6,10 +6,13 @@ import { getDashboard } from 'support/api/dashboards';
 
 context('dashboard', function() {
   specify('display dashboard', function() {
+    const testDashboardId = uuid();
+
     const testDashboard = getDashboard({
+      id: testDashboardId,
       attributes: {
         name: 'Test Dashboard',
-        embed_url: '/test_dashboard',
+        embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
       },
     });
 
@@ -19,6 +22,9 @@ context('dashboard', function() {
         fx.data = testDashboard;
 
         return fx;
+      })
+      .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
+        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
       })
       .visit(`/dashboards/${ testDashboard.id }`)
       .wait('@routeDashboard');
@@ -31,7 +37,8 @@ context('dashboard', function() {
     cy
       .get('.dashboard__frame')
       .find('.dashboard__iframe iframe')
-      .should('have.attr', 'src', '/test_dashboard');
+      .should('have.attr', 'src')
+      .and('include', `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?`);
 
     cy
       .get('.dashboard__frame')

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -18,7 +18,7 @@ context('dashboard', function() {
         return fx;
       })
       .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
-        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
+        req.reply('<html><body>Test Iframe Content</body></html>');
       })
       .visit(`/dashboards/${ testDashboard.id }`)
       .wait('@routeDashboard');

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -6,14 +6,8 @@ import { getDashboard } from 'support/api/dashboards';
 
 context('dashboard', function() {
   specify('display dashboard', function() {
-    const testDashboardId = uuid();
-
     const testDashboard = getDashboard({
-      id: testDashboardId,
-      attributes: {
-        name: 'Test Dashboard',
-        embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
-      },
+      attributes: { name: 'Test Dashboard' },
     });
 
     cy
@@ -38,7 +32,7 @@ context('dashboard', function() {
       .get('.dashboard__frame')
       .find('.dashboard__iframe iframe')
       .should('have.attr', 'src')
-      .and('include', `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?`);
+      .and('include', `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboard.id }?`);
 
     cy
       .get('.dashboard__frame')

--- a/test/integration/dashboards/dashboards-all.js
+++ b/test/integration/dashboards/dashboards-all.js
@@ -1,11 +1,7 @@
-import { v4 as uuid } from 'uuid';
-
 import { getDashboard } from 'support/api/dashboards';
 
 context('dashboards all list', function() {
   specify('display dashboards list', function() {
-    const testDashboardId = uuid();
-
     const testDashboards = [
       getDashboard({
         attributes: { name: 'Daily Dashboards' },
@@ -14,11 +10,7 @@ context('dashboards all list', function() {
         attributes: { name: 'Weekly Dashboard' },
       }),
       getDashboard({
-        id: testDashboardId,
-        attributes: {
-          name: 'Monthly Dashboard',
-          embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
-        },
+        attributes: { name: 'Monthly Dashboard' },
       }),
     ];
 
@@ -74,15 +66,9 @@ context('dashboards all list', function() {
   });
 
   specify('find in list', function() {
-    const testDashboardId = uuid();
-
     const testDashboards = [
       getDashboard({
-        id: testDashboardId,
-        attributes: {
-          name: 'Daily Dashboards',
-          embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
-        },
+        attributes: { name: 'Daily Dashboards' },
       }),
       getDashboard({
         attributes: { name: 'Weekly Dashboard' },

--- a/test/integration/dashboards/dashboards-all.js
+++ b/test/integration/dashboards/dashboards-all.js
@@ -1,7 +1,11 @@
+import { v4 as uuid } from 'uuid';
+
 import { getDashboard } from 'support/api/dashboards';
 
 context('dashboards all list', function() {
   specify('display dashboards list', function() {
+    const testDashboardId = uuid();
+
     const testDashboards = [
       getDashboard({
         attributes: { name: 'Daily Dashboards' },
@@ -10,7 +14,11 @@ context('dashboards all list', function() {
         attributes: { name: 'Weekly Dashboard' },
       }),
       getDashboard({
-        attributes: { name: 'Monthly Dashboard' },
+        id: testDashboardId,
+        attributes: {
+          name: 'Monthly Dashboard',
+          embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
+        },
       }),
     ];
 
@@ -24,6 +32,9 @@ context('dashboards all list', function() {
         fx.data = testDashboards[2];
 
         return fx;
+      })
+      .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
+        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
       })
       .visit('/dashboards')
       .wait('@routeDashboards');
@@ -63,9 +74,15 @@ context('dashboards all list', function() {
   });
 
   specify('find in list', function() {
+    const testDashboardId = uuid();
+
     const testDashboards = [
       getDashboard({
-        attributes: { name: 'Daily Dashboards' },
+        id: testDashboardId,
+        attributes: {
+          name: 'Daily Dashboards',
+          embed_url: `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboardId }?identityprovider=quicksight`,
+        },
       }),
       getDashboard({
         attributes: { name: 'Weekly Dashboard' },
@@ -82,6 +99,9 @@ context('dashboards all list', function() {
         fx.data = testDashboards[0];
 
         return fx;
+      })
+      .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
+        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
       })
       .visit('/dashboards')
       .wait('@routeDashboards');

--- a/test/integration/dashboards/dashboards-all.js
+++ b/test/integration/dashboards/dashboards-all.js
@@ -26,7 +26,7 @@ context('dashboards all list', function() {
         return fx;
       })
       .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
-        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
+        req.reply('<html><body>Test Iframe Content</body></html>');
       })
       .visit('/dashboards')
       .wait('@routeDashboards');
@@ -87,7 +87,7 @@ context('dashboards all list', function() {
         return fx;
       })
       .intercept('GET', 'https://*.quicksight.aws.amazon.com/**', req => {
-        req.reply('<html><body class="test-iframe-content">Test Iframe Content</body></html>');
+        req.reply('<html><body>Test Iframe Content</body></html>');
       })
       .visit('/dashboards')
       .wait('@routeDashboards');


### PR DESCRIPTION
Shortcut Story ID: [sc-61175]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dashboards are now embedded using Amazon QuickSight's official embedding SDK, providing a more dynamic and integrated experience.
- **Bug Fixes**
  - Ensured dashboard IDs and embed URLs are consistently matched in test fixtures.
- **Tests**
  - Updated integration tests to accommodate the new embedding method and mock external QuickSight requests for reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->