### PR TITLE
Add test to ensure pop region doesn't show outside viewport bounds

### DIFF
--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -705,6 +705,24 @@ context('schedule page', function() {
       .get('[data-date-filter-region]')
       .find('.js-next')
       .should('not.exist');
+
+    cy
+      .get('[data-date-filter-region]')
+      .should('contain', 'All Time')
+      .click();
+
+    cy
+      .get('.app-frame__pop-region')
+      .then($el => {
+        // checks that pop region doesn't show outside viewport bounds
+        const elInfo = $el[0].getBoundingClientRect();
+        const viewportWidth = Cypress.config('viewportWidth');
+        const viewportHeight = Cypress.config('viewportHeight');
+
+        const isOutOfBounds = elInfo.right > viewportWidth || elInfo.bottom > viewportHeight || elInfo.left < 0 || elInfo.top < 0;
+
+        expect(isOutOfBounds).to.be.false;
+      });
   });
 
   specify('restricted employee', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-62279]

This gets code coverage for [this code](https://github.com/RoundingWell/care-ops-frontend/blob/develop/src/js/views/globals/root_views.js#L176-L179). And the test will fail in the future if that `if ()` check is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a test to verify that the date filter pop-up remains fully visible within the viewport when opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->