### PR TITLE
`.trim()` patient search user input to ignore just spaces

### DIFF
--- a/src/js/entities-service/entities/patient-search-results.js
+++ b/src/js/entities-service/entities/patient-search-results.js
@@ -19,6 +19,8 @@ const Collection = BaseCollection.extend({
   search(
     /* istanbul ignore next */
     search = '') {
+    search = search.trim();
+
     if (search.length < 3) {
       if (!search.length || !this.prevSearch.includes(search)) {
         this.reset();

--- a/test/integration/services/patient-quick-search.js
+++ b/test/integration/services/patient-quick-search.js
@@ -184,6 +184,20 @@ context('Patient Quick Search', function() {
 
     cy
       .get('@searchModal')
+      .find('.patient-search__input')
+      .type('   ');
+
+    cy
+      .get('@searchModal')
+      .should('contain', 'No results match your query');
+
+    cy
+      .get('@searchModal')
+      .find('.patient-search__input')
+      .clear();
+
+    cy
+      .get('@searchModal')
       .should('contain', 'Search by');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-60137]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Patient search now trims leading/trailing spaces and ignores whitespace-only input, preventing unnecessary searches and ensuring consistent “No results match your query” behavior.

- Tests
  - Added integration test covering whitespace-only input to confirm correct no-results handling and stability after prior searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->