### PR TITLE
Update Cypress to v15

### DIFF
--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig({
     supportFile: 'test/support/e2e.js',
     setupNodeEvents,
     experimentalRunAllSpecs: true,
+    experimentalStudio: true,
   },
 
   env: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@stylistic/eslint-plugin": "^4.4.1",
         "babel-plugin-istanbul": "^7.0.0",
         "browserslist-to-esbuild": "^2.1.1",
-        "cypress": "^14.0.0",
+        "cypress": "^15.0.0",
         "cypress-plugin-tab": "^1.0.5",
         "cypress-vite": "^1.5.0",
         "eslint": "^9.5.0",
@@ -1941,9 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.8.tgz",
-      "integrity": "sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
+      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1953,7 +1953,7 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~4.0.0",
+        "form-data": "~4.0.4",
         "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -2633,9 +2633,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2706,13 +2706,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -5864,14 +5864,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "14.5.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.2.tgz",
-      "integrity": "sha512-O4E4CEBqDHLDrJD/dfStHPcM+8qFgVVZ89Li7xDU0yL/JxO/V0PEcfF2I8aGa7uA2MGNLkNUAnghPM83UcHOJw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.0.0.tgz",
+      "integrity": "sha512-OH5Srk10qTzHYYt3BsP9V1DPYIAzms55s3xQn4mGmYO4k6pi25MCajDyPbiULfNDhNcthNQ2xmYvu1JdeEw1Hw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.8",
+        "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -5911,7 +5911,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.3",
+        "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
@@ -5920,7 +5920,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/cypress-plugin-tab": {
@@ -12277,9 +12277,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@stylistic/eslint-plugin": "^4.4.1",
     "babel-plugin-istanbul": "^7.0.0",
     "browserslist-to-esbuild": "^2.1.1",
-    "cypress": "^14.0.0",
+    "cypress": "^15.0.0",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-vite": "^1.5.0",
     "eslint": "^9.5.0",


### PR DESCRIPTION
Include `experimentalStudio`

We should do this on e2e for sure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled Cypress Studio in end-to-end tests to simplify recording and maintaining scenarios, improving test coverage, stability, and developer productivity.
* **Chores**
  * Upgraded Cypress to v15 for the latest fixes and improvements in our testing toolkit, enhancing CI reliability and compatibility.
  
No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->