### PR TITLE
Fix createClient pattern

### DIFF
--- a/packages/care-ops-auth/providers/kinde.js
+++ b/packages/care-ops-auth/providers/kinde.js
@@ -26,29 +26,24 @@ export class KindeAuthProvider extends AuthProvider {
     });
   }
 
-  async _initClient() {
-    return new Promise(resolve => {
-      const clientConfig = {
-        ...this.config.createParams,
-        redirect_uri: location.origin + AuthProvider.PATH_AUTHD,
-        logout_uri: location.origin,
-        on_redirect_callback: (user, { path } = {}) => {
-          if (!user) {
-            this.loginPrompt({ appState: path });
-            return;
-          }
+  async _initClient(success) {
+    const clientConfig = {
+      ...this.config.createParams,
+      redirect_uri: location.origin + AuthProvider.PATH_AUTHD,
+      logout_uri: location.origin,
+      on_redirect_callback: (user, { path } = {}) => {
+        if (!user) {
+          this.loginPrompt({ appState: path });
+          return;
+        }
 
-          this.handleAuthedPath(path);
+        this.handleAuthedPath(path);
 
-          resolve();
-        },
-      };
+        success();
+      },
+    };
 
-      createKindeClient(clientConfig)
-        .then(client => {
-          this.client = client;
-        });
-    });
+    return createKindeClient(clientConfig);
   }
 
   async auth(success) {
@@ -61,12 +56,9 @@ export class KindeAuthProvider extends AuthProvider {
 
     const pathName = location.pathname;
 
-    await this._initClient();
+    this.client = await this._initClient(success);
 
-    if (pathName === AuthProvider.PATH_AUTHD) {
-      success();
-      return;
-    }
+    if (pathName === AuthProvider.PATH_AUTHD) return;
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;

--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -35,29 +35,24 @@ export class WorkosAuthProvider extends AuthProvider {
     return clientId;
   }
 
-  async _initClient(clientId) {
-    return new Promise(resolve => {
-      const clientConfig = {
-        redirectUri: location.origin + AuthProvider.PATH_AUTHD,
-        onRedirectCallback: ({ user, state }) => {
-          const path = state;
-          if (!user) {
-            this.loginPrompt(path);
-            return;
-          }
+  async _initClient(clientId, success) {
+    const clientConfig = {
+      redirectUri: location.origin + AuthProvider.PATH_AUTHD,
+      onRedirectCallback: ({ user, state }) => {
+        const path = state;
+        if (!user) {
+          this.loginPrompt(path);
+          return;
+        }
 
-          this.handleAuthedPath(path);
+        this.handleAuthedPath(path);
 
-          resolve();
-        },
-        ...this.config.createClientOptions,
-      };
+        success();
+      },
+      ...this.config.createClientOptions,
+    };
 
-      createClient(clientId, clientConfig)
-        .then(client => {
-          this.client = client;
-        });
-    });
+    return createClient(clientId, clientConfig);
   }
 
   async auth(success) {
@@ -72,12 +67,10 @@ export class WorkosAuthProvider extends AuthProvider {
 
     const clientId = this._getClientId(pathName);
 
-    await this._initClient(clientId);
+    this.client = await this._initClient(clientId, success);
 
-    if (pathName === AuthProvider.PATH_AUTHD) {
-      success();
-      return;
-    }
+    // pathName will be PATH_AUTHD here if we are expecting client.onRedirectCallback
+    if (pathName === AuthProvider.PATH_AUTHD) return;
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
@@ -96,6 +89,7 @@ export class WorkosAuthProvider extends AuthProvider {
       this.replaceState(AuthProvider.PATH_ROOT);
     }
 
+    // If we're already authenticated and at the right path
     success();
   }
 }


### PR DESCRIPTION
onRedirectCallback is called when  `pathName === AuthProvider.PATH_AUTHD`

but the auth -> redirect to PATH_AUTHD happens down at `if (!isAuthenticated) {`

so the client needs to resolve so that the login prompt can occur

Shortcut Story ID: [sc-63142]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More reliable redirect completion so sign-in finishes automatically after returning to the app.

- Bug Fixes
  - Resolved scenarios where authentication could hang or require a manual refresh.
  - Better handling when offline or already-authenticated to avoid unnecessary prompts.

- Refactor
  - Consolidated auth initialization and callback flow for more consistent, faster login behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->