### PR TITLE
Updates to icd codes graphql endpoint

### DIFF
--- a/src/js/entities-service/graphql.js
+++ b/src/js/entities-service/graphql.js
@@ -6,9 +6,12 @@ const Entity = BaseEntity.extend({
     'fetch:icd': 'fetchIcd',
   },
   fetchIcd({ term, prefixes, year = 2024 }) {
-    const variables = { term, prefixes, year };
-    const query = `query ($term: String!, $prefixes: [String!], $year: Int!) {
-      icd_codes(term: $term, prefixes: $prefixes, year: $year) {
+    const variables = {
+      filter: { term, prefixes, year },
+    };
+
+    const query = `query ($filter: IcdCodeFilter) {
+      icd_codes(filter: $filter) {
         code
         description
         hcc_v24

--- a/src/js/entities-service/graphql.js
+++ b/src/js/entities-service/graphql.js
@@ -8,7 +8,7 @@ const Entity = BaseEntity.extend({
   fetchIcd({ term, prefixes, year = 2024 }) {
     const variables = { term, prefixes, year };
     const query = `query ($term: String!, $prefixes: [String!], $year: Int!) {
-      icdCodes(term: $term, prefixes: $prefixes, year: $year) {
+      icd_codes(term: $term, prefixes: $prefixes, year: $year) {
         code
         description
         hcc_v24

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -200,7 +200,7 @@ export default App.extend({
     const message = 'fetch:icd';
     return Promise.resolve(Radio.request('entities', 'fetch:icd', by))
       .then(icd => {
-        this.send(message, { value: get(icd, ['data', 'icdCodes']) }, requestId);
+        this.send(message, { value: get(icd, ['data', 'icd_codes']) }, requestId);
       })
       .catch(({ responseData }) => {
         this.send(message, { error: responseData }, requestId);

--- a/test/integration/forms/form.js
+++ b/test/integration/forms/form.js
@@ -576,7 +576,7 @@ context('Noncontext Form', function() {
       .intercept('POST', '/api/graphql', {
         body: {
           data: {
-            icdCodes: [
+            icd_codes: [
               {
                 code: 'X1',
                 description: 'Typhoid infection',


### PR DESCRIPTION
Shortcut Story ID: [sc-64270]

To align with BE changes in this file: https://github.com/RoundingWell/care-ops-backend/blob/faead8d9ffd3452831960a3deab6c7ed3a86a9d0/src/Graph/schema.graphql

Changes:

1. Switch type: `icdCodes` => `icd_codes`.
2. Nest query params in  a`filter: {}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ICD lookup to use a consolidated filter input and standardized response naming; no change to UI or returned data content.
* **Chores**
  * Aligned services with the latest GraphQL API contract to ensure ongoing compatibility and stability.
* **Tests**
  * Updated integration tests to reflect the new response shape for ICD data, keeping test coverage and behavior consistent for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->