### PR TITLE
Fix bug: bulk edit states button label is blank when all selected states are the same

### DIFF
--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -1,4 +1,4 @@
-import { some } from 'underscore';
+import { get, some } from 'underscore';
 import dayjs from 'dayjs';
 import hbs from 'handlebars-inline-precompile';
 import Radio from 'backbone.radio';
@@ -167,7 +167,7 @@ const BulkEditActionsBodyView = View.extend({
     }
 
     return new StateComponent({
-      stateId: this.model.get('stateId'),
+      stateId: get(this.model.get('state'), 'id'),
       state: { isDisabled },
     });
   },
@@ -376,7 +376,7 @@ const BulkEditFlowsBodyView = View.extend({
 
     return new FlowsStateComponent({
       flows: this.collection,
-      stateId: this.model.get('stateId'),
+      stateId: get(this.model.get('state'), 'id'),
       state: { isDisabled },
     });
   },

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -519,6 +519,16 @@ context('Worklist bulk editing', function() {
     cy
       .get('@bulkEditSidebar')
       .find('[data-state-region]')
+      .contains('Done');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-owner-region]')
+      .contains('Nurse');
+
+    cy
+      .get('@bulkEditSidebar')
+      .find('[data-state-region]')
       .click();
 
     cy
@@ -880,6 +890,26 @@ context('Worklist bulk editing', function() {
       .get('[data-filters-region]')
       .find('.js-bulk-edit')
       .click();
+
+    cy
+      .get('[data-state-region]')
+      .should('contain', 'To Do');
+
+    cy
+      .get('[data-owner-region]')
+      .should('contain', 'Nurse');
+
+    cy
+      .get('[data-due-date-region]')
+      .should('contain', formatDate(tomorrow, 'LONG'));
+
+    cy
+      .get('[data-due-time-region]')
+      .should('contain', '10:00 AM');
+
+    cy
+      .get('[data-duration-region]')
+      .should('contain', '5 mins');
 
     cy
       .intercept('PATCH', '/api/actions/*', {


### PR DESCRIPTION
Shortcut Story ID: [sc-64560]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of patient bulk-edit when state information is missing or structured differently, reducing errors when changing states in bulk.

* **Tests**
  * Strengthened end-to-end checks for bulk-edit flows to ensure state, owner, due date/time, and duration display expected values during the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->