### PR TITLE
On `GET /api/actions` & `GET /api/flows` 400 errors, reset to default filters state

### DIFF
--- a/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
+++ b/src/js/apps/patients/schedule/reduced-schedule/reduced_schedule_app.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
@@ -39,15 +40,15 @@ export default App.extend({
   startFiltersApp({ setDefaults } = {}) {
     const filtersApp = this.startChildApp('filters', { state: this.getState().getFiltersState() });
 
-    const filterState = filtersApp.getState();
+    this.filterState = filtersApp.getState();
 
-    filtersApp.listenTo(filterState, 'change', () => {
-      this.setState(filterState.getFiltersState());
+    filtersApp.listenTo(this.filterState, 'change', () => {
+      this.setState(this.filterState.getFiltersState());
     });
 
-    if (setDefaults) filterState.setDefaultFilterStates();
+    if (setDefaults) this.filterState.setDefaultFilterStates();
 
-    this.setState(filterState.getFiltersState());
+    this.setState(this.filterState.getFiltersState());
   },
   onChangeSearchQuery(state) {
     this.currentSearchQuery = state.get('searchQuery');
@@ -112,6 +113,12 @@ export default App.extend({
     this.showCountView();
 
     this.showList();
+  },
+  /* istanbul ignore next: error handling */
+  onFail(options, error) {
+    if (get(error, ['response', 'status']) === 400) {
+      this.filterState.setDefaultFilterStates();
+    }
   },
   setWorklist(worklist) {
     this.getState().setWorklist(worklist);

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
@@ -46,15 +47,15 @@ export default App.extend({
   startFiltersApp({ setDefaults } = {}) {
     const filtersApp = this.startChildApp('filters', { state: this.getState().getFiltersState() });
 
-    const filterState = filtersApp.getState();
+    this.filterState = filtersApp.getState();
 
-    filtersApp.listenTo(filterState, 'change', () => {
-      this.setState(filterState.getFiltersState());
+    filtersApp.listenTo(this.filterState, 'change', () => {
+      this.setState(this.filterState.getFiltersState());
     });
 
-    if (setDefaults) filterState.setDefaultFilterStates();
+    if (setDefaults) this.filterState.setDefaultFilterStates();
 
-    this.setState(filterState.getFiltersState());
+    this.setState(this.filterState.getFiltersState());
   },
   onChangeSelected() {
     this.toggleBulkSelect();
@@ -132,6 +133,12 @@ export default App.extend({
     this.toggleBulkSelect();
 
     this.showList();
+  },
+  /* istanbul ignore next: error handling */
+  onFail(options, error) {
+    if (get(error, ['response', 'status']) === 400) {
+      this.filterState.setDefaultFilterStates();
+    }
   },
   setWorklist(worklist) {
     this.getState().setWorklist(worklist);

--- a/src/js/apps/patients/worklist/worklist_app.js
+++ b/src/js/apps/patients/worklist/worklist_app.js
@@ -1,3 +1,4 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 
 import intl, { renderTemplate } from 'js/i18n';
@@ -52,15 +53,15 @@ export default App.extend({
   startFiltersApp({ setDefaults } = {}) {
     const filtersApp = this.startChildApp('filters', { state: this.getState().getFiltersState() });
 
-    const filterState = filtersApp.getState();
+    this.filterState = filtersApp.getState();
 
-    filtersApp.listenTo(filterState, 'change', () => {
-      this.setState(filterState.getFiltersState());
+    filtersApp.listenTo(this.filterState, 'change', () => {
+      this.setState(this.filterState.getFiltersState());
     });
 
-    if (setDefaults) filterState.setDefaultFilterStates();
+    if (setDefaults) this.filterState.setDefaultFilterStates();
 
-    this.setState(filterState.getFiltersState());
+    this.setState(this.filterState.getFiltersState());
   },
   onChangeStateSort() {
     if (!this.isRunning()) return;
@@ -161,6 +162,12 @@ export default App.extend({
     this.toggleBulkSelect();
 
     this.showList();
+  },
+  /* istanbul ignore next: error handling */
+  onFail(options, error) {
+    if (get(error, ['response', 'status']) === 400) {
+      this.filterState.setDefaultFilterStates();
+    }
   },
   setWorklist(worklist) {
     this.getState().setWorklist(worklist);

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -11,6 +11,9 @@ import { getPatient } from 'support/api/patients';
 import { stateTodo, stateInProgress } from 'support/api/states';
 import { getFlow } from 'support/api/flows';
 import { teamCoordinator } from 'support/api/teams';
+import { workspaceOne } from 'support/api/workspaces';
+
+const STATE_VERSION = 'v6';
 
 context('reduced schedule page', function() {
   specify('display schedule', function() {
@@ -541,6 +544,67 @@ context('reduced schedule page', function() {
       .get('.list-page__header')
       .find('[data-search-region] .list-search__container')
       .should('have.class', 'is-applied');
+  });
+
+  specify('400 error - set default filter state', function() {
+    const currentClinician = getCurrentClinician({
+      relationships: {
+        role: getRelationship(roleReducedEmployee),
+      },
+    });
+
+    localStorage.setItem(`reduced-schedule_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'reduced-schedule',
+      customFilters: {
+        invalid_filter: 'Medicare',
+      },
+      states: [stateTodo.id, stateInProgress.id],
+      flowStates: [stateTodo.id, stateInProgress.id],
+    }));
+
+    cy
+      .routesForPatientAction()
+      .routeCurrentClinician(fx => {
+        fx.data = currentClinician;
+
+        return fx;
+      })
+      .routeActions()
+      .visit()
+      .wait('@routeActions');
+
+    cy
+      .intercept('GET', /\/api\/actions.*filter\[%40invalid_filter\]/, {
+        statusCode: 400,
+        body: {},
+      })
+      .as('routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-states-filters-region]')
+      .find('[data-check-region]')
+      .eq(0)
+      .click()
+      .wait('@routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .should('not.contain', '2')
+      .should(() => {
+        const storage = JSON.parse(localStorage.getItem(`reduced-schedule_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`));
+
+        expect(storage.customFilters).to.deep.equal({});
+        expect(storage.states).to.deep.equal([stateTodo.id, stateInProgress.id]);
+      });
   });
 
   specify('500 error', function() {

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -1841,6 +1841,56 @@ context('schedule page', function() {
       .should('not.exist');
   });
 
+  specify('400 error - set default filter state', function() {
+    localStorage.setItem(`schedule_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'schedule',
+      customFilters: {
+        invalid_filter: 'Medicare',
+      },
+      states: [stateTodo.id, stateInProgress.id],
+      flowStates: [stateTodo.id, stateInProgress.id],
+    }));
+
+    cy
+      .routesForPatientAction()
+      .routeActions()
+      .visit('/schedule')
+      .wait('@routeActions');
+
+    cy
+      .intercept('GET', /\/api\/actions.*filter\[%40invalid_filter\]/, {
+        statusCode: 400,
+        body: {},
+      })
+      .as('routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-states-filters-region]')
+      .find('[data-check-region]')
+      .eq(0)
+      .click()
+      .wait('@routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .should('not.contain', '2')
+      .should(() => {
+        const storage = JSON.parse(localStorage.getItem(`schedule_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`));
+
+        expect(storage.customFilters).to.deep.equal({});
+        expect(storage.states).to.deep.equal([stateTodo.id, stateInProgress.id]);
+      });
+  });
+
   specify('500 error', function() {
     cy
       .routesForPatientAction()

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -5020,6 +5020,56 @@ context('worklist page', function() {
       .click();
   });
 
+  specify('400 error - set default filter state', function() {
+    localStorage.setItem(`owned-by_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'owned-by',
+      customFilters: {
+        invalid_filter: 'Medicare',
+      },
+      states: [stateTodo.id, stateInProgress.id],
+      flowStates: [stateTodo.id, stateInProgress.id],
+    }));
+
+    cy
+      .routesForPatientAction()
+      .routeActions()
+      .visit('/worklist/owned-by')
+      .wait('@routeActions');
+
+    cy
+      .intercept('GET', /\/api\/actions.*filter\[%40invalid_filter\]/, {
+        statusCode: 400,
+        body: {},
+      })
+      .as('routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .find('[data-states-filters-region]')
+      .find('[data-check-region]')
+      .eq(0)
+      .click()
+      .wait('@routeActionsError');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .should('not.contain', '2')
+      .should(() => {
+        const storage = JSON.parse(localStorage.getItem(`owned-by_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`));
+
+        expect(storage.customFilters).to.deep.equal({});
+        expect(storage.states).to.deep.equal([stateTodo.id, stateInProgress.id]);
+      });
+  });
+
   specify('500 error', function() {
     cy
       .routesForPatientAction()


### PR DESCRIPTION
Shortcut Story ID: [sc-63625]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filters in Schedule, Reduced Schedule, and Worklist now reset to safe defaults on specific 400 responses, clearing incompatible custom filters to avoid stuck or inconsistent views.

* **Refactor**
  * Filter state was consolidated onto the app instance for more consistent, persistent behavior across pages.

* **Tests**
  * Added end-to-end tests verifying 400-error recovery and local preference reset (workspace- and version-scoped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->