### PR TITLE
Create AWS Quicksight embedding context once and cache for future reuse

### DIFF
--- a/src/js/apps/dashboards/dashboard_app.js
+++ b/src/js/apps/dashboards/dashboard_app.js
@@ -1,4 +1,5 @@
 import Radio from 'backbone.radio';
+import * as QuicksightEmbedding from 'amazon-quicksight-embedding-sdk';
 
 import App from 'js/base/app';
 import { LayoutView, ContextTrailView, IframeView } from 'js/views/dashboards/dashboard_views';
@@ -6,20 +7,31 @@ import { LayoutView, ContextTrailView, IframeView } from 'js/views/dashboards/da
 import intl from 'js/i18n';
 
 export default App.extend({
+  getEmbedContext() {
+    if (!this.embeddingContext) {
+      this.embeddingContext = QuicksightEmbedding.createEmbeddingContext();
+    }
+
+    return this.embeddingContext;
+  },
   onBeforeStart() {
     this.showView(new LayoutView());
     this.getRegion('dashboard').startPreloader();
   },
   beforeStart({ dashboardId }) {
-    return Radio.request('entities', 'fetch:dashboards:model', dashboardId);
+    return [
+      Radio.request('entities', 'fetch:dashboards:model', dashboardId),
+      this.getEmbedContext(),
+    ];
   },
-  onStart(options, dashboard) {
+  onStart(options, dashboard, embeddingContext) {
     this.showChildView('contextTrail', new ContextTrailView({
       model: dashboard,
     }));
 
     this.showChildView('dashboard', new IframeView({
       model: dashboard,
+      embeddingContext,
     }));
   },
   onFail() {

--- a/src/js/views/dashboards/dashboard_views.js
+++ b/src/js/views/dashboards/dashboard_views.js
@@ -1,6 +1,5 @@
 import Radio from 'backbone.radio';
 import hbs from 'handlebars-inline-precompile';
-import * as QuicksightEmbedding from 'amazon-quicksight-embedding-sdk';
 
 import { View } from 'marionette';
 
@@ -27,15 +26,13 @@ const ContextTrailView = View.extend({
 const IframeView = View.extend({
   className: 'flex-grow',
   template: false,
-  initialize() {
-    QuicksightEmbedding.createEmbeddingContext().then((embeddingContext => {
-      embeddingContext.embedDashboard({
-        url: this.model.get('embed_url'),
-        container: this.el,
-        height: '100%',
-        width: '100%',
-      });
-    }));
+  initialize({ embeddingContext }) {
+    embeddingContext.embedDashboard({
+      url: this.model.get('embed_url'),
+      container: this.el,
+      height: '100%',
+      width: '100%',
+    });
   },
 });
 

--- a/test/integration/dashboards/dashboard.js
+++ b/test/integration/dashboards/dashboard.js
@@ -11,7 +11,11 @@ context('dashboard', function() {
     });
 
     cy
-      .routeDashboards()
+      .routeDashboards(fx => {
+        fx.data = [testDashboard];
+
+        return fx;
+      })
       .routeDashboard(fx => {
         fx.data = testDashboard;
 
@@ -43,6 +47,19 @@ context('dashboard', function() {
       .url()
       .should('not.contain', `dashboards/${ testDashboard.id }`)
       .should('contain', 'dashboards');
+
+    cy
+      .get('.table-list')
+      .find('.table-list__item')
+      .first()
+      .click();
+
+    // dashboard loaded using cached aws sdk embedding context
+    cy
+      .get('.dashboard__frame')
+      .find('.dashboard__iframe iframe')
+      .should('have.attr', 'src')
+      .and('include', `https://us-west-2.quicksight.aws.amazon.com/embed/embed_id/dashboards/${ testDashboard.id }?`);
   });
 
   specify('dashboard does not exist', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-61845]

Before a quicksight dashboard can be embedded, the `embeddingContext` needs to be created via `QuicksightEmbedding.createEmbeddingContext()`. We were doing this every time a dashboard page was loaded, which was causing errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dashboard embedding with improved integration of Amazon Quicksight, providing a smoother and more reliable user experience.

- **Refactor**
  - Optimized dashboard loading by centralizing embedding context management, improving performance when navigating between dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->