### PR TITLE
In patient search results, bold dob column value when `results.match.label === 'Birth Date'`

### DIFF
--- a/src/js/views/globals/search/patient-search_views.js
+++ b/src/js/views/globals/search/patient-search_views.js
@@ -95,7 +95,11 @@ const PicklistItem = View.extend({
     </div>
     <div class="patient-search__picklist-item-meta">
       <div class="patient-search__picklist-item-dob u-text--overflow">
-        {{formatDateTime birth_date "MM/DD/YYYY"}}
+        {{#if isDobMatch}}
+          <strong>{{formatDateTime birth_date "MM/DD/YYYY"}}</strong>
+        {{else}}
+          {{formatDateTime birth_date "MM/DD/YYYY"}}
+        {{/if}}
       </div>
       <div class="patient-search__picklist-item-status u-text--overflow">
         {{status}}
@@ -117,6 +121,7 @@ const PicklistItem = View.extend({
       name: `${ this.model.get('first_name') } ${ this.model.get('last_name') }`,
       search: this.state.get('search'),
       shouldShowMatch: this.shouldShowMatch(),
+      isDobMatch: this.isDobMatch(),
     };
   },
   shouldShowMatch() {
@@ -124,6 +129,12 @@ const PicklistItem = View.extend({
     const i18n = intl.globals.search.patientSearchViews.picklistItemView;
 
     return label !== i18n.labelName && label !== i18n.labelDob;
+  },
+  isDobMatch() {
+    const label = this.model.get('match').label;
+    const i18n = intl.globals.search.patientSearchViews.picklistItemView;
+
+    return label === i18n.labelDob;
   },
 });
 

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -393,7 +393,7 @@ context('Patient Quick Search', function() {
       body: {
         data: [{
           ...searchResult,
-          attributes: { ...searchResult.attributes, match: { label: 'DOB', value: '2008-01-16' } },
+          attributes: { ...searchResult.attributes, match: { label: 'Name', value: `${ first_name } ${ last_name }` } },
         }],
         included: [getResource(testPatient, 'patients')],
       },
@@ -404,15 +404,27 @@ context('Patient Quick Search', function() {
     cy
       .get('.patient-search__modal')
       .find('.patient-search__input')
-      .invoke('val', '2008-01-16')
+      .invoke('val', `${ first_name }`)
       .trigger('input')
       .wait('@routePatientSearch');
 
     cy
       .get('.patient-search__modal')
-      .find('.js-picklist-item strong')
-      .parents('.js-picklist-item')
-      .should('contain', '2008-01-16');
+      .find('.js-picklist-item')
+      .first()
+      .find('.patient-search__picklist-item-result-value')
+      .should($el => {
+        expect($el.text().trim()).to.be.empty;
+      });
+
+    cy
+      .get('.patient-search__modal')
+      .find('.js-picklist-item')
+      .first()
+      .find('.patient-search__picklist-item-result-label')
+      .should($el => {
+        expect($el.text().trim()).to.be.empty;
+      });
   });
 
   specify('No Results with Patient Add', function() {

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -11,12 +11,13 @@ context('Patient Quick Search', function() {
         attributes: {
           first_name: 'Test',
           last_name: `${ index } Patient`,
+          birth_date: '2008-01-16',
           status: index % 2 ? 'inactive' : 'active',
         },
       });
     });
 
-    const data = _.map(patients, patient => {
+    const searchResults = _.map(patients, patient => {
       const { first_name, last_name, birth_date, status } = patient.attributes;
 
       return {
@@ -50,7 +51,7 @@ context('Patient Quick Search', function() {
         }
         req.reply({
           body: {
-            data,
+            data: searchResults,
             included: [...getResource(patients, 'patients')],
           },
           delay: 300,
@@ -250,6 +251,32 @@ context('Patient Quick Search', function() {
     cy
       .get('@searchModal')
       .should('contain', 'Search by');
+
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: {
+        data: [{
+          ...searchResults[0],
+          attributes: { ...searchResults[0].attributes, match: { label: 'Birth Date', value: '2008-01-16' } },
+        }],
+        included: [getResource(patients[0], 'patients')],
+      },
+      delay: 300,
+    }).as('routePatientSearch');
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
+      .clear()
+      .type('01/16/2008')
+      .wait('@routePatientSearch');
+
+    cy
+      .get('@searchModal')
+      .find('.js-picklist-item strong')
+      .should('contain', '01/16/2008');
 
     cy
       .go('back');


### PR DESCRIPTION
Shortcut Story ID: [sc-63163]

A dob match in search results only happens on an exact match. So we don't need to handle partial matches like the other columns, where partial strings are highlighted.

So for the dob column we can simply check `results.match.label === 'Birth Date'`. If `true`, wrap dob value in `<strong></strong>` tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Patient quick search results now bold the Birth Date when your query matches a patient’s DOB, improving visual clarity.
  - Picklist items more accurately reflect the matched field (e.g., Birth Date vs. Name) in the results.

- Tests
  - Expanded quick search coverage to validate DOB-based and Name-based matches, including realistic patient data and UI assertions for both scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->