### PR TITLE
Fix coverage miss for tooltip delay branches

### DIFF
--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -32,8 +32,7 @@ const TooltipView = View.extend({
 export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
-  /* istanbul ignore next: Branch only for testing */
-  delay: _TEST_ ? 0 : 200,
+  delay: /* istanbul ignore next: Branch only for testing */ _TEST_ ? 0 : 200,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 


### PR DESCRIPTION
Shortcut Story ID: [sc-64824]

Fix coverage miss here: https://coveralls.io/builds/76111569/source?filename=src%2Fjs%2Fcomponents%2Ftooltip%2Findex.js#L36