### PR TITLE
Extract formio related postMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,9 +158,7 @@
     "exclude": [
       "src/**/*.cy.js",
       "src/js/base/**/*.js",
-      "src/js/auth.js",
       "src/js/auth/*.js",
-      "src/js/formapp.js",
       "src/js/formapp/**/*.js",
       "src/js/index.js",
       "src/js/datadog.js",

--- a/package.json
+++ b/package.json
@@ -159,11 +159,9 @@
       "src/**/*.cy.js",
       "src/js/base/**/*.js",
       "src/js/auth.js",
-      "src/js/auth0.js",
       "src/js/auth/*.js",
       "src/js/formapp.js",
       "src/js/formapp/**/*.js",
-      "src/js/formservice.js",
       "src/js/index.js",
       "src/js/datadog.js",
       "src/js/config.js"

--- a/src/js/auth/index.js
+++ b/src/js/auth/index.js
@@ -1,9 +1,9 @@
 import Radio from 'backbone.radio';
 
-import * as auth0 from './auth/auth0';
-import * as none from './auth/none';
-import * as kinde from './auth/kinde';
-import * as workos from './auth/workos';
+import * as auth0 from './auth0';
+import * as none from './none';
+import * as kinde from './kinde';
+import * as workos from './workos';
 
 import 'scss/app-root.scss';
 

--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -1,26 +1,10 @@
-import { get, size } from 'underscore';
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
 const TYPE = 'forms';
-
-const defaultReducer = `
-  const subm = _.extend({ patient: {} }, formSubmission,  formData);
-
-  subm.patient.fields = _.extend({}, _.get(formSubmission, 'patient.fields'), _.get(formData, 'patient.fields'));
-
-  return subm;
-`;
-
-const defaultSubmitReducer = `
-  formData.fields = formSubmission.fields || _.get(formSubmission, 'patient.fields');
-
-  return formData;
-`;
-
-const defaultBeforeSubmit = 'return formSubmission;';
 
 const _Model = BaseModel.extend({
   type: TYPE,
@@ -33,32 +17,6 @@ const _Model = BaseModel.extend({
   },
   isSubmitHidden() {
     return get(this.get('options'), 'submit_hidden');
-  },
-  getContext() {
-    return {
-      contextScripts: this.getContextScripts(),
-      loaderReducers: this.getLoaderReducers(),
-      changeReducers: this.getChangeReducers(),
-      beforeSubmit: this.getBeforeSubmit(),
-      submitReducers: this.getSubmitReducers(),
-    };
-  },
-  getContextScripts() {
-    return get(this.get('options'), 'context', []);
-  },
-  getLoaderReducers() {
-    return get(this.get('options'), 'reducers', [defaultReducer]);
-  },
-  getChangeReducers() {
-    return get(this.get('options'), 'changeReducers', []);
-  },
-  getBeforeSubmit() {
-    return get(this.get('options'), 'beforeSubmit', defaultBeforeSubmit);
-  },
-  getSubmitReducers() {
-    const submitReducers = get(this.get('options'), 'submitReducers');
-
-    return size(submitReducers) ? submitReducers : [defaultSubmitReducer];
   },
   getWidgets() {
     const formWidgets = get(this.get('options'), ['widgets', 'widgets']);

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -1,4 +1,4 @@
-/* global Formio, FormioUtils */
+/* global Formio */
 import 'formiojs/dist/formio.form.min';
 import 'formiojs/dist/formio.form.css';
 import '@fortawesome/fontawesome-pro/scss/fontawesome.scss';
@@ -20,6 +20,7 @@ import intl from 'js/i18n';
 import { versions } from './config';
 
 import {
+  getBeforeSubmit,
   getScriptContext,
   getSubmission,
   getChangeReducers,
@@ -88,10 +89,12 @@ const onChange = function(form, changeReducers) {
 
 const onChangeDebounce = debounce(onChange, 100);
 
-async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, responseData, loaderReducers, changeReducers, submitReducers, contextScripts, beforeSubmit }) {
-  const evalContext = await getContext(contextScripts);
+async function renderForm({ definition, isReadOnly, storedSubmission, formData, formSubmission, responseData, options }) {
+  const { reducers, changeReducers, submitReducers, context, beforeSubmit } = options;
 
-  const submission = storedSubmission || await getSubmission(formData, formSubmission, responseData, loaderReducers, evalContext);
+  const evalContext = await getContext(context);
+
+  const submission = storedSubmission || await getSubmission(formData, formSubmission, responseData, reducers, evalContext);
   prevSubmission = structuredClone(submission);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
@@ -148,7 +151,7 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
       return;
     }
 
-    const data = FormioUtils.evaluate(beforeSubmit, form.evalContext({ formSubmission: response.data }));
+    const data = getBeforeSubmit(form, beforeSubmit, response.data);
 
     if (!data) {
       router.trigger('form:errors', [intl.formapp.failedSubmit]);
@@ -176,8 +179,8 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
 }
 
 
-async function renderResponse({ definition, formSubmission, contextScripts }) {
-  const evalContext = await getContext(contextScripts);
+async function renderResponse({ definition, formSubmission, options }) {
+  const evalContext = await getContext(options.context);
 
   extend(evalContext, { isResponse: true });
 
@@ -192,10 +195,11 @@ async function renderResponse({ definition, formSubmission, contextScripts }) {
   });
 }
 
-async function renderPdf({ definition, formData, formSubmission, responseData, loaderReducers, contextScripts }) {
-  const evalContext = await getContext(contextScripts);
+async function renderPdf({ definition, formData, formSubmission, responseData, options }) {
+  const { reducers, context } = options;
+  const evalContext = await getContext(context);
 
-  const submission = await getSubmission(formData, formSubmission, responseData, loaderReducers, evalContext);
+  const submission = await getSubmission(formData, formSubmission, responseData, reducers, evalContext);
 
   const form = await Formio.createForm(document.getElementById('root'), definition, {
     evalContext,

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -175,13 +175,6 @@ async function renderForm({ definition, isReadOnly, storedSubmission, formData, 
   form._isReady = true;
 }
 
-async function renderPreview({ definition, contextScripts }) {
-  const evalContext = await getContext(contextScripts);
-
-  extend(evalContext, { isPreview: true });
-
-  Formio.createForm(document.getElementById('root'), definition, { evalContext });
-}
 
 async function renderResponse({ definition, formSubmission, contextScripts }) {
   const evalContext = await getContext(contextScripts);
@@ -309,16 +302,12 @@ const Router = Backbone.Router.extend({
   },
   routes: {
     'formapp/': 'renderForm',
-    'formapp/preview': 'renderPreview',
     'formapp/:id': 'renderResponse',
     'formapp/pdf/action/:actionId': 'renderActionPdf',
     'formapp/pdf/:formId/:patientId(/:responseId)': 'renderPdf',
   },
   renderForm() {
     this.request('fetch:form:data').then(renderForm);
-  },
-  renderPreview() {
-    this.request('fetch:form').then(renderPreview);
   },
   renderResponse(responseId) {
     this.request('fetch:form:response', { responseId }).then(renderResponse);

--- a/src/js/formapp.js
+++ b/src/js/formapp.js
@@ -311,10 +311,20 @@ const Router = Backbone.Router.extend({
     'formapp/pdf/:formId/:patientId(/:responseId)': 'renderPdf',
   },
   renderForm() {
-    this.request('fetch:form:data').then(renderForm);
+    Promise.all([
+      this.request('fetch:form:definition'),
+      this.request('fetch:form:data'),
+    ]).then(([definition, data]) => {
+      renderForm({ definition, ...data });
+    });
   },
   renderResponse(responseId) {
-    this.request('fetch:form:response', { responseId }).then(renderResponse);
+    Promise.all([
+      this.request('fetch:form:definition'),
+      this.request('fetch:form:response', { responseId }),
+    ]).then(([definition, data]) => {
+      renderResponse({ definition, ...data });
+    });
   },
   renderActionPdf(actionId) {
     this.once('form:pdf', renderPdf);

--- a/src/js/formapp/index.js
+++ b/src/js/formapp/index.js
@@ -17,7 +17,7 @@ import { addError } from 'js/datadog';
 
 import intl from 'js/i18n';
 
-import { versions } from './config';
+import { versions } from '../config';
 
 import {
   getBeforeSubmit,
@@ -25,9 +25,9 @@ import {
   getSubmission,
   getChangeReducers,
   getResponse,
-} from 'js/formapp/utils';
+} from './utils';
 
-import 'js/formapp/components';
+import './components';
 
 import 'scss/formapp/comment.scss';
 import 'scss/formapp/form.scss';

--- a/src/js/formapp/utils.js
+++ b/src/js/formapp/utils.js
@@ -1,6 +1,22 @@
 /* global Formio, FormioUtils */
-import { extend, reduce, values } from 'underscore';
+import { extend, reduce, values, size } from 'underscore';
 import { addError } from 'js/datadog';
+
+const defaultLoaderReducers = [`
+  const subm = _.extend({ patient: {} }, formSubmission,  formData);
+
+  subm.patient.fields = _.extend({}, _.get(formSubmission, 'patient.fields'), _.get(formData, 'patient.fields'));
+
+  return subm;
+`];
+
+const defaultSubmitReducers = [`
+  formData.fields = formSubmission.fields || _.get(formSubmission, 'patient.fields');
+
+  return formData;
+`];
+
+const defaultBeforeSubmit = 'return formSubmission;';
 
 // Mostly disables formio translations
 Formio.Components.components.htmlelement.prototype.t = txt => txt;
@@ -51,7 +67,7 @@ function getScriptContext(contextScripts, baseContext) {
   });
 }
 
-function getSubmission(formData, formSubmission, responseData, reducers, evalContext) {
+function getSubmission(formData, formSubmission, responseData, reducers = defaultLoaderReducers, evalContext) {
   return Formio.createForm(document.createElement('div'), {}, { evalContext }).then(form => {
     const submission = reduce(reducers, (memo, reducer) => {
       return FormioUtils.evaluate(reducer, form.evalContext({ formSubmission: memo, formData, responseData })) || memo;
@@ -76,6 +92,8 @@ function getChangeReducers(form, changeReducers, curSubmission, prevSubmission) 
 function getResponse(form, submitReducers, formSubmission) {
   const formData = { fields: {}, action: {}, flow: {}, artifacts: {} };
 
+  if (!size(submitReducers)) submitReducers = defaultSubmitReducers;
+
   return reduce(submitReducers, (memo, reducer) => {
     const context = form.evalContext({ formSubmission, formData: memo });
     const reducerFunction = evaluator(reducer, context);
@@ -85,7 +103,12 @@ function getResponse(form, submitReducers, formSubmission) {
   }, formData);
 }
 
+function getBeforeSubmit(form, beforeSubmit = defaultBeforeSubmit, formSubmission) {
+  return FormioUtils.evaluate(beforeSubmit, form.evalContext({ formSubmission }));
+}
+
 export {
+  getBeforeSubmit,
   getScriptContext,
   getSubmission,
   getChangeReducers,

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -8,6 +8,7 @@ import App from 'js/base/app';
 
 import 'js/entities-service';
 
+// TODO: Move definition request to optional
 const ActionFormApp = App.extend({
   beforeStart({ actionId }) {
     return [

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -27,8 +27,7 @@ const ActionFormApp = App.extend({
           formData: data.attributes,
           responseData: response.getFormData(),
           formSubmission: response.getResponse(),
-          contextScripts: form.getContextScripts(),
-          loaderReducers: form.getLoaderReducers(),
+          options: form.get('options'),
         } }, window.origin);
       });
   },
@@ -61,8 +60,7 @@ const FormApp = App.extend({
       formData: data.attributes,
       responseData: response.getFormData(),
       formSubmission: response.getResponse(),
-      contextScripts: form.getContextScripts(),
-      loaderReducers: form.getLoaderReducers(),
+      options: form.get('options'),
     } }, window.origin);
   },
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,7 +21,7 @@ function startOutreach() {
 }
 
 function startForm() {
-  import('./formapp')
+  import('./formapp/index')
     .then(({ startFormApp }) => {
       startFormApp();
     });
@@ -42,7 +42,7 @@ function startFormService() {
 }
 
 function startAuth() {
-  import('./auth')
+  import('./auth/index')
     .then(({ auth }) => {
       auth(start);
     });

--- a/src/js/outreach/apps/form_app.js
+++ b/src/js/outreach/apps/form_app.js
@@ -51,7 +51,7 @@ export default App.extend({
       definition: this.definition,
       formData: this.formData,
       formSubmission: {},
-      ...this.form.getContext(),
+      options: this.form.get('options'),
     });
   },
   showFormSaveDisabled() {

--- a/src/js/outreach/apps/form_app.js
+++ b/src/js/outreach/apps/form_app.js
@@ -17,7 +17,6 @@ export default App.extend({
   beforeStart({ actionId }) {
     return [
       Radio.request('entities', 'fetch:forms:byAction', actionId),
-      Radio.request('entities', 'fetch:forms:definition:byAction', actionId),
       Radio.request('entities', 'fetch:forms:data', actionId),
     ];
   },
@@ -27,10 +26,9 @@ export default App.extend({
     dialogView.showChildView('content', new ErrorView());
     this.showView(dialogView);
   },
-  onStart({ actionId }, form, definition, data) {
+  onStart({ actionId }, form, data) {
     this.actionId = actionId;
     this.form = form;
-    this.definition = definition;
     this.formData = data.attributes;
     this.setView(new iFrameFormView({ model: this.form }));
     this.startService();
@@ -44,11 +42,18 @@ export default App.extend({
       'ready:form': this.showFormSave,
       'submit:form': this.submitForm,
       'fetch:form:data': this.getFormPrefill,
+      'fetch:form:definition': this.getFormDefinition,
     }, this);
+  },
+  getFormDefinition() {
+    const fetchFormDefinition = Radio.request('entities', 'fetch:forms:definition', this.form.id);
+
+    fetchFormDefinition.then(definition => {
+      this.channel.request('send', 'fetch:form:definition', definition);
+    });
   },
   getFormPrefill() {
     this.channel.request('send', 'fetch:form:data', {
-      definition: this.definition,
       formData: this.formData,
       formSubmission: {},
       options: this.form.get('options'),

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -49,7 +49,7 @@ export default App.extend({
     'submit:form': 'submitForm',
     'fetch:clinicians': 'fetchClinicians',
     'fetch:directory': 'fetchDirectory',
-
+    'fetch:form:definition': 'fetchFormDefinition',
     'fetch:form:data': 'fetchFormPrefill',
     'fetch:form:response': 'fetchFormResponse',
     'update:storedSubmission': 'updateStoredSubmission',
@@ -91,6 +91,8 @@ export default App.extend({
     return (this.latestResponse && this.latestResponse.getDraft()) || {};
   },
   getStoredSubmission() {
+    if (this.isReadOnly()) return {};
+
     const draft = this.getLatestDraft();
     const localDraft = store.get(this.getStoreId()) || {};
 
@@ -181,68 +183,49 @@ export default App.extend({
         this.channelRequest('send', 'fetch:icd', { error: responseData, requestId });
       });
   },
-  fetchFormStoreSubmission({ submission }) {
-    return Promise.all([
-      Radio.request('entities', 'fetch:forms:definition', this.form.id),
-    ]).then(([definition]) => {
-      this.channelRequest('send', 'fetch:form:data', {
-        definition,
-        storedSubmission: submission,
-        options: this.form.get('options'),
-      });
+  fetchFormDefinition() {
+    const fetchFormDefinition = Radio.request('entities', 'fetch:forms:definition', this.form.id);
+
+    fetchFormDefinition.then(definition => {
+      this.channelRequest('send', 'fetch:form:definition', definition);
     });
   },
-  _getPrefillFilters(form, action, flow) {
+  fetchOtherFormResponse(flow) {
     const flowId = flow && flow.id;
-    const patientId = action.getPatient().id;
-    const actionTags = form.getPrefillActionTag();
-    const formId = !actionTags && form.getPrefillFormId();
-    const submittedAt = form.isReport() && `<=${ action.get('created_at') }`;
+    const patientId = this.action.getPatient().id;
+    const actionTags = this.form.getPrefillActionTag();
+    const formId = !actionTags && this.form.getPrefillFormId();
+    const submittedAt = this.form.isReport() && `<=${ this.action.get('created_at') }`;
 
-    return { patientId, flowId, formId, actionTags, submittedAt };
+    return Radio.request('entities', 'fetch:formResponses:byPatient', { patientId, flowId, formId, actionTags, submittedAt });
   },
-  fetchLatestFormSubmission(flow) {
-    const isReadOnly = this.isReadOnly();
-    const filter = this._getPrefillFilters(this.form, this.action, flow);
-
-    return Promise.all([
-      Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      Radio.request('entities', 'fetch:forms:data', this.action.id, this.patient.id, this.form.id),
-      Radio.request('entities', 'fetch:formResponses:byPatient', filter),
-    ]).then(([definition, data, response]) => {
-      this.channelRequest('send', 'fetch:form:data', {
-        definition,
-        isReadOnly,
-        formData: data.attributes,
-        responseData: response.getFormData(),
-        formSubmission: response.getResponse(),
-        options: this.form.get('options'),
-      });
-    });
-  },
-  fetchFormPrefill() {
-    const storedSubmission = this.getStoredSubmission();
-    const isReadOnly = this.isReadOnly();
-
-    if (!isReadOnly && storedSubmission.updated) {
-      return this.fetchFormStoreSubmission(storedSubmission);
-    }
-
+  fetchLatestFormResponse() {
     const firstResponse = this.responses && this.responses.getFirstSubmission();
 
     if (!firstResponse && this.action) {
-      if (this.action.hasTag('prefill-latest-response')) return this.fetchLatestFormSubmission();
-      if (this.action.hasTag('prefill-flow-response')) return this.fetchLatestFormSubmission(this.action.getFlow());
+      if (this.action.hasTag('prefill-latest-response')) return this.fetchOtherFormResponse();
+      if (this.action.hasTag('prefill-flow-response')) return this.fetchOtherFormResponse(this.action.getFlow());
     }
 
-    return Promise.all([
-      Radio.request('entities', 'fetch:forms:definition', this.form.id),
-      Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
-      Radio.request('entities', 'fetch:formResponses:model', get(firstResponse, 'id')),
-    ]).then(([definition, data, response]) => {
+    return Radio.request('entities', 'fetch:formResponses:model', get(firstResponse, 'id'));
+  },
+  fetchFormPrefill() {
+    const storedSubmission = this.getStoredSubmission();
+
+    if (storedSubmission.updated) {
       this.channelRequest('send', 'fetch:form:data', {
-        definition,
-        isReadOnly,
+        storedSubmission: storedSubmission.submission,
+        options: this.form.get('options'),
+      });
+      return;
+    }
+
+    Promise.all([
+      Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
+      this.fetchLatestFormResponse(),
+    ]).then(([data, response]) => {
+      this.channelRequest('send', 'fetch:form:data', {
+        isReadOnly: this.isReadOnly(),
         formData: data.attributes,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
@@ -252,11 +235,9 @@ export default App.extend({
   },
   fetchFormResponse({ responseId }) {
     return Promise.all([
-      Radio.request('entities', 'fetch:forms:definition', this.form.id),
       Radio.request('entities', 'fetch:formResponses:model', responseId),
-    ]).then(([definition, response]) => {
+    ]).then(([response]) => {
       this.channelRequest('send', 'fetch:form:response', {
-        definition,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         options: this.form.get('options'),

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -1,4 +1,4 @@
-import { map, get, debounce, omit } from 'underscore';
+import { map, get, debounce } from 'underscore';
 import dayjs from 'dayjs';
 import store from 'store';
 
@@ -188,7 +188,7 @@ export default App.extend({
       this.channelRequest('send', 'fetch:form:data', {
         definition,
         storedSubmission: submission,
-        ...omit(this.form.getContext(), 'loaderReducers'),
+        options: this.form.get('options'),
       });
     });
   },
@@ -216,7 +216,7 @@ export default App.extend({
         formData: data.attributes,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
-        ...this.form.getContext(),
+        options: this.form.get('options'),
       });
     });
   },
@@ -246,7 +246,7 @@ export default App.extend({
         formData: data.attributes,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
-        ...this.form.getContext(),
+        options: this.form.get('options'),
       });
     });
   },
@@ -259,7 +259,7 @@ export default App.extend({
         definition,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
-        contextScripts: this.form.getContextScripts(),
+        options: this.form.get('options'),
       });
     });
   },

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -2,66 +2,89 @@ import { testTs } from 'helpers/test-timestamp';
 import { getRelationship } from 'helpers/json-api';
 
 import { getAction } from 'support/api/actions';
-import { getForm } from 'support/api/forms';
 import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
+import { getFormFields } from 'support/api/form-fields';
 import { getFormResponse } from 'support/api/form-responses';
+import { getForm, testForm } from 'support/api/forms';
+
+const testPatient = getPatient();
 
 context('Formservice', function() {
   specify('display form with a response', function() {
-    cy
-      .visit('/formapp/pdf/1/1/1', { noWait: true, isRoot: true });
-
-    cy
-      .get('iframe')
-      .should('have.attr', 'src', '/formservice/1/1/1');
-
-    cy
-      .window()
-      .then(win => {
-        win.postMessage({ message: 'form:pdf', args: {
-          definition: {
-            components: [
-              {
-                key: 'fields.insurance',
-                type: 'container',
-                input: true,
-                label: 'Insurance',
-                tableView: false,
-                components: [
-                  {
-                    key: 'name',
-                    type: 'textfield',
-                    input: true,
-                    label: 'Insurance Name',
-                    tableView: true,
-                  },
-                ],
-              },
-            ],
-          },
-          formData: {
-            fields: {
-              insurance: {
-                name: 'Show the form submission',
-              },
-            },
-          },
-          formSubmission: {
+    const testFormResponse = getFormResponse({
+      attributes: {
+        response: {
+          data: {
             fields: {
               insurance: {
                 name: 'Test Insurance Name',
               },
             },
           },
-          contextScripts: {},
-          reducers: [],
-        } }, win.origin);
+        },
+      },
+    });
+
+    cy
+      .routeForm(fx => {
+        fx.data = testForm;
+
+        return fx;
+      })
+      .routeFormDefinition(fx => {
+        return {
+          display: 'form',
+          components: [
+            {
+              key: 'fields.insurance',
+              type: 'container',
+              input: true,
+              label: 'Insurance',
+              tableView: false,
+              components: [
+                {
+                  key: 'name',
+                  type: 'textfield',
+                  input: true,
+                  label: 'Insurance Name',
+                  tableView: true,
+                },
+              ],
+            },
+          ],
+        };
+      })
+      .routeFormFields(fx => {
+        fx.data = getFormFields({
+          attributes: {
+            fields: {
+              insurance: {
+                name: 'Show the form submission',
+              },
+            },
+          },
+        });
+
+        return fx;
+      })
+      .routeFormResponse(() => {
+        return {
+          data: testFormResponse,
+        };
       });
+
+
+    cy
+      .visit(`/formapp/pdf/${ testForm.id }/${ testPatient.id }/${ testFormResponse.id }`, { noWait: true, isRoot: true })
+      .wait('@routeForm')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields')
+      .wait('@routeFormResponse');
 
     cy
       .get('[name="data[fields.insurance][name]"]')
-      .should('have.value', 'Test Insurance Name');
+      .should('have.value', 'Show the form submission');
   });
 
   specify('formservice iframe makes correct api requests', function() {
@@ -101,67 +124,10 @@ context('Formservice', function() {
       .wait('@routeFormResponse');
   });
 
-  specify('display action form with a response', function() {
-    cy
-      .visit('/formapp/pdf/action/1', { noWait: true, isRoot: true });
-
-    cy
-      .get('iframe')
-      .should('have.attr', 'src', '/formservice/action/1');
-
-    cy
-      .window()
-      .then(win => {
-        win.postMessage({ message: 'form:pdf', args: {
-          definition: {
-            components: [
-              {
-                key: 'fields.insurance',
-                type: 'container',
-                input: true,
-                label: 'Insurance',
-                tableView: false,
-                components: [
-                  {
-                    key: 'name',
-                    type: 'textfield',
-                    input: true,
-                    label: 'Insurance Name',
-                    tableView: true,
-                  },
-                ],
-              },
-            ],
-          },
-          formData: {
-            fields: {
-              insurance: {
-                name: 'Use form submission',
-              },
-            },
-          },
-          formSubmission: {
-            fields: {
-              insurance: {
-                name: 'Test Insurance Name',
-              },
-            },
-          },
-          contextScripts: {},
-          reducers: [],
-        } }, win.origin);
-      });
-
-    cy
-      .get('[name="data[fields.insurance][name]"]')
-      .should('have.value', 'Test Insurance Name');
-  });
-
   specify('action formservice latest response from action tags', function() {
     const createdAt = testTs();
 
     const testFlow = getFlow();
-    const testPatient = getPatient();
 
     const testReportForm = getForm({
       attributes: {
@@ -214,7 +180,64 @@ context('Formservice', function() {
     cy
       .intercept('GET', '/api/actions/1/form', {
         statusCode: 200,
-        body: { data: getForm() },
+        body: { data: getForm({
+          attributes: {
+            options: {
+              is_report: true,
+            },
+          },
+        }) },
+      })
+      .as('routeFormModelByAction');
+
+    cy
+      .intercept('GET', '/api/actions/1/form/definition', {
+        statusCode: 200,
+        body: { data: {} },
+      })
+      .as('routeFormDefinitionByAction');
+
+    cy
+      .intercept('GET', '/api/actions/1/form/fields', {
+        statusCode: 200,
+        body: { data: [] },
+      })
+      .as('routeActionFormFields');
+
+    cy
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 200,
+        body: { data: getAction() },
+      })
+      .as('routeAction');
+
+    cy
+      .intercept('GET', '/api/patients/**/form-responses/submitted*', {
+        statusCode: 200,
+        body: { data: getFormResponse() },
+      })
+      .as('routeLatestFormSubmission');
+
+    cy
+      .visit('/formservice/action/1', { noWait: true, isRoot: true })
+      .wait('@routeFormModelByAction')
+      .wait('@routeFormDefinitionByAction')
+      .wait('@routeActionFormFields')
+      .wait('@routeAction')
+      .wait('@routeLatestFormSubmission');
+  });
+
+  specify('action non-report formservice iframe makes correct api requests', function() {
+    cy
+      .intercept('GET', '/api/actions/1/form', {
+        statusCode: 200,
+        body: { data: getForm({
+          attributes: {
+            options: {
+              is_report: false,
+            },
+          },
+        }) },
       })
       .as('routeFormModelByAction');
 

--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -237,7 +237,7 @@ context('Outreach', function() {
 
         return fx;
       })
-      .routeFormActionDefinition()
+      .routeFormDefinition()
       .routeFormActionFields()
       .visit(`/outreach/${ testAction.id }`, { noWait: true, isRoot: true })
       .wait('@routeOutreachStatus');
@@ -547,7 +547,7 @@ context('Outreach', function() {
 
         return fx;
       })
-      .routeFormActionDefinition()
+      .routeFormDefinition()
       .routeFormActionFields(fx => {
         fx.data = getFormFields({
           attributes: {
@@ -605,7 +605,7 @@ context('Outreach', function() {
       .wait('@routeVerifyCodeRequest')
       .wait('@routeFormByAction')
       .wait('@routeFormActionFields')
-      .wait('@routeFormActionDefinition');
+      .wait('@routeFormDefinition');
 
     cy
       .get('.form__title')
@@ -695,7 +695,7 @@ context('Outreach', function() {
 
         return fx;
       })
-      .routeFormActionDefinition()
+      .routeFormDefinition()
       .routeFormActionFields(fx => {
         fx.data = getFormFields({
           attributes: {
@@ -746,7 +746,7 @@ context('Outreach', function() {
       .click()
       .wait('@routeVerifyCodeRequest')
       .wait('@routeFormByAction')
-      .wait('@routeFormActionDefinition')
+      .wait('@routeFormDefinition')
       .wait('@routeFormActionFields');
 
     cy
@@ -776,7 +776,7 @@ context('Outreach', function() {
         });
       })
       .routeFormByAction()
-      .routeFormActionDefinition()
+      .routeFormDefinition()
       .routeFormActionFields()
       .visit(`/outreach/${ testAction.id }`, { noWait: true, isRoot: true });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-61768]

I move all form.io specific code from the main app window, which mostly affected the form entity with the exception of a few form service postMessage requests, but those requests are now separate from the other requests.

I also moved auth and formapp into it's own directory which keeps things a little more extractable if we choose to do so.

This does not fully account for the pdf forms which still request the form definition on load.. this may need a separate solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined form data fetching and prefill logic for improved efficiency and reduced redundant requests.
  - Simplified and unified the handling of form options and context across form rendering, messaging, and service communication.
  - Adjusted import paths and consolidated utility usage for better maintainability.
  - Updated form rendering to fetch definitions and data concurrently, improving load performance.
  - Removed deprecated preview functionality and redundant methods.

- **New Features**
  - Introduced default scripts for loading, submitting, and pre-submitting form data to ensure consistent data processing.
  - Added on-demand form definition fetching to decouple it from app startup.

- **Bug Fixes**
  - Improved handling of read-only forms and submission retrieval for more accurate data presentation.

- **Tests**
  - Enhanced and expanded integration tests for form services, including new scenarios with thorough API route stubbing and fixture usage.
  - Removed deprecated tests and improved coverage of action formservice workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->