### PR TITLE
Add preloader to patient flow app prior to content load

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -40,7 +40,8 @@ export default SubRouterApp.extend({
   },
   onBeforeStart() {
     this.resetStateDefaults();
-    this.showView(new LayoutView());
+
+    this.getRegion().startPreloader();
   },
   beforeStart({ flowId }) {
     return [
@@ -68,6 +69,8 @@ export default SubRouterApp.extend({
     this.addOpts = this.getAddOpts(this.flow.getProgramFlow());
 
     this.subscribe();
+
+    this.showView(new LayoutView());
 
     this.showChildView('contextTrail', new ContextTrailView({
       model: this.flow,


### PR DESCRIPTION
Shortcut Story ID: [sc-63490]

This PR implements a top-level preloader region on the flow page app. Fixing a bug where the flow page was showing empty region's borders before content was loaded.

Bug screen recording: https://github.com/user-attachments/assets/e6ee6a45-0e0b-43c6-912c-48ac236b432d
Fixed screen recording: https://github.com/user-attachments/assets/1906f6b7-65c8-44a3-b4cb-a266609aba3a

Screen recordings were done with my network speed throttled to 4G via the dev tools settings. On average to fast speed networks, the preloader will likely not be given enough time to show. But regardless, it will keep the borders from showing before the content loads.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displays a preloader while the patient flow initializes, providing immediate visual feedback.
  * Renders the patient layout after initial setup completes, reducing flicker and partial UI states.
  * Smoother transition into the patient view for a more polished loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->