### PR TITLE
In search results, don't show match column data if `match.label` equals `Name` or `Birth Date`

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -241,6 +241,9 @@ careOptsFrontend:
           patient: Patient
           results: Results
           workspaceStatus: Status
+        picklistItemView:
+          labelDob: Birth Date
+          labelName: Name
   patients:
     patient:
       archive:

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -6,6 +6,8 @@ import { View, CollectionView, Region } from 'marionette';
 import 'scss/modules/buttons.scss';
 import 'scss/modules/modals.scss';
 
+import intl from 'js/i18n';
+
 import Component from 'js/base/component';
 
 import InputFocusBehavior from 'js/behaviors/input-focus';
@@ -99,26 +101,29 @@ const PicklistItem = View.extend({
         {{status}}
       </div>
       <div class="patient-search__picklist-item-result-value u-text--overflow">
-        {{#unless isDefaultMatchType}}
+        {{#if shouldShowMatch}}
           {{matchText match.value search}}
-        {{/unless}}
+        {{/if}}
       </div>
       <div class="patient-search__picklist-item-result-label u-text--overflow">
-        {{#unless isDefaultMatchType}}
+        {{#if shouldShowMatch}}
           {{match.label}}
-        {{/unless}}
+        {{/if}}
       </div>
     </div>
   `,
   templateContext() {
-    const match = this.model.get('match');
-    const isDefaultMatchType = match.label === 'Name' || match.label === 'Birth Date';
-
     return {
-      isDefaultMatchType,
       name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
+      shouldShowMatch: this.shouldShowMatch(),
     };
+  },
+  shouldShowMatch() {
+    const label = this.model.get('match').label;
+    const i18n = intl.globals.search.patientSearchViews.picklistItemView;
+
+    return label !== i18n.labelName && label !== i18n.labelDob;
   },
 });
 

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -89,7 +89,7 @@ const PicklistItem = View.extend({
       {{far "address-card"}}
     </div>
     <div class="patient-search__picklist-item-name-text">
-      <span class="u-text--overflow">{{first_name}} {{last_name}}{{~ remove_whitespace ~}}</span>
+      <span class="u-text--overflow">{{matchText name search}}{{~ remove_whitespace ~}}</span>
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
@@ -108,6 +108,7 @@ const PicklistItem = View.extend({
   `,
   templateContext() {
     return {
+      name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
     };
   },

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -99,15 +99,23 @@ const PicklistItem = View.extend({
         {{status}}
       </div>
       <div class="patient-search__picklist-item-result-value u-text--overflow">
-        {{matchText match.value search}}
+        {{#unless isDefaultMatchType}}
+          {{matchText match.value search}}
+        {{/unless}}
       </div>
       <div class="patient-search__picklist-item-result-label u-text--overflow">
-        {{match.label}}
+        {{#unless isDefaultMatchType}}
+          {{match.label}}
+        {{/unless}}
       </div>
     </div>
   `,
   templateContext() {
+    const match = this.model.get('match');
+    const isDefaultMatchType = match.label === 'Name' || match.label === 'Birth Date';
+
     return {
+      isDefaultMatchType,
       name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
     };

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -151,7 +151,10 @@ context('Patient Quick Search', function() {
       .find('.js-picklist-item strong')
       .contains('2')
       .parents('.js-picklist-item')
+      .find('.patient-search__picklist-item-meta')
       .should('contain', 'active')
+      .should('not.contain', 'Patient')
+      .should('not.contain', 'Name')
       .click();
 
     cy
@@ -314,7 +317,8 @@ context('Patient Quick Search', function() {
       .get('.patient-search__modal')
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
-      .should('contain', 'identifier-001');
+      .should('contain', 'identifier-001')
+      .should('contain', 'MRN');
   });
 
   specify('Search by patient field', function() {
@@ -379,7 +383,8 @@ context('Patient Quick Search', function() {
       .get('.patient-search__modal')
       .find('.js-picklist-item strong')
       .parents('.js-picklist-item')
-      .should('contain', '+6513216543');
+      .should('contain', '+6513216543')
+      .should('contain', 'Phone Number');
 
     cy.intercept({
       method: 'GET',


### PR DESCRIPTION
Shortcut Story ID: [sc-62877]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved patient search picklist: patient names are highlighted; redundant labels (Name, Birth Date) are hidden for clarity.
  * Match metadata (identifiers, phone numbers) is shown only when meaningful.
  * Added localization entries for the picklist item labels to control visibility.

* **Tests**
  * Updated integration tests to verify active picklist behavior and that identifiers and phone numbers display with their labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->