### PR TITLE
Fix FF crypto in cypress

### DIFF
--- a/src/js/formapp/index.js
+++ b/src/js/formapp/index.js
@@ -10,6 +10,7 @@ import 'scss/formapp-core.scss';
 
 import { extend, map, debounce, each, isEmpty, isObject } from 'underscore';
 import $ from 'jquery';
+import { v4 as uuid } from 'uuid';
 import Backbone from 'backbone';
 import Handlebars from 'handlebars/runtime';
 import parsePhoneNumber from 'libphonenumber-js/min';
@@ -239,7 +240,7 @@ const Router = Backbone.Router.extend({
     parent.postMessage({ message, args }, window.origin);
   },
   request(message, args = {}) {
-    const requestId = crypto.randomUUID();
+    const requestId = uuid();
     return new Promise((resolve, reject) => {
       this.pending.set(requestId, { resolve, reject });
       parent.postMessage({ message, args, requestId }, window.origin);


### PR DESCRIPTION
although crypto.randomUUID is supposedly available since FF 95, in the cypress tests crypto is a different interface.

Just using uuid will solve the issue.

Shortcut Story ID: [sc-62087]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the method used for generating unique request IDs to improve consistency across environments. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->