### PR TITLE
In patient search, update UI when search results collection is updated

### DIFF
--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -39,9 +39,6 @@ const TipTemplate = hbs`
 `;
 
 const EmptyView = View.extend({
-  collectionEvents: {
-    'search': 'render',
-  },
   tagName: 'li',
   className: 'patient-search__no-results',
   initialize({ state }) {
@@ -184,7 +181,7 @@ const HeaderView = View.extend({
 const DialogView = View.extend({
   className: 'patient-search__picklist',
   collectionEvents: {
-    'search': 'showHeader',
+    'search': 'onSearchComplete',
   },
   modelEvents: {
     'change:search': 'showHeader',
@@ -222,10 +219,11 @@ const DialogView = View.extend({
   `,
   onRender() {
     this.showHeader();
-    this.showChildView('list', new ListView({
-      collection: this.collection,
-      model: this.model,
-    }));
+    this.showList();
+  },
+  onSearchComplete() {
+    this.showHeader();
+    this.showList();
   },
   showHeader() {
     if (!this.collection.length) {
@@ -234,6 +232,12 @@ const DialogView = View.extend({
     }
 
     this.showChildView('header', new HeaderView({ collection: this.collection }));
+  },
+  showList() {
+    this.showChildView('list', new ListView({
+      collection: this.collection,
+      model: this.model,
+    }));
   },
 });
 

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -260,7 +260,7 @@ context('Patient Quick Search', function() {
 
     const { first_name, last_name, birth_date, status } = testPatient.attributes;
 
-    const searchResultData = [{
+    const searchResult = {
       id: testPatient.id,
       type: 'patient-search-results',
       attributes: {
@@ -274,14 +274,14 @@ context('Patient Quick Search', function() {
       relationships: {
         patient: getRelationship(testPatient, 'patients'),
       },
-    }];
+    };
 
     cy.intercept({
       method: 'GET',
       url: '/api/patients?filter*',
     }, {
       body: {
-        data: searchResultData,
+        data: [searchResult],
         included: [getResource(testPatient, 'patients')],
       },
       delay: 300,
@@ -315,12 +315,15 @@ context('Patient Quick Search', function() {
 
   specify('Search by patient field', function() {
     const testPatient = getPatient({
-      attributes: { status: 'active' },
+      attributes: {
+        status: 'active',
+        birth_date: '2008-01-16',
+      },
     });
 
     const { first_name, last_name, birth_date, status } = testPatient.attributes;
 
-    const searchResultData = [{
+    const searchResult = {
       id: testPatient.id,
       type: 'patient-search-results',
       attributes: {
@@ -334,14 +337,14 @@ context('Patient Quick Search', function() {
       relationships: {
         patient: getRelationship(testPatient, 'patients'),
       },
-    }];
+    };
 
     cy.intercept({
       method: 'GET',
       url: '/api/patients?filter*',
     }, {
       body: {
-        data: searchResultData,
+        data: [searchResult],
         included: [getResource(testPatient, 'patients')],
       },
       delay: 300,
@@ -371,6 +374,40 @@ context('Patient Quick Search', function() {
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
       .should('contain', '+6513216543');
+
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: {
+        data: [{
+          ...searchResult,
+          attributes: { ...searchResult.attributes, value: null },
+        }],
+        included: [getResource(testPatient, 'patients')],
+      },
+      delay: 300,
+    }).as('routePatientSearch');
+
+    // header & list views should re-render when users copy/paste/replace a search input
+    cy
+      .get('.modal--large')
+      .find('.patient-search__input')
+      .invoke('val', '2008-01-16')
+      .trigger('input')
+      .wait('@routePatientSearch');
+
+    cy
+      .get('.modal--large')
+      .find('.patient-search__picklist-header-meta')
+      .children()
+      .should('have.length', 2);
+
+    cy
+      .get('.modal--large')
+      .find('.patient-search__picklist-item-meta')
+      .children()
+      .should('have.length', 2);
   });
 
   specify('No Results with Patient Add', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-62702]

To fix a bug where the UI doesn't always update properly when copy/pasting search queries.

Video example of the bug this PR fixes:

https://github.com/user-attachments/assets/25c674bd-d661-42ec-87d5-54c466c9ffd0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the responsiveness of patient search views, ensuring that updates to the collection are immediately reflected in the interface.
* **Tests**
  * Enhanced patient search tests to cover additional input scenarios and verify correct UI updates during searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->