### PR TITLE
Replace our custom `fixWidth()` method with `scrollbar-gutter` css property

### DIFF
--- a/src/js/views/patients/worklist/layout.hbs
+++ b/src/js/views/patients/worklist/layout.hbs
@@ -13,6 +13,6 @@
       <span class="worklist-list__filter-sort" data-sort-region></span>
     </div>
   </div>
-  <table class="worklist__header w-100 js-list-header" data-table-region></table>
+  <table class="worklist__header w-100" data-table-region></table>
 </div>
-<div class="flex-region list-page__list js-list" data-list-region></div>
+<div class="flex-region list-page__list" data-list-region></div>

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -47,31 +47,11 @@ const LayoutView = View.extend({
     search: '[data-search-region]',
     count: '[data-count-region]',
   },
-  childViewEvents: {
-    'update:listDom': 'fixWidth',
-  },
   triggers: {
     'click @ui.select': 'click:select',
   },
   ui: {
-    listHeader: '.js-list-header',
-    list: '.js-list',
     select: '.js-select',
-  },
-  initialize() {
-    const userActivityCh = Radio.channel('user-activity');
-    this.listenTo(userActivityCh, 'window:resize', this.fixWidth);
-  },
-  fixWidth() {
-    /* istanbul ignore if */
-    if (!this.isRendered()) return;
-
-    const headerWidth = this.ui.listHeader.width();
-    const listWidth = this.ui.list.contents().width();
-    const listPadding = parseInt(this.ui.list.css('paddingRight'), 10);
-    const scrollbarWidth = headerWidth - listWidth;
-
-    this.ui.list.css({ paddingRight: `${ listPadding - scrollbarWidth }px` });
   },
 });
 
@@ -317,14 +297,11 @@ const ListView = CollectionView.extend({
     this.listenTo(state, 'change:searchQuery', this.searchList);
   },
   onAttach() {
-    this.triggerMethod('update:listDom', this);
-
     this.searchList(null, this.state.get('searchQuery'));
   },
   /* istanbul ignore next: future proof */
   onRenderChildren() {
     if (!this.isAttached()) return;
-    this.triggerMethod('update:listDom', this);
     this.triggerMethod('filtered', this.children.map('model'));
   },
   onSelect(selectedView, isShiftKeyPressed) {

--- a/src/scss/modules/list-pages.scss
+++ b/src/scss/modules/list-pages.scss
@@ -11,7 +11,8 @@
 
 .list-page__list {
   overflow-y: auto;
-  padding: 0 24px;
+  padding: 0 12px;
+  scrollbar-gutter: stable both-edges;
 }
 
 .list-page__title {


### PR DESCRIPTION
Shortcut Story ID: [sc-61785]

For setting the width of the list when the list is scrollable (scrollbar is present).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Reduced left and right padding on the list view for a more compact appearance.
	- Improved scrollbar handling to prevent layout shifts when scrollbars appear or disappear.
- **Refactor**
	- Simplified the list view layout by removing unnecessary CSS classes and layout adjustment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->