### PR TITLE
In `intl.patients.widgets.widgets.dob`, ensure `0` age values are displayed as a string

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -613,7 +613,7 @@ careOptsFrontend:
             updatedAt: Updated
     widgets:
       widgets:
-        dob: "{ dob } &ndash; (Age { age })"
+        dob: "{ dob } &ndash; (Age { age, number })"
         sex: |
           {sex, select,
             m {Male}


### PR DESCRIPTION
Shortcut Story ID: [sc-63165]

It was being treated as falsey and therefore not being displayed at all in the UI [screenshot](https://github.com/user-attachments/assets/2d395629-e2b0-4f72-a2d7-99170c9967d6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the age display in the Date of Birth widget for the en-US locale to use proper numeric formatting. Ages now render as numbers per locale conventions, improving readability and consistency across the interface, preventing placeholder text from appearing, and aligning the output with other numerically formatted fields for accurate localization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->