### PR TITLE
Support patient field queries setting for patient search

### DIFF
--- a/src/js/entities-service/entities/patient-search-results.js
+++ b/src/js/entities-service/entities/patient-search-results.js
@@ -22,6 +22,7 @@ const Collection = BaseCollection.extend({
     if (search.length < 3) {
       if (!search.length || !this.prevSearch.includes(search)) {
         delete this._hasIdentifiers;
+        delete this._hasFieldQueryResults;
         this.reset();
         this.prevSearch = '';
       }
@@ -33,6 +34,13 @@ const Collection = BaseCollection.extend({
     this.prevSearch = search;
     this.isSearching = true;
     this._debouncedSearch(search);
+  },
+  hasFieldQueryResults() {
+    if (isBoolean(this._hasFieldQueryResults)) return this._hasFieldQueryResults;
+
+    this._hasFieldQueryResults = this.some(model => model.has('value'));
+
+    return this._hasFieldQueryResults;
   },
   hasIdentifiers() {
     if (isBoolean(this._hasIdentifiers)) return this._hasIdentifiers;
@@ -47,6 +55,7 @@ const Collection = BaseCollection.extend({
     const filter = { search };
 
     delete this._hasIdentifiers;
+    delete this._hasFieldQueryResults;
     this.controller.abort();
     this.controller = new AbortController();
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -238,6 +238,7 @@ careOptsFrontend:
           shortcut: "Keyboard Shortcut: /"
         headerView:
           dob: DOB
+          fieldQuery: Results
           id: Identifier
           patient: Patient
           workspaceStatus: Workspace Status

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -69,11 +69,8 @@
   width: 100px;
 }
 
-.patient-search__picklist-header-identifier {
-  margin-left: 16px;
-  width: 100px;
-}
-
+.patient-search__picklist-header-identifier,
+.patient-search__picklist-header-query,
 .patient-search__picklist-header-status {
   margin-left: 16px;
   width: 100px;
@@ -137,7 +134,8 @@
   width: 100px;
 }
 
-.patient-search__picklist-item-identifier {
+.patient-search__picklist-item-identifier,
+.patient-search__picklist-item-query {
   margin-left: 16px;
   width: 100px;
 }

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -28,6 +28,12 @@ const TipTemplate = hbs`
         {{ @intl.globals.search.patientSearchViews.emptyView.exampleId }} {{this.example}}
       </div>
     {{/each}}
+    {{#each settings.queries}}
+      <div class="u-margin--t-8 qa-search-option">
+        <span class="patient-search__search-by-label">{{this.label}}</span>
+        {{ @intl.globals.search.patientSearchViews.emptyView.exampleId }} {{this.example}}
+      </div>
+    {{/each}}
   </div>
   <div class="patient-search__shortcut">{{fas "keyboard"}}<strong class="u-margin--l-8">{{ @intl.globals.search.patientSearchViews.emptyView.shortcut }}</strong></div>
 `;
@@ -96,7 +102,12 @@ const PicklistItem = View.extend({
       </div>
       {{#if hasIdentifiers}}
         <div class="patient-search__picklist-item-identifier u-text--overflow">
-          {{#if identifiers.0.value}}{{matchText identifiers.0.value search}}{{else}}&ndash;{{/if}}
+          {{matchText identifiers.0.value search}}
+        </div>
+      {{/if}}
+      {{#if hasFieldQueryResults}}
+        <div class="patient-search__picklist-item-query u-text--overflow">
+          {{matchText value search}}
         </div>
       {{/if}}
       <div class="patient-search__picklist-item-status u-text--overflow">
@@ -109,6 +120,7 @@ const PicklistItem = View.extend({
       name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
       hasIdentifiers: this.collection.hasIdentifiers(),
+      hasFieldQueryResults: this.collection.hasFieldQueryResults(),
     };
   },
 });
@@ -151,6 +163,11 @@ const HeaderView = View.extend({
           {{ @intl.globals.search.patientSearchViews.headerView.id }}
         </div>
       {{/if}}
+      {{#if hasFieldQueryResults}}
+        <div class="patient-search__picklist-header-query">
+          {{ @intl.globals.search.patientSearchViews.headerView.fieldQuery }}
+        </div>
+      {{/if}}
       <div class="patient-search__picklist-header-status">
         {{ @intl.globals.search.patientSearchViews.headerView.workspaceStatus }}
       </div>
@@ -159,6 +176,7 @@ const HeaderView = View.extend({
   templateContext() {
     return {
       hasIdentifiers: this.collection.hasIdentifiers(),
+      hasFieldQueryResults: this.collection.hasFieldQueryResults(),
     };
   },
 });

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -27,6 +27,13 @@
           "label": "Health Plan ID",
           "example": "123456789"
         }
+      ],
+      "queries": [
+        {
+          "id": "bcff68e4-49c6-4dbf-8f5b-45e63d664162",
+          "label": "Phone Number",
+          "example": "555-1290"
+        }
       ]
     }
   },

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -5,29 +5,29 @@ import { getRelationship, getResource } from 'helpers/json-api';
 import { getPatient } from 'support/api/patients';
 
 context('Patient Quick Search', function() {
-  const patients = _.times(10, index => {
-    return getPatient({
-      attributes: {
-        first_name: 'Test',
-        last_name: `${ index } Patient`,
-        identifiers: index % 2 ? [] : [{ type: 'mrn', value: 'identifier-001' }],
-        status: index % 2 ? 'inactive' : 'active',
-      },
+  specify('Modal & default searching functionality', function() {
+    const patients = _.times(10, index => {
+      return getPatient({
+        attributes: {
+          first_name: 'Test',
+          last_name: `${ index } Patient`,
+          status: index % 2 ? 'inactive' : 'active',
+        },
+      });
     });
-  });
 
-  beforeEach(function() {
     const data = _.map(patients, patient => {
-      const { id, first_name, last_name, birth_date, identifiers, status } = patient.attributes;
+      const { first_name, last_name, birth_date, status } = patient.attributes;
 
       return {
-        id,
+        id: patient.id,
         type: 'patient-search-results',
         attributes: {
           first_name,
           last_name,
           birth_date,
-          identifiers,
+          identifiers: [],
+          value: null,
           status,
         },
         relationships: {
@@ -39,7 +39,7 @@ context('Patient Quick Search', function() {
     cy
       .intercept({
         method: 'GET',
-        url: 'api/patients?filter*',
+        url: '/api/patients?filter*',
       }, req => {
         if (req.url.includes('None')) {
           req.reply({ body: { data: [] } });
@@ -55,9 +55,7 @@ context('Patient Quick Search', function() {
         });
         req.alias = 'routePatientSearch';
       });
-  });
 
-  specify('Modal', function() {
     cy
       .routesForPatientDashboard()
       .routeSettings('manual_patient_creation', false)
@@ -85,7 +83,7 @@ context('Patient Quick Search', function() {
     cy
       .get('@searchModal')
       .find('.qa-search-option')
-      .should('have.length', 3);
+      .should('have.length', 4);
 
     cy
       .get('@searchModal')
@@ -104,9 +102,16 @@ context('Patient Quick Search', function() {
     cy
       .get('@searchModal')
       .find('.qa-search-option')
-      .last()
+      .eq(2)
       .should('contain', 'Health Plan ID')
       .should('contain', 'For example: 123456789');
+
+    cy
+      .get('@searchModal')
+      .find('.qa-search-option')
+      .last()
+      .should('contain', 'Phone Number')
+      .should('contain', 'For example: 555-1290');
 
     cy
       .get('@searchModal')
@@ -144,7 +149,6 @@ context('Patient Quick Search', function() {
       .find('.js-picklist-item strong')
       .contains('2')
       .parents('.js-picklist-item')
-      .should('contain', 'identifier-001')
       .should('contain', 'active')
       .click();
 
@@ -246,7 +250,137 @@ context('Patient Quick Search', function() {
       .go('back');
   });
 
+  specify('Search by identifier', function() {
+    const testPatient = getPatient({
+      attributes: {
+        status: 'active',
+        identifiers: [{ type: 'mrn', value: 'identifier-001' }],
+      },
+    });
+
+    const { first_name, last_name, birth_date, status } = testPatient.attributes;
+
+    const searchResultData = [{
+      id: testPatient.id,
+      type: 'patient-search-results',
+      attributes: {
+        first_name,
+        last_name,
+        birth_date,
+        identifiers: [{ type: 'mrn', value: 'identifier-001' }],
+        status,
+        value: null,
+      },
+      relationships: {
+        patient: getRelationship(testPatient, 'patients'),
+      },
+    }];
+
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: {
+        data: searchResultData,
+        included: [getResource(testPatient, 'patients')],
+      },
+      delay: 300,
+    }).as('routePatientSearch');
+
+    cy
+      .routesForPatientDashboard()
+      .routeSettings('manual_patient_creation', false)
+      .routeActions()
+      .visit()
+      .wait('@routeActions');
+
+    cy
+      .get('.app-frame__nav')
+      .find('.js-search')
+      .as('search')
+      .click();
+
+    cy
+      .get('.modal--large')
+      .find('.patient-search__input')
+      .type('identifier-001')
+      .wait('@routePatientSearch');
+
+    cy
+      .get('.modal--large')
+      .find('.js-picklist-item strong')
+      .parents('.js-picklist-item')
+      .should('contain', 'identifier-001');
+  });
+
+  specify('Search by patient field', function() {
+    const testPatient = getPatient({
+      attributes: { status: 'active' },
+    });
+
+    const { first_name, last_name, birth_date, status } = testPatient.attributes;
+
+    const searchResultData = [{
+      id: testPatient.id,
+      type: 'patient-search-results',
+      attributes: {
+        first_name,
+        last_name,
+        birth_date,
+        identifiers: [],
+        status,
+        value: '+6513216543',
+      },
+      relationships: {
+        patient: getRelationship(testPatient, 'patients'),
+      },
+    }];
+
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: {
+        data: searchResultData,
+        included: [getResource(testPatient, 'patients')],
+      },
+      delay: 300,
+    }).as('routePatientSearch');
+
+    cy
+      .routesForPatientDashboard()
+      .routeSettings('manual_patient_creation', false)
+      .routeActions()
+      .visit()
+      .wait('@routeActions');
+
+    cy
+      .get('.app-frame__nav')
+      .find('.js-search')
+      .as('search')
+      .click();
+
+    cy
+      .get('.modal--large')
+      .find('.patient-search__input')
+      .type('+6513216543')
+      .wait('@routePatientSearch');
+
+    cy
+      .get('.modal--large')
+      .find('.js-picklist-item strong')
+      .parents('.js-picklist-item')
+      .should('contain', '+6513216543');
+  });
+
   specify('No Results with Patient Add', function() {
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: { data: [] },
+    }).as('routeEmptyPatientSearch');
+
     cy
       .routeSettings('manual_patient_creation', true)
       .routesForPatientDashboard()


### PR DESCRIPTION
Shortcut Story ID: [sc-62563]

- [x] Support patient field queries setting
- [x] Add test for search by patient phone number
- [x] Split search by identifier testing into its own test



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying field query results (e.g., phone numbers) alongside identifiers in patient search results.
  * Patient search UI now shows additional search examples and a new column for field query results when available.

* **Style**
  * Updated styles to ensure consistent appearance for new field query result elements in search results.

* **Documentation**
  * Added a new translation key for field query result headers.

* **Tests**
  * Expanded and updated tests to cover searching by patient identifiers and fields such as phone numbers.
  * Adjusted test data and assertions to reflect UI changes and improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->