### PR TITLE
On bulk editing flows, batch `PATCH /flows/:id/relationships/actions` requests

### DIFF
--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -37,4 +37,21 @@ export default Backbone.Collection.extend(extend({
 
     return Promise.all(destroys);
   },
+  async batchInvoke(methodName, batchSize, ...args) {
+    /* istanbul ignore next: Branch only for testing */
+    const size = _TEST_ ? 2 : batchSize;
+    const results = [];
+    let count = 0;
+
+    while (count < this.length) {
+      const batch = new this.constructor(this.slice(count, count + size));
+      const batchInvokes = batch.invoke(methodName, ...args);
+      const batchResults = await Promise.all(batchInvokes);
+
+      results.push(...batchResults);
+      count += size;
+    }
+
+    return results;
+  },
 }, JsonApiMixin));

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -288,26 +288,7 @@ const Collection = BaseCollection.extend({
   url: '/api/actions',
   model: Model,
   save(attrs) {
-    return this._processBatches(attrs);
-  },
-  async _processBatches(
-    attrs,
-    /* istanbul ignore next: Branch only for testing */
-    batchSize = _TEST_ ? 2 : 25,
-  ) {
-    const results = [];
-    let count = 0;
-
-    while (count < this.length) {
-      const batch = new Collection(this.slice(count, count + batchSize));
-      const batchSaves = batch.invoke('saveAll', attrs);
-      const batchResults = await Promise.all(batchSaves);
-
-      results.push(...batchResults);
-      count += batchSize;
-    }
-
-    return results;
+    return this.batchInvoke('saveAll', 25, attrs);
   },
   groupByDate() {
     const groupedCollection = this.groupBy('due_date');

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -131,19 +131,23 @@ const Collection = BaseCollection.extend({
   url: '/api/flows',
   model: Model,
   save(attrs) {
-    return this._processBatches(attrs);
+    return this._processBatches('saveAll', attrs);
+  },
+  applyOwner(owner) {
+    return this._processBatches('applyOwner', owner);
   },
   async _processBatches(
-    attrs,
-    /* istanbul ignore next: Branch only for testing */
-    batchSize = _TEST_ ? 2 : 25,
+    methodName,
+    ...args
   ) {
+    /* istanbul ignore next: Branch only for testing */
+    const batchSize = _TEST_ ? 2 : 20;
     const results = [];
     let count = 0;
 
     while (count < this.length) {
       const batch = new Collection(this.slice(count, count + batchSize));
-      const batchSaves = batch.invoke('saveAll', attrs);
+      const batchSaves = batch.invoke(methodName, ...args);
       const batchResults = await Promise.all(batchSaves);
 
       results.push(...batchResults);
@@ -151,11 +155,6 @@ const Collection = BaseCollection.extend({
     }
 
     return results;
-  },
-  applyOwner(owner) {
-    const saves = this.invoke('applyOwner', owner);
-
-    return Promise.all(saves);
   },
 });
 

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -131,30 +131,10 @@ const Collection = BaseCollection.extend({
   url: '/api/flows',
   model: Model,
   save(attrs) {
-    return this._processBatches('saveAll', attrs);
+    return this.batchInvoke('saveAll', 20, attrs);
   },
   applyOwner(owner) {
-    return this._processBatches('applyOwner', owner);
-  },
-  async _processBatches(
-    methodName,
-    ...args
-  ) {
-    /* istanbul ignore next: Branch only for testing */
-    const batchSize = _TEST_ ? 2 : 20;
-    const results = [];
-    let count = 0;
-
-    while (count < this.length) {
-      const batch = new Collection(this.slice(count, count + batchSize));
-      const batchSaves = batch.invoke(methodName, ...args);
-      const batchResults = await Promise.all(batchSaves);
-
-      results.push(...batchResults);
-      count += batchSize;
-    }
-
-    return results;
+    return this.batchInvoke('applyOwner', 20, owner);
   },
 });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-64748]

Two changes made:

* Batch `PATCH /flows/:id/relationships/actions` requests when flows are being bulk edited. (`Apply Owner to Flow Actions` option selected)
* Create a new `batchInvoke()` method in `/js/base/collection` that we can use to send batch requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal batch processing utilities for collection operations to improve code maintainability and consistency. Collection save and owner application workflows now utilize centralized batch handling with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->