### PR TITLE
Use url attribute for form iframe url

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -20,7 +20,7 @@ const _Model = BaseModel.extend({
   },
   getFormUrl() {
     // NOTE: /formapp/ is legacy formio
-    return get(this.get('options'), 'url', `/formapp/index.html?_TEST_=${ _TEST_ }`);
+    return this.get('url') || `/formapp/index.html?_TEST_=${ _TEST_ }`;
   },
   getWidgets() {
     const formWidgets = get(this.get('options'), ['widgets', 'widgets']);

--- a/test/fixtures/config/forms.js
+++ b/test/fixtures/config/forms.js
@@ -5,6 +5,7 @@ export default () => {
   return {
     id: faker.string.uuid(),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
+    url: null,
     created_at: faker.date.between({
       from: dayjs().subtract(3, 'week').format(),
       to: dayjs().subtract(2, 'week').format(),

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -704,9 +704,7 @@ context('Noncontext Form', function() {
   specify('form custom url', { retries: 4 }, function() {
     const testCustomForm = getForm({
       attributes: {
-        options: {
-          url: '/images/roundingwell-logo.svg',
-        },
+        url: '/images/roundingwell-logo.svg',
       },
     });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-63579]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved form URL resolution to avoid blank or incorrect iframe sources when a form's URL is missing or falsy, ensuring fallback to the legacy form URL.

- Tests
  - Updated integration tests to align with the new URL handling and added a URL field to test fixtures to verify iframe source and form load behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->