### PR TITLE
Bulk edit request batching

### DIFF
--- a/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
@@ -151,7 +151,7 @@ export default App.extend({
   onSubmit() {
     this.setState({ isSaving: true });
 
-    this.modal.disableSubmit();
+    this.modal.showSavingFooter();
 
     this.triggerMethod('save', this.getState().getData());
   },

--- a/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
@@ -128,6 +128,7 @@ export default App.extend({
     const headerView = new BulkEditActionsHeaderView({
       collection: this.getState('collection'),
     });
+
     const bodyView = new BulkEditActionsBodyView({
       model: this.getState(),
       collection: this.getState('collection'),
@@ -148,7 +149,10 @@ export default App.extend({
     });
   },
   onSubmit() {
+    this.setState({ isSaving: true });
+
     this.modal.disableSubmit();
+
     this.triggerMethod('save', this.getState().getData());
   },
   onStop() {

--- a/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
@@ -91,11 +91,15 @@ export default App.extend({
     });
   },
   onSubmit() {
+    this.setState({ isSaving: true });
+
     this.modal.disableSubmit();
+
     const applyOwner = !!this.getState('applyOwner');
     if (applyOwner) {
       this.triggerMethod('applyOwner', this.getState('owner'));
     }
+
     this.triggerMethod('save', this.getState().getData());
   },
   onStop() {

--- a/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-flows_app.js
@@ -93,7 +93,7 @@ export default App.extend({
   onSubmit() {
     this.setState({ isSaving: true });
 
-    this.modal.disableSubmit();
+    this.modal.showSavingFooter();
 
     const applyOwner = !!this.getState('applyOwner');
     if (applyOwner) {

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -288,9 +288,26 @@ const Collection = BaseCollection.extend({
   url: '/api/actions',
   model: Model,
   save(attrs) {
-    const saves = this.invoke('saveAll', attrs);
+    return this._processBatches(attrs);
+  },
+  async _processBatches(
+    attrs,
+    /* istanbul ignore next: Branch only for testing */
+    batchSize = _TEST_ ? 2 : 25,
+  ) {
+    const results = [];
+    let count = 0;
 
-    return Promise.all(saves);
+    while (count < this.length) {
+      const batch = new Collection(this.slice(count, count + batchSize));
+      const batchSaves = batch.invoke('saveAll', attrs);
+      const batchResults = await Promise.all(batchSaves);
+
+      results.push(...batchResults);
+      count += batchSize;
+    }
+
+    return results;
   },
   groupByDate() {
     const groupedCollection = this.groupBy('due_date');

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -131,9 +131,26 @@ const Collection = BaseCollection.extend({
   url: '/api/flows',
   model: Model,
   save(attrs) {
-    const saves = this.invoke('saveAll', attrs);
+    return this._processBatches(attrs);
+  },
+  async _processBatches(
+    attrs,
+    /* istanbul ignore next: Branch only for testing */
+    batchSize = _TEST_ ? 2 : 25,
+  ) {
+    const results = [];
+    let count = 0;
 
-    return Promise.all(saves);
+    while (count < this.length) {
+      const batch = new Collection(this.slice(count, count + batchSize));
+      const batchSaves = batch.invoke('saveAll', attrs);
+      const batchResults = await Promise.all(batchSaves);
+
+      results.push(...batchResults);
+      count += batchSize;
+    }
+
+    return results;
   },
   applyOwner(owner) {
     const saves = this.invoke('applyOwner', owner);

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -189,6 +189,8 @@ careOptsFrontend:
       modalViews:
         modalView:
           cancelText: Cancel
+          savingInfoText: Applying your changes.
+          savingSubmitText: Saving...
           submitText: Save
         viewOnlyForm:
           doneText: Done

--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -1,4 +1,5 @@
 import { extend } from 'underscore';
+import { animate } from 'animejs';
 import hbs from 'handlebars-inline-precompile';
 import { View, Region } from 'marionette';
 
@@ -19,6 +20,36 @@ const i18n = intl.globals.modal.modalViews;
 
 const ReplaceElRegion = Region.extend({ replaceElement: true, timeout: 0 });
 
+const SavingFooterView = View.extend({
+  className: 'flex',
+  template: hbs`
+    <div class="button--text" disabled>{{ savingInfoText }}</div>
+    <button class="{{ buttonClass }} js-loading" disabled>
+      <span>{{ savingSubmitText }}</span>
+    </button>
+  `,
+  ui: {
+    loading: '.js-loading',
+  },
+  serializeData() {
+    return extend({}, this.options);
+  },
+  onRender() {
+    this.animation = animate(this.ui.loading[0], {
+      opacity: [1, 0.5],
+      loop: Infinity,
+      duration: 400,
+      ease: 'inOutSine',
+      alternate: true,
+    });
+  },
+  onBeforeDestroy() {
+    if (this.animation) {
+      this.animation.cancel();
+    }
+  },
+});
+
 const ModalView = View.extend({
   className: 'modal',
   buttonClass: 'button--green',
@@ -26,6 +57,8 @@ const ModalView = View.extend({
   headerIconType: 'far',
   cancelText: i18n.modalView.cancelText,
   submitText: i18n.modalView.submitText,
+  savingSubmitText: i18n.modalView.savingSubmitText,
+  savingInfoText: i18n.modalView.savingInfoText,
   regionClass: ReplaceElRegion,
   regions: {
     header: '[data-header-region]',
@@ -33,7 +66,10 @@ const ModalView = View.extend({
       el: '[data-body-region]',
       regionClass: PreloadRegion.extend({ timeout: 0 }),
     },
-    footer: '[data-footer-region]',
+    footer: {
+      el: '[data-footer-region]',
+      replaceElement: false,
+    },
     info: '[data-info-region]',
   },
   childViewTriggers: {
@@ -63,6 +99,13 @@ const ModalView = View.extend({
   },
   onCancel() {
     this.destroy();
+  },
+  showSavingFooter() {
+    this.showChildView('footer', new SavingFooterView({
+      buttonClass: this.buttonClass,
+      savingSubmitText: this.savingSubmitText,
+      savingInfoText: this.savingInfoText,
+    }));
   },
   disableSubmit(disable = true) {
     this.ui.submit.prop('disabled', disable);

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit-flow-body.hbs
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit-flow-body.hbs
@@ -1,3 +1,12 @@
-<div class="flex"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.stateLabel }}</h4><div class="flex-grow" data-state-region></div></div>
-<div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.ownerLabel }}</h4><div class="flex-grow" data-owner-region></div></div>
-<div class="flex u-margin--t-8 u-margin--b-8"><div class="flex-grow" data-apply-owner-region></div></div>
+<div class="flex">
+  <h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.stateLabel }}</h4>
+  <div class="flex-grow" data-state-region></div>
+</div>
+<div class="flex u-margin--t-8">
+  <h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.ownerLabel }}</h4>
+  <div class="flex-grow" data-owner-region></div>
+</div>
+<div class="flex u-margin--t-16 u-margin--b-8">
+  <div class="sidebar__label u-margin--t-8"></div>
+  <div class="flex-grow" data-apply-owner-region></div>
+</div>

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -407,7 +407,7 @@ const ApplyOwnerView = View.extend({
     'change:applyOwner': 'render',
     'change:ownerMulti': 'render',
   },
-  className: 'u-margin--t-4 u-margin--l-16',
+  className: 'u-margin--l-16',
   template: hbs`
     <button class="button--checkbox js-apply-owner"{{#if isDisabled}} disabled{{/if}}>
       {{#if applyOwner}}{{fas "square-check"}}{{else}}{{fal "square"}}{{/if~}}

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -220,6 +220,7 @@ const BulkEditActionsBodyView = View.extend({
     'change:date': 'showDueDateTime',
     'change:timeMulti': 'showDueTime',
     'change:durationMulti': 'showDuration',
+    'change:isSaving': 'render',
   },
   className: 'modal__content--sidebar',
   template: BulkEditActionBodyTemplate,
@@ -231,25 +232,35 @@ const BulkEditActionsBodyView = View.extend({
     duration: '[data-duration-region]',
   },
   onRender() {
+    this.isSaving = this.model.get('isSaving');
+
     this.showState();
     this.showOwner();
     this.showDueDateTime();
     this.showDuration();
   },
   getStateComponent() {
+    const isDisabled = this.isSaving;
+
     if (this.model.get('stateMulti')) {
       return new StateComponent({
         viewOptions: {
+          attributes: {
+            disabled: isDisabled,
+          },
           className: 'button-secondary w-100',
           template: hbs`{{fas "circle-dot"}}<span class="button__value--indeterminate">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkStateDefaultText }}</span>`,
         },
       });
     }
 
-    return new StateComponent({ stateId: this.model.get('stateId') });
+    return new StateComponent({
+      stateId: this.model.get('stateId'),
+      state: { isDisabled },
+    });
   },
   getOwnerComponent() {
-    const isDisabled = this.model.someComplete();
+    const isDisabled = this.model.someComplete() || this.isSaving;
 
     if (this.model.get('ownerMulti')) {
       return new OwnerComponent({
@@ -270,7 +281,7 @@ const BulkEditActionsBodyView = View.extend({
     });
   },
   getDueDateComponent() {
-    const isDisabled = this.model.someComplete();
+    const isDisabled = this.model.someComplete() || this.isSaving;
 
     if (this.model.get('dateMulti')) {
       return new DueComponent({
@@ -302,7 +313,7 @@ const BulkEditActionsBodyView = View.extend({
       return new TimeComponent({
         viewOptions: {
           attributes: {
-            disabled: this.model.get('dateMulti') || this.model.someComplete(),
+            disabled: this.model.get('dateMulti') || this.model.someComplete() || this.isSaving,
           },
           className: 'button-secondary time-component w-100',
           template: hbs`{{far "clock"}} <span class="button__value--indeterminate">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkDueTimeDefaultText }}</span>`,
@@ -311,7 +322,7 @@ const BulkEditActionsBodyView = View.extend({
     }
 
     const time = this.model.get('time');
-    const isDisabled = (this.model.get('dateMulti') && !time) || !this.model.get('date') || this.model.someComplete();
+    const isDisabled = (this.model.get('dateMulti') && !time) || !this.model.get('date') || this.model.someComplete() || this.isSaving;
     const isOverdue = getIsOverdue(this.model.get('date'), time);
 
     return new TimeComponent({
@@ -321,7 +332,7 @@ const BulkEditActionsBodyView = View.extend({
     });
   },
   getDurationComponent() {
-    const isDisabled = this.model.someComplete();
+    const isDisabled = this.model.someComplete() || this.isSaving;
 
     if (this.model.get('durationMulti')) {
       return new DurationComponent({
@@ -398,12 +409,17 @@ const ApplyOwnerView = View.extend({
   },
   className: 'u-margin--t-4 u-margin--l-16',
   template: hbs`
-    <button class="button--checkbox js-apply-owner"{{#if ownerMulti}} disabled{{/if}}>
+    <button class="button--checkbox js-apply-owner"{{#if isDisabled}} disabled{{/if}}>
       {{#if applyOwner}}{{fas "square-check"}}{{else}}{{fal "square"}}{{/if~}}
       <span>{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.applyOwnerLabel }}</span>
     </button>`,
   triggers: {
     'click .js-apply-owner': 'click:select',
+  },
+  templateContext() {
+    return {
+      isDisabled: this.model.get('ownerMulti') || this.model.get('isSaving'),
+    };
   },
   onClickSelect() {
     this.model.set('applyOwner', !this.model.get('applyOwner'));
@@ -414,6 +430,7 @@ const BulkEditFlowsBodyView = View.extend({
   modelEvents: {
     'change:stateMulti': 'showState',
     'change:ownerMulti': 'showOwner',
+    'change:isSaving': 'render',
   },
   className: 'modal__content--sidebar',
   template: BulkEditFlowBodyTemplate,
@@ -423,15 +440,22 @@ const BulkEditFlowsBodyView = View.extend({
     applyOwner: '[data-apply-owner-region]',
   },
   onRender() {
+    this.isSaving = this.model.get('isSaving');
+
     this.showState();
     this.showOwner();
     this.showApplyOwner();
   },
   getStateComponent() {
+    const isDisabled = this.isSaving;
+
     if (this.model.get('stateMulti')) {
       return new FlowsStateComponent({
         flows: this.collection,
         viewOptions: {
+          attributes: {
+            disabled: isDisabled,
+          },
           className: 'button-secondary w-100',
           template: hbs`{{fas "circle-dot"}}<span class="button__value--indeterminate">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkStateDefaultText }}</span>`,
         },
@@ -441,10 +465,11 @@ const BulkEditFlowsBodyView = View.extend({
     return new FlowsStateComponent({
       flows: this.collection,
       stateId: this.model.get('stateId'),
+      state: { isDisabled },
     });
   },
   getOwnerComponent() {
-    const isDisabled = this.model.someComplete();
+    const isDisabled = this.model.someComplete() || this.isSaving;
 
     if (this.model.get('ownerMulti')) {
       return new OwnerComponent({

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -108,7 +108,7 @@ const BulkEditActionsHeaderView = View.extend({
       </div>
       <div>
         {{#if isDevelop}}<button class="button--icon u-margin--r-8 js-menu">{{far "ellipsis"}}</button>{{/if}}
-        <button class="button--icon js-close">{{far "xmark"}}</button>
+        <button class="button--icon js-close">{{fas "xmark"}}</button>
       </div>
     </div>
   `,
@@ -167,7 +167,7 @@ const BulkEditFlowsHeaderView = View.extend({
       </div>
       <div>
         <button class="button--icon u-margin--r-8 js-menu">{{far "ellipsis"}}</button>
-        <button class="button--icon js-close">{{far "xmark"}}</button>
+        <button class="button--icon js-close">{{fas "xmark"}}</button>
       </div>
     </div>
   `,

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -392,6 +392,7 @@ context('Worklist bulk editing', function() {
       .intercept('PATCH', `/api/flows/${ testFlows[0].id }`, {
         statusCode: 204,
         body: {},
+        delay: 100, // give extra time to check button disabled attributes before modal is closed
       })
       .as('patchFlow1')
       .intercept('PATCH', `/api/flows/${ testFlows[2].id }`, {
@@ -426,6 +427,21 @@ context('Worklist bulk editing', function() {
       .get('@bulkEditSidebar')
       .find('.js-submit')
       .click();
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-state-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-owner-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-apply-owner-region] button')
+      .should('be.disabled');
 
     cy
       .wait('@patchFlow1')
@@ -721,6 +737,7 @@ context('Worklist bulk editing', function() {
       .intercept('PATCH', `/api/actions/${ testActions[0].id }`, {
         statusCode: 204,
         body: {},
+        delay: 100, // give extra time to check button disabled attributes before modal is closed
       })
       .as('patchAction1')
       .intercept('PATCH', `/api/actions/${ testActions[2].id }`, {
@@ -834,6 +851,31 @@ context('Worklist bulk editing', function() {
       .get('@bulkEditSidebar')
       .find('.js-submit')
       .click();
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-state-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-owner-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-due-date-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-due-time-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-duration-region] button')
+      .should('be.disabled');
 
     cy
       .wait('@patchAction1')

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -444,6 +444,12 @@ context('Worklist bulk editing', function() {
       .should('be.disabled');
 
     cy
+      .get('@bulkEditSidebar')
+      .find('[data-footer-region] button')
+      .should('not.have.class', 'js-submit')
+      .should('be.disabled');
+
+    cy
       .wait('@patchFlow1')
       .its('request.body')
       .should(({ data }) => {
@@ -875,6 +881,12 @@ context('Worklist bulk editing', function() {
     cy
       .get('@bulkEditSidebar')
       .find('[data-duration-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-footer-region] button')
+      .should('not.have.class', 'js-submit')
       .should('be.disabled');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-64448]

To-do:
- [x] Batch requests 25 at a time, set to a batch of 2 in tests
- [x] Disable option buttons/droplists when bulk edit request is submitted
- [x] Use new loading UI for submit button and info text of modal (without breaking functionality for other modals)
- [x] Update submit button loading animation
- [x] Fix `Apply Owner to Flow Actions` spacing
- [x] Fix `X` close icon weight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated saving indicator and status messages in modals during bulk operations
  * Save actions now run as multiple batched requests instead of a single bulk request

* **UI Improvements**
  * Modal footer shows persistent saving state and prevents further edits while saving
  * Bulk edit buttons/inputs are disabled during and immediately after save
  * Minor header icon and layout refinements for bulk-edit forms

* **Tests**
  * Added UI assertions to verify disabled states during and after bulk saves
<!-- end of auto-generated comment: release notes by coderabbit.ai -->