### PR TITLE
Fix progress bar not being shown when manually uploading an attachment

### DIFF
--- a/src/js/regions/preload_region.js
+++ b/src/js/regions/preload_region.js
@@ -32,6 +32,7 @@ const LoadingView = View.extend({
   },
   showLoader(delay, duration) {
     const anim = createTimeline({
+      autoplay: false,
       defaults: {
         ease: 'inQuad',
         delay,
@@ -45,6 +46,9 @@ const LoadingView = View.extend({
       .add(this.ui.loading[0], {
         opacity: { to: 1, duration: duration - 100 },
       }, 100);
+
+    anim.init();
+    anim.play();
   },
 });
 

--- a/src/scss/modules/loader.scss
+++ b/src/scss/modules/loader.scss
@@ -13,7 +13,6 @@
   border-radius: 8px;
   height: 8px;
   margin: 0 auto;
-  opacity: 0;
   width: 196px;
 }
 
@@ -39,7 +38,6 @@
   font-size: 12px;
   line-height: 1;
   margin: 24px auto 0;
-  opacity: 0;
   text-align: center;
 }
 


### PR DESCRIPTION
Shortcut Story ID: [sc-63926]

Was broken by adding `opacity: 0;` to the loader bar in this PR: https://github.com/RoundingWell/care-ops-frontend/pull/1516. More context in this comment: https://github.com/RoundingWell/care-ops-frontend/pull/1516/files#r2356814356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of the preload loader animation by explicitly initializing and starting it, reducing cases where it failed to play.
- Style
  - Removed forced opacity on loader bar and text, allowing them to inherit/default visibility and fade as driven by animations.
- Refactor
  - Transitioned loader animation to manual control (no implicit autoplay) to better align with render timing without changing the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->