### PR TITLE
Fix e2e auth

### DIFF
--- a/packages/care-ops-auth/AuthProvider.js
+++ b/packages/care-ops-auth/AuthProvider.js
@@ -8,7 +8,7 @@ export class AuthProvider {
   constructor(config = {}, LoginView = null) {
     this.config = config;
     this.LoginView = LoginView;
-    this.token = null;
+    this.token = config.token || null;
     this.client = null;
   }
 


### PR DESCRIPTION
The config in cypress passes in the token

e2e tests are failing because I left out the token config for the appconfig override on cypress.

Side note: Actually think we should probably add a test for the AuthProvider class.. can't reasonably test the auth implementations, but the class is generic.

If this looks good, we need to merge and run a new release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication setup by allowing tokens to be pre-set during initialization, enabling smoother sign-in experiences when a token is already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->