### PR TITLE
Support custom url form

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -18,6 +18,9 @@ const _Model = BaseModel.extend({
   isSubmitHidden() {
     return get(this.get('options'), 'submit_hidden');
   },
+  getFormUrl() {
+    return get(this.get('options'), 'url');
+  },
   getWidgets() {
     const formWidgets = get(this.get('options'), ['widgets', 'widgets']);
 

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -188,10 +188,17 @@ const LayoutView = View.extend({
 const IframeView = View.extend({
   behaviors: [IframeFormBehavior],
   className: 'form__content',
-  template: hbs`<iframe src="/formapp/{{#if responseId}}{{ responseId }}{{/if}}"></iframe>`,
+  getTemplate() {
+    const url = this.model.getFormUrl();
+
+    if (url) return hbs`<iframe src="{{ url }}{{#if responseId}}?responseId={{ responseId }}{{/if}}"></iframe>`;
+
+    return hbs`<iframe src="/formapp/{{#if responseId}}{{ responseId }}{{/if}}"></iframe>`;
+  },
   templateContext() {
     return {
       responseId: this.getOption('responseId'),
+      url: this.model.getFormUrl(),
     };
   },
 });

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -618,6 +618,38 @@ context('Noncontext Form', function() {
       .should('contain', 'Error');
   });
 
+  specify('form custom url', { retries: 4 }, function() {
+    const testCustomForm = getForm({
+      attributes: {
+        options: {
+          url: '/images/roundingwell-logo.svg',
+        },
+      },
+    });
+
+    cy
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeForm(fx => {
+        fx.data = testCustomForm;
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routeLatestFormResponse()
+      .routeFormFields()
+      .visit(`/patient/${ testPatient.id }/form/${ testCustomForm.id }`)
+      .wait('@routePatient')
+      .wait('@routeForm');
+
+    cy
+      .get('iframe')
+      .should('have.attr', 'src', '/images/roundingwell-logo.svg');
+  });
+
   specify('form scripts and reducers', { retries: 4 }, function() {
     const testScriptReducerForm = getForm({
       attributes: {


### PR DESCRIPTION
Shortcut Story ID: [sc-61787]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying forms using a custom URL, allowing forms to be rendered from external sources when a URL is provided.
- **Bug Fixes**
  - Improved iframe template selection to dynamically use a custom URL if available, falling back to the default path otherwise.
- **Tests**
  - Added an integration test to verify that forms with a custom URL are correctly rendered using the specified URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->