### PR TITLE
Remove `cypress-plugin-tab` & use `cy.press()` instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "babel-plugin-istanbul": "^7.0.0",
         "browserslist-to-esbuild": "^2.1.1",
         "cypress": "^15.0.0",
-        "cypress-plugin-tab": "^1.0.5",
         "cypress-vite": "^1.5.0",
         "editorconfig-checker": "^6.1.0",
         "eslint": "^9.5.0",
@@ -4489,17 +4488,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "node_modules/amazon-quicksight-embedding-sdk": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/amazon-quicksight-embedding-sdk/-/amazon-quicksight-embedding-sdk-2.10.1.tgz",
@@ -5784,13 +5772,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5861,16 +5842,6 @@
       },
       "engines": {
         "node": "^20.1.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/cypress-plugin-tab": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
-      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ally.js": "^1.4.1"
       }
     },
     "node_modules/cypress-vite": {
@@ -10198,13 +10169,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "babel-plugin-istanbul": "^7.0.0",
     "browserslist-to-esbuild": "^2.1.1",
     "cypress": "^15.0.0",
-    "cypress-plugin-tab": "^1.0.5",
     "cypress-vite": "^1.5.0",
     "editorconfig-checker": "^6.1.0",
     "eslint": "^9.5.0",

--- a/test/integration/clinicians/clinician-sidebar.js
+++ b/test/integration/clinicians/clinician-sidebar.js
@@ -410,8 +410,11 @@ context('clinician sidebar', function() {
       .find('[data-email-region] .js-input')
       .clear()
       .type('edited.email@roundingwell.com')
-      .tab()
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-cancel')
       .typeEnter();
 
@@ -440,7 +443,10 @@ context('clinician sidebar', function() {
       .should('have.value', 'test.clinician@roundingwell.com')
       .clear()
       .type('edited.email@roundingwell.com')
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-save')
       .typeEnter();
 
@@ -475,7 +481,10 @@ context('clinician sidebar', function() {
       .find('[data-email-region] .js-input')
       .clear()
       .type('edited.email@roundingwell.com')
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .typeEnter()
       .wait('@routePatchClinicianError');
 

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -111,9 +111,12 @@ context('program action sidebar', function() {
       .get('.sidebar')
       .find('[data-name-region] .js-input')
       .type('Test Name')
-      .tab()
-      .tab()
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-cancel')
       .typeEnter();
 
@@ -188,7 +191,10 @@ context('program action sidebar', function() {
       .find('[data-details-region] .js-input')
       .type('a{backspace}')
       .type('Test{enter} Details')
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-save')
       .typeEnter();
 

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -271,7 +271,10 @@ context('program flow sidebar', function() {
       .get('@flowSidebar')
       .find('[data-details-region] textarea')
       .type('Here are some details')
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-save')
       .typeEnter();
 

--- a/test/integration/programs/sidebar/program-sidebar.js
+++ b/test/integration/programs/sidebar/program-sidebar.js
@@ -218,9 +218,12 @@ context('program sidebar', function() {
       .find('[data-name-region] .js-input')
       .clear()
       .type('cancel this text')
-      .tab()
-      .tab()
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-cancel')
       .typeEnter();
 
@@ -329,8 +332,11 @@ context('program sidebar', function() {
       .find('[data-name-region] .js-input')
       .clear()
       .type('Tester McProgramington')
-      .tab()
-      .tab()
+      .press(Cypress.Keyboard.Keys.TAB)
+      .press(Cypress.Keyboard.Keys.TAB);
+
+    cy
+      .focused()
       .should('have.class', 'js-save')
       .typeEnter();
 

--- a/test/support/commands.js
+++ b/test/support/commands.js
@@ -118,7 +118,6 @@ Cypress.Commands.add('typeEnter', { prevSubject: true }, $el => {
 
   cy
     .wrap($el)
-    // cypress-plugin-tab can cause issues with focus/typing
     .blur()
     // Need force because Cypress does not recognize the element is typeable
     .type('{enter}', { force: true });

--- a/test/support/e2e.js
+++ b/test/support/e2e.js
@@ -12,7 +12,6 @@
 // You can read more here:
 // https://on.cypress.io/guides/configuration#section-global
 // ***********************************************************
-import 'cypress-plugin-tab';
 import 'js/base/dayjs';
 
 import './defaults';


### PR DESCRIPTION
Shortcut Story ID: [sc-64268]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an external test tab plugin and its global loading to simplify the dev/test setup.
* **Tests**
  * Updated integration tests to use explicit TAB key presses and focused-element checks instead of chained tab helpers for more reliable, deterministic keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->