### PR TITLE
Add a 100ms delay to tooltip showing on hover

### DIFF
--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -32,7 +32,7 @@ const TooltipView = View.extend({
 export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
-  delay: 0,
+  delay: _TEST_ ? 0 : 100,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 


### PR DESCRIPTION
Shortcut Story ID: [sc-63848]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltips now display after a brief 100 ms delay, providing a smoother, less jittery experience when hovering or focusing elements.
  * Reduces accidental popups during quick cursor movements while maintaining responsiveness for intended interactions, including keyboard focus.
  * No configuration changes required—existing tooltips automatically adopt the improved timing for a more polished feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->