### PR TITLE
Increase tooltip show delay to 200ms

### DIFF
--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -32,7 +32,7 @@ const TooltipView = View.extend({
 export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
-  delay: _TEST_ ? 0 : 100,
+  delay: _TEST_ ? 0 : 200,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 


### PR DESCRIPTION
Shortcut Story ID: [sc-63848]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the tooltip show delay, making tooltips appear slightly later on hover. This reduces accidental pop-ups, improves readability, and creates a calmer interaction across the app. Users should notice fewer unintended tooltips while moving the cursor and a more deliberate reveal when hovering over help icons or labels. No visual design changes; only the timing of when tooltips appear has been tuned for smoother UX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->