### PR TITLE
Fix overline data request

### DIFF
--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -129,7 +129,7 @@ export default App.extend({
     const entityRequest = isFlowType ? 'fetch:flows:collection' : 'fetch:actions:collection';
 
     const includes = ['patient', ...this.sortOptions.getInclude()];
-    const fields = { patients: ['first_name', 'last_name', 'patient-fields'] };
+    const fields = { patients: ['first_name', 'last_name', 'patient-fields', 'segment'] };
     this.filters = this.getState().getEntityFilter();
 
     if (!isFlowType) {

--- a/src/js/views/patients/patient/flow/header.hbs
+++ b/src/js/views/patients/patient/flow/header.hbs
@@ -1,7 +1,7 @@
 <h1 class="patient-flow__name">{{fas "folder-open"}} {{ name }}</h1>
 <div>
   <span class="patient-flow__details">{{ details }}</span>
-  <span class="patient-flow__meta" data-state-region></span>
-  <span class="patient-flow__meta" data-owner-region></span>
+  <span class="patient-flow__meta" data-state-region></span>{{~ remove_whitespace ~}}
+  <span class="patient-flow__meta" data-owner-region></span>{{~ remove_whitespace ~}}
   <progress class="js-progress progress-bar patient-flow__progress" value={{ _progress.complete }} max={{ _progress.total }}></progress>
 </div>

--- a/src/js/views/patients/patient/flow/patient-flow.scss
+++ b/src/js/views/patients/patient/flow/patient-flow.scss
@@ -80,9 +80,11 @@
   color: #{$black-60};
   display: inline-block;
   font-size: 14px;
-  padding-right: 24px;
+  margin-right: 16px;
   vertical-align: top;
-  width: calc(40% + 98px);
+
+  /* 48 + 32 + 16 icon */
+  width: calc(40% + 96px);
 }
 
 .patient-flow__meta {
@@ -98,7 +100,7 @@
 .patient-flow__table-list {
   grid-template-columns:
     48px
-    30px
+    32px
     minmax(100px, 40%)
     minmax(max-content, auto)
     minmax(max-content, 84px);

--- a/src/js/views/programs/program/flow/program-flow.scss
+++ b/src/js/views/programs/program/flow/program-flow.scss
@@ -79,7 +79,9 @@
   font-size: 14px;
   margin-right: 16px;
   vertical-align: top;
-  width: calc(40% + 22px);
+
+  /* 60 - 16px */
+  width: calc(40% + 44px);
 }
 
 .program-flow__meta {

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -132,6 +132,7 @@ context('worklist page', function() {
       .wait('@routeFlows')
       .itsUrl()
       .its('search')
+      .should('contain', 'fields[patients]=first_name,last_name,patient-fields,segment')
       .should('not.contain', 'fields[flows]=name,state');
 
     cy
@@ -1710,6 +1711,7 @@ context('worklist page', function() {
       .wait('@routeActions')
       .itsUrl()
       .its('search')
+      .should('contain', 'fields[patients]=first_name,last_name,patient-fields,segment')
       .should('contain', 'fields[flows]=name,state');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-63258]

I over removed remove-whitespace in the patient flow header.. and that along with last minute spacing adjustments in the list made the header off.  It's worth noting that the header alignment is ballpark.. only works sometimes when things are wide.  So this includes small alignment 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Worklists now include patient "segment" data in requests so segment is available alongside existing patient fields.

* Style
  * Removed extra spacing between inline elements in patient flow header.
  * Adjusted details panel widths in patient and program flows for improved layout balance.

* Tests
  * Added tests to verify patient segment is requested in worklist routes and validated with flow data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->