### PR TITLE
Send token as array for WS authentication

### DIFF
--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -25,7 +25,7 @@ context('WS Service', function() {
   beforeEach(function() {
     Radio.reply('bootstrap', 'currentUser', { clientKey });
     Radio.reply('workspace', 'current', { id: workspace });
-    Radio.reply('auth', 'getToken', () => 'token');
+    Radio.reply('auth', 'getToken', () => 'Bearer token');
     const url = 'ws://cypress-websocket/ws';
     cy.mockWs(url);
     service = new WSService({ url });

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -39,7 +39,7 @@ export default App.extend({
   },
 
   onStart({ data }, token) {
-    this.ws = new WebSocket(this.url, token);
+    this.ws = new WebSocket(this.url, token.split(' '));
     this.ws.addEventListener('open', this.onOpen.bind(this, data));
     this.ws.addEventListener('close', this.onClose.bind(this));
     this.ws.addEventListener('message', this.onMessage.bind(this));


### PR DESCRIPTION
I don’t know how to realistically test this from Cypress.. it’s kind of a JS protocol thing… that only fails when the cypress stub isn’t there.

But we can’t send a space in the sub-protocol, but apparently we can send an array which will come across as `Sec-WebSocket-Protocol: Bearer, eyJhbGciOiJIUzI1NiIsInR…`

Shortcut Story ID: [sc-###]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of authentication tokens during WebSocket connection, ensuring tokens with prefixes (e.g., "Bearer") are correctly processed. 

- **Tests**
  - Updated test setup to reflect the new token format used in authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->