### PR TITLE
In tests, verify web socket subscription filters & resources data on page load

### DIFF
--- a/test/fixtures/test/states.json
+++ b/test/fixtures/test/states.json
@@ -58,17 +58,5 @@
       "icon": "arrow-right-arrow-left",
       "color": "purple"
     }
-  },
-  {
-    "id": "0a520cc9-a745-4f63-af63-03261c16948b",
-    "name": "Evernorth",
-    "slug": "evernorth",
-    "sequence": 500,
-    "status": "done",
-    "options": {
-      "iconType": "far",
-      "icon": "circle-dashed",
-      "color": "purple"
-    }
   }
 ]

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -472,10 +472,7 @@ context('patient archive page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const patient = testPatient.id;
         const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();
@@ -720,10 +717,7 @@ context('patient archive page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const patient = testPatient.id;
         const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { NIL as NIL_UUID } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateSubtract } from 'helpers/test-date';
@@ -10,7 +11,7 @@ import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
 import { workspaceOne } from 'support/api/workspaces';
 import { testForm } from 'support/api/forms';
-import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransferred } from 'support/api/states';
+import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransferred, stateEvernorth } from 'support/api/states';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
@@ -473,6 +474,24 @@ context('patient archive page', function() {
       .get('@wsHandleMessage')
       .should('have.been.calledOnce');
 
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const patient = testPatient.id;
+        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          actions: { states, patient, flow: NIL_UUID },
+          flows: { states, patient },
+        });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketFlow).data,
+        ]);
+      });
+
     // state was set to be not done, which means it's removed from the list
     cy.sendWs({
       category: 'StateChanged',
@@ -702,6 +721,24 @@ context('patient archive page', function() {
     cy
       .get('@wsHandleMessage')
       .should('have.been.calledOnce');
+
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const patient = testPatient.id;
+        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          actions: { states, patient, flow: NIL_UUID },
+          flows: { states, patient },
+        });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketAction).data,
+        ]);
+      });
 
     // state was set to done, which means it's removed from the list
     cy.sendWs({

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -11,7 +11,7 @@ import { getFlow } from 'support/api/flows';
 import { getPatient } from 'support/api/patients';
 import { workspaceOne } from 'support/api/workspaces';
 import { testForm } from 'support/api/forms';
-import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransferred, stateEvernorth } from 'support/api/states';
+import { stateDone, stateInProgress, stateTodo, stateUnableToComplete, stateThmgTransferred } from 'support/api/states';
 import { getClinician, getCurrentClinician } from 'support/api/clinicians';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
@@ -475,7 +475,7 @@ context('patient archive page', function() {
       .should('have.been.calledOnce')
       .then(stub => {
         const patient = testPatient.id;
-        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();
+        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id].join();
 
         const { filters, resources } = stub.getCall(0).args[0].data;
 
@@ -720,7 +720,7 @@ context('patient archive page', function() {
       .should('have.been.calledOnce')
       .then(stub => {
         const patient = testPatient.id;
-        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id, stateEvernorth.id].join();
+        const states = [stateDone.id, stateUnableToComplete.id, stateThmgTransferred.id].join();
 
         const { filters, resources } = stub.getCall(0).args[0].data;
 

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1073,11 +1073,17 @@ context('patient dashboard page', function() {
       .then(stub => {
         const states = [stateTodo.id, stateInProgress.id].join();
         const patient = testPatient.id;
-        const { filters } = stub.getCall(0).args[0].data;
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
         expect(filters).to.deep.equal({
           actions: { states, patient, flow: NIL_UUID },
           flows: { states, patient },
         });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketFlow).data,
+        ]);
       });
 
     cy.sendWs({
@@ -1347,6 +1353,24 @@ context('patient dashboard page', function() {
     cy
       .get('@wsHandleMessage')
       .should('have.been.calledOnce');
+
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const states = [stateTodo.id, stateInProgress.id].join();
+        const patient = testPatient.id;
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          actions: { states, patient, flow: NIL_UUID },
+          flows: { states, patient },
+        });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketAction).data,
+        ]);
+      });
 
     cy.sendWs({
       category: 'NameChanged',

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1066,10 +1066,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const states = [stateTodo.id, stateInProgress.id].join();
         const patient = testPatient.id;
@@ -1352,10 +1349,7 @@ context('patient dashboard page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const states = [stateTodo.id, stateInProgress.id].join();
         const patient = testPatient.id;

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2699,6 +2699,7 @@ context('patient flow page', function() {
 
     cy
       .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const { filters, resources } = stub.getCall(0).args[0].data;
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -2700,7 +2700,13 @@ context('patient flow page', function() {
     cy
       .get('@wsHandleMessage')
       .then(stub => {
-        expect(stub.getCall(0).args[0].data.resources).to.deep.equal([
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          actions: { flow: testSocketFlow.id },
+        });
+
+        expect(resources).to.deep.equal([
           getRelationship(testSocketFlow).data,
           getRelationship(testSocketAction).data,
         ]);

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -395,10 +395,7 @@ context('worklist page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const startOfMonth = dayjs().startOf('month').format();
         const endOfMonth = dayjs().endOf('month').format();
@@ -1298,10 +1295,7 @@ context('worklist page', function() {
 
     cy
       .get('@wsHandleMessage')
-      .should('have.been.calledOnce');
-
-    cy
-      .get('@wsHandleMessage')
+      .should('have.been.calledOnce')
       .then(stub => {
         const startOfMonth = dayjs().startOf('month').format();
         const endOfMonth = dayjs().endOf('month').format();

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -397,6 +397,27 @@ context('worklist page', function() {
       .get('@wsHandleMessage')
       .should('have.been.calledOnce');
 
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const startOfMonth = dayjs().startOf('month').format();
+        const endOfMonth = dayjs().endOf('month').format();
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          flows: {
+            created_at: [startOfMonth, endOfMonth].join(),
+            states: NIL_UUID,
+            clinicians: currentClinician.id,
+          },
+        });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketFlow).data,
+        ]);
+      });
+
     cy.sendWs({
       category: 'NameChanged',
       resource: {
@@ -1278,6 +1299,29 @@ context('worklist page', function() {
     cy
       .get('@wsHandleMessage')
       .should('have.been.calledOnce');
+
+    cy
+      .get('@wsHandleMessage')
+      .then(stub => {
+        const startOfMonth = dayjs().startOf('month').format();
+        const endOfMonth = dayjs().endOf('month').format();
+        const states = [stateTodo.id, stateInProgress.id].join();
+
+        const { filters, resources } = stub.getCall(0).args[0].data;
+
+        expect(filters).to.deep.equal({
+          actions: {
+            created_at: [startOfMonth, endOfMonth].join(),
+            states,
+            flow_states: states,
+            clinicians: currentClinician.id,
+          },
+        });
+
+        expect(resources).to.deep.equal([
+          getRelationship(testSocketAction).data,
+        ]);
+      });
 
     cy.sendWs({
       category: 'NameChanged',

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -26,7 +26,6 @@ export const stateInProgress = getStateBySlug('in-progress');
 export const stateDone = getStateBySlug('done');
 export const stateUnableToComplete = getStateBySlug('unable-to-complete');
 export const stateThmgTransferred = getStateBySlug('thmg-transferred');
-export const stateEvernorth = getStateBySlug('evernorth');
 
 Cypress.Commands.add('routeStates', (mutator = _.identity) => {
   const data = getStates();

--- a/test/support/api/states.js
+++ b/test/support/api/states.js
@@ -26,6 +26,7 @@ export const stateInProgress = getStateBySlug('in-progress');
 export const stateDone = getStateBySlug('done');
 export const stateUnableToComplete = getStateBySlug('unable-to-complete');
 export const stateThmgTransferred = getStateBySlug('thmg-transferred');
+export const stateEvernorth = getStateBySlug('evernorth');
 
 Cypress.Commands.add('routeStates', (mutator = _.identity) => {
   const data = getStates();


### PR DESCRIPTION
Shortcut Story ID: [sc-61834]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced integration tests for patient archive, dashboard, flow, and worklist pages with more detailed assertions to verify correct WebSocket subscription payloads, including filters and resources.
- **Chores**
  - Updated test fixture data by removing one state entry from the states JSON file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->