### PR TITLE
Apply 'fix-list-width' behavior to clinicians & quicksight dashboards pages

### DIFF
--- a/src/js/views/clinicians/clinicians-all_views.js
+++ b/src/js/views/clinicians/clinicians-all_views.js
@@ -7,6 +7,8 @@ import intl from 'js/i18n';
 
 import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
+import FixListWidthBehavior from 'js/behaviors/fix-list-width';
+
 import PreloadRegion from 'js/regions/preload_region';
 import { RoleComponent, TeamComponent, StateComponent } from 'js/views/clinicians/shared/clinicians_views';
 
@@ -128,8 +130,9 @@ const ItemView = View.extend({
 
 const LayoutView = View.extend({
   className: 'flex-region',
+  behaviors: [FixListWidthBehavior],
   template: hbs`
-    <div class="list-page__header">
+    <div class="list-page__header js-list-header">
       <div class="flex list-page__title">
         <div class="flex list-page__title-filter">
           <span class="list-page__title-icon">{{far "users-gear"}}</span>{{ @intl.clinicians.cliniciansAllViews.layoutView.title }}
@@ -137,16 +140,16 @@ const LayoutView = View.extend({
         <div class="clinicians__list-search" data-search-region></div>
       </div>
       <button class="u-margin--b-16 button-primary js-add-clinician">{{far "circle-plus"}}<span>{{ @intl.clinicians.cliniciansAllViews.layoutView.addClinicianButton }}</span></button>
+      <table class="w-100">
+        <tr>
+          <td class="table-list__header w-20">{{ @intl.clinicians.cliniciansAllViews.layoutView.clinicianHeader }}</td>
+          <td class="table-list__header w-30">{{ @intl.clinicians.cliniciansAllViews.layoutView.workspacesHeader }}</td>
+          <td class="table-list__header w-30">{{ @intl.clinicians.cliniciansAllViews.layoutView.attributesHeader }}</td>
+          <td class="table-list__header w-20">{{ @intl.clinicians.cliniciansAllViews.layoutView.lastActiveHeader }}</td>
+        </tr>
+      </table>
     </div>
-    <div class="flex-region list-page__list">
-      <table class="w-100"><tr>
-        <td class="table-list__header w-20">{{ @intl.clinicians.cliniciansAllViews.layoutView.clinicianHeader }}</td>
-        <td class="table-list__header w-30">{{ @intl.clinicians.cliniciansAllViews.layoutView.workspacesHeader }}</td>
-        <td class="table-list__header w-30">{{ @intl.clinicians.cliniciansAllViews.layoutView.attributesHeader }}</td>
-        <td class="table-list__header w-20">{{ @intl.clinicians.cliniciansAllViews.layoutView.lastActiveHeader }}</td>
-      </tr></table>
-      <div class="flex-region" data-list-region></div>
-    </div>
+    <div class="flex-region list-page__list js-list" data-list-region></div>
   `,
   regions: {
     list: {
@@ -162,6 +165,10 @@ const LayoutView = View.extend({
   },
   triggers: {
     'click .js-add-clinician': 'click:addClinician',
+  },
+  childViewTriggers: {
+    'render:children': 'childView:render:children',
+    'attach': 'childView:attach',
   },
 });
 

--- a/src/js/views/dashboards/dashboards-all_views.js
+++ b/src/js/views/dashboards/dashboards-all_views.js
@@ -5,6 +5,8 @@ import { View, CollectionView } from 'marionette';
 
 import buildMatchersArray from 'js/utils/formatting/build-matchers-array';
 
+import FixListWidthBehavior from 'js/behaviors/fix-list-width';
+
 import PreloadRegion from 'js/regions/preload_region';
 
 const ItemView = View.extend({
@@ -82,21 +84,22 @@ const ListView = CollectionView.extend({
 
 const LayoutView = View.extend({
   className: 'flex-region',
+  behaviors: [FixListWidthBehavior],
   template: hbs`
-  <div class="list-page__header">
-    <div class="flex list-page__title">
-      <div class="flex list-page__title-filter">
-        <span class="list-page__title-icon">{{far "gauge"}}</span>{{ @intl.dashboards.dashboardsAllViews.layoutView.title }}
+    <div class="list-page__header js-list-header">
+      <div class="flex list-page__title">
+        <div class="flex list-page__title-filter">
+          <span class="list-page__title-icon">{{far "gauge"}}</span>{{ @intl.dashboards.dashboardsAllViews.layoutView.title }}
+        </div>
+        <div class="u-margin--l-auto" data-search-region></div>
       </div>
-      <div class="u-margin--l-auto" data-search-region></div>
+      <table class="w-100">
+        <tr>
+          <td class="table-list__header w-100">{{ @intl.dashboards.dashboardsAllViews.layoutView.nameHeader }}</td>
+        </tr>
+      </table>
     </div>
-  </div>
-  <div class="flex-region list-page__list">
-    <table class="w-100"><tr>
-      <td class="table-list__header w-100">{{ @intl.dashboards.dashboardsAllViews.layoutView.nameHeader }}</td>
-    </tr></table>
-    <div class="flex-region" data-list-region></div>
-  </div>
+    <div class="flex-region list-page__list js-list" data-list-region></div>
   `,
   regions: {
     search: '[data-search-region]',
@@ -104,6 +107,10 @@ const LayoutView = View.extend({
       el: '[data-list-region]',
       regionClass: PreloadRegion,
     },
+  },
+  childViewTriggers: {
+    'render:children': 'childView:render:children',
+    'attach': 'childView:attach',
   },
 });
 

--- a/test/integration/clinicians/clinicians-all.js
+++ b/test/integration/clinicians/clinicians-all.js
@@ -38,7 +38,7 @@ context('clinicians list', function() {
       .wait('@routeClinicians');
 
     cy
-      .get('.list-page__list')
+      .get('.list-page__header')
       .find('.table-list__header')
       .first()
       .should('contain', 'Clinician')


### PR DESCRIPTION
Shortcut Story ID: [sc-62261]

This should have been included in https://github.com/RoundingWell/care-ops-frontend/pull/1461.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved list header layout for clinicians and dashboards lists, providing clearer separation between headers and list content.
  - Enhanced list width consistency for clinicians and dashboards views.

- **Style**
  - Updated header and list region styling for a more organized and visually distinct presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->