### PR TITLE
Support nested values array for field history

### DIFF
--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -156,7 +156,7 @@ export default App.extend({
       _patient: this.patient.getResource(),
     }, { limit, sort })
       .then(field => {
-        this.send(message, { value: field.get('value') }, requestId);
+        this.send(message, { value: field.get('values') }, requestId);
       })
       .catch(
         /* istanbul ignore next: Don't test BE errors */

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -291,11 +291,24 @@ context('Noncontext Form', function() {
         return fx;
       }, 'foo')
       .routePatientFieldHistory(fx => {
-        fx.data = getTestPatientField('foo', [3, 4]);
+        fx.data = {
+          attributes: {
+            values: [
+              {
+                value: [3, 4],
+              },
+              {
+                value: [1, 2],
+              },
+            ],
+          },
+        };
         return fx;
       }, 'foo')
       .routePatientFieldHistory(fx => {
-        fx.data = getTestPatientField('bar', [5, 6]);
+        fx.data = {
+          attributes: { values: [{ value: [5, 6] }] },
+        };
         return fx;
       }, 'bar')
       .intercept('GET', `/api/patients/${ testPatient.id }/fields/bar`, {
@@ -342,7 +355,7 @@ context('Noncontext Form', function() {
               custom: `
                 getFieldHistory('foo')
                   .then(value => {
-                    data.opts = value;
+                    data.opts = _.concat(value[0].value, value[1].value);
                   });
               `,
             },
@@ -355,7 +368,7 @@ context('Noncontext Form', function() {
               custom: `
                 getFieldHistory('bar', 2, 'oldest')
                   .then(value => {
-                    data.opts = value;
+                    data.opts = value[0].value;
                   });
               `,
             },


### PR DESCRIPTION
Shortcut Story ID: [sc-###]

@zfixler this ought to support the nested values array for history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted field history data to return multiple historical values instead of a single value when fetching field history.

* **Tests**
  * Updated integration tests to handle and verify the new field history data structure that includes multiple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->