### PR TITLE
Add success callback for auth

### DIFF
--- a/packages/care-ops-auth/AuthProvider.js
+++ b/packages/care-ops-auth/AuthProvider.js
@@ -12,11 +12,15 @@ export class AuthProvider {
     this.client = null;
   }
 
-  async auth() {
+  async auth(success) {
     if (location.pathname === AuthProvider.PATH_LOGOUT) {
       this.logout();
       return;
     }
+
+    this.handleAuthedPath(location.pathname);
+
+    success();
   }
 
   frameBust() {

--- a/packages/care-ops-auth/providers/auth0.js
+++ b/packages/care-ops-auth/providers/auth0.js
@@ -25,10 +25,11 @@ export class Auth0AuthProvider extends AuthProvider {
     this.client.loginWithRedirect({ prompt: 'login', ...opts });
   }
 
-  async _authenticate() {
+  async _authenticate(success) {
     try {
       const { appState } = await this.client.handleRedirectCallback();
       this.handleAuthedPath(appState);
+      success();
     } catch {
       this.loginPrompt();
     }
@@ -51,17 +52,20 @@ export class Auth0AuthProvider extends AuthProvider {
     this.client = await createAuth0Client(clientConfig);
   }
 
-  async auth() {
+  async auth(success) {
     this.frameBust();
 
-    if (!navigator.onLine) return;
+    if (!navigator.onLine) {
+      success();
+      return;
+    }
 
     const appState = location.pathname;
 
     await this._initClient();
 
     if (appState === AuthProvider.PATH_AUTHD) {
-      await this._authenticate();
+      await this._authenticate(success);
       return;
     }
 
@@ -90,5 +94,7 @@ export class Auth0AuthProvider extends AuthProvider {
     if (appState === AuthProvider.PATH_LOGIN) {
       this.replaceState(AuthProvider.PATH_ROOT);
     }
+
+    success();
   }
 }

--- a/packages/care-ops-auth/providers/kinde.js
+++ b/packages/care-ops-auth/providers/kinde.js
@@ -51,16 +51,22 @@ export class KindeAuthProvider extends AuthProvider {
     });
   }
 
-  async auth() {
+  async auth(success) {
     this.frameBust();
 
-    if (!navigator.onLine) return;
+    if (!navigator.onLine) {
+      success();
+      return;
+    }
 
     const pathName = location.pathname;
 
     await this._initClient();
 
-    if (pathName === AuthProvider.PATH_AUTHD) return;
+    if (pathName === AuthProvider.PATH_AUTHD) {
+      success();
+      return;
+    }
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
@@ -84,5 +90,7 @@ export class KindeAuthProvider extends AuthProvider {
     if (pathName === AuthProvider.PATH_LOGIN) {
       this.replaceState(AuthProvider.PATH_ROOT);
     }
+
+    success();
   }
 }

--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -60,10 +60,13 @@ export class WorkosAuthProvider extends AuthProvider {
     });
   }
 
-  async auth() {
+  async auth(success) {
     this.frameBust();
 
-    if (!navigator.onLine) return;
+    if (!navigator.onLine) {
+      success();
+      return;
+    }
 
     const pathName = location.pathname;
 
@@ -71,7 +74,10 @@ export class WorkosAuthProvider extends AuthProvider {
 
     await this._initClient(clientId);
 
-    if (pathName === AuthProvider.PATH_AUTHD) return;
+    if (pathName === AuthProvider.PATH_AUTHD) {
+      success();
+      return;
+    }
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
@@ -89,5 +95,7 @@ export class WorkosAuthProvider extends AuthProvider {
     if (pathName === AuthProvider.PATH_LOGIN) {
       this.replaceState(AuthProvider.PATH_ROOT);
     }
+
+    success();
   }
 }

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -90,7 +90,9 @@ Radio.reply('auth', {
 
 async function auth() {
   const agent = await getAuthAgent();
-  return agent.auth();
+  return new Promise(resolve => {
+    agent.auth(resolve);
+  });
 }
 
 export {


### PR DESCRIPTION
In some cases we were created a race condition where the auth function was “resolving” during the auth0 sdk redirect, and so a request was made 401’d and logged out prior to auth0 successfully authing.

success prevents a `return;` from ending the auth await in the index.

Shortcut Story ID: [sc-63128]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smoother post-sign-in experience across all authentication providers; the app now proceeds automatically once authentication completes.
* **Bug Fixes**
  * Resolved intermittent hangs after login by ensuring authentication consistently signals completion.
  * Improved offline handling during authentication so the app continues gracefully when no network is available.
  * Standardized behavior across Auth0, Kinde, and WorkOS providers for consistent navigation after auth.
* **Refactor**
  * Internal auth flow now completes via a unified callback/promise mechanism for more reliable user transitions after sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->