### PR TITLE
Expose Field history with limit,sort to form.io

### DIFF
--- a/src/js/entities-service/entities/patient-fields.js
+++ b/src/js/entities-service/entities/patient-fields.js
@@ -2,6 +2,8 @@ import { extend } from 'underscore';
 import Store from 'backbone.store';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
+import { v5 as uuid } from 'uuid';
+import { RWELL_NS } from 'js/static';
 
 const TYPE = 'patient-fields';
 
@@ -14,6 +16,17 @@ const _Model = BaseModel.extend({
   getPatient() {
     return this.getRelationship('_patient');
   },
+  createId() {
+    const patient = this.getPatient();
+    const name = this.get('name');
+
+    /* istanbul ignore next: dev protection */
+    if (!patient || !name) {
+      throw new Error('Cannot create patient-field without patient or name');
+    }
+
+    return uuid(`patient:${ patient.id }:field:${ String(name).toLowerCase() }`, RWELL_NS);
+  },
   saveAll(attrs) {
     attrs = extend({}, this.attributes, attrs);
 
@@ -21,7 +34,7 @@ const _Model = BaseModel.extend({
       patient: this.toRelation(attrs._patient),
     };
 
-    return this.save(attrs, { relationships }, { wait: true });
+    return this.save(attrs, { relationships }, { wait: true, type: 'PATCH' });
   },
 });
 

--- a/src/js/entities-service/patient-fields.js
+++ b/src/js/entities-service/patient-fields.js
@@ -1,18 +1,11 @@
-import { extend } from 'underscore';
-import { v5 as uuid } from 'uuid';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/patient-fields';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
-    'patientFields:model': 'getPatientField',
+    'patientFields:model': 'getModel',
     'patientFields:collection': 'getCollection',
-  },
-  getPatientField(attrs) {
-    const id = uuid(`resource:field:${ attrs.name.toLowerCase() }`, attrs._patient.id);
-
-    return this.getModel(extend({ id }, attrs));
   },
 });
 

--- a/src/js/entities-service/patient-fields.js
+++ b/src/js/entities-service/patient-fields.js
@@ -6,6 +6,12 @@ const Entity = BaseEntity.extend({
   radioRequests: {
     'patientFields:model': 'getModel',
     'patientFields:collection': 'getCollection',
+    'fetch:patientFields:model:history': 'getModelHistory',
+  },
+  getModelHistory({ _patient, name }, { limit, sort }) {
+    const model = this.getModel({ _patient, name }).clone();
+    const data = { limit, sort };
+    return model.fetch({ url: `${ model.url() }/history`, data });
   },
 });
 

--- a/src/js/formapp/index.js
+++ b/src/js/formapp/index.js
@@ -52,6 +52,10 @@ function getField(fieldName) {
   return router.request('fetch:field', { fieldName });
 }
 
+function getFieldHistory(fieldName, limit = 10, sort = 'newest') {
+  return router.request('fetch:fieldHistory', { fieldName, limit, sort });
+}
+
 function getClinicians({ teamId } = {}) {
   return router.request('fetch:clinicians', { teamId });
 }
@@ -67,7 +71,7 @@ function getIcd(by) {
 }
 
 function getContext(contextScripts) {
-  return getScriptContext(contextScripts, { getClinicians, getDirectory, getField, updateField, getIcd, Handlebars, TEMPLATES: {}, parsePhoneNumber });
+  return getScriptContext(contextScripts, { getClinicians, getDirectory, getField, getFieldHistory, updateField, getIcd, Handlebars, TEMPLATES: {}, parsePhoneNumber });
 }
 
 let prevSubmission;

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -56,6 +56,7 @@ export default App.extend({
     'get:storedSubmission': 'getStoredSubmission',
     'clear:storedSubmission': 'clearStoredSubmission',
     'fetch:field': 'fetchField',
+    'fetch:fieldHistory': 'fetchFieldHistory',
     'update:field': 'updateField',
     'fetch:icd': 'fetchIcd',
     'version': 'checkVersion',
@@ -146,6 +147,22 @@ export default App.extend({
       .catch(({ responseData }) => {
         this.send(message, { error: responseData }, requestId);
       });
+  },
+  fetchFieldHistory({ fieldName, limit, sort }, requestId) {
+    const message = 'fetch:fieldHistory';
+
+    return Radio.request('entities', 'fetch:patientFields:model:history', {
+      name: fieldName,
+      _patient: this.patient.getResource(),
+    }, { limit, sort })
+      .then(field => {
+        this.send(message, { value: field.get('value') }, requestId);
+      })
+      .catch(
+        /* istanbul ignore next: Don't test BE errors */
+        ({ responseData }) => {
+          this.send(message, { error: responseData }, requestId);
+        });
   },
   updateField({ fieldName, value }, requestId) {
     const field = Radio.request('entities', 'patientFields:model', {

--- a/test/integration/clinicians/clinician-modal.js
+++ b/test/integration/clinicians/clinician-modal.js
@@ -4,8 +4,7 @@ import stateColors from 'helpers/state-colors';
 import { workspaceOne } from 'support/api/workspaces';
 import { roleManager } from 'support/api/roles';
 import { teamNurse } from 'support/api/teams';
-import { v5 as uuid } from 'uuid';
-import { RWELL_NS } from 'js/static';
+import { getClinicianId } from 'support/api/clinicians';
 
 context('clinicians modal', function() {
   specify('add clinician', function() {
@@ -127,7 +126,7 @@ context('clinicians modal', function() {
       .wait('@routePostClinician')
       .its('request.body')
       .should(({ data }) => {
-        expect(data.id).to.equal(uuid('clinician:test.clinician@roundingwell.com', RWELL_NS));
+        expect(data.id).to.equal(getClinicianId('test.clinician@roundingwell.com'));
         expect(data.attributes.name).to.equal('Test Clinician');
         expect(data.attributes.email).to.equal('test.clinician@roundingwell.com');
         expect(data.relationships.role.data.id).to.equal(roleManager.id);

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -1,11 +1,9 @@
-import { v5 as uuid } from 'uuid';
-
 import { getRelationship, getErrors } from 'helpers/json-api';
 
 import { getAction } from 'support/api/actions';
 import { getCurrentClinician, getClinician } from 'support/api/clinicians';
 import { getPatient } from 'support/api/patients';
-import { getPatientField } from 'support/api/patient-fields';
+import { getPatientField, getPatientFieldId } from 'support/api/patient-fields';
 import { teamCoordinator, teamNurse } from 'support/api/teams';
 import { getFormFields } from 'support/api/form-fields';
 import { getForm, testForm } from 'support/api/forms';
@@ -14,8 +12,10 @@ const testPatient = getPatient();
 
 function getTestPatientField(name, value) {
   return getPatientField({
-    id: uuid(`resource:field:${ name }`, testPatient.id),
     attributes: { name, value },
+    relationships: {
+      patient: getRelationship(testPatient),
+    },
   });
 }
 
@@ -439,7 +439,7 @@ context('Noncontext Form', function() {
       .wait('@routePatchPatientFieldFoo')
       .its('request.body.data')
       .then(data => {
-        expect(data.id).to.equal(uuid('resource:field:foo', testPatient.id));
+        expect(data.id).to.equal(getPatientFieldId(testPatient.id, 'foo'));
         expect(data.attributes.name).to.equal('foo');
         expect(data.attributes.value).to.deep.equal(['one', 'two']);
       })
@@ -457,7 +457,7 @@ context('Noncontext Form', function() {
       .click()
       .wait('@routePatchPatientFieldBar')
       .its('request.body.data.id')
-      .should('equal', uuid('resource:field:bar', testPatient.id))
+      .should('equal', getPatientFieldId(testPatient.id, 'bar'))
       .wait(100);
 
     cy
@@ -472,7 +472,7 @@ context('Noncontext Form', function() {
       .click()
       .wait('@routePatchPatientFieldBazinga')
       .its('request.body.data.id')
-      .should('equal', uuid('resource:field:bazinga', testPatient.id))
+      .should('equal', getPatientFieldId(testPatient.id, 'bazinga'))
       .wait(100);
 
     cy

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -290,6 +290,14 @@ context('Noncontext Form', function() {
         fx.data = getTestPatientField('foo', [1, 2]);
         return fx;
       }, 'foo')
+      .routePatientFieldHistory(fx => {
+        fx.data = getTestPatientField('foo', [3, 4]);
+        return fx;
+      }, 'foo')
+      .routePatientFieldHistory(fx => {
+        fx.data = getTestPatientField('bar', [5, 6]);
+        return fx;
+      }, 'bar')
       .intercept('GET', `/api/patients/${ testPatient.id }/fields/bar`, {
         statusCode: 400,
         body: { errors },
@@ -320,6 +328,32 @@ context('Noncontext Form', function() {
               input: true,
               custom: `
                 getField('foo')
+                  .then(value => {
+                    data.opts = value;
+                  });
+              `,
+            },
+            {
+              label: 'Test Get Field History',
+              action: 'custom',
+              key: 'test1-1',
+              type: 'button',
+              input: true,
+              custom: `
+                getFieldHistory('foo')
+                  .then(value => {
+                    data.opts = value;
+                  });
+              `,
+            },
+            {
+              label: 'Test Get Field History Filter',
+              action: 'custom',
+              key: 'test1-2',
+              type: 'button',
+              input: true,
+              custom: `
+                getFieldHistory('bar', 2, 'oldest')
                   .then(value => {
                     data.opts = value;
                   });
@@ -417,6 +451,42 @@ context('Noncontext Form', function() {
       .iframe()
       .find('.qa-results')
       .should('contain', '1,2');
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Get Field History')
+      .click()
+      .wait('@routePatientFieldfooHistory')
+      .its('request.query')
+      .then(data => {
+        expect(data.limit).to.equal('10');
+        expect(data.sort).to.equal('newest');
+      })
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('.qa-results')
+      .should('contain', '3,4');
+
+    cy
+      .iframe()
+      .find('button')
+      .contains('Test Get Field History Filter')
+      .click()
+      .wait('@routePatientFieldbarHistory')
+      .its('request.query')
+      .then(data => {
+        expect(data.limit).to.equal('2');
+        expect(data.sort).to.equal('oldest');
+      })
+      .wait(100);
+
+    cy
+      .iframe()
+      .find('.qa-results')
+      .should('contain', '5,6');
 
     cy
       .iframe()

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
-
+import { v4 as uuid, v5 as uuidv5 } from 'uuid';
+import { RWELL_NS } from 'js/static';
 import { testTs } from 'helpers/test-timestamp';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
@@ -14,6 +14,10 @@ const TYPE = 'clinicians';
 
 const fxCurrentClinician = _.first(fxTestClinicians);
 const fxClinicians = _.rest(fxTestClinicians);
+
+export function getClinicianId(email) {
+  return uuidv5(`clinician:${ String(email).toLowerCase() }`, RWELL_NS);
+}
 
 export function getCurrentClinician(data, { depth = 0 } = {}) {
   const defaultRelationships = {

--- a/test/support/api/patient-fields.js
+++ b/test/support/api/patient-fields.js
@@ -40,3 +40,14 @@ Cypress.Commands.add('routePatientField', (mutator = _.identity, fieldName) => {
     })
     .as(alias);
 });
+
+Cypress.Commands.add('routePatientFieldHistory', (mutator = _.identity, fieldName) => {
+  const data = getPatientField();
+  const alias = fieldName ? `routePatientField${ fieldName }History` : 'routePatientFieldHistory';
+
+  cy
+    .intercept('GET', `/api/patients/**/fields/${ fieldName || '**' }/history**`, {
+      body: mutator({ data, included: [] }),
+    })
+    .as(alias);
+});

--- a/test/support/api/patient-fields.js
+++ b/test/support/api/patient-fields.js
@@ -1,20 +1,32 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v5 as uuid } from 'uuid';
+import { RWELL_NS } from 'js/static';
 import { getResource, mergeJsonApi } from 'helpers/json-api';
+import { getPatient } from 'support/api/patients';
 
 import fxPatientFields from 'fixtures/collections/patient-fields';
 
 const TYPE = 'patient-fields';
 
+export function getPatientFieldId(patientId, fieldName) {
+  return uuid(`patient:${ patientId }:field:${ String(fieldName).toLowerCase() }`, RWELL_NS);
+}
+
 export function getPatientField(data) {
   const resource = getResource(_.sample(fxPatientFields), TYPE);
 
-  data = _.extend({ id: uuid() }, data);
+  const patientField = mergeJsonApi(resource, data);
 
-  return mergeJsonApi(resource, data);
+  const patientId = _.get(patientField, 'relationships.patient.id') || getPatient({}, { depth: 1 }).id;
+
+  patientField.id = getPatientFieldId(patientId, patientField.attributes.name);
+
+  return patientField;
 }
 
-export function getPatientFields({ attributes, relationships, meta } = {}, { sample = 3 } = {}) {
+export function getPatientFields({ attributes, relationships, meta } = {}, { sample = 3, depth } = {}) {
+  if (depth++ > 1) return;
+
   return _.times(sample, () => getPatientField({ attributes, relationships, meta }));
 }
 

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -17,7 +17,7 @@ export function getPatient(data, { depth = 0 } = {}) {
   const defaultRelationships = {
     'actions': getRelationship(getActions({}, { sample: 3, depth })),
     'flows': getRelationship(getFlows({}, { sample: 2, depth })),
-    'patient-fields': getRelationship(getPatientFields({}, { sample: 3 })),
+    'patient-fields': getRelationship(getPatientFields({}, { sample: 3, depth })),
     'visits': getRelationship([]),
     'workspaces': getRelationship(getWorkspaces()),
   };


### PR DESCRIPTION
Shortcut Story ID: [sc-62392]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to fetch and display the history of patient field values, including support for pagination and sorting.
  * Introduced new buttons in forms to retrieve and show field history data.

* **Bug Fixes**
  * Improved the generation of patient field and clinician IDs to be deterministic and consistent across the app.

* **Tests**
  * Enhanced integration tests to cover field history retrieval and updated test helpers for deterministic ID generation.
  * Added new Cypress commands for intercepting field history API calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->