### PR TITLE
Implement `match` object in patient search api response data

### DIFF
--- a/src/js/entities-service/entities/patient-search-results.js
+++ b/src/js/entities-service/entities/patient-search-results.js
@@ -1,4 +1,4 @@
-import { debounce, get, isBoolean } from 'underscore';
+import { debounce } from 'underscore';
 import BaseCollection from 'js/base/collection';
 import BaseModel from 'js/base/model';
 
@@ -21,8 +21,6 @@ const Collection = BaseCollection.extend({
     search = '') {
     if (search.length < 3) {
       if (!search.length || !this.prevSearch.includes(search)) {
-        delete this._hasIdentifiers;
-        delete this._hasFieldQueryResults;
         this.reset();
         this.prevSearch = '';
       }
@@ -35,27 +33,9 @@ const Collection = BaseCollection.extend({
     this.isSearching = true;
     this._debouncedSearch(search);
   },
-  hasFieldQueryResults() {
-    if (isBoolean(this._hasFieldQueryResults)) return this._hasFieldQueryResults;
-
-    this._hasFieldQueryResults = this.some(model => model.has('value'));
-
-    return this._hasFieldQueryResults;
-  },
-  hasIdentifiers() {
-    if (isBoolean(this._hasIdentifiers)) return this._hasIdentifiers;
-
-    this._hasIdentifiers = !!this.find(model => {
-      return get(model.get('identifiers'), 'length');
-    });
-
-    return this._hasIdentifiers;
-  },
   _debouncedSearch(search) {
     const filter = { search };
 
-    delete this._hasIdentifiers;
-    delete this._hasFieldQueryResults;
     this.controller.abort();
     this.controller = new AbortController();
 

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -238,10 +238,9 @@ careOptsFrontend:
           shortcut: "Keyboard Shortcut: /"
         headerView:
           dob: DOB
-          fieldQuery: Results
-          id: Identifier
           patient: Patient
-          workspaceStatus: Workspace Status
+          results: Results
+          workspaceStatus: Status
   patients:
     patient:
       archive:

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -1,3 +1,7 @@
+.patient-search__modal {
+  width: 700px;
+}
+
 .patient-search__picklist {
   display: flex;
   flex-direction: column;
@@ -50,14 +54,13 @@
   }
 }
 
-.patient-search__picklist-header-name {
-  display: flex;
-  flex: 2;
-}
-
 .patient-search__picklist-header-name-icon {
   margin-right: 16px;
   width: 28px;
+}
+
+.patient-search__picklist-header-name-text {
+  flex: 1;
 }
 
 .patient-search__picklist-header-meta {
@@ -114,19 +117,19 @@
   content: '–';
 }
 
-.patient-search__picklist-item-name {
-  display: flex;
-  flex: 2;
-  font-size: 16px;
-  padding-right: 4px;
-}
-
 .patient-search__picklist-item-name-icon {
   align-items: center;
   display: flex;
   justify-content: center;
   margin-right: 16px;
   width: 28px;
+}
+
+.patient-search__picklist-item-name-text {
+  display: flex;
+  flex: 1;
+  margin-right: 8px;
+  min-width: 0;
 }
 
 .patient-search__picklist-item-meta {

--- a/src/js/views/globals/search/patient-search.scss
+++ b/src/js/views/globals/search/patient-search.scss
@@ -1,7 +1,7 @@
 .patient-search__picklist {
   display: flex;
   flex-direction: column;
-  height: 420px;
+  height: 460px;
 }
 
 .patient-search__close {
@@ -69,10 +69,10 @@
   width: 100px;
 }
 
-.patient-search__picklist-header-identifier,
-.patient-search__picklist-header-query,
+.patient-search__picklist-header-results,
+.patient-search__picklist-header-results-label,
 .patient-search__picklist-header-status {
-  margin-left: 16px;
+  margin-left: 12px;
   width: 100px;
 }
 
@@ -88,6 +88,10 @@
   &.is-inactive {
     color: #{$black-60};
     font-style: italic;
+
+    .patient-search__picklist-item-result-label {
+      font-style: normal;
+    }
   }
 
   &.is-highlighted,
@@ -96,7 +100,8 @@
     color: #{$white};
 
     .patient-search__picklist-item,
-    .patient-search__picklist-item-meta {
+    .patient-search__picklist-item-meta,
+    .patient-search__picklist-item-result-label {
       color: #{$white};
     }
   }
@@ -127,22 +132,26 @@
 .patient-search__picklist-item-meta {
   display: flex;
   flex: 1;
-  font-size: 14px;
 }
 
 .patient-search__picklist-item-dob {
   width: 100px;
 }
 
-.patient-search__picklist-item-identifier,
-.patient-search__picklist-item-query {
-  margin-left: 16px;
+.patient-search__picklist-item-status {
+  margin-left: 12px;
+  text-transform: capitalize;
   width: 100px;
 }
 
-.patient-search__picklist-item-status {
-  margin-left: 16px;
-  text-transform: capitalize;
+.patient-search__picklist-item-result-value {
+  margin-left: 12px;
+  width: 100px;
+}
+
+.patient-search__picklist-item-result-label {
+  color: #{$black-60};
+  margin-left: 12px;
   width: 100px;
 }
 

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -90,25 +90,21 @@ const PicklistItem = View.extend({
         {{far "address-card"}}
       </div>
       <div class="patient-search__picklist-item-name-text">
-        <span>{{matchText name search}}{{~ remove_whitespace ~}}</span>
+        <span>{{name}}{{~ remove_whitespace ~}}</span>
       </div>
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
         {{formatDateTime birth_date "MM/DD/YYYY"}}
       </div>
-      {{#if hasIdentifiers}}
-        <div class="patient-search__picklist-item-identifier u-text--overflow">
-          {{matchText identifiers.0.value search}}
-        </div>
-      {{/if}}
-      {{#if hasFieldQueryResults}}
-        <div class="patient-search__picklist-item-query u-text--overflow">
-          {{matchText value search}}
-        </div>
-      {{/if}}
       <div class="patient-search__picklist-item-status u-text--overflow">
         {{status}}
+      </div>
+      <div class="patient-search__picklist-item-result-value u-text--overflow">
+        {{matchText match.value search}}
+      </div>
+      <div class="patient-search__picklist-item-result-label u-text--overflow">
+        {{match.label}}
       </div>
     </div>
   `,
@@ -116,8 +112,6 @@ const PicklistItem = View.extend({
     return {
       name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
-      hasIdentifiers: this.collection.hasIdentifiers(),
-      hasFieldQueryResults: this.collection.hasFieldQueryResults(),
     };
   },
 });
@@ -155,27 +149,15 @@ const HeaderView = View.extend({
       <div class="patient-search__picklist-header-dob">
         {{ @intl.globals.search.patientSearchViews.headerView.dob }}
       </div>
-      {{#if hasIdentifiers}}
-        <div class="patient-search__picklist-header-identifier">
-          {{ @intl.globals.search.patientSearchViews.headerView.id }}
-        </div>
-      {{/if}}
-      {{#if hasFieldQueryResults}}
-        <div class="patient-search__picklist-header-query">
-          {{ @intl.globals.search.patientSearchViews.headerView.fieldQuery }}
-        </div>
-      {{/if}}
       <div class="patient-search__picklist-header-status">
         {{ @intl.globals.search.patientSearchViews.headerView.workspaceStatus }}
       </div>
+      <div class="patient-search__picklist-header-results">
+        {{ @intl.globals.search.patientSearchViews.headerView.results }}
+      </div>
+      <div class="patient-search__picklist-header-results-label"></div>
     </div>
   `,
-  templateContext() {
-    return {
-      hasIdentifiers: this.collection.hasIdentifiers(),
-      hasFieldQueryResults: this.collection.hasFieldQueryResults(),
-    };
-  },
 });
 
 const DialogView = View.extend({

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -85,13 +85,11 @@ const PicklistItem = View.extend({
     this.state.set({ selected: this.model });
   },
   template: hbs`
-    <div class="patient-search__picklist-item-name u-text--overflow">
-      <div class="patient-search__picklist-item-name-icon">
-        {{far "address-card"}}
-      </div>
-      <div class="patient-search__picklist-item-name-text">
-        <span>{{name}}{{~ remove_whitespace ~}}</span>
-      </div>
+    <div class="patient-search__picklist-item-name-icon">
+      {{far "address-card"}}
+    </div>
+    <div class="patient-search__picklist-item-name-text">
+      <span class="u-text--overflow">{{name}}{{~ remove_whitespace ~}}</span>
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
@@ -139,11 +137,9 @@ const ListView = CollectionView.extend({
 const HeaderView = View.extend({
   className: 'patient-search__picklist-header',
   template: hbs`
-    <div class="patient-search__picklist-header-name">
-      <div class="patient-search__picklist-header-name-icon"></div>
-      <div class="patient-search__picklist-header-name-text">
-        {{ @intl.globals.search.patientSearchViews.headerView.patient }}
-      </div>
+    <div class="patient-search__picklist-header-name-icon"></div>
+    <div class="patient-search__picklist-header-name-text">
+      {{ @intl.globals.search.patientSearchViews.headerView.patient }}
     </div>
     <div class="patient-search__picklist-header-meta">
       <div class="patient-search__picklist-header-dob">
@@ -247,7 +243,7 @@ const PatientSearchPicklist = Component.extend({
 });
 
 const PatientSearchModal = View.extend({
-  className: 'modal--large',
+  className: 'modal patient-search__modal',
   template: hbs`
     <a href="#" class="button--icon patient-search__close js-close">{{far "xmark"}}</a>
     <div data-picklist-region></div>

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -89,7 +89,7 @@ const PicklistItem = View.extend({
       {{far "address-card"}}
     </div>
     <div class="patient-search__picklist-item-name-text">
-      <span class="u-text--overflow">{{name}}{{~ remove_whitespace ~}}</span>
+      <span class="u-text--overflow">{{first_name}} {{last_name}}{{~ remove_whitespace ~}}</span>
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
@@ -108,7 +108,6 @@ const PicklistItem = View.extend({
   `,
   templateContext() {
     return {
-      name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
     };
   },

--- a/src/scss/modules/modals.scss
+++ b/src/scss/modules/modals.scss
@@ -16,7 +16,7 @@
 .modal--large {
   @extend .modal;
 
-  min-width: 600px;
+  min-width: 700px;
   width: auto;
 }
 

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -415,7 +415,7 @@ context('App Nav', function() {
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.js-close')
       .click();
 
@@ -932,17 +932,17 @@ context('App Nav', function() {
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.patient-search__input')
       .should('have.value', 'First New Last');
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.js-close .icon')
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .should('not.exist');
   });
 

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -76,7 +76,7 @@ context('Patient Quick Search', function() {
       .should('have.class', 'is-active');
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .as('searchModal')
       .should('contain', 'Search by')
       .find('.patient-search__input')
@@ -305,13 +305,13 @@ context('Patient Quick Search', function() {
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.patient-search__input')
       .type('identifier-001')
       .wait('@routePatientSearch');
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
       .should('contain', 'identifier-001');
@@ -370,13 +370,13 @@ context('Patient Quick Search', function() {
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.patient-search__input')
       .type('+6513216543')
       .wait('@routePatientSearch');
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
       .should('contain', '+6513216543');
@@ -397,14 +397,14 @@ context('Patient Quick Search', function() {
 
     // list view should re-render when users copy/paste/replace a search input
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.patient-search__input')
       .invoke('val', '2008-01-16')
       .trigger('input')
       .wait('@routePatientSearch');
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
       .should('contain', '2008-01-16');
@@ -432,7 +432,7 @@ context('Patient Quick Search', function() {
       .click();
 
     cy
-      .get('.modal--large')
+      .get('.patient-search__modal')
       .as('searchModal')
       .find('.patient-search__input')
       .type('None')

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -26,9 +26,11 @@ context('Patient Quick Search', function() {
           first_name,
           last_name,
           birth_date,
-          identifiers: [],
-          value: null,
           status,
+          match: {
+            label: 'Name',
+            value: `${ first_name } ${ last_name }`,
+          },
         },
         relationships: {
           patient: getRelationship(patient, 'patients'),
@@ -267,9 +269,11 @@ context('Patient Quick Search', function() {
         first_name,
         last_name,
         birth_date,
-        identifiers: [{ type: 'mrn', value: 'identifier-001' }],
         status,
-        value: null,
+        match: {
+          label: 'MRN',
+          value: 'identifier-001',
+        },
       },
       relationships: {
         patient: getRelationship(testPatient, 'patients'),
@@ -330,9 +334,11 @@ context('Patient Quick Search', function() {
         first_name,
         last_name,
         birth_date,
-        identifiers: [],
         status,
-        value: '+6513216543',
+        match: {
+          label: 'Phone Number',
+          value: '+6513216543',
+        },
       },
       relationships: {
         patient: getRelationship(testPatient, 'patients'),
@@ -382,14 +388,14 @@ context('Patient Quick Search', function() {
       body: {
         data: [{
           ...searchResult,
-          attributes: { ...searchResult.attributes, value: null },
+          attributes: { ...searchResult.attributes, match: { label: 'DOB', value: '2008-01-16' } },
         }],
         included: [getResource(testPatient, 'patients')],
       },
       delay: 300,
     }).as('routePatientSearch');
 
-    // header & list views should re-render when users copy/paste/replace a search input
+    // list view should re-render when users copy/paste/replace a search input
     cy
       .get('.modal--large')
       .find('.patient-search__input')
@@ -399,15 +405,9 @@ context('Patient Quick Search', function() {
 
     cy
       .get('.modal--large')
-      .find('.patient-search__picklist-header-meta')
-      .children()
-      .should('have.length', 2);
-
-    cy
-      .get('.modal--large')
-      .find('.patient-search__picklist-item-meta')
-      .children()
-      .should('have.length', 2);
+      .find('.js-picklist-item strong')
+      .parents('.js-picklist-item')
+      .should('contain', '2008-01-16');
   });
 
   specify('No Results with Patient Add', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-62877]

Corresponding BE PR: https://github.com/RoundingWell/care-ops-backend/pull/957301

<img width="1396" height="922" alt="Screenshot 2025-08-06 at 10 32 02 AM" src="https://github.com/user-attachments/assets/0ae1bc42-673a-41af-b5c3-dbb9e116b713" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Patient search results now consistently display a unified result value and label for each entry, improving clarity in the search picklist.

* **Style**
  * Increased the height of the patient search picklist and updated spacing and styling for headers and result labels.
  * Enlarged the minimum width of large modals for better content display.

* **Bug Fixes**
  * Improved consistency in displaying search results by removing conditional rendering of identifiers and field query results.

* **Documentation**
  * Updated localization strings to reflect new result labeling and simplified status indicators.

* **Tests**
  * Updated test data and assertions to align with the new unified match structure in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->