### PR TITLE
Remove extra visit in test for firefox

### DIFF
--- a/test/integration/outreach/outreach.js
+++ b/test/integration/outreach/outreach.js
@@ -167,9 +167,6 @@ context('Outreach', function() {
 
   specify('Opt-In error', function() {
     cy
-      .visit('/outreach/opt-in', { noWait: true, isRoot: true });
-
-    cy
       .intercept('POST', '/api/outreach', {
         delay: 100,
         statusCode: 400,


### PR DESCRIPTION
Doesn’t make sense but this passes in FF.. didn’t before.. js file module failed without it.  No changes other than just moving the position

Shortcut Story ID: [sc-63221]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Improved reliability of the opt-in error integration test by ensuring the simulated server error is registered before visiting the page.
  - Verifies error messaging, retry behavior, and that the flow resets (heading and submit button) after “Try again.”
  - Removed a redundant duplicate test; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->