### PR TITLE
Remove button styling from bulk edit `Applying your changes` text

### DIFF
--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -21,9 +21,9 @@ const i18n = intl.globals.modal.modalViews;
 const ReplaceElRegion = Region.extend({ replaceElement: true, timeout: 0 });
 
 const SavingFooterView = View.extend({
-  className: 'flex',
+  className: 'flex flex-align-center',
   template: hbs`
-    <div class="button--text" disabled>{{ savingInfoText }}</div>
+    <div class="modal__footer-saving-info">{{ savingInfoText }}</div>
     <button class="{{ buttonClass }} js-loading" disabled>
       <span>{{ savingSubmitText }}</span>
     </button>

--- a/src/scss/modules/modals.scss
+++ b/src/scss/modules/modals.scss
@@ -97,6 +97,13 @@
   flex-direction: row-reverse;
 }
 
+.modal__footer-saving-info {
+  color: #{$black-60};
+  font-size: 14px;
+  font-weight: 600;
+  margin-right: 16px;
+}
+
 .modal__footer-info {
   flex-grow: 1;
   font-size: 12px;


### PR DESCRIPTION
Shortcut Story ID: [sc-64558]

Follow up code change after https://github.com/RoundingWell/care-ops-frontend/pull/1538


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout alignment and centering in the modal footer saving information display.
  * Enhanced visual styling of the saving indicator with refined typography and spacing for better readability and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->