### PR TITLE
Simplify form services requests

### DIFF
--- a/src/js/behaviors/iframe-form.js
+++ b/src/js/behaviors/iframe-form.js
@@ -11,9 +11,9 @@ export default Behavior.extend({
     this.channel = Radio.channel(`form${ this.view.model.id }`);
   },
   replies: {
-    send(message, args = {}) {
+    send(message, args = {}, requestId) {
       const iframeWindow = this.ui.iframe[0].contentWindow;
-      iframeWindow.postMessage({ message, args }, window.origin);
+      iframeWindow.postMessage({ message, args, requestId }, window.origin);
     },
     focus() {
       Radio.trigger('user-activity', 'iframe:focus', this.ui.iframe[0]);
@@ -27,7 +27,7 @@ export default Behavior.extend({
       /* istanbul ignore next: security check */
       if (origin !== window.origin || !data || !data.message) return;
 
-      this.channel.request(data.message, data.args);
+      this.channel.request(data.message, data.args, data.requestId);
     });
   },
   onBeforeDetach() {

--- a/src/js/formapp/index.js
+++ b/src/js/formapp/index.js
@@ -8,7 +8,7 @@ import 'scss/formapp/bootstrap.min.css';
 
 import 'scss/formapp-core.scss';
 
-import { extend, map, debounce, uniqueId, each, isEmpty, isObject } from 'underscore';
+import { extend, map, debounce, each, isEmpty, isObject } from 'underscore';
 import $ from 'jquery';
 import Backbone from 'backbone';
 import Handlebars from 'handlebars/runtime';
@@ -44,25 +44,25 @@ function scrollTop() {
 }
 
 function updateField(fieldName, value) {
-  return router.updateField({ fieldName, value });
+  return router.request('update:field', { fieldName, value });
 }
 
 function getField(fieldName) {
-  return router.getField({ fieldName });
+  return router.request('fetch:field', { fieldName });
 }
 
 function getClinicians({ teamId } = {}) {
-  return router.getClinicians({ teamId });
+  return router.request('fetch:clinicians', { teamId });
 }
 
 function getDirectory(directoryName, query) {
-  return router.getDirectory({ directoryName, query });
+  return router.request('fetch:directory', { directoryName, query });
 }
 
 function getIcd(by) {
   // NOTE: Backwards compatible API
-  if (!isObject(by)) return router.getIcd({ by: { term: by } });
-  return router.getIcd({ by });
+  const args = isObject(by) ? { by } : { by: { term: by } };
+  return router.request('fetch:icd', args);
 }
 
 function getContext(contextScripts) {
@@ -211,98 +211,39 @@ async function renderPdf({ definition, formData, formSubmission, responseData, o
 
 const Router = Backbone.Router.extend({
   initialize() {
+    this.pending = {};
+
     window.addEventListener('message', ({ data, origin }) => {
       /* istanbul ignore next: security check */
-      if (origin !== window.origin || !data || !data.message) return;
+      if (origin !== window.origin || !data || !data.message || !data.args) return;
 
-      this.trigger(data.message, data.args);
+      const { value, error } = data.args;
+
+      if (this.pending[data.requestId]) {
+        const { resolve, reject } = this.pending[data.requestId];
+        delete this.pending[data.requestId];
+
+        error ? reject(error) : resolve(value);
+      }
+
+      this.trigger(data.message, error || value);
     }, false);
 
     $(window).on('focus', () => {
-      this.request('focus');
+      this.send('focus');
     });
 
-    this.request('version', versions.frontend);
-    this.requestResolves = {};
-    this.on({
-      'fetch:clinicians': this.onFetchClinicians,
-      'fetch:directory': this.onFetchDirectory,
-      'fetch:field': this.onFetchField,
-      'update:field': this.onUpdateField,
-      'fetch:icd': this.onFetchIcd,
-    });
+    this.send('version', versions.frontend);
+  },
+  send(message, args = {}) {
+    parent.postMessage({ message, args }, window.origin);
   },
   request(message, args = {}) {
-    const request = new Promise(resolve => {
-      this.once(message, resolve);
-      parent.postMessage({ message, args }, window.origin);
+    const requestId = crypto.randomUUID();
+    return new Promise((resolve, reject) => {
+      this.pending[requestId] = { resolve, reject, message };
+      parent.postMessage({ message, args, requestId }, window.origin);
     });
-
-    return request;
-  },
-  requestValue({ args, message, requestId }) {
-    const request = new Promise((resolve, reject) => {
-      this.requestResolves[requestId] = { resolve, reject };
-      parent.postMessage({
-        message,
-        args: extend({ requestId }, args),
-      }, window.origin);
-    });
-
-    return request;
-  },
-  resolveValue({ value, error, requestId }) {
-    // Prevents an edge case where a request is resolved
-    // after the form is submitted and reloaded
-    if (!this.requestResolves[requestId]) return;
-    const { resolve, reject } = this.requestResolves[requestId];
-    delete this.requestResolves[requestId];
-    error ? reject(error) : resolve(value);
-  },
-  getClinicians(args) {
-    const message = 'fetch:clinicians';
-    const requestId = uniqueId('clinicians');
-
-    return this.requestValue({ args, message, requestId });
-  },
-  onFetchClinicians(args) {
-    this.resolveValue(args);
-  },
-  getDirectory(args) {
-    const message = 'fetch:directory';
-    const requestId = uniqueId('directory');
-
-    return this.requestValue({ args, message, requestId });
-  },
-  onFetchDirectory(args) {
-    this.resolveValue(args);
-  },
-  getField(args) {
-    const message = 'fetch:field';
-    const requestId = uniqueId('field');
-
-    return this.requestValue({ args, message, requestId });
-  },
-  onFetchField(args) {
-    this.resolveValue(args);
-  },
-  updateField(args) {
-    const message = 'update:field';
-    const requestId = uniqueId('field');
-
-    return this.requestValue({ args, message, requestId });
-  },
-  onUpdateField(args) {
-    this.resolveValue(args);
-  },
-  getIcd(args) {
-    const message = 'fetch:icd';
-    const requestId = uniqueId('icd');
-
-    return this.requestValue({ args, message, requestId });
-  },
-  onFetchIcd(args) {
-    this.resolveValue(args);
   },
   routes: {
     'formapp/': 'renderForm',

--- a/src/js/formapp/index.js
+++ b/src/js/formapp/index.js
@@ -211,7 +211,7 @@ async function renderPdf({ definition, formData, formSubmission, responseData, o
 
 const Router = Backbone.Router.extend({
   initialize() {
-    this.pending = {};
+    this.pending = new Map();
 
     window.addEventListener('message', ({ data, origin }) => {
       /* istanbul ignore next: security check */
@@ -219,9 +219,9 @@ const Router = Backbone.Router.extend({
 
       const { value, error } = data.args;
 
-      if (this.pending[data.requestId]) {
-        const { resolve, reject } = this.pending[data.requestId];
-        delete this.pending[data.requestId];
+      if (this.pending.has(data.requestId)) {
+        const { resolve, reject } = this.pending.get(data.requestId);
+        this.pending.delete(data.requestId);
 
         error ? reject(error) : resolve(value);
       }
@@ -241,7 +241,7 @@ const Router = Backbone.Router.extend({
   request(message, args = {}) {
     const requestId = crypto.randomUUID();
     return new Promise((resolve, reject) => {
-      this.pending[requestId] = { resolve, reject, message };
+      this.pending.set(requestId, { resolve, reject });
       parent.postMessage({ message, args, requestId }, window.origin);
     });
   },

--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -23,13 +23,13 @@ const ActionFormApp = App.extend({
 
     return Promise.resolve(Radio.request('entities', 'fetch:formResponses:byPatient', filter))
       .then(response => {
-        parent.postMessage({ message: 'form:pdf', args: {
+        parent.postMessage({ message: 'form:pdf', args: { value: {
           definition,
           formData: data.attributes,
           responseData: response.getFormData(),
           formSubmission: response.getResponse(),
           options: form.get('options'),
-        } }, window.origin);
+        } } }, window.origin);
       });
   },
   _getPrefillFilters(form, action) {
@@ -56,13 +56,13 @@ const FormApp = App.extend({
     ];
   },
   onStart(opts, form, definition, data, response) {
-    parent.postMessage({ message: 'form:pdf', args: {
+    parent.postMessage({ message: 'form:pdf', args: { value: {
       definition,
       formData: data.attributes,
       responseData: response.getFormData(),
       formSubmission: response.getResponse(),
       options: form.get('options'),
-    } }, window.origin);
+    } } }, window.origin);
   },
 });
 

--- a/src/js/outreach/apps/form_app.js
+++ b/src/js/outreach/apps/form_app.js
@@ -41,23 +41,23 @@ export default App.extend({
     this.channel.reply({
       'ready:form': this.showFormSave,
       'submit:form': this.submitForm,
-      'fetch:form:data': this.getFormPrefill,
-      'fetch:form:definition': this.getFormDefinition,
+      'fetch:form:data': this.getFormData,
+      'fetch:form:definition': this.fetchFormDefinition,
     }, this);
   },
-  getFormDefinition() {
+  fetchFormDefinition(args, requestId) {
     const fetchFormDefinition = Radio.request('entities', 'fetch:forms:definition', this.form.id);
 
     fetchFormDefinition.then(definition => {
-      this.channel.request('send', 'fetch:form:definition', definition);
+      this.channel.request('send', 'fetch:form:definition', { value: definition }, requestId);
     });
   },
-  getFormPrefill() {
-    this.channel.request('send', 'fetch:form:data', {
+  getFormData(args, requestId) {
+    this.channel.request('send', 'fetch:form:data', { value: {
       formData: this.formData,
       formSubmission: {},
       options: this.form.get('options'),
-    });
+    } }, requestId);
   },
   showFormSaveDisabled() {
     if (this.form.isReadOnly()) return;
@@ -85,8 +85,8 @@ export default App.extend({
         this.showFormSave();
         /* istanbul ignore next: Don't handle non-API errors */
         if (!responseData) return;
-        const errors = map(responseData.errors, 'detail');
-        this.channel.request('send', 'form:errors', errors);
+        const error = map(responseData.errors, 'detail');
+        this.channel.request('send', 'form:errors', { error });
       });
   },
 });

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -197,6 +197,7 @@ export default App.extend({
         this.send(message, { value: definition }, requestId);
       })
       .catch(({ responseData }) => {
+        /* istanbul ignore next: Don't test BE errors */
         this.send(message, { error: responseData }, requestId);
       });
   },
@@ -243,6 +244,7 @@ export default App.extend({
         options: this.form.get('options'),
       } }, requestId);
     }).catch(({ responseData }) => {
+      /* istanbul ignore next: Don't test BE errors */
       this.send(message, { error: responseData }, requestId);
     });
   },
@@ -257,6 +259,7 @@ export default App.extend({
         options: this.form.get('options'),
       } }, requestId);
     }).catch(({ responseData }) => {
+      /* istanbul ignore next: Don't test BE errors */
       this.send(message, { error: responseData }, requestId);
     });
   },

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -25,12 +25,12 @@ export default App.extend({
   channelName() {
     return `form${ this.getOption('form').id }`;
   },
-  channelRequest() {
+  send(message, ...args) {
     if (this.isDestroyed()) return;
 
     const channel = this.getChannel();
 
-    return channel.request(...arguments);
+    return channel.request('send', message, ...args);
   },
   initialize(options) {
     this.updateDraft = debounce(this.updateDraft, 15000);
@@ -50,7 +50,7 @@ export default App.extend({
     'fetch:clinicians': 'fetchClinicians',
     'fetch:directory': 'fetchDirectory',
     'fetch:form:definition': 'fetchFormDefinition',
-    'fetch:form:data': 'fetchFormPrefill',
+    'fetch:form:data': 'fetchFormData',
     'fetch:form:response': 'fetchFormResponse',
     'update:storedSubmission': 'updateStoredSubmission',
     'get:storedSubmission': 'getStoredSubmission',
@@ -131,64 +131,74 @@ export default App.extend({
     store.remove(this.getStoreId());
     this.trigger('update:submission');
   },
-  fetchField({ fieldName, requestId }) {
+  fetchField({ fieldName }, requestId) {
     const field = Radio.request('entities', 'patientFields:model', {
       name: fieldName,
       _patient: this.patient.getResource(),
     });
 
+    const message = 'fetch:field';
+
     return field.fetch()
       .then(() => {
-        this.channelRequest('send', 'fetch:field', { value: field.get('value'), requestId });
+        this.send(message, { value: field.get('value') }, requestId);
       })
       .catch(({ responseData }) => {
-        this.channelRequest('send', 'fetch:field', { error: responseData, requestId });
+        this.send(message, { error: responseData }, requestId);
       });
   },
-  updateField({ fieldName, value, requestId }) {
+  updateField({ fieldName, value }, requestId) {
     const field = Radio.request('entities', 'patientFields:model', {
       name: fieldName,
       value,
       _patient: this.patient.getResource(),
     });
 
+    const message = 'update:field';
+
     return field.saveAll()
       .then(() => {
-        this.channelRequest('send', 'update:field', { value: field.get('value'), requestId });
+        this.send(message, { value: field.get('value') }, requestId);
       })
       .catch(({ responseData }) => {
-        this.channelRequest('send', 'update:field', { error: responseData, requestId });
+        this.send(message, { error: responseData }, requestId);
       });
   },
-  fetchClinicians({ teamId, requestId }) {
+  fetchClinicians({ teamId }, requestId) {
     const clinicians = getClinicians(teamId);
 
-    this.channelRequest('send', 'fetch:directory', { value: clinicians.toJSON(), requestId });
+    this.send('fetch:directory', { value: clinicians.toJSON() }, requestId);
   },
-  fetchDirectory({ directoryName, query, requestId }) {
+  fetchDirectory({ directoryName, query }, requestId) {
+    const message = 'fetch:directory';
     return Promise.resolve(Radio.request('entities', 'fetch:directories:model', directoryName, query))
       .then(directory => {
-        this.channelRequest('send', 'fetch:directory', { value: directory.get('value'), requestId });
+        this.send(message, { value: directory.get('value') }, requestId);
       })
       .catch(({ responseData }) => {
-        this.channelRequest('send', 'fetch:directory', { error: responseData, requestId });
+        this.send(message, { error: responseData }, requestId);
       });
   },
-  fetchIcd({ by, requestId }) {
+  fetchIcd({ by }, requestId) {
+    const message = 'fetch:icd';
     return Promise.resolve(Radio.request('entities', 'fetch:icd', by))
       .then(icd => {
-        this.channelRequest('send', 'fetch:icd', { value: get(icd, ['data', 'icdCodes']), requestId });
+        this.send(message, { value: get(icd, ['data', 'icdCodes']) }, requestId);
       })
       .catch(({ responseData }) => {
-        this.channelRequest('send', 'fetch:icd', { error: responseData, requestId });
+        this.send(message, { error: responseData }, requestId);
       });
   },
-  fetchFormDefinition() {
+  fetchFormDefinition(args, requestId) {
     const fetchFormDefinition = Radio.request('entities', 'fetch:forms:definition', this.form.id);
-
-    fetchFormDefinition.then(definition => {
-      this.channelRequest('send', 'fetch:form:definition', definition);
-    });
+    const message = 'fetch:form:definition';
+    fetchFormDefinition
+      .then(definition => {
+        this.send(message, { value: definition }, requestId);
+      })
+      .catch(({ responseData }) => {
+        this.send(message, { error: responseData }, requestId);
+      });
   },
   fetchOtherFormResponse(flow) {
     const flowId = flow && flow.id;
@@ -209,14 +219,15 @@ export default App.extend({
 
     return Radio.request('entities', 'fetch:formResponses:model', get(firstResponse, 'id'));
   },
-  fetchFormPrefill() {
+  fetchFormData(args, requestId) {
+    const message = 'fetch:form:data';
     const storedSubmission = this.getStoredSubmission();
 
     if (storedSubmission.updated) {
-      this.channelRequest('send', 'fetch:form:data', {
+      this.send(message, { value: {
         storedSubmission: storedSubmission.submission,
         options: this.form.get('options'),
-      });
+      } }, requestId);
       return;
     }
 
@@ -224,24 +235,29 @@ export default App.extend({
       Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
       this.fetchLatestFormResponse(),
     ]).then(([data, response]) => {
-      this.channelRequest('send', 'fetch:form:data', {
+      this.send(message, { value: {
         isReadOnly: this.isReadOnly(),
         formData: data.attributes,
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         options: this.form.get('options'),
-      });
+      } }, requestId);
+    }).catch(({ responseData }) => {
+      this.send(message, { error: responseData }, requestId);
     });
   },
-  fetchFormResponse({ responseId }) {
+  fetchFormResponse({ responseId }, requestId) {
+    const message = 'fetch:form:response';
     return Promise.all([
       Radio.request('entities', 'fetch:formResponses:model', responseId),
     ]).then(([response]) => {
-      this.channelRequest('send', 'fetch:form:response', {
+      this.send(message, { value: {
         responseData: response.getFormData(),
         formSubmission: response.getResponse(),
         options: this.form.get('options'),
-      });
+      } }, requestId);
+    }).catch(({ responseData }) => {
+      this.send(message, { error: responseData }, requestId);
     });
   },
   useLatestDraft(responseData) {
@@ -302,8 +318,8 @@ export default App.extend({
 
         this.trigger('error', responseData.errors);
 
-        const errors = map(responseData.errors, 'detail');
-        this.channelRequest('send', 'form:errors', errors);
+        const error = map(responseData.errors, 'detail');
+        this.send('form:errors', { error });
       });
   },
 });


### PR DESCRIPTION
We had two postMessage requests.. the original using this.once on the backbone radio, and the requestValues which utilized a unique-ish id.

Both of these were effectively doing the same work, so I made them both use the { value, error } api, but extracted the requestId to an additional argument.

Shortcut Story ID: [sc-61862]

The catches should make all our AI friend happier too, though we're not specifically handling them.. I probably need to add some istanbul ignores to those.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved reliability of form-related requests and responses by introducing request tracking and better error handling.
- **Refactor**
	- Unified and streamlined communication between forms and parent windows using a Promise-based request-response pattern with unique request IDs.
	- Standardized the structure of messages and error handling across all form interactions.
	- Renamed and updated several methods for clarity and consistency in form data handling.
	- Updated message payloads to consistently wrap data and errors within value or error objects.
- **Bug Fixes**
	- Enhanced error reporting for form submissions and data fetching, ensuring users receive clearer feedback on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->