### PR TITLE
Include flow on schedule pages

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -99,7 +99,7 @@ export default App.extend({
   beforeStart() {
     const filter = this.getState().getEntityFilter();
     const fields = { flows: ['name', 'state'], patients: ['first_name', 'last_name'] };
-    const include = 'patient';
+    const include = 'patient,flow';
     return Radio.request('entities', 'fetch:actions:collection', { data: { filter, fields, include } });
   },
   onStart(options, collection) {

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -115,7 +115,7 @@ export default App.extend({
   beforeStart() {
     const filter = this.getState().getEntityFilter();
     const fields = { flows: ['name', 'state'], patients: ['first_name', 'last_name'] };
-    const include = 'patient';
+    const include = 'patient,flow';
     return Radio.request('entities', 'fetch:actions:collection', { data: { filter, fields, include } });
   },
   onStart(options, collection) {

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -100,7 +100,7 @@ context('reduced schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'include=patient')
+      .should('contain', 'include=patient,flow')
       .should('contain', `filter[clinicians]=${ currentClinician.id }`)
       .should('contain', `filter[states]=${ stateTodo.id },${ stateInProgress.id }`)
       .should('contain', 'fields[flows]=name,state');

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1871,7 +1871,7 @@ context('schedule page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
-      .should('contain', 'include=patient')
+      .should('contain', 'include=patient,flow')
       .should('contain', `filter[states]=${ stateInProgress.id }`);
 
     cy


### PR DESCRIPTION
[sc-63104]
We were already filtering the fields, but didn’t include it.  This broken when we removed the default includes on the BE.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved Schedule and Reduced Schedule views to load additional related data for patients, ensuring more complete and reliable action lists.
  - Reduces instances where context could be missing when viewing patient schedules.

- Tests
  - Updated integration tests for schedule pages to validate the expanded data retrieval and ensure consistent behavior across scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->