### PR TITLE
Add phone dialer component to the action sidebar

### DIFF
--- a/fontawesome.json
+++ b/fontawesome.json
@@ -92,6 +92,7 @@
     "paper-plane",
     "pen",
     "pen-to-square",
+    "phone",
     "right-left",
     "screwdriver-wrench",
     "share-from-square",

--- a/fontawesome.json
+++ b/fontawesome.json
@@ -23,6 +23,7 @@
     "check",
     "chevron-left",
     "chevron-right",
+    "circle",
     "circle-check",
     "circle-dot",
     "circle-exclamation",

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -32,6 +32,7 @@ export default App.extend(extend({
   },
   onStateChangeCanEdit() {
     this.showAction();
+    this.showDialer();
   },
   onStateChangeCanDelete() {
     this.showMenu();
@@ -181,7 +182,10 @@ export default App.extend(extend({
   showDialer() {
     if (!Radio.request('settings', 'get', 'dialer')) return;
 
-    this.showContentView('dialer', new DialerView({ model: this.action }));
+    this.showContentView('dialer', new DialerView({
+      model: this.action,
+      canEdit: this.getState('canEdit'),
+    }));
   },
   showActivity() {
     const activitiesView = new ActivitiesView({

--- a/src/js/apps/patients/sidebar/action-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/action-sidebar_app.js
@@ -13,6 +13,7 @@ import { SidebarMixin } from 'js/services/sidebar';
 
 import { SidebarView, MenuView, HeadingView, FooterView } from 'js/views/patients/sidebar/action/action-sidebar_views';
 import { ActionView, ReadOnlyActionView } from 'js/views/patients/sidebar/action/action-sidebar-action_views';
+import { DialerView } from 'js/views/patients/sidebar/action/action-sidebar-dialer_views';
 import { FormLayoutView } from 'js/views/patients/sidebar/action/action-sidebar-forms_views';
 import { CommentFormView } from 'js/views/patients/shared/comments_views';
 import { ActivitiesView, TimestampsView } from 'js/views/patients/sidebar/action/action-sidebar-activity-views';
@@ -108,6 +109,7 @@ export default App.extend(extend({
     this.showChildView('content', sidebarView);
     this.showAction();
     this.showForm();
+    this.showDialer();
 
     sidebarView.getRegion('activity').startPreloader();
   },
@@ -175,6 +177,11 @@ export default App.extend(extend({
   },
   onClickUndoCancel() {
     this.action.save({ sharing: ACTION_SHARING.PENDING });
+  },
+  showDialer() {
+    if (!Radio.request('settings', 'get', 'dialer')) return;
+
+    this.showContentView('dialer', new DialerView({ model: this.action }));
   },
   showActivity() {
     const activitiesView = new ActivitiesView({

--- a/src/js/components/optionlist/index.js
+++ b/src/js/components/optionlist/index.js
@@ -49,6 +49,12 @@ export default Picklist.extend({
     if (model.get('isDisabled')) return;
 
     const onSelect = model.get('onSelect');
+
+    if (!onSelect) {
+      this.destroy();
+      return;
+    }
+
     onSelect.call(this, model);
 
     this.destroy();

--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -1,5 +1,4 @@
 import { debounce, each, extend, noop, pick, result, size } from 'underscore';
-import { animate } from 'animejs';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
 
@@ -54,34 +53,15 @@ const PicklistEmpty = View.extend({
   className: 'picklist__message',
   template: hbs`
     {{#if isLoading}}
-      <div class="picklist__message-loading js-loading">
+      <div class="picklist__message-loading">
         {{fas "circle"}}{{ loadingText }}
       </div>
     {{else}}
       {{ noResultsText }}
     {{/if}}
   `,
-  ui: {
-    loading: '.js-loading',
-  },
   serializeData() {
     return this.options;
-  },
-  onRender() {
-    if (this.getOption('isLoading')) {
-      this._loadingAnimation = animate(this.ui.loading[0], {
-        opacity: { to: 1, duration: 400 },
-        loop: Infinity,
-        ease: 'inOutSine',
-        alternate: true,
-      });
-    }
-  },
-  onDestroy() {
-    if (this._loadingAnimation) {
-      this._loadingAnimation.cancel();
-      this._loadingAnimation = null;
-    }
   },
 });
 

--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -50,14 +50,15 @@ const isSelectList = false;
 
 const PicklistEmpty = View.extend({
   tagName: 'li',
-  className: 'picklist__message',
   template: hbs`
     {{#if isLoading}}
       <div class="picklist__message-loading">
         {{fas "circle"}}{{ loadingText }}
       </div>
     {{else}}
-      {{ noResultsText }}
+      <div class="picklist__message">
+        {{ noResultsText }}
+      </div>
     {{/if}}
   `,
   serializeData() {

--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -1,4 +1,5 @@
 import { debounce, each, extend, noop, pick, result, size } from 'underscore';
+import { animate } from 'animejs';
 import hbs from 'handlebars-inline-precompile';
 import { View, CollectionView } from 'marionette';
 
@@ -53,13 +54,26 @@ const PicklistEmpty = View.extend({
   className: 'picklist__message',
   template: hbs`
     {{#if isLoading}}
-      {{ loadingText }}
+      <div class="picklist__message-loading js-loading">
+        {{fas "circle"}}{{ loadingText }}
+      </div>
     {{else}}
       {{ noResultsText }}
     {{/if}}
   `,
+  ui: {
+    loading: '.js-loading',
+  },
   serializeData() {
     return this.options;
+  },
+  onRender() {
+    animate(this.ui.loading[0], {
+      opacity: { to: 1, duration: 400 },
+      loop: Infinity,
+      ease: 'inOutSine',
+      alternate: true,
+    });
   },
 });
 

--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -68,12 +68,20 @@ const PicklistEmpty = View.extend({
     return this.options;
   },
   onRender() {
-    animate(this.ui.loading[0], {
-      opacity: { to: 1, duration: 400 },
-      loop: Infinity,
-      ease: 'inOutSine',
-      alternate: true,
-    });
+    if (this.getOption('isLoading')) {
+      this._loadingAnimation = animate(this.ui.loading[0], {
+        opacity: { to: 1, duration: 400 },
+        loop: Infinity,
+        ease: 'inOutSine',
+        alternate: true,
+      });
+    }
+  },
+  onDestroy() {
+    if (this._loadingAnimation) {
+      this._loadingAnimation.cancel();
+      this._loadingAnimation = null;
+    }
   },
 });
 

--- a/src/js/components/picklist/picklist.cy.js
+++ b/src/js/components/picklist/picklist.cy.js
@@ -194,7 +194,7 @@ context('Picklist', function() {
       }))
       .as('root');
 
-    cy.get('.picklist__message').should('contain', 'Loading Items...');
+    cy.get('.picklist__message-loading').should('contain', 'Loading Items...');
 
     cy.then(() => resolveLists(lists));
 
@@ -214,9 +214,9 @@ context('Picklist', function() {
       loadingText: 'Please Wait...',
     }));
 
-    cy.get('.picklist__message').should('contain', 'Please Wait...');
+    cy.get('.picklist__message-loading').should('contain', 'Please Wait...');
     cy.then(() => resolveLists(lists));
-    cy.get('.picklist__message').should('not.exist');
+    cy.get('.picklist__message-loading').should('not.exist');
   });
 
   specify('it should show no results when promise resolves empty', function() {
@@ -232,7 +232,7 @@ context('Picklist', function() {
       noResultsText: 'No Results Found',
     }));
 
-    cy.get('.picklist__message').should('contain', 'Loading Items...');
+    cy.get('.picklist__message-loading').should('contain', 'Loading Items...');
     cy.then(() => resolveLists([]));
     cy.get('.picklist__message').should('contain', 'No Results Found');
   });

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -69,8 +69,19 @@
   padding: 4px 16px;
 }
 
+@keyframes picklist-pulse {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .picklist__message-loading {
   align-items: center;
+  animation: picklist-pulse 400ms ease-in-out infinite alternate;
   display: flex;
   font-size: 12px;
   font-style: normal;

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -82,11 +82,11 @@
 .picklist__message-loading {
   align-items: center;
   animation: picklist-pulse 400ms ease-in-out infinite alternate;
+  color: #{$black-60};
   display: flex;
   font-size: 12px;
-  font-style: normal;
   justify-content: center;
-  margin: 8px 0;
+  margin: 16px 0;
 
   .icon {
     font-size: 8px;

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -67,8 +67,18 @@
   font-size: 14px;
   font-style: italic;
   padding: 4px 16px;
+}
 
-  .icon:first-child {
+.picklist__message-loading {
+  align-items: center;
+  display: flex;
+  font-size: 12px;
+  font-style: normal;
+  justify-content: center;
+  margin: 8px 0;
+
+  .icon {
+    font-size: 8px;
     margin-right: 8px;
   }
 }

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -408,6 +408,10 @@ careOptsFrontend:
               lastweek {Last Week}
               today {Today}
               yesterday {Yesterday}}"
+        dialerComponent:
+          callLabel: Call
+          defaultText: Call Number...
+          headingText: Phone Numbers
         dueComponent:
           defaultText: Select Date...
         durationComponent:
@@ -543,6 +547,8 @@ careOptsFrontend:
             edited: (Edited)
           createdAt: Added
           updatedAt: Updated
+        dialerView:
+          label: Dialer
         formSharingTemplate:
           buttonCancelText: Cancel Share
           buttonResponseText: View Response

--- a/src/js/views/patients/shared/components/dialer-component.scss
+++ b/src/js/views/patients/shared/components/dialer-component.scss
@@ -17,7 +17,7 @@
     display: none;
 
     .icon {
-      font-size: 11px;
+      font-size: 12px;
       margin: 0 0 2px 4px;
     }
   }

--- a/src/js/views/patients/shared/components/dialer-component.scss
+++ b/src/js/views/patients/shared/components/dialer-component.scss
@@ -1,13 +1,13 @@
 .dialer-component__phone-icon {
-  color: #0582DA;
+  color: color(blue);
 
   .picklist__item.is-highlighted & {
-    color: white;
+    color: #{$white};
   }
 }
 
 .dialer-component__phone-label {
-  color: #999;
+  color: #{$black-60};
   font-size: 12px;
   margin-left: auto;
   text-transform: capitalize;
@@ -23,7 +23,7 @@
   }
 
   .picklist__item.is-highlighted & {
-    color: white;
+    color: #{$white};
 
     .dialer-component__phone-label-default {
       display: none;

--- a/src/js/views/patients/shared/components/dialer-component.scss
+++ b/src/js/views/patients/shared/components/dialer-component.scss
@@ -1,0 +1,36 @@
+.dialer-component__phone-icon {
+  color: #0582DA;
+
+  .picklist__item.is-highlighted & {
+    color: white;
+  }
+}
+
+.dialer-component__phone-label {
+  color: #999;
+  font-size: 12px;
+  margin-left: auto;
+  text-transform: capitalize;
+
+  .dialer-component__phone-label-call {
+    align-items: center;
+    display: none;
+
+    .icon {
+      font-size: 11px;
+      margin: 0 0 2px 4px;
+    }
+  }
+
+  .picklist__item.is-highlighted & {
+    color: white;
+
+    .dialer-component__phone-label-default {
+      display: none;
+    }
+
+    .dialer-component__phone-label-call {
+      display: flex;
+    }
+  }
+}

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -1,0 +1,96 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+import hbs from 'handlebars-inline-precompile';
+import { Component } from 'marionette.toolkit';
+
+import intl from 'js/i18n';
+
+import 'scss/modules/buttons.scss';
+
+import Optionlist from 'js/components/optionlist';
+
+import './dialer-component.scss';
+
+const i18n = intl.patients.shared.components.dialerComponent;
+
+export default Component.extend({
+  initialize({ action }) {
+    this.field = this.getField(action);
+  },
+  getField(action) {
+    const patient = action.getPatient();
+
+    return Radio.request('entities', 'patientFields:model', {
+      name: 'phones',
+      _patient: patient.getResource(),
+    });
+  },
+  getLists() {
+    if (this._lists) return this._lists;
+
+    this._lists = new Promise(resolve => {
+      this.field.fetch().then(() => {
+        const phones = this.getPhones();
+        resolve([{ collection: phones }]);
+      });
+    });
+
+    return this._lists;
+  },
+  getPhones() {
+    const phones = new Backbone.Collection(this.field.get('value'), {
+      comparator(model) {
+        return model.get('preferred') ? 0 : 1;
+      },
+    });
+
+    phones.each(model => {
+      model.set('onSelect', () => {
+        Radio.request('dialer', 'call', model.get('number'));
+      });
+    });
+
+    return phones;
+  },
+  viewEvents: {
+    'click': 'onClick',
+  },
+  viewOptions() {
+    return {
+      tagName: 'button',
+      className: 'button-secondary w-100 action-sidebar__form',
+      template: hbs`{{far "phone"}}<span>{{ @intl.patients.shared.components.dialerComponent.defaultText }}</span>`,
+      triggers: {
+        'click': 'click',
+      },
+    };
+  },
+  onClick() {
+    const view = this.getView();
+    view.$el.blur();
+
+    const lists = this.getLists();
+
+    const optionlist = new Optionlist({
+      attr: 'number',
+      ui: view.$el,
+      uiView: view,
+      headingText: i18n.headingText,
+      itemTemplate: hbs`
+        <span class="dialer-component__phone-icon">{{far "phone"}}</span>
+        {{formatPhoneNumber number}}
+        <span class="dialer-component__phone-label">
+          <span class="dialer-component__phone-label-default">{{label}}</span>
+          <span class="dialer-component__phone-label-call">
+            {{ @intl.patients.shared.components.dialerComponent.callLabel }}{{far "arrow-up-right-from-square"}}
+          </span>
+        </span>
+      `,
+      lists,
+      isListsAsync: true,
+      popWidth: view.$el.outerWidth(),
+    });
+
+    optionlist.show();
+  },
+});

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -58,7 +58,7 @@ export default Component.extend({
       attributes: {
         disabled: isDisabled,
       },
-      className: 'button-secondary w-100 action-sidebar__dialer-button',
+      className: 'button-secondary w-100 action-sidebar__button',
       template: hbs`{{far "phone"}}<span>{{ @intl.patients.shared.components.dialerComponent.defaultText }}</span>`,
       triggers: {
         'click': 'click',

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -77,7 +77,6 @@ export default Component.extend({
     const lists = this.getLists();
 
     const optionlist = new Optionlist({
-      attr: 'number',
       ui: view.$el,
       uiView: view,
       headingText: i18n.headingText,

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -45,12 +45,6 @@ export default Component.extend({
       },
     });
 
-    phones.each(model => {
-      model.set('onSelect', () => {
-        Radio.request('dialer', 'call', model.get('number'), this.action);
-      });
-    });
-
     return phones;
   },
   viewEvents: {
@@ -94,6 +88,10 @@ export default Component.extend({
       lists,
       isListsAsync: true,
       popWidth: view.$el.outerWidth(),
+    });
+
+    this.listenTo(optionlist, 'select', ({ model }) => {
+      Radio.request('dialer', 'call', model.get('number'), this.action);
     });
 
     optionlist.show();

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -56,8 +56,13 @@ export default Component.extend({
     'click': 'onClick',
   },
   viewOptions() {
+    const isDisabled = this.getState('isDisabled');
+
     return {
       tagName: 'button',
+      attributes: {
+        disabled: isDisabled,
+      },
       className: 'button-secondary w-100 action-sidebar__form',
       template: hbs`{{far "phone"}}<span>{{ @intl.patients.shared.components.dialerComponent.defaultText }}</span>`,
       triggers: {

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -63,7 +63,7 @@ export default Component.extend({
       attributes: {
         disabled: isDisabled,
       },
-      className: 'button-secondary w-100 action-sidebar__form',
+      className: 'button-secondary w-100 action-sidebar__dialer-button',
       template: hbs`{{far "phone"}}<span>{{ @intl.patients.shared.components.dialerComponent.defaultText }}</span>`,
       triggers: {
         'click': 'click',

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -15,10 +15,11 @@ const i18n = intl.patients.shared.components.dialerComponent;
 
 export default Component.extend({
   initialize({ action }) {
-    this.field = this.getField(action);
+    this.action = action;
+    this.field = this.getField();
   },
-  getField(action) {
-    const patient = action.getPatient();
+  getField() {
+    const patient = this.action.getPatient();
 
     return Radio.request('entities', 'patientFields:model', {
       name: 'phones',
@@ -46,7 +47,7 @@ export default Component.extend({
 
     phones.each(model => {
       model.set('onSelect', () => {
-        Radio.request('dialer', 'call', model.get('number'));
+        Radio.request('dialer', 'call', model.get('number'), this.action);
       });
     });
 

--- a/src/js/views/patients/sidebar/action/action-sidebar-dialer_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-dialer_views.js
@@ -1,0 +1,34 @@
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import 'scss/modules/buttons.scss';
+import 'scss/modules/sidebar.scss';
+
+import DialerComponent from 'js/views/patients/shared/components/dialer_component.js';
+
+import './action-sidebar.scss';
+
+const DialerView = View.extend({
+  className: 'flex u-margin--t-8',
+  template: hbs`
+    <h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.sidebar.action.dialerView.label }}</h4>
+    <div class="flex-grow" data-dialer-button-region></div>
+  `,
+  regions: {
+    dialerButton: '[data-dialer-button-region]',
+  },
+  onRender() {
+    this.showDialerButton();
+  },
+  showDialerButton() {
+    const dialerComponent = new DialerComponent({
+      action: this.model,
+    });
+
+    this.showChildView('dialerButton', dialerComponent);
+  },
+});
+
+export {
+  DialerView,
+};

--- a/src/js/views/patients/sidebar/action/action-sidebar-dialer_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-dialer_views.js
@@ -17,12 +17,18 @@ const DialerView = View.extend({
   regions: {
     dialerButton: '[data-dialer-button-region]',
   },
+  modelEvents: {
+    'change:_state': 'render',
+  },
   onRender() {
     this.showDialerButton();
   },
   showDialerButton() {
+    const isDisabled = this.model.isDone() || !this.getOption('canEdit');
+
     const dialerComponent = new DialerComponent({
       action: this.model,
+      state: { isDisabled },
     });
 
     this.showChildView('dialerButton', dialerComponent);

--- a/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
@@ -19,7 +19,7 @@ const FormView = View.extend({
     };
   },
   tagName: 'button',
-  className: 'button-secondary w-100 action-sidebar__form-button',
+  className: 'button-secondary w-100 action-sidebar__button',
   template: hbs`{{far "square-poll-horizontal"}}<span>{{ name }}</span>`,
   triggers: {
     'click': 'click',

--- a/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-forms_views.js
@@ -19,7 +19,7 @@ const FormView = View.extend({
     };
   },
   tagName: 'button',
-  className: 'button-secondary w-100 action-sidebar__form',
+  className: 'button-secondary w-100 action-sidebar__form-button',
   template: hbs`{{far "square-poll-horizontal"}}<span>{{ name }}</span>`,
   triggers: {
     'click': 'click',

--- a/src/js/views/patients/sidebar/action/action-sidebar.scss
+++ b/src/js/views/patients/sidebar/action/action-sidebar.scss
@@ -5,8 +5,7 @@
   padding: 8px 0;
 }
 
-.action-sidebar__form-button,
-.action-sidebar__dialer-button {
+.action-sidebar__button {
   color: color(blue);
 }
 

--- a/src/js/views/patients/sidebar/action/action-sidebar.scss
+++ b/src/js/views/patients/sidebar/action/action-sidebar.scss
@@ -5,7 +5,8 @@
   padding: 8px 0;
 }
 
-.action-sidebar__form {
+.action-sidebar__form-button,
+.action-sidebar__dialer-button {
   color: color(blue);
 }
 

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -61,12 +61,14 @@ const SidebarView = View.extend({
   className: 'flex-grow',
   template: hbs`
     <div data-action-region></div>
+    <div data-dialer-region></div>
     <div data-form-region></div>
     <div data-attachments-region></div>
     <div class="action-sidebar__activity" data-activity-region></div>
   `,
   regions: {
     action: '[data-action-region]',
+    dialer: '[data-dialer-region]',
     form: {
       el: '[data-form-region]',
       replaceElement: true,

--- a/test/fixtures/test/settings.json
+++ b/test/fixtures/test/settings.json
@@ -76,5 +76,9 @@
   {
     "id": "custom_filters",
     "value": []
+  },
+  {
+    "id": "dialer",
+    "value": null
   }
 ]

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -21,6 +21,7 @@ import { getProgram } from 'support/api/programs';
 import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { getFlow } from 'support/api/flows';
 import { getFile } from 'support/api/files';
+import { getPatientField } from 'support/api/patient-fields';
 
 context('action sidebar', function() {
   specify('display action sidebar', function() {
@@ -630,6 +631,11 @@ context('action sidebar', function() {
 
     cy
       .get('.sidebar')
+      .find('[data-dialer-region]')
+      .should('be.empty');
+
+    cy
+      .get('.sidebar')
       .find('[data-attachments-region]')
       .should('be.empty');
 
@@ -710,6 +716,158 @@ context('action sidebar', function() {
     cy
       .get('.alert-box')
       .should('contain', 'The Action you requested does not exist');
+  });
+
+  specify('action phone dialer', function() {
+    const testFlow = getFlow({
+      relationships: {
+        state: getRelationship(stateTodo),
+      },
+    });
+
+    const testAction = getAction({
+      relationships: {
+        state: getRelationship(stateTodo),
+        flow: getRelationship(testFlow),
+      },
+    });
+
+    cy
+      .routeSettings('dialer', 'five9')
+      .routesForPatientAction()
+      .routeFlow(fx => {
+        fx.data = testFlow;
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = [testAction];
+
+        return fx;
+      })
+      .routePatientField(fx => {
+        fx.data = getPatientField({
+          attributes: {
+            name: 'phones',
+            value: [
+              {
+                label: 'home',
+                number: '+16195561434',
+                preferred: false,
+              },
+              {
+                label: 'mobile',
+                number: '+13215551234',
+                preferred: true,
+              },
+            ],
+          },
+        });
+
+        return fx;
+      })
+      .routePatientByFlow()
+
+      .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
+      .wait('@routeFlow');
+
+    cy
+      .intercept('PATCH', `/api/actions/${ testAction.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routePatchAction');
+
+    cy
+      .intercept('PATCH', `/api/flows/${ testFlow.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routePatchFlow');
+
+    cy
+      .get('.sidebar')
+      .find('[data-dialer-region] button')
+      .as('actionDialerButton')
+      .click()
+      .wait('@routePatientField');
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .should('have.length', 2)
+      .first()
+      .should('contain', '(321) 555-1234');
+
+    cy
+      .get('body')
+      .type('{esc}');
+
+    cy
+      .get('@actionDialerButton')
+      .click();
+
+    cy
+      .get('@routePatientField.all')
+      .should('have.length', 1);
+
+    cy
+      .get('body')
+      .type('{esc}');
+
+    cy
+      .get('.sidebar')
+      .find('[data-state-region] button')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Complete')
+      .click()
+      .wait('@routePatchAction');
+
+    cy
+      .get('@actionDialerButton')
+      .should('be.disabled');
+
+    cy
+      .get('.sidebar')
+      .find('[data-state-region] button')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('To Do')
+      .click()
+      .wait('@routePatchAction');
+
+    cy
+      .get('@actionDialerButton')
+      .should('not.be.disabled');
+
+    cy
+      .get('[data-header-region]')
+      .find('[data-state-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Complete')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click();
+
+    cy
+      .get('@actionDialerButton')
+      .should('be.disabled');
   });
 
   specify('action attachments', function() {

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -22,7 +22,6 @@ import { roleNoFilterEmployee, roleTeamEmployee } from 'support/api/roles';
 import { getFlow } from 'support/api/flows';
 import { getFile } from 'support/api/files';
 
-// TODO: Update to mergejson api
 context('action sidebar', function() {
   specify('display action sidebar', function() {
     const testTime = dayjs(testDate()).hour(12).valueOf();
@@ -319,7 +318,8 @@ context('action sidebar', function() {
       .wait('@routePatientFlows')
       .wait('@routeAction')
       .wait('@routeActionActivity')
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .tick(350); // since this test uses visitOnClock, we need this for the sidebar animation
 
     cy
       .get('.sidebar')


### PR DESCRIPTION
Shortcut Story ID: [sc-63637]

- [x] Implement in app UI
- [x] Disabled when action is in read only state
- [x] Cypress tests
- [x] Code cleanup/refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Patient sidebar adds a Dialer for quick access to patient phone numbers and one‑click calling (when enabled); new dialer component and view integrated.

- **UI**
  - Picklist shows an animated loading state with an icon; sidebar has a dedicated dialer area.

- **Style**
  - New styles for dialer button, labels, highlighted states, and loading animation.

- **Localization**
  - Added English dialer labels and texts.

- **Tests**
  - Integration specs covering the dialer workflow and UI interactions.

- **Bug Fixes**
  - Option list selection now safely handles missing selection callbacks; added two new icons: circle and phone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->