### PR TITLE
Use `scrollbar-gutter` css property for action/flow/patient sidebars

### DIFF
--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -1,7 +1,8 @@
 .worklist-patient-sidebar {
   border-left: 1px solid #{$black-90};
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 16px 8px;
+  scrollbar-gutter: stable both-edges;
   width: 256px;
 }
 

--- a/src/scss/modules/sidebar.scss
+++ b/src/scss/modules/sidebar.scss
@@ -1,7 +1,8 @@
 .sidebar {
   border-left: 1px solid #{$black-90};
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 16px 12px;
+  scrollbar-gutter: stable both-edges;
   width: 400px;
 }
 


### PR DESCRIPTION
Shortcut Story ID: [sc-61623]

To fix layout shift that happens as a result of the browser scrollbar.

Video screengrab of the fix, where layout no longer shifts in these sidebars:

https://github.com/user-attachments/assets/3451b1ba-d031-4c15-a8c7-cbf82670fe1d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Reduced horizontal padding in sidebars for a more compact layout.
	- Improved sidebar stability by reserving space for scrollbars, preventing layout shifts when scrollbars appear or disappear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->