### PR TITLE
Support matching text substrings for patient search

### DIFF
--- a/src/js/base/helpers.cy.js
+++ b/src/js/base/helpers.cy.js
@@ -11,6 +11,7 @@ context('Handlebars helpers', function() {
       template: hbs`
         <div class="test-null">{{matchText "Patient Name" null}}</div>
         <div class="test-match">{{matchText "Patient Name" "Patient"}}</div>
+        <div class="test-match-substring">{{matchText "TestPatient Name" "patient" includeSubstrings=true}}</div>
         <div class="test-noescape">{{matchText "<span style='color: green'>Patient</span> Name" "Patient" noEscape=true}}</div>
       `,
     });
@@ -29,6 +30,11 @@ context('Handlebars helpers', function() {
     cy
       .get('@root')
       .find('.test-match strong')
+      .should('contain', 'Patient');
+
+    cy
+      .get('@root')
+      .find('.test-match-substring strong')
       .should('contain', 'Patient');
 
     cy

--- a/src/js/base/helpers.js
+++ b/src/js/base/helpers.js
@@ -12,7 +12,11 @@ const helpers = {
 
     if (!hash.noEscape) text = Handlebars.escapeExpression(text);
 
-    return new Handlebars.SafeString(matchText(text, query));
+    const options = {
+      includeSubstrings: !!hash.includeSubstrings,
+    };
+
+    return new Handlebars.SafeString(matchText(text, query, options));
   },
   formatDateTime(date, format, { hash = {} }) {
     if (!date) return new Handlebars.SafeString(hash.defaultHtml || '');

--- a/src/js/utils/formatting/build-matcher-substrings.js
+++ b/src/js/utils/formatting/build-matcher-substrings.js
@@ -1,0 +1,11 @@
+// takes a search string and builds a search for each word without the match tag
+import { map, memoize } from 'underscore';
+
+import words from 'js/utils/formatting/words';
+import searchSanitize from 'js/utils/formatting/search-sanitize';
+
+export default memoize(function(query) {
+  const searchWords = map(words(searchSanitize(query)), RegExp.escape);
+
+  return new RegExp(searchWords.join('|'), 'gi');
+});

--- a/src/js/utils/formatting/formatting.cy.js
+++ b/src/js/utils/formatting/formatting.cy.js
@@ -1,4 +1,5 @@
 import buildMatcher from './build-matcher';
+import buildMatcherSubstrings from './build-matcher-substrings';
 import buildMatchersArray from './build-matchers-array';
 import collectionOf from './collection-of';
 import hasAllText from './has-all-text';
@@ -13,8 +14,12 @@ import words from './words';
 context('formatting', function() {
   specify('buildMatcher', function() {
     const matcher = buildMatcher('test string');
-
     expect(matcher).to.eql(/\btest|string/gi);
+  });
+
+  specify('buildMatcher - include substrings', function() {
+    const match = buildMatcherSubstrings('test string');
+    expect(match).to.eql(/test|string/gi);
   });
 
   specify('buildMatchersArray', function() {
@@ -52,7 +57,7 @@ context('formatting', function() {
 
     expect(result, 'default tag').to.equal('This is a <strong>test</strong>');
 
-    const result2 = matchText('This is a test', 'test', 'p class="test"', 'p');
+    const result2 = matchText('This is a test', 'test', { pretag: 'p class="test"', posttag: 'p' });
 
     expect(result2).to.equal('This is a <p class="test">test</p>');
   });

--- a/src/js/utils/formatting/match-text.js
+++ b/src/js/utils/formatting/match-text.js
@@ -2,14 +2,16 @@
 // and wraps it in the pretag posttag.  Defaulting to <strong></strong>
 
 import buildMatcher from 'js/utils/formatting/build-matcher';
+import buildMatcherSubstrings from 'js/utils/formatting/build-matcher-substrings';
 
-export default (text, query, pretag, posttag) => {
+export default (text, query, options = {}) => {
   if (!text) return;
 
-  pretag = pretag || 'strong';
-  posttag = posttag || pretag;
+  const pretag = options.pretag || 'strong';
+  const posttag = options.posttag || pretag;
+  const includeSubstrings = !!options.includeSubstrings;
 
-  const matcher = buildMatcher(query);
+  const matcher = includeSubstrings ? buildMatcherSubstrings(query) : buildMatcher(query);
 
   return text.replace(matcher, `<${ pretag }>$&</${ posttag }>`);
 };

--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -91,7 +91,7 @@ const PicklistItem = View.extend({
       {{far "address-card"}}
     </div>
     <div class="patient-search__picklist-item-name-text">
-      <span class="u-text--overflow">{{matchText name search}}{{~ remove_whitespace ~}}</span>
+      <span class="u-text--overflow">{{matchText name search includeSubstrings=true}}{{~ remove_whitespace ~}}</span>
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
@@ -102,7 +102,7 @@ const PicklistItem = View.extend({
       </div>
       <div class="patient-search__picklist-item-result-value u-text--overflow">
         {{#if shouldShowMatch}}
-          {{matchText match.value search}}
+          {{matchText match.value search includeSubstrings=true}}
         {{/if}}
       </div>
       <div class="patient-search__picklist-item-result-label u-text--overflow">

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -275,7 +275,7 @@ context('Patient Quick Search', function() {
         status,
         match: {
           label: 'MRN',
-          value: 'identifier-001',
+          value: '311300999',
         },
       },
       relationships: {
@@ -310,14 +310,14 @@ context('Patient Quick Search', function() {
     cy
       .get('.patient-search__modal')
       .find('.patient-search__input')
-      .type('identifier-001')
+      .type('311300999')
       .wait('@routePatientSearch');
 
     cy
       .get('.patient-search__modal')
       .find('.js-picklist-item strong')
+      .should('contain', '311300999')
       .parents('.js-picklist-item')
-      .should('contain', 'identifier-001')
       .should('contain', 'MRN');
   });
 
@@ -341,7 +341,7 @@ context('Patient Quick Search', function() {
         status,
         match: {
           label: 'Phone Number',
-          value: '+6513216543',
+          value: '+16513216543',
         },
       },
       relationships: {
@@ -376,14 +376,14 @@ context('Patient Quick Search', function() {
     cy
       .get('.patient-search__modal')
       .find('.patient-search__input')
-      .type('+6513216543')
+      .type('65132')
       .wait('@routePatientSearch');
 
     cy
       .get('.patient-search__modal')
       .find('.js-picklist-item strong')
+      .should('contain', '65132')
       .parents('.js-picklist-item')
-      .should('contain', '+6513216543')
       .should('contain', 'Phone Number');
 
     cy.intercept({


### PR DESCRIPTION
Shortcut Story ID: [sc-63161]

So we can highlight matches that are not at the beginning of a word or string in patient search results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Search results now highlight substring matches within patient names and matched values, making partial query matches visibly emphasized.

- **Style**
  - Updated display format for MRNs and phone numbers in Patient Quick Search results for clearer, more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->