### PR TITLE
Scroll patient sidebar independently

### DIFF
--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -13,6 +13,7 @@
   background: #{$black-95};
   display: flex;
   flex: 1;
+  height: 100vh;
   opacity: 0;
 
   &:not(:empty) {

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -271,7 +271,7 @@ const LayoutView = View.extend({
     },
   },
   template: hbs`
-    <div>
+    <div class="patient__tabs">
       <button class="patient__tab js-dashboard">
         {{~ @intl.patients.patient.archive.archiveViews.dashboardBtn ~}}
       </button>
@@ -279,7 +279,9 @@ const LayoutView = View.extend({
         {{~ @intl.patients.patient.archive.archiveViews.archiveBtn ~}}
       </span>
     </div>
-    <div data-content-region></div>
+    <div class="patient__list-container flex-region">
+      <div data-content-region></div>
+    </div>
   `,
   triggers: {
     'click .js-dashboard': 'click:dashboard',

--- a/src/js/views/patients/patient/dashboard/layout.hbs
+++ b/src/js/views/patients/patient/dashboard/layout.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="patient__tabs">
   <span class="patient__tab--selected">
     {{~ @intl.patients.patient.dashboard.dashboardViews.dashboardBtn ~}}
   </span>
@@ -6,12 +6,16 @@
     {{~ @intl.patients.patient.dashboard.dashboardViews.archiveBtn ~}}
   </button>
 </div>
-<div class="patient__actions" data-add-workflow-region>
-  <span class="button-primary">
-    <span class="js-loading">
-      {{far "circle-plus"}}
-      <span>{{ @intl.patients.patient.dashboard.dashboardViews.actionLoading }}</span>
+<div class="patient__actions-container">
+  <div class="patient__actions" data-add-workflow-region>
+    <span class="button-primary">
+      <span class="js-loading">
+        {{far "circle-plus"}}
+        <span>{{ @intl.patients.patient.dashboard.dashboardViews.actionLoading }}</span>
+      </span>
     </span>
-  </span>
+  </div>
 </div>
-<div data-content-region></div>
+<div class="patient__list-container flex-region">
+  <div data-content-region></div>
+</div>

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -357,12 +357,16 @@ const LayoutView = View.extend({
   template: hbs`
     <div class="patient-flow__layout">
       <div data-context-trail-region></div>
-      <div data-header-region></div>
-      <div class="patient-flow__actions">
-        <div data-select-all-region></div>
-        <div data-tools-region></div>
+      <div class="patient-flow__header-container" data-header-region></div>
+      <div class="patient-flow__actions-container">
+        <div class="patient-flow__actions">
+          <div data-select-all-region></div>
+          <div data-tools-region></div>
+        </div>
       </div>
-      <div data-action-list-region></div>
+      <div class="patient-flow__list-container flex-region">
+        <div data-action-list-region></div>
+      </div>
     </div>
     <div class="patient-flow__sidebar" data-sidebar-region></div>
   `,

--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -1,6 +1,7 @@
 .patient-flow__frame {
   display: flex;
   flex: 1;
+  height: 100vh;
 }
 
 .patient-flow__layout {
@@ -8,7 +9,7 @@
   flex: 1;
   flex-direction: column;
   min-width: 744px;
-  padding: 0 24px;
+  padding: 0 12px;
   width: 100%;
 }
 
@@ -23,7 +24,7 @@
   background: #{$white};
   color: #{$black-20};
   line-height: 1;
-  padding: 16px 0;
+  padding: 16px 20px;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -45,6 +46,10 @@
   &:hover {
     color: color(blue);
   }
+}
+
+.patient-flow__header-container {
+  padding: 0 20px;
 }
 
 .patient-flow__header {
@@ -85,9 +90,19 @@
   width: 562px;
 }
 
+.patient-flow__actions-container {
+  padding: 0 20px;
+}
+
 .patient-flow__actions {
   border-top: #{$black-90} 1px solid;
   padding: 16px 0;
+}
+
+.patient-flow__list-container {
+  overflow-y: auto;
+  padding: 0 8px;
+  scrollbar-gutter: stable both-edges;
 }
 
 .patient-flow__list {

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -1,6 +1,7 @@
 .patient__frame {
   display: flex;
   flex: 1;
+  height: 100vh;
 }
 
 .patient__layout {
@@ -8,7 +9,7 @@
   flex: 1;
   flex-direction: column;
   min-width: 744px;
-  padding: 0 24px;
+  padding: 0 12px;
   width: 100%;
 }
 
@@ -29,7 +30,7 @@
 
   // NOTE: Margin added for alignment with sidebar icon & patient name.
   margin-bottom: 6px;
-  padding: 16px 0;
+  padding: 16px 20px;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -51,6 +52,10 @@
   &:hover {
     color: color(blue);
   }
+}
+
+.patient__tabs {
+  padding: 0 20px;
 }
 
 .patient__tab,
@@ -87,9 +92,19 @@
   }
 }
 
+.patient__actions-container {
+  padding: 0 20px;
+}
+
 .patient__actions {
   border-top: solid 1px #{$black-90};
   padding: 16px 0;
+}
+
+.patient__list-container {
+  overflow-y: auto;
+  padding: 0 8px;
+  scrollbar-gutter: stable both-edges;
 }
 
 .patient__list {

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -1,7 +1,7 @@
 .patient-sidebar {
   border-left: 1px solid #{$black-90};
   overflow-y: auto;
-  padding: 52px 16px 0;
+  padding: 52px 12px 0;
   position: relative;
   scrollbar-gutter: stable both-edges;
   width: 256px;

--- a/src/js/views/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/views/patients/patient/sidebar/patient-sidebar.scss
@@ -1,7 +1,9 @@
 .patient-sidebar {
   border-left: 1px solid #{$black-90};
-  padding: 52px 24px 0;
+  overflow-y: auto;
+  padding: 52px 16px 0;
   position: relative;
+  scrollbar-gutter: stable both-edges;
   width: 256px;
 }
 

--- a/src/js/views/patients/sidebar/patient/patient-sidebar.scss
+++ b/src/js/views/patients/sidebar/patient/patient-sidebar.scss
@@ -1,7 +1,7 @@
 .worklist-patient-sidebar {
   border-left: 1px solid #{$black-90};
   overflow-y: auto;
-  padding: 16px 8px;
+  padding: 16px 12px;
   scrollbar-gutter: stable both-edges;
   width: 256px;
 }


### PR DESCRIPTION
- Shortcut Story ID: [sc-61626] [sc-61625]

Needs to be done on:

- [x] Form page
- [x] Patient dashboard page
- [x] Patient archive page
- [x] Flow page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout consistency and spacing across patient-related views and sidebars.
  - Added new container classes to enhance structure and scrolling behavior for patient lists and actions.
  - Set key frames and layouts to fill the viewport height for a more consistent appearance.
  - Adjusted sidebar padding and introduced stable scrollbar gutters to prevent layout shifts during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->