### PR TITLE
Add a loading state to a picklist

### DIFF
--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -26,8 +26,10 @@ const CLASS_OPTIONS = [
   'emptyViewOptions',
   'headingText',
   'infoText',
+  'isListsAsync',
   'isSelectlist',
   'lists',
+  'loadingText',
   'noResultsText',
   'placeholderText',
   'template',
@@ -48,8 +50,14 @@ const isSelectList = false;
 
 const PicklistEmpty = View.extend({
   tagName: 'li',
-  className: 'picklist--no-results',
-  template: hbs`{{ noResultsText }}`,
+  className: 'picklist__message',
+  template: hbs`
+    {{#if isLoading}}
+      {{ loadingText }}
+    {{else}}
+      {{ noResultsText }}
+    {{/if}}
+  `,
   serializeData() {
     return this.options;
   },
@@ -175,7 +183,22 @@ const Picklists = CollectionView.extend({
 
     this.debouncedFilter = debounce(this.filter, 1);
 
-    each(this.lists, this.addList, this);
+    if (this.isListsAsync) {
+      this.isLoading = true;
+      this.lists.then(lists => {
+        this.isLoading = false;
+        this.addLists(lists);
+        if (!this.children.length) this.render();
+      });
+
+      return;
+    }
+
+    this.addLists(this.lists);
+  },
+  addLists(lists) {
+    this.lists = lists;
+    each(lists, this.addList, this);
   },
   addList(list) {
     const options = extend({
@@ -205,7 +228,11 @@ const Picklists = CollectionView.extend({
     this.$('.js-picklist-item').first().addClass('is-highlighted');
   },
   emptyViewOptions() {
-    return { noResultsText: this.noResultsText };
+    return {
+      isLoading: this.isLoading,
+      loadingText: this.loadingText,
+      noResultsText: this.noResultsText,
+    };
   },
   templateContext() {
     return {
@@ -229,6 +256,7 @@ export default Component.extend({
   clearText: intl.components.picklist.clearText,
   headingText: '',
   infoText: '',
+  loadingText: intl.components.picklist.loadingText,
   noResultsText: intl.components.picklist.noResultsText,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);

--- a/src/js/components/picklist/picklist.cy.js
+++ b/src/js/components/picklist/picklist.cy.js
@@ -178,4 +178,62 @@ context('Picklist', function() {
       .get('.picklist')
       .contains('Infotext:');
   });
+
+  specify('it should show loading then render promise lists', function() {
+    let resolveLists;
+    const listsPromise = new Promise(resolve => {
+      resolveLists = resolve;
+    });
+
+    cy
+      .mount(() => new Picklist({
+        isListsAsync: true,
+        lists: listsPromise,
+        loadingText: 'Loading Items...',
+        noResultsText: 'Nothing Here',
+      }))
+      .as('root');
+
+    cy.get('.picklist__message').should('contain', 'Loading Items...');
+
+    cy.then(() => resolveLists(lists));
+
+    cy.get('.picklist__message').should('not.exist');
+    cy.get('.picklist').find('.js-picklist-item').its('length').should('be.greaterThan', 0);
+  });
+
+  specify('it should support custom loading text', function() {
+    let resolveLists;
+    const listsPromise = new Promise(resolve => {
+      resolveLists = resolve;
+    });
+
+    cy.mount(() => new Picklist({
+      isListsAsync: true,
+      lists: listsPromise,
+      loadingText: 'Please Wait...',
+    }));
+
+    cy.get('.picklist__message').should('contain', 'Please Wait...');
+    cy.then(() => resolveLists(lists));
+    cy.get('.picklist__message').should('not.exist');
+  });
+
+  specify('it should show no results when promise resolves empty', function() {
+    let resolveLists;
+    const listsPromise = new Promise(resolve => {
+      resolveLists = resolve;
+    });
+
+    cy.mount(() => new Picklist({
+      isListsAsync: true,
+      lists: listsPromise,
+      loadingText: 'Loading Items...',
+      noResultsText: 'No Results Found',
+    }));
+
+    cy.get('.picklist__message').should('contain', 'Loading Items...');
+    cy.then(() => resolveLists([]));
+    cy.get('.picklist__message').should('contain', 'No Results Found');
+  });
 });

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -62,7 +62,7 @@
   }
 }
 
-.picklist--no-results {
+.picklist__message {
   color: #{$black-60};
   font-size: 14px;
   font-style: italic;

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -81,6 +81,7 @@ careOptsFrontend:
       defaultText: Choose One...
     picklist:
       clearText: Clear Selection
+      loadingText: Loading...
       noResultsText: No results found
   dashboards:
     dashboardApp:

--- a/src/js/views/patients/shared/add-workflow/add-workflow_views.js
+++ b/src/js/views/patients/shared/add-workflow/add-workflow_views.js
@@ -51,7 +51,7 @@ const AddButtonView = View.extend({
 
 const itemClasses = {
   new: 'u-text--italic',
-  noResults: 'picklist--no-results',
+  noResults: 'picklist__message',
 };
 
 export {

--- a/src/js/views/shared/components/team/team-component.cy.js
+++ b/src/js/views/shared/components/team/team-component.cy.js
@@ -31,7 +31,7 @@ context('Team Component', function() {
 
     cy
       .get('.picklist')
-      .find('.picklist--no-results');
+      .find('.picklist__message');
   });
 
   specify('isCompact', function() {


### PR DESCRIPTION
Shortcut Story ID: [sc-64013]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Picklist now supports asynchronous data loading and shows a loading message while options load.
  - Added customizable loading text, with a localized default (“Loading…”).
  - Empty state is now loading-aware, clearly distinguishing between “loading” and “no results.”

- Style
  - Updated the styling and standardized the class used for the picklist’s empty/message state for consistency across the app.

- Tests
  - Added integration tests covering async loading behavior, custom loading text, and empty results handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->