### PR TITLE
Remove editorconfig from CI run jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,6 @@ jobs:
       - run:
           name: Stylelint
           command: npm run stylelint
-      - run:
-          name: EditorConfig
-          command: npm run editorconfig
 
   run-cypress:
     parameters:


### PR DESCRIPTION
Shortcut Story ID: [sc-64519]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline configuration by streamlining the lint job to its core linting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->