### PR TITLE
Fix spacing for info section of clinician sidebar

### DIFF
--- a/src/js/views/clinicians/sidebar/clinician-sidebar.hbs
+++ b/src/js/views/clinicians/sidebar/clinician-sidebar.hbs
@@ -6,5 +6,5 @@
 <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.clinicians.sidebar.clinicianSidebarTemplate.role }}</h4><div class="flex-grow" data-role-region></div></div>
 <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.clinicians.sidebar.clinicianSidebarTemplate.team }}</h4><div class="flex-grow" data-team-region></div></div>
 <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.clinicians.sidebar.clinicianSidebarTemplate.workspaces }}</h4><div class="flex-grow clinician-sidebar__workspaces" data-workspaces-region></div></div>
-<div class="flex u-margin--t-8"><div class="flex-grow" data-info-region></div></div>
+<div class="flex u-margin--t-8"><div class="sidebar__label u-margin--t-8"></div><div class="flex-grow" data-info-region></div></div>
 <div class="flex u-margin--t-8"><div class="flex-grow" data-worklist-region></div></div>

--- a/src/scss/modules/sidebar.scss
+++ b/src/scss/modules/sidebar.scss
@@ -38,6 +38,7 @@
 .sidebar__label {
   color: #{$black-60};
   display: inline-block;
+  flex-shrink: 0;
   font-size: 12px;
   font-weight: 600;
   line-height: 1.2;
@@ -67,7 +68,6 @@
   font-size: 12px;
   line-height: 16px;
   margin-top: 8px;
-  max-width: 232px;
   padding: 8px;
 
   .icon {


### PR DESCRIPTION
Shortcut Story ID: [sc-61849]

Bug screenshot:

<img width="393" alt="Screenshot 2025-05-22 at 4 01 40 PM" src="https://github.com/user-attachments/assets/edca1c0c-23ea-4c3a-aaeb-c69875f417f7" />

Fix screenshot: 

<img width="396" alt="Screenshot 2025-05-22 at 4 00 42 PM" src="https://github.com/user-attachments/assets/b6e12dae-7fcf-4ea5-9a3e-e8d0264aaef1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted sidebar layout to include a label area, improving alignment with other sections.
  - Updated sidebar styles to prevent label shrinking and allow content region to expand beyond previous width limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->