### PR TITLE
Refactor optionlist onSelect handlers

### DIFF
--- a/src/js/apps/patients/patient/dashboard/add-workflow_app.js
+++ b/src/js/apps/patients/patient/dashboard/add-workflow_app.js
@@ -1,15 +1,10 @@
-import { bind, noop } from 'underscore';
+import { noop } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
 
 import { AddButtonView, i18n, itemClasses } from 'js/views/patients/shared/add-workflow/add-workflow_views';
-
-const optEvents = {
-  'program-actions': 'add:programAction',
-  'program-flows': 'add:programFlow',
-};
 
 export default App.extend({
   beforeStart() {
@@ -31,9 +26,20 @@ export default App.extend({
 
     programs.reset(addablePrograms);
 
-    this.showView(new AddButtonView({
+    const addButtonView = new AddButtonView({
       lists: this.getProgramsOpts(programs),
-    }));
+    });
+
+    this.listenTo(addButtonView, {
+      'add:programAction'(programItem) {
+        this.triggerMethod('add:programAction', programItem);
+      },
+      'add:programFlow'(programItem) {
+        this.triggerMethod('add:programFlow', programItem);
+      },
+    });
+
+    this.showView(addButtonView);
   },
   getProgramsOpts(programs) {
     return programs.map(program => {
@@ -68,7 +74,7 @@ export default App.extend({
         text: item.get('name'),
         itemType: item.type,
         hasOutreach: item.type === 'program-actions' && item.hasOutreach(),
-        onSelect: bind(this.triggerMethod, this, optEvents[item.type], item),
+        programItem: item,
       };
     });
   },

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -1,4 +1,4 @@
-import { bind, get } from 'underscore';
+import { get } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
@@ -146,16 +146,22 @@ export default SubRouterApp.extend({
         text: action.get('name'),
         itemType: action.type,
         hasOutreach: action.hasOutreach(),
-        onSelect: bind(this.triggerMethod, this, 'add:programAction', action),
+        programItem: action,
       };
     });
   },
 
   showAdd() {
-    this.showChildView('tools', new AddButtonView({
+    const addButtonView = new AddButtonView({
       headingText: i18n.addActionHeadingText,
       lists: [{ collection: new Backbone.Collection(this.addOpts) }],
-    }));
+    });
+
+    this.listenTo(addButtonView, 'add:programAction', programItem => {
+      this.triggerMethod('add:programAction', programItem);
+    });
+
+    this.showChildView('tools', addButtonView);
   },
 
   toggleBulkSelect() {

--- a/src/js/components/optionlist/index.js
+++ b/src/js/components/optionlist/index.js
@@ -30,7 +30,9 @@ export default Picklist.extend({
   },
   viewTriggers: {
     'close': 'close',
-    'picklist:item:select': 'select',
+  },
+  viewEvents: {
+    'picklist:item:select': 'onPicklistSelect',
   },
   position() {
     return this.uiView.getBounds(this.ui);
@@ -45,17 +47,10 @@ export default Picklist.extend({
   onClose() {
     this.destroy();
   },
-  onSelect({ model }) {
+  onPicklistSelect({ model }) {
     if (model.get('isDisabled')) return;
 
-    const onSelect = model.get('onSelect');
-
-    if (!onSelect) {
-      this.destroy();
-      return;
-    }
-
-    onSelect.call(this, model);
+    this.triggerMethod('select', model);
 
     this.destroy();
   },

--- a/src/js/components/optionlist/optionlist.cy.js
+++ b/src/js/components/optionlist/optionlist.cy.js
@@ -27,19 +27,14 @@ context('Optionlist', function() {
   });
 
   specify('Displaying', function() {
-    const onSelect = cy.stub();
     const collection = new Backbone.Collection([
       {
         text: 'Test 1',
-        onSelect,
       },
       {
         text: 'Test 2',
         isDisabled: true,
         hasDivider: true,
-      },
-      {
-        text: 'Test 3',
       },
     ]);
 
@@ -64,9 +59,7 @@ context('Optionlist', function() {
       .first()
       .click()
       .then(picklistItem => {
-        expect(onSelect).to.be.calledOnce;
         expect(picklistItem).to.not.exist;
-        onSelect.resetHistory();
       });
 
     cy
@@ -80,23 +73,7 @@ context('Optionlist', function() {
       .first()
       .click()
       .then(picklistItem => {
-        expect(onSelect).to.not.be.called;
         expect(picklistItem).to.exist;
-      });
-
-    cy
-      .get('@root')
-      .contains('Test Menu')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .last()
-      .click()
-      .then(picklistItem => {
-        expect(onSelect).to.not.be.called;
-        expect(picklistItem).to.not.exist;
       });
 
     cy

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -1,4 +1,3 @@
-import { bind } from 'underscore';
 import Radio from 'backbone.radio';
 import Backbone from 'backbone';
 import { View } from 'marionette';
@@ -69,23 +68,21 @@ const SidebarView = View.extend({
 
     const menuOptions = new Backbone.Collection([
       {
+        event: canEditPatient ? 'click:patientEdit' : 'click:patientView',
         text: canEditPatient ? i18n.menuOptions.edit : i18n.menuOptions.view,
-        onSelect: bind(this.triggerMethod, this, canEditPatient ? 'click:patientEdit' : 'click:patientView'),
       },
     ]);
 
     if (workspacePatient.canEdit()) {
       menuOptions.push({
+        event: 'click:activeStatus',
         text: workspacePatientStatus !== PATIENT_STATUS.ACTIVE ? i18n.menuOptions.activate : i18n.menuOptions.inactivate,
-        onSelect: bind(this.triggerMethod, this, 'click:activeStatus'),
       });
 
       if (workspacePatientStatus !== PATIENT_STATUS.ARCHIVED) {
         menuOptions.push({
+          event: 'click:shouldArchive',
           text: i18n.menuOptions.archive,
-          onSelect: () => {
-            this.showConfirmArchiveModal();
-          },
         });
       }
     }
@@ -100,9 +97,15 @@ const SidebarView = View.extend({
       popWidth: 248,
     });
 
+    this.listenTo(optionlist, 'select', ({ model }) => {
+      const event = model.get('event');
+
+      this.triggerMethod(event);
+    });
+
     optionlist.show();
   },
-  showConfirmArchiveModal() {
+  onClickShouldArchive() {
     const modal = Radio.request('modal', 'show:small', {
       bodyText: i18n.archiveModal.bodyText,
       headingText: i18n.archiveModal.headingText,

--- a/src/js/views/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/views/patients/patient/sidebar/sidebar_views.js
@@ -97,7 +97,7 @@ const SidebarView = View.extend({
       popWidth: 248,
     });
 
-    this.listenTo(optionlist, 'select', ({ model }) => {
+    this.listenTo(optionlist, 'select', model => {
       const event = model.get('event');
 
       this.triggerMethod(event);

--- a/src/js/views/patients/shared/add-workflow/add-workflow_views.js
+++ b/src/js/views/patients/shared/add-workflow/add-workflow_views.js
@@ -45,6 +45,17 @@ const AddButtonView = View.extend({
       lists: this.getOption('lists'),
     });
 
+    this.listenTo(optionlist, 'select', ({ model }) => {
+      const programItem = model.get('programItem');
+
+      if (!programItem) return;
+
+      const isProgramAction = model.get('itemType') === 'program-actions';
+      const messageType = isProgramAction ? 'add:programAction' : 'add:programFlow';
+
+      this.triggerMethod(messageType, programItem);
+    });
+
     optionlist.show();
   },
 });

--- a/src/js/views/patients/shared/add-workflow/add-workflow_views.js
+++ b/src/js/views/patients/shared/add-workflow/add-workflow_views.js
@@ -45,7 +45,7 @@ const AddButtonView = View.extend({
       lists: this.getOption('lists'),
     });
 
-    this.listenTo(optionlist, 'select', ({ model }) => {
+    this.listenTo(optionlist, 'select', model => {
       const programItem = model.get('programItem');
 
       if (!programItem) return;

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -1,4 +1,4 @@
-import { bind, some } from 'underscore';
+import { some } from 'underscore';
 import Backbone from 'backbone';
 import dayjs from 'dayjs';
 import hbs from 'handlebars-inline-precompile';
@@ -125,11 +125,7 @@ const BulkEditActionsHeaderView = View.extend({
   },
   onClickMenu() {
     const itemCount = this.collection.length;
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'confirm:delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.ui.menu,
@@ -140,6 +136,10 @@ const BulkEditActionsHeaderView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('confirm:delete');
     });
 
     optionlist.show();
@@ -179,11 +179,7 @@ const BulkEditFlowsHeaderView = View.extend({
   },
   onClickMenu() {
     const itemCount = this.collection.length;
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'confirm:delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.ui.menu,
@@ -194,6 +190,10 @@ const BulkEditFlowsHeaderView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('confirm:delete');
     });
 
     optionlist.show();

--- a/src/js/views/patients/shared/components/dialer_component.js
+++ b/src/js/views/patients/shared/components/dialer_component.js
@@ -90,7 +90,7 @@ export default Component.extend({
       popWidth: view.$el.outerWidth(),
     });
 
-    this.listenTo(optionlist, 'select', ({ model }) => {
+    this.listenTo(optionlist, 'select', model => {
       Radio.request('dialer', 'call', model.get('number'), this.action);
     });
 

--- a/src/js/views/patients/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar_views.js
@@ -1,4 +1,3 @@
-import { bind } from 'underscore';
 import Backbone from 'backbone';
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'marionette';
@@ -37,11 +36,7 @@ const MenuView = View.extend({
     'click': 'click',
   },
   onClick() {
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.$el,
@@ -51,6 +46,10 @@ const MenuView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('delete');
     });
 
     optionlist.show();

--- a/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/patients/sidebar/flow/flow-sidebar_views.js
@@ -1,4 +1,4 @@
-import { bind, extend } from 'underscore';
+import { extend } from 'underscore';
 import Backbone from 'backbone';
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'marionette';
@@ -40,11 +40,7 @@ const MenuView = View.extend({
     'click': 'click',
   },
   onClick() {
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.$el,
@@ -54,6 +50,10 @@ const MenuView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('delete');
     });
 
     optionlist.show();

--- a/src/js/views/programs/program/sidebar/sidebar-views.js
+++ b/src/js/views/programs/program/sidebar/sidebar-views.js
@@ -1,4 +1,3 @@
-import { bind } from 'underscore';
 import Backbone from 'backbone';
 import hbs from 'handlebars-inline-precompile';
 
@@ -37,7 +36,6 @@ const SidebarView = View.extend({
   onClickMenu() {
     const menuOptions = new Backbone.Collection([
       {
-        onSelect: bind(this.triggerMethod, this, 'edit'),
         icon: 'pen-to-square',
         className: 'program-sidebar__edit',
         text: i18n.menuOptions.edit,
@@ -52,6 +50,10 @@ const SidebarView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('edit');
     });
 
     optionlist.show();

--- a/src/js/views/programs/sidebar/action/action-sidebar_views.js
+++ b/src/js/views/programs/sidebar/action/action-sidebar_views.js
@@ -1,4 +1,3 @@
-import { bind } from 'underscore';
 import dayjs from 'dayjs';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
@@ -200,11 +199,7 @@ const MenuView = View.extend({
     'click': 'click',
   },
   onClick() {
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.$el,
@@ -214,6 +209,10 @@ const MenuView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('delete');
     });
 
     optionlist.show();

--- a/src/js/views/programs/sidebar/flow/flow-sidebar_views.js
+++ b/src/js/views/programs/sidebar/flow/flow-sidebar_views.js
@@ -1,4 +1,4 @@
-import { bind, extend } from 'underscore';
+import { extend } from 'underscore';
 import dayjs from 'dayjs';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
@@ -133,11 +133,7 @@ const MenuView = View.extend({
     'click': 'click',
   },
   onClick() {
-    const menuOptions = new Backbone.Collection([
-      {
-        onSelect: bind(this.triggerMethod, this, 'delete'),
-      },
-    ]);
+    const menuOptions = new Backbone.Collection([{}]);
 
     const optionlist = new Optionlist({
       ui: this.$el,
@@ -147,6 +143,10 @@ const MenuView = View.extend({
       lists: [{ collection: menuOptions }],
       align: 'right',
       popWidth: 248,
+    });
+
+    this.listenTo(optionlist, 'select', () => {
+      this.triggerMethod('delete');
     });
 
     optionlist.show();

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1043,7 +1043,8 @@ context('patient flow page', function() {
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
+      .wait('@routeFlowActions')
+      .wait(60); // for ListView debounce of 'change:canEdit' trigger
 
     const conditionalAction = getAction({
       attributes: {
@@ -1084,15 +1085,6 @@ context('patient flow page', function() {
       .last()
       .should('contain', 'Published')
       .should('not.contain', 'Draft');
-
-    cy
-      .get('body')
-      .type('{esc}');
-
-    cy
-      .get('.patient-flow__actions')
-      .contains('Add')
-      .click();
 
     cy
       .get('.picklist')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1086,6 +1086,15 @@ context('patient flow page', function() {
       .should('not.contain', 'Draft');
 
     cy
+      .get('body')
+      .type('{esc}');
+
+    cy
+      .get('.patient-flow__actions')
+      .contains('Add')
+      .click();
+
+    cy
       .get('.picklist')
       .find('.picklist__item')
       .first()


### PR DESCRIPTION
Shortcut Story ID: [sc-64123]

- [x] Relatively simple refactors
- [x] Refactor add workflow app/views optionlist
- [x] Remove code from optionlist component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified option selection across menus to a centralized event-driven flow, replacing per-item callbacks.
  * Standardized triggers for add, edit, delete, and archive actions for more consistent behavior.
  * Reduced reliance on utility bindings for cleaner, more maintainable code.

* **Improvements**
  * More reliable action handling from menus.
  * Bulk select toggles only when needed, avoiding unnecessary state changes.

* **Tests**
  * Updated component and integration tests to align with the new selection flow.
  * Added brief waits to stabilize list updates during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->