### PR TITLE
Use the callData.interactionId as the identifier

### DIFF
--- a/packages/care-ops-five9/five9_app.js
+++ b/packages/care-ops-five9/five9_app.js
@@ -54,9 +54,9 @@ export default App.extend({
       callEnded: () => {
         this.setState('callTime', null);
       },
-      callFinished: ({ callLogData }) => {
+      callFinished: ({ callLogData, callData }) => {
         this.setState('isCalling', false);
-        Radio.request('dialer', 'five9CallComplete', callLogData);
+        Radio.request('dialer', 'five9CallComplete', callData.interactionId, callLogData);
       },
     });
   },

--- a/src/js/services/dialer.cy.js
+++ b/src/js/services/dialer.cy.js
@@ -29,8 +29,7 @@ context('Dialer Service', function() {
     cy
       .get('@root')
       .then(() => {
-        Radio.request('dialer', 'five9CallComplete', {
-          sessionID: 'abc1234',
+        Radio.request('dialer', 'five9CallComplete', 'abc1234', {
           callDuration: 42,
           disposition: 'completed',
         });
@@ -47,7 +46,6 @@ context('Dialer Service', function() {
             artifact: 'five9-call-log',
             identifier: 'abc1234',
             values: {
-              sessionID: 'abc1234',
               callDuration: 42,
               disposition: 'completed',
             },

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -27,11 +27,11 @@ export default App.extend({
   call(number, action) {
     this._call(number, action);
   },
-  five9CallComplete(data) {
+  five9CallComplete(identifier, values) {
     Radio.request('entities', 'save:artifacts:model', {
       artifact: 'five9-call-log',
-      identifier: data.sessionID,
-      values: data,
+      identifier,
+      values,
     });
   },
 });


### PR DESCRIPTION
callData is available and therefore so is interactionId. The interactionId is created with `callStarted` so it is the most reasonable id to use anyhow, but is not by default available in the callLogData

Shortcut Story ID: [sc-64429]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Call completion now reliably ties each call to its interaction identifier, improving association and post-call processing.
  * Faster, more consistent syncing of call outcomes with clearer payloads for backend updates.

* **Bug Fixes**
  * Fixed cases where session identifiers were omitted, preventing mismatched or missing call logs after calls end.
  * Reduced errors and improved stability when finalizing calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->