### PR TITLE
Fix coverage branch miss when destroying modal animation

### DIFF
--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -44,6 +44,7 @@ const SavingFooterView = View.extend({
     });
   },
   onBeforeDestroy() {
+    /* istanbul ignore else */
     if (this.animation) {
       this.animation.cancel();
     }


### PR DESCRIPTION
Shortcut Story ID: [sc-64824]

To fix a coveralls branch miss: https://coveralls.io/builds/76185913/source?filename=src%2Fjs%2Fviews%2Fglobals%2Fmodal%2Fmodal_views.js#L47