### PR TITLE
Remove coverage from nightly component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ workflows:
           name: Chrome nightly Component
           parallelism: 6
           should_build: false
+          upload_coverage: false
           cypress_command: >
             npx cypress run --component
             --browser chrome
@@ -187,6 +188,7 @@ workflows:
           name: Firefox nightly Component
           parallelism: 6
           should_build: false
+          upload_coverage: false
           cypress_command: >
             npx cypress run --component
             --browser firefox
@@ -208,6 +210,7 @@ workflows:
           name: Edge nightly Component
           parallelism: 6
           should_build: false
+          upload_coverage: false
           cypress_command: >
             npx cypress run --component
             --browser edge


### PR DESCRIPTION
Trivial setting overlooked on our nightly tests.  Needs a quick review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled coverage upload for nightly component Cypress test runs on Chrome, Firefox, and Edge browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->