### PR TITLE
Fix bug where `AttachmentAdded` not working in action sidebar in some scenarios

### DIFF
--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -87,6 +87,9 @@ export default App.extend(extend({
     this.attachments.add(model);
 
     Radio.request('ws', 'add', model);
+
+    // to cover the scenario where the AttachmentsView hasn't been shown yet
+    if (this.attachments.length === 1) this.showAttachments();
   },
   onStart(options, activity, comments, attachments) {
     this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -113,7 +113,6 @@ context('patient flow page', function() {
 
   specify('patient flow action sidebar', function() {
     const testFileId = uuid();
-    const testOtherFile = getFile();
     const testComment = getComment();
 
     const testPatient = getPatient({
@@ -148,13 +147,13 @@ context('patient flow page', function() {
         'form': getRelationship(testForm),
         'patient': getRelationship(testPatient),
         'program-action': getRelationship(testProgramAction),
-        'files': getRelationship([testOtherFile]),
+        'files': getRelationship([]),
       },
     });
 
     cy
       .routesForPatientAction()
-      .routeSettings('upload_attachments', true)
+      .routeSettings('upload_attachments', false)
       .routeFlow(fx => {
         fx.data = testFlow;
 
@@ -173,7 +172,7 @@ context('patient flow page', function() {
         return fx;
       })
       .routeActionFiles(fx => {
-        fx.data = [testOtherFile];
+        fx.data = [];
 
         return fx;
       })
@@ -439,7 +438,7 @@ context('patient flow page', function() {
       .get('[data-attachments-files-region]')
       .children()
       .as('attachmentItems')
-      .should('have.length', 2);
+      .should('have.length', 1);
 
     cy
       .get('@attachmentItems')
@@ -476,7 +475,7 @@ context('patient flow page', function() {
     cy
       .get('[data-attachments-files-region]')
       .children()
-      .should('have.length', 2);
+      .should('have.length', 1);
 
     cy
       .get('@attachmentItem')
@@ -489,6 +488,37 @@ context('patient flow page', function() {
       .contains('Download')
       .should('have.attr', 'href')
       .and('contain', `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/HRA_v2.pdf`);
+
+    cy.sendWs({
+      category: 'AttachmentAdded',
+      resource: {
+        type: testFlowAction.type,
+        id: testFlowAction.id,
+      },
+      payload: {
+        clinician: {
+          type: 'clinicians',
+          id: uuid(),
+        },
+        file: {
+          type: 'files',
+          id: uuid(),
+        },
+        attributes: {
+          path: `patients/${ testPatient.id }/Other_HRA.pdf`,
+          bucket: 'bucket_name',
+          urls: {
+            view: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/view/Other_HRA.pdf`,
+            download: `https://www.bucket_name.s3.amazonaws.com/patients/${ testPatient.id }/download/Other_HRA.pdf`,
+          },
+        },
+      },
+    });
+
+    cy
+      .get('[data-attachments-files-region]')
+      .children()
+      .should('have.length', 2);
 
     cy.sendWs({
       category: 'FileRemoved',


### PR DESCRIPTION
Shortcut Story ID: [sc-63256]

Scenario where the bug was occuring:

1. Action sidebar open on a patient flow page.
2. Manual uploading of attachments for the action is not allowed. (due to `org_settings.upload_attachments` or action `canEdit` data).
3. Action has no attachments added to it yet.
4. `AttachmentAdded` ws notification is received for the action.

In this scenario the Attachments UI section is not shown at all in the sidebar. So when we get a `AttachmentAdded` ws notification, we update the collection but the view doesn't exist so it doesn't update and nothing becomes visible to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Attachments panel now displays automatically when the first attachment is added in real time.
  - Attachment list updates immediately on add, replace, and remove events, ensuring the sidebar reflects the current state.

- Tests
  - Updated patient flow tests to cover real-time attachment additions, replacements, and removals.
  - Adjusted scenarios to start without pre-existing attachments and validate dynamic count changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->