### PR TITLE
Use uuid v5 for clinician create

### DIFF
--- a/src/js/base/uuid.js
+++ b/src/js/base/uuid.js
@@ -9,7 +9,7 @@ Backbone.Model.prototype.sync = function(method, model, options) {
   if (method === 'create') {
     let data = options.data || options.attrs || model.toJSON(options);
     if (isString(data)) data = JSON.parse(data);
-    data.data.id = uuid();
+    data.data.id = (model && model.createId) ? model.createId() : uuid();
     options.data = JSON.stringify(data);
   }
 

--- a/src/js/entities-service/entities/clinicians.js
+++ b/src/js/entities-service/entities/clinicians.js
@@ -3,7 +3,8 @@ import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
-import { NIL as NIL_UUID } from 'uuid';
+import { NIL as NIL_UUID, v5 as uuid } from 'uuid';
+import { RWELL_NS } from 'js/static';
 
 import trim from 'js/utils/formatting/trim';
 
@@ -12,6 +13,16 @@ const TYPE = 'clinicians';
 const _Model = BaseModel.extend({
   type: TYPE,
   urlRoot: '/api/clinicians',
+  createId() {
+    const email = this.get('email');
+
+    /* istanbul ignore next: dev protection */
+    if (!email) {
+      throw new Error('Cannot create clinician without email');
+    }
+
+    return uuid(`clinician:${ String(email).toLowerCase() }`, RWELL_NS);
+  },
   preinitialize() {
     this.on('change:_team', this.onChangeTeam);
   },

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -1,3 +1,5 @@
+const RWELL_NS = '17167534-18f9-5622-81b0-872907d3efa5';
+
 const ACTION_OUTREACH = {
   DISABLED: 'disabled',
   PATIENT: 'patient',
@@ -78,4 +80,5 @@ export {
   RELATIVE_DATE_RANGES,
   STATE_STATUS,
   PATIENT_STATUS,
+  RWELL_NS,
 };

--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -4,6 +4,8 @@ import stateColors from 'helpers/state-colors';
 import { workspaceOne } from 'support/api/workspaces';
 import { roleManager } from 'support/api/roles';
 import { teamNurse } from 'support/api/teams';
+import { v5 as uuid } from 'uuid';
+import { RWELL_NS } from 'js/static';
 
 context('clinicians modal', function() {
   specify('add clinician', function() {
@@ -125,6 +127,7 @@ context('clinicians modal', function() {
       .wait('@routePostClinician')
       .its('request.body')
       .should(({ data }) => {
+        expect(data.id).to.equal(uuid('clinician:test.clinician@roundingwell.com', RWELL_NS));
         expect(data.attributes.name).to.equal('Test Clinician');
         expect(data.attributes.email).to.equal('test.clinician@roundingwell.com');
         expect(data.relationships.role.data.id).to.equal(roleManager.id);


### PR DESCRIPTION
Shortcut Story ID: [sc-62231]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clinician records now use a consistent, deterministic ID based on their email address.
- **Bug Fixes**
  - Improved ID generation logic to support custom methods when creating records.
- **Tests**
  - Added a test to verify that clinician IDs are correctly generated from email addresses.
- **Chores**
  - Introduced a new constant for the namespace used in ID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->