### PR TITLE
On pt dashboard/archive, subscribe via `Radio.request('ws', 'add', action)` when flow/action is added to collection

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -110,8 +110,6 @@ export default SubRouterApp.extend({
   onAddAction(action) {
     this.editableCollection.add(action);
 
-    Radio.request('ws', 'add', action);
-
     this._setFlowProgress();
   },
   onActionChangeState() {

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -11,6 +11,7 @@ const AdderApp = App.extend({
   },
   onStart({ model, collection }) {
     collection.add(model);
+    Radio.request('ws', 'add', model);
   },
 });
 

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -532,6 +532,20 @@ context('patient archive page', function() {
       .its('request.url')
       .should('contain', testNewSocketFlow.id);
 
+    // verify the new flow is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketFlow.id,
+          type: testNewSocketFlow.type,
+        });
+      });
+
     cy
       .get('.app-frame__content')
       .find('.table-list__item')
@@ -776,6 +790,20 @@ context('patient archive page', function() {
       .wait('@routeAction')
       .its('request.url')
       .should('contain', testNewSocketAction.id);
+
+    // verify the new action is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketAction.id,
+          type: testNewSocketAction.type,
+        });
+      });
 
     cy
       .get('.app-frame__content')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1191,6 +1191,20 @@ context('patient dashboard page', function() {
       .its('request.url')
       .should('contain', testNewSocketFlow.id);
 
+    // verify the new flow is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketFlow.id,
+          type: testNewSocketFlow.type,
+        });
+      });
+
     cy
       .get('@firstRow')
       .should('contain', 'New Flow - Created Elsewhere');
@@ -1564,6 +1578,20 @@ context('patient dashboard page', function() {
       .wait('@routeAction')
       .its('request.url')
       .should('contain', testNewSocketAction.id);
+
+    // verify the new action is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketAction.id,
+          type: testNewSocketAction.type,
+        });
+      });
 
     cy
       .get('@firstRow')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1077,65 +1077,6 @@ context('patient flow page', function() {
       .get('[data-content-region]')
       .find('.is-selected')
       .contains('Conditional');
-
-    const otherAction = getAction({
-      attributes: {
-        name: 'Socket Action',
-      },
-      relationships: {
-        flow: getRelationship(testFlow),
-        state: getRelationship(stateTodo),
-      },
-    });
-
-    cy
-      .routeAction(fx => {
-        fx.data = otherAction;
-
-        return fx;
-      });
-
-    cy.sendWs({
-      category: 'ResourceCreated',
-      resource: {
-        type: otherAction.type,
-        id: otherAction.id,
-      },
-      payload: {},
-    });
-
-    // a notification that is sent for a resource we are currently fetching
-    // this notification is queued until model.fetch() is done for that action
-    cy.sendWs({
-      category: 'StateChanged',
-      resource: {
-        type: otherAction.type,
-        id: otherAction.id,
-      },
-      payload: {
-        state: {
-          type: stateInProgress.type,
-          id: stateInProgress.id,
-        },
-      },
-    });
-
-    cy
-      .wait('@routeAction')
-      .its('request.url')
-      .should('contain', otherAction.id);
-
-    cy
-      .get('[data-content-region]')
-      .find('.is-selected')
-      .next()
-      .contains('Socket Action');
-
-    cy
-      .get('[data-content-region]')
-      .find('.is-selected')
-      .next()
-      .find('[data-state-region] .fa-circle-dot');
   });
 
   specify('failed flow', function() {
@@ -2670,6 +2611,17 @@ context('patient flow page', function() {
       },
     });
 
+    const testNewSocketAction = getAction({
+      attributes: {
+        name: 'New Action - Created Elsewhere',
+      },
+      relationships: {
+        flow: getRelationship(testSocketFlow),
+        state: getRelationship(stateTodo),
+        owner: getRelationship(teamOther),
+      },
+    });
+
     cy
       .routesForPatientAction()
       .routeFlow(fx => {
@@ -3050,5 +3002,63 @@ context('patient flow page', function() {
     cy
       .get('.patient-flow__empty-list')
       .contains('No Actions');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {},
+    });
+
+    // a notification that is sent for a resource we are currently fetching
+    // this notification is queued until model.fetch() is done for that action
+    cy.sendWs({
+      category: 'StateChanged',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {
+        state: {
+          type: stateInProgress.type,
+          id: stateInProgress.id,
+        },
+      },
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewSocketAction.id);
+
+    // verify the new flow is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketAction.id,
+          type: testNewSocketAction.type,
+        });
+      });
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .first()
+      .should('contain', 'New Action - Created Elsewhere')
+      .find('[data-state-region] .fa-circle-dot');
   });
 });

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -536,6 +536,20 @@ context('worklist page', function() {
       .its('request.url')
       .should('contain', testNewSocketFlow.id);
 
+    // verify the new flow is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketFlow.id,
+          type: testNewSocketFlow.type,
+        });
+      });
+
     cy
       .get('[data-count-region]')
       .should('contain', '2 Flows');
@@ -1522,6 +1536,20 @@ context('worklist page', function() {
         },
       },
     });
+
+    // verify the new action is added to the ws subscription resources
+    cy
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(stub => {
+        const secondCallData = stub.getCall(1).args[0].data;
+        const { resources } = secondCallData;
+
+        expect(resources).to.deep.include({
+          id: testNewSocketAction.id,
+          type: testNewSocketAction.type,
+        });
+      });
 
     cy
       .wait('@routeAction')


### PR DESCRIPTION
Shortcut Story ID: [sc-62143]

This PR is to fix a bug where actions/flows added to the patient dashboard/archive do not receive ws notifications for `Done` vs. `Non-Done` states. i.e. action/flow on the pt dashboard changed to a done state or switched to a non-done state on the pt archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of real-time updates, ensuring new flows and actions are correctly added to WebSocket subscriptions and reflected in the UI.

* **Tests**
  * Enhanced integration tests for patient archive, dashboard, flow, and worklist pages to verify that WebSocket subscription resources update accurately when new flows or actions are created remotely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->