### PR TITLE
Silence some of the browser console logging done by five9

### DIFF
--- a/packages/care-ops-five9/sdk/five9.crm.sdk.js
+++ b/packages/care-ops-five9/sdk/five9.crm.sdk.js
@@ -19,6 +19,16 @@ window.crmSdkVersion = '1.0.11';
     root.Five9.CrmSdk = factory();
   }
 }(globalThis, function () {
+  // Patched by care-ops: silence noisy Five9 logging
+  var __five9Console = globalThis.console || {};
+  var console = {
+    log: function () {},
+    debug: function () {},
+    info: function () {},
+    warn: __five9Console.warn ? __five9Console.warn.bind(__five9Console) : function () {},
+    error: __five9Console.error ? __five9Console.error.bind(__five9Console) : function () {},
+  };
+
 
 // We use RequireJS modules inside.
 // Since this library can be included into projects with JS/node modules support

--- a/packages/care-ops-five9/update-sdk.js
+++ b/packages/care-ops-five9/update-sdk.js
@@ -64,6 +64,31 @@ async function downloadSDK() {
       '}(globalThis, function',
     );
 
+    // Silence verbose logging without touching the global console
+    const consoleSilencer = [
+      '  // Patched by care-ops: silence noisy Five9 logging',
+      '  var __five9Console = globalThis.console || {};',
+      '  var console = {',
+      '    log: function () {},',
+      '    debug: function () {},',
+      '    info: function () {},',
+      '    warn: __five9Console.warn ? __five9Console.warn.bind(__five9Console) : function () {},',
+      '    error: __five9Console.error ? __five9Console.error.bind(__five9Console) : function () {},',
+      '  };',
+    ].join('\n');
+
+    if (!fixedContent.includes('__five9Console')) {
+      const factoryWrapperPattern = /}\(globalThis,\s*function\s*\(\)\s*{/;
+      if (factoryWrapperPattern.test(fixedContent)) {
+        fixedContent = fixedContent.replace(
+          factoryWrapperPattern,
+          match => `${ match }\n${ consoleSilencer }\n`,
+        );
+      } else {
+        console.warn('⚠️  Could not locate Five9 factory wrapper to silence logging');
+      }
+    }
+
     // Add eslint disable comment at the top since this is a third-party file
     if (!fixedContent.startsWith('/* eslint-disable */')) {
       fixedContent = `/* eslint-disable */\n${ fixedContent }`;


### PR DESCRIPTION
Shortcut Story ID: [sc-64900]

This stops console.logs from happening from the `packages/care-ops-five9/sdk/five9.crm.sdk.js` file.

Note: there is other code that five9 loads in the iframe that logs a lot to the console. But that is cross origin content, so we can't stop it from logging to the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive console logging from the Five9 SDK integration. Informational and debug messages are now suppressed, while critical warnings and errors remain visible for troubleshooting purposes. No changes to SDK functionality or API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->