### PR TITLE
In `patient_app`, clear action `isEditing` state in `startRoute()`

### DIFF
--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -36,6 +36,13 @@ export default SubRouterApp.extend({
     };
   },
 
+  onBeforeStartRoute() {
+    if (this.action) {
+      this.action.trigger('editing', false);
+      delete this.action;
+    }
+  },
+
   onBeforeStart() {
     this.getRegion().startPreloader();
   },

--- a/src/js/base/subrouterapp.js
+++ b/src/js/base/subrouterapp.js
@@ -20,12 +20,17 @@ export default App.extend({
   },
 
   // Start a route from a currentRoute passed from a routerapp
-  startRoute({ event, eventArgs }) {
+  startRoute(currentRoute) {
+    this.triggerMethod('before:startRoute', currentRoute);
+
+    const { event, eventArgs } = currentRoute;
     const action = this._eventRoutes[event];
 
     if (!action) return;
 
     action.apply(this, eventArgs);
+
+    this.triggerMethod('startRoute', currentRoute);
   },
 
   mixinOptions(options) {

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -238,7 +238,8 @@ context('patient dashboard page', function() {
     cy
       .get('.list-page__list')
       .contains('First In List')
-      .click();
+      .click()
+      .tick(350); // this test uses visitOnClock, so needed for the sidebar animation
 
     cy
       .get('.list-page__list')
@@ -320,6 +321,27 @@ context('patient dashboard page', function() {
       .should(({ data }) => {
         expect(data.attributes.due_time).to.equal('09:45:00');
       });
+
+    cy
+      .get('.patient__tabs')
+      .find('.js-archive')
+      .click();
+
+    cy
+      .get('.patient__tabs')
+      .find('.js-dashboard')
+      .click();
+
+    cy
+      .get('.list-page__list')
+      .find('.is-selected')
+      .should('not.exist');
+
+    cy
+      .get('.list-page__list')
+      .contains('First In List')
+      .click()
+      .tick(350); // this test uses visitOnClock, so needed for the sidebar animation
 
     cy
       .get('.list-page__list')


### PR DESCRIPTION
Shortcut Story ID: [sc-63858]

To fix bug where isEditing (adds `.is-selected` to action list items) persists when navigating between patient dashboard & archive routes.

To do:

- [x] Add section to cypress test that fails without clearing `this.action` cache between route changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Editing mode now reliably exits when navigating within the patient app.
  - Selection state is cleared after switching between Dashboard and Archive tabs and returning to Dashboard.
  - Smoother sidebar behavior reduces flicker during tab transitions.

- Tests
  - Expanded integration tests to cover tab switching (Dashboard ↔ Archive), selection reset, and animation timing to ensure stable UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->