### PR TITLE
Display program/patient action name icons in UI

### DIFF
--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -1,5 +1,10 @@
 <div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
-<div class="u-text--overflow-two-lines">{{ name }}</div>
+<div class="u-text--overflow-two-lines">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{/if}}
+  {{ name }}
+</div>
 <div class="table-list__meta">
   <span class="table-list__icon u-margin--r-8" data-details-region></span>
   <span data-state-region></span>

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -16,6 +16,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 import ActionItemTemplate from './action-item.hbs';
 import FlowItemTemplate from './flow-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 
 const EmptyView = View.extend({

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -1,6 +1,9 @@
 
 <div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
 <div class="u-text--overflow-two-lines">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{/if}}
   {{ name }}
   {{~#unless name}}<em>{{ @intl.patients.patient.dashboard.dashboardViews.newAction }}</em>{{/unless~}}
 </div>

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -20,6 +20,7 @@ import FlowItemTemplate from './flow-item.hbs';
 import LayoutTemplate from './layout.hbs';
 
 import 'scss/domain/action-state.scss';
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 
 const EmptyView = View.extend({

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -1,6 +1,9 @@
 <div class="table-list__item-check js-no-click"><span data-check-region></span></div>
 <div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
 <div class="u-text--overflow-two-lines">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{/if}}
   {{ name }}
   {{~#unless name}}<em>{{ @intl.patients.patient.dashboard.dashboardViews.newAction }}</em>{{/unless~}}
 </div>

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -16,6 +16,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 import HeaderTemplate from './header.hbs';
 import ActionItemTemplate from './action-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 import './patient-flow.scss';
 

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -21,6 +21,7 @@ import { CheckComponent, DetailsTooltip } from 'js/views/patients/shared/actions
 
 import LayoutTemplate from './layout.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './schedule-list.scss';
 
 const LayoutView = View.extend({
@@ -191,7 +192,12 @@ const DayItemView = View.extend({
     <div class="schedule-list__patient-name u-text--overflow-two-lines {{#if isReduced}}is-reduced{{else}}js-patient{{/if}}">{{ patient.first_name }} {{ patient.last_name }}&#8203;</div>
     <div class="schedule-list__action-meta">
       <span class="schedule-list__action-state action--{{ stateOptions.color }}">{{fa stateOptions.iconType stateOptions.icon}}</span><span class="schedule-list__search-helper">{{ state }}</span>&#8203;
-      <span class="u-text--overflow-two-lines{{#unless isReduced}} js-action{{/unless}}">{{ name }}</span>&#8203;
+      <span class="u-text--overflow-two-lines{{#unless isReduced}} js-action{{/unless}}">
+        {{#if options.icon}}
+          <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+        {{/if}}
+        {{ name }}
+      </span>&#8203;
       <span class="schedule-list__search-helper">{{ flow }}</span>&#8203;
     </div>
     <div class="schedule-list__action-details" data-details-region></div>

--- a/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-action_views.js
@@ -14,10 +14,18 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateTimeView, ReadOnly
 
 import ActionDetailsTemplate from './action-details.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './action-sidebar.scss';
 
 const NameView = View.extend({
-  template: hbs`<div class="action-sidebar__name">{{ name }}</div>`,
+  template: hbs`
+    <div class="action-sidebar__name flex flex-align-center">
+      {{#if options.icon}}
+        <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+      {{/if}}
+      {{ name }}
+    </div>
+  `,
 });
 
 const SaveView = View.extend({

--- a/src/js/views/patients/sidebar/action/action-sidebar.scss
+++ b/src/js/views/patients/sidebar/action/action-sidebar.scss
@@ -3,6 +3,11 @@
   font-weight: 600;
   margin-bottom: 8px;
   padding: 8px 0;
+
+  .icon {
+    margin-right: 4px;
+    width: 16px;
+  }
 }
 
 .action-sidebar__button {

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -11,7 +11,12 @@
 <div class="worklist-list__action-icon">{{far icon}}</div>
 <div>
   {{#if flowName}}<div class="u-text--overflow-two-lines worklist-list__overline">{{ flowName }}&#8203;</div>{{/if}}
-  <span class="u-text--overflow-two-lines">{{ name }}&#8203;</span>
+  <span class="u-text--overflow-two-lines">
+    {{#if options.icon}}
+      <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+    {{/if}}
+    {{ name }}&#8203;
+  </span>
 </div>
 <div class="table-list__meta">
   <span class="worklist-list__details-icon" data-details-region></span>

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -9,6 +9,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 
 import ActionItemTemplate from './action-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './worklist-list.scss';
 
 const ActionTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.actionViews.actionListTooltips") title=worklistId team=owner}}`;

--- a/src/js/views/programs/program/flow/action-item.hbs
+++ b/src/js/views/programs/program/flow/action-item.hbs
@@ -1,5 +1,8 @@
 <div class="table-list__icon--large program-flow__action-icon">{{far icon}}</div>
 <div class="u-text--overflow-two-lines">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{/if}}
   {{ name }}
   {{~#unless name}}<em>{{ @intl.programs.program.flow.actionItemTemplate.newProgramFlowAction }}</em>{{/unless~}}
 </div>

--- a/src/js/views/programs/program/flow/flow_views.js
+++ b/src/js/views/programs/program/flow/flow_views.js
@@ -11,6 +11,7 @@ import SortableList from 'js/behaviors/sortable-list';
 import ActionItemTemplate from './action-item.hbs';
 import HeaderTemplate from './header.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './program-flow.scss';
 
 const ContextTrailView = View.extend({

--- a/src/js/views/programs/program/workflows/action-item.hbs
+++ b/src/js/views/programs/program/workflows/action-item.hbs
@@ -1,6 +1,9 @@
 <div>
   <span class="table-list__icon--large workflows__action-icon">{{far icon}}</span>
-  <span>
+  <span class="workflows__action-name">
+    {{#if options.icon}}
+      <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+    {{/if}}
     {{ name }}
     {{~#unless name}}<em>{{ @intl.programs.program.workflows.actionItemTemplate.newProgramAction }}</em>{{/unless~}}
   </span>

--- a/src/js/views/programs/program/workflows/workflows.scss
+++ b/src/js/views/programs/program/workflows/workflows.scss
@@ -42,6 +42,11 @@
   color: color(blue);
 }
 
+.workflows__action-name .icon {
+  margin-right: 4px;
+  width: 16px;
+}
+
 .workflows__item-ts {
   font-size: 12px;
   text-align: right;

--- a/src/js/views/programs/program/workflows/workflows_views.js
+++ b/src/js/views/programs/program/workflows/workflows_views.js
@@ -23,6 +23,7 @@ import FlowItemTemplate from './flow-item.hbs';
 import LayoutTemplate from './layout.hbs';
 
 import 'scss/domain/program-action-state.scss';
+import 'scss/domain/action-icons.scss';
 import './workflows.scss';
 
 const EmptyView = View.extend({

--- a/src/scss/core/_text.scss
+++ b/src/scss/core/_text.scss
@@ -19,6 +19,11 @@
   -webkit-line-clamp: 2;
   line-clamp: 2;
   overflow: hidden;
+
+  .icon {
+    margin-right: 4px;
+    width: 16px;
+  }
 }
 
 .u-text--nowrap {

--- a/src/scss/domain/action-icons.scss
+++ b/src/scss/domain/action-icons.scss
@@ -1,0 +1,23 @@
+.action-icon--black {
+  color: #{$black-20};
+}
+
+.action-icon--grey {
+  color: #{$black-60};
+}
+
+.action-icon--red {
+  color: color(red);
+}
+
+.action-icon--green {
+  color: color(green);
+}
+
+.action-icon--orange {
+  color: color(orange);
+}
+
+.action-icon--purple {
+  color: color(purple);
+}

--- a/test/fixtures/config/actions.js
+++ b/test/fixtures/config/actions.js
@@ -38,6 +38,7 @@ export default () => {
     }),
     sequence: faker.number.int(100),
     created_at: created,
+    options: {},
     outreach: 'disabled',
     sharing: 'disabled',
     updated_at: faker.date.between({

--- a/test/fixtures/config/program-actions.js
+++ b/test/fixtures/config/program-actions.js
@@ -10,6 +10,7 @@ export default () => {
       min: 0,
       max: 99,
     }),
+    options: {},
     outreach: 'disabled',
     published_at: faker.helpers.arrayElement([faker.date.between({
       from: dayjs().subtract(2, 'week').format(),

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -44,6 +44,11 @@ context('patient archive page', function() {
           due_date: null,
           due_time: null,
           updated_at: testTs(),
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           owner: getRelationship(currentClinican),
@@ -173,12 +178,30 @@ context('patient archive page', function() {
       .get('.list-page__list')
       .find('.table-list__item')
       .first()
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'First In List')
-      .next()
-      .should('contain', 'Second In List')
-      .next()
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(1)
+      .should('contain', 'Second In List');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(2)
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'Third In List')
-      .next()
+      .find('svg')
+      .should('not.exist');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Last In List');
 
     cy

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -65,6 +65,11 @@ context('patient dashboard page', function() {
         due_date: null,
         due_time: null,
         updated_at: testTs(),
+        options: {
+          icon: 'caret-down',
+          iconType: 'fas',
+          color: 'red',
+        },
       },
       relationships: {
         owner: getRelationship(teamCoordinator),
@@ -203,10 +208,24 @@ context('patient dashboard page', function() {
       .get('.list-page__list')
       .find('.table-list__item')
       .first()
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'First In List')
-      .next()
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(1)
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'Second In List')
-      .next()
+      .find('svg')
+      .should('not.exist');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(2)
       .should('contain', 'Third In List')
       .next()
       .should('contain', 'Outreach')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -626,6 +626,11 @@ context('patient flow page', function() {
               sequence: 1,
               outreach: 'patient',
               sharing: 'sent',
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
             relationships: {
               flow: getRelationship(testFlow),
@@ -695,6 +700,7 @@ context('patient flow page', function() {
       .find('.table-list__item')
       .first()
       .should($action => {
+        expect($action.find('.u-text--overflow-two-lines').find('svg.fa-caret-down')).to.exist;
         expect($action.find('.fa-circle-exclamation')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('NUR');
         expect($action.find('[data-due-date-region] .is-overdue')).to.exist;
@@ -710,6 +716,7 @@ context('patient flow page', function() {
       .first()
       .next()
       .should($action => {
+        expect($action.find('.u-text--overflow-two-lines').find('svg')).to.not.exist;
         expect($action.find('.fa-circle-dot')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('OT');
         expect($action.find('.fa-paperclip')).to.not.exist;

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -56,6 +56,11 @@ context('action sidebar', function() {
         due_time: '06:01:00',
         updated_at: testTs(),
         sharing: true,
+        options: {
+          icon: 'caret-down',
+          iconType: 'fas',
+          color: 'red',
+        },
       },
       relationships: {
         owner: getRelationship(currentClinician),
@@ -321,6 +326,12 @@ context('action sidebar', function() {
       .wait('@routeActionActivity')
       .wait('@routePatient')
       .tick(350); // since this test uses visitOnClock, we need this for the sidebar animation
+
+    cy
+      .get('.sidebar')
+      .find('[data-action-region] .action-sidebar__name')
+      .find('svg.fa-caret-down')
+      .should('exist');
 
     cy
       .get('.sidebar')
@@ -1881,7 +1892,9 @@ context('action sidebar', function() {
 
     cy
       .get('.action-sidebar__name')
-      .should('contain', 'Program Action Name');
+      .should('contain', 'Program Action Name')
+      .find('svg')
+      .should('not.exist');
 
     cy
       .get('.sidebar')

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -37,6 +37,11 @@ context('reduced schedule page', function() {
         name: 'Test Action',
         due_date: testDate(),
         due_time: null,
+        options: {
+          icon: 'caret-down',
+          iconType: 'fas',
+          color: 'red',
+        },
       },
       relationships: {
         patient: getRelationship(testPatient),
@@ -209,6 +214,15 @@ context('reduced schedule page', function() {
       .first()
       .find('.schedule-list__day-list-row')
       .should('have.class', 'is-reduced')
+      .find('.schedule-list__action-meta .u-text--overflow-two-lines')
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .first()
+      .find('.schedule-list__day-list-row')
       .contains('Test Action')
       .click();
 
@@ -228,6 +242,15 @@ context('reduced schedule page', function() {
       .url()
       .should('contain', `patient-action/${ testAction.id }/form/${ testForm.id }`)
       .go('back');
+
+    cy
+      .get('@scheduleList')
+      .find('.schedule-list__list-row')
+      .eq(1)
+      .find('.schedule-list__day-list-row')
+      .find('.schedule-list__action-meta .u-text--overflow-two-lines')
+      .find('svg')
+      .should('not.exist');
 
     cy
       .get('@scheduleList')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -65,6 +65,11 @@ context('schedule page', function() {
           name: 'Outreach Planning: Review Referral, Medical Chart Review, Targeting Interventions, and other tasks',
           due_date: testDate(),
           due_time: '06:45:00',
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           patient: getRelationship(testPatient2),
@@ -204,12 +209,22 @@ context('schedule page', function() {
       .find('.schedule-list__day-list-row')
       .first()
       .should('contain', '6:45 AM')
-      .should('contain', 'Outreach Planning')
       .find('.is-overdue')
-      .parents('.schedule-list__day-list-row')
-      .next()
+      .parent()
+      .find('.js-action')
+      .should('contain', 'Outreach Planning')
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('@actionList')
+      .find('.schedule-list__day-list-row')
+      .eq(1)
       .should('contain', '10:31 AM')
-      .should('contain', 'Second Action');
+      .find('.js-action')
+      .should('contain', 'Second Action')
+      .find('svg')
+      .should('not.exist');
 
     cy
       .get('@actionList')

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -754,6 +754,11 @@ context('worklist page', function() {
           due_date: testDate(),
           due_time: '06:01:00',
           updated_at: testTs(),
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           state: getRelationship(stateTodo),
@@ -849,12 +854,26 @@ context('worklist page', function() {
       .find('.table-list__item')
       .first()
       .as('firstRow')
-      .should('contain', 'First In List')
-      .should('contain', 'Test Flow')
       .should('have.class', 'is-selected')
-      .next()
+      .should('contain', 'Test Flow')
+      .find('.u-text--overflow-two-lines')
+      .should('contain', 'First In List')
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(1)
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'Second In List')
-      .next()
+      .find('svg')
+      .should('not.exist');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Last In List');
 
     cy

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -337,6 +337,11 @@ context('program flow page', function() {
               name: 'First In List',
               updated_at: testTs(),
               outreach: 'patient',
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
             relationships: {
               'owner': getRelationship(),
@@ -462,10 +467,25 @@ context('program flow page', function() {
       .as('actionList')
       .find('.table-list__item')
       .first()
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'Second In List')
-      .next()
+      .find('svg')
+      .should('not.exist');
+
+    cy
+      .get('@actionList')
+      .find('.table-list__item')
+      .eq(1)
+      .find('.u-text--overflow-two-lines')
       .should('contain', 'First In List')
-      .next()
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('.program-flow__list')
+      .as('actionList')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Third In List');
 
     cy

--- a/test/integration/programs/program/workflows.js
+++ b/test/integration/programs/program/workflows.js
@@ -21,6 +21,11 @@ context('program workflows page', function() {
         days_until_due: null,
         created_at: testTs(),
         updated_at: testTs(),
+        options: {
+          icon: 'caret-down',
+          iconType: 'fas',
+          color: 'red',
+        },
       },
       relationships: {
         'program': getRelationship(testProgram),
@@ -92,10 +97,26 @@ context('program workflows page', function() {
       .get('.table-list__list')
       .find('.table-list__item')
       .first()
+      .find('.workflows__action-icon')
+      .next()
       .should('contain', 'First In List')
+      .find('svg.fa-caret-down')
+      .should('exist');
+
+    cy
+      .get('.table-list__list')
+      .find('.table-list__item')
+      .eq(1)
+      .find('.workflows__action-icon')
       .next()
       .should('contain', 'Second In List')
-      .next()
+      .find('svg')
+      .should('not.exist');
+
+    cy
+      .get('.table-list__list')
+      .find('.table-list__item')
+      .eq(2)
       .should('contain', 'Third In List')
       .next()
       .should('contain', 'Fourth In List');


### PR DESCRIPTION
Shortcut Story ID: [sc-65172]

To be displayed inline with action names in the follow places where action data is displayed:

1. Worklists
2. Schedule/Reduced Schedule
3. Patient flow
4. Patient dashboard/archive
5. Action sidebar
6. Program workflows
7. Program flow

Example:

<img width="351" height="87" alt="Screenshot 2025-11-19 at 11 11 59 AM" src="https://github.com/user-attachments/assets/0e1a46fc-e2bc-4d65-a080-7b7ae1fdddcf" />


Corresponding BE PRs: https://github.com/RoundingWell/care-ops-backend/pull/10095, https://github.com/RoundingWell/care-ops-backend/pull/10107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying colored icons alongside action names throughout the application. Icons can now appear in patient views, programs, schedules, and worklists with available color options: black, grey, red, green, orange, and purple.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->