### PR TITLE
Display custom action icons

### DIFF
--- a/fontawesome.json
+++ b/fontawesome.json
@@ -66,6 +66,8 @@
     "bolt",
     "calendar-days",
     "calendar-star",
+    "chart-line-down",
+    "chart-line-up",
     "circle-check",
     "circle-dashed",
     "circle-exclamation",

--- a/src/js/apps/patients/patient/dashboard/add-workflow_app.js
+++ b/src/js/apps/patients/patient/dashboard/add-workflow_app.js
@@ -74,6 +74,7 @@ export default App.extend({
         text: item.get('name'),
         itemType: item.type,
         hasOutreach: item.type === 'program-actions' && item.hasOutreach(),
+        customIcon: item.get('options'),
         programItem: item,
       };
     });

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -146,6 +146,7 @@ export default SubRouterApp.extend({
         text: action.get('name'),
         itemType: action.type,
         hasOutreach: action.hasOutreach(),
+        customIcon: action.get('options'),
         programItem: action,
       };
     });

--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -1,4 +1,10 @@
-<div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
+<div class="table-list__icon--large patient__action-icon">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{else}}
+    {{far icon}}
+  {{/if}}
+</div>
 <div class="u-text--overflow-two-lines">{{ name }}</div>
 <div class="table-list__meta">
   <span class="table-list__icon u-margin--r-8" data-details-region></span>

--- a/src/js/views/patients/patient/archive/archive_views.js
+++ b/src/js/views/patients/patient/archive/archive_views.js
@@ -16,6 +16,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 import ActionItemTemplate from './action-item.hbs';
 import FlowItemTemplate from './flow-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 
 const EmptyView = View.extend({

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -1,5 +1,11 @@
 
-<div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
+<div class="table-list__icon--large patient__action-icon">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{else}}
+    {{far icon}}
+  {{/if}}
+</div>
 <div class="u-text--overflow-two-lines">
   {{ name }}
   {{~#unless name}}<em>{{ @intl.patients.patient.dashboard.dashboardViews.newAction }}</em>{{/unless~}}

--- a/src/js/views/patients/patient/dashboard/dashboard_views.js
+++ b/src/js/views/patients/patient/dashboard/dashboard_views.js
@@ -20,6 +20,7 @@ import FlowItemTemplate from './flow-item.hbs';
 import LayoutTemplate from './layout.hbs';
 
 import 'scss/domain/action-state.scss';
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 
 const EmptyView = View.extend({

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -1,5 +1,11 @@
 <div class="table-list__item-check js-no-click"><span data-check-region></span></div>
-<div class="table-list__icon--large patient__action-icon">{{far icon}}</div>
+<div class="table-list__icon--large patient__action-icon">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{else}}
+    {{far icon}}
+  {{/if}}
+</div>
 <div class="u-text--overflow-two-lines">
   {{ name }}
   {{~#unless name}}<em>{{ @intl.patients.patient.dashboard.dashboardViews.newAction }}</em>{{/unless~}}

--- a/src/js/views/patients/patient/flow/flow_views.js
+++ b/src/js/views/patients/patient/flow/flow_views.js
@@ -16,6 +16,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 import HeaderTemplate from './header.hbs';
 import ActionItemTemplate from './action-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import '../patient.scss';
 import './patient-flow.scss';
 

--- a/src/js/views/patients/patient/patient.scss
+++ b/src/js/views/patients/patient/patient.scss
@@ -109,7 +109,7 @@
   text-align: right;
 }
 
-.patient__action-icon .icon {
+.patient__action-icon {
   color: color(blue);
 }
 

--- a/src/js/views/patients/shared/add-workflow/add-workflow_views.js
+++ b/src/js/views/patients/shared/add-workflow/add-workflow_views.js
@@ -8,6 +8,7 @@ import Optionlist from 'js/components/optionlist';
 
 import intl from 'js/i18n';
 
+import 'scss/domain/action-icons.scss';
 import './add-workflow.scss';
 
 const i18n = intl.patients.shared.addWorkflow.addWorkflowViews;
@@ -18,10 +19,24 @@ const AddWorkflowOptlist = Optionlist.extend({
   placeholderText: i18n.addWorkflowOptlist.placeholderText,
   itemTemplateContext() {
     const isProgramAction = this.model.get('itemType') === 'program-actions';
-    const actionIcon = this.model.get('hasOutreach') ? 'share-from-square' : 'file-lines';
+    const defaultActionIcon = this.model.get('hasOutreach') ? 'share-from-square' : 'file-lines';
+    const hasCustomIcon = this.model.get('customIcon')?.icon;
+
+    if (hasCustomIcon) {
+      const customIcon = this.model.get('customIcon');
+
+      return {
+        icon: {
+          icon: customIcon.icon,
+          type: customIcon.iconType,
+          classes: `action-icon--${ customIcon.color }`,
+        },
+      };
+    }
+
     return {
       icon: {
-        icon: isProgramAction ? actionIcon : 'folder',
+        icon: isProgramAction ? defaultActionIcon : 'folder',
         type: isProgramAction ? 'far' : 'fas',
         classes: 'add-workflow__picklist-icon',
       },

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -8,7 +8,13 @@
   {{#if patient.segment}}<div class="u-text--overflow-two-lines worklist-list__overline">{{ patient.segment }}&#8203;</div>{{/if}}
   <span class="u-text--overflow-two-lines worklist-list__patient-name">{{ patient.first_name }} {{ patient.last_name }}&#8203;</span>
 </div>
-<div class="worklist-list__action-icon">{{far icon}}</div>
+<div class="worklist-list__action-icon">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{else}}
+    {{far icon}}
+  {{/if}}
+</div>
 <div>
   {{#if flowName}}<div class="u-text--overflow-two-lines worklist-list__overline">{{ flowName }}&#8203;</div>{{/if}}
   <span class="u-text--overflow-two-lines">{{ name }}&#8203;</span>

--- a/src/js/views/patients/worklist/action_views.js
+++ b/src/js/views/patients/worklist/action_views.js
@@ -9,6 +9,7 @@ import { ReadOnlyStateView, ReadOnlyOwnerView, ReadOnlyDueDateView, ReadOnlyDueT
 
 import ActionItemTemplate from './action-item.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './worklist-list.scss';
 
 const ActionTooltipTemplate = hbs`{{formatMessage (intlGet "patients.worklist.actionViews.actionListTooltips") title=worklistId team=owner}}`;

--- a/src/js/views/patients/worklist/worklist-list.scss
+++ b/src/js/views/patients/worklist/worklist-list.scss
@@ -23,10 +23,13 @@
   }
 }
 
-.worklist-list__action-icon .icon {
+.worklist-list__action-icon {
   color: color(blue);
-  font-size: 20px;
-  width: 20px;
+
+  .icon {
+    font-size: 20px;
+    width: 20px;
+  }
 }
 
 .worklist-list__flow-icon .icon {

--- a/src/js/views/programs/program/flow/action-item.hbs
+++ b/src/js/views/programs/program/flow/action-item.hbs
@@ -1,4 +1,10 @@
-<div class="table-list__icon--large program-flow__action-icon">{{far icon}}</div>
+<div class="table-list__icon--large program-flow__action-icon">
+  {{#if options.icon}}
+    <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+  {{else}}
+    {{far icon}}
+  {{/if}}
+</div>
 <div class="u-text--overflow-two-lines">
   {{ name }}
   {{~#unless name}}<em>{{ @intl.programs.program.flow.actionItemTemplate.newProgramFlowAction }}</em>{{/unless~}}

--- a/src/js/views/programs/program/flow/flow_views.js
+++ b/src/js/views/programs/program/flow/flow_views.js
@@ -11,6 +11,7 @@ import SortableList from 'js/behaviors/sortable-list';
 import ActionItemTemplate from './action-item.hbs';
 import HeaderTemplate from './header.hbs';
 
+import 'scss/domain/action-icons.scss';
 import './program-flow.scss';
 
 const ContextTrailView = View.extend({

--- a/src/js/views/programs/program/flow/program-flow.scss
+++ b/src/js/views/programs/program/flow/program-flow.scss
@@ -103,7 +103,7 @@
     60px;
 }
 
-.program-flow__action-icon .icon {
+.program-flow__action-icon {
   color: color(blue);
 }
 

--- a/src/js/views/programs/program/workflows/action-item.hbs
+++ b/src/js/views/programs/program/workflows/action-item.hbs
@@ -1,5 +1,11 @@
 <div>
-  <span class="table-list__icon--large workflows__action-icon">{{far icon}}</span>
+  <span class="table-list__icon--large workflows__action-icon">
+    {{#if options.icon}}
+      <span class="action-icon--{{options.color}}">{{fa options.iconType options.icon}}</span>
+    {{else}}
+      {{far icon}}
+    {{/if}}
+  </span>
   <span>
     {{ name }}
     {{~#unless name}}<em>{{ @intl.programs.program.workflows.actionItemTemplate.newProgramAction }}</em>{{/unless~}}

--- a/src/js/views/programs/program/workflows/workflows.scss
+++ b/src/js/views/programs/program/workflows/workflows.scss
@@ -38,7 +38,7 @@
   color: #{$black-60};
 }
 
-.workflows__action-icon .icon {
+.workflows__action-icon {
   color: color(blue);
 }
 

--- a/src/js/views/programs/program/workflows/workflows_views.js
+++ b/src/js/views/programs/program/workflows/workflows_views.js
@@ -23,6 +23,7 @@ import FlowItemTemplate from './flow-item.hbs';
 import LayoutTemplate from './layout.hbs';
 
 import 'scss/domain/program-action-state.scss';
+import 'scss/domain/action-icons.scss';
 import './workflows.scss';
 
 const EmptyView = View.extend({

--- a/src/scss/domain/action-icons.scss
+++ b/src/scss/domain/action-icons.scss
@@ -1,0 +1,23 @@
+.action-icon--black {
+  color: #{$black-20};
+}
+
+.action-icon--grey {
+  color: #{$black-60};
+}
+
+.action-icon--red {
+  color: color(red);
+}
+
+.action-icon--green {
+  color: color(green);
+}
+
+.action-icon--orange {
+  color: color(orange);
+}
+
+.action-icon--purple {
+  color: color(purple);
+}

--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -44,6 +44,11 @@ context('patient archive page', function() {
           due_date: null,
           due_time: null,
           updated_at: testTs(),
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           owner: getRelationship(currentClinican),
@@ -174,11 +179,27 @@ context('patient archive page', function() {
       .find('.table-list__item')
       .first()
       .should('contain', 'First In List')
-      .next()
-      .should('contain', 'Second In List')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.action-icon--red .fa-caret-down');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(1)
+      .should('contain', 'Second In List');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(2)
       .should('contain', 'Third In List')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.fa-share-from-square');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Last In List');
 
     cy

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -539,6 +539,11 @@ context('patient dashboard page', function() {
           archived_at: null,
           details: 'details',
           days_until_due: 1,
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           owner: getRelationship(teamCoordinator),
@@ -847,19 +852,54 @@ context('patient dashboard page', function() {
 
     cy
       .get('.picklist')
+      .contains('No Actions, No Flows')
+      .next()
+      .find('.picklist__item')
+      .first()
+      .find('.fa-file-lines');
+
+    cy
+      .get('.picklist')
       .contains('Two Actions, One Published, One Flow')
       .next()
+      .find('.picklist__item')
+      .first()
       .should('contain', '1 Flow')
-      .should('contain', 'One of One');
+      .find('.fa-folder');
+
+    cy
+      .get('.picklist')
+      .contains('Two Actions, One Published, One Flow')
+      .next()
+      .find('.picklist__item')
+      .last()
+      .should('contain', 'One of One')
+      .find('.action-icon--red.fa-caret-down');
 
     cy
       .get('.picklist')
       .contains('Two Published Actions and Flows')
       .next()
       .should('contain', '2 Flow')
-      .should('contain', '3 Flow')
+      .should('contain', '3 Flow');
+
+    cy
+      .get('.picklist')
+      .contains('Two Published Actions and Flows')
+      .next()
+      .find('.picklist__item')
+      .eq(2)
       .should('contain', 'One of Two')
-      .should('contain', 'Two of Two');
+      .find('.fa-share-from-square');
+
+    cy
+      .get('.picklist')
+      .contains('Two Published Actions and Flows')
+      .next()
+      .find('.picklist__item')
+      .last()
+      .should('contain', 'Two of Two')
+      .find('.fa-file-lines');
 
     cy
       .get('.picklist')

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -65,6 +65,11 @@ context('patient dashboard page', function() {
         due_date: null,
         due_time: null,
         updated_at: testTs(),
+        options: {
+          icon: 'caret-down',
+          iconType: 'fas',
+          color: 'red',
+        },
       },
       relationships: {
         owner: getRelationship(teamCoordinator),
@@ -204,13 +209,35 @@ context('patient dashboard page', function() {
       .find('.table-list__item')
       .first()
       .should('contain', 'First In List')
-      .next()
-      .should('contain', 'Second In List')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.action-icon--red .fa-caret-down');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(1)
+      .should('contain', 'Second In List');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(2)
       .should('contain', 'Third In List')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.fa-file-lines');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .eq(3)
       .should('contain', 'Outreach')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.fa-share-from-square');
+
+    cy
+      .get('.list-page__list')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Last In List');
 
     cy

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -927,6 +927,11 @@ context('patient flow page', function() {
               details: 'details',
               days_until_due: 1,
               sequence: 1,
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
             relationships: {
               owner: getRelationship(teamCoordinator),
@@ -1093,7 +1098,8 @@ context('patient flow page', function() {
       .find('.picklist__item')
       .last()
       .should('contain', 'Published')
-      .should('not.contain', 'Draft');
+      .should('not.contain', 'Draft')
+      .find('.action-icon--red.fa-caret-down');
 
     cy
       .get('.picklist')

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -591,6 +591,7 @@ context('patient flow page', function() {
         details: null,
         due_date: testDateAdd(1),
         created_at: testTsSubtract(3),
+        outreach: 'patient',
         sequence: 3,
       },
       relationships: {
@@ -626,6 +627,11 @@ context('patient flow page', function() {
               sequence: 1,
               outreach: 'patient',
               sharing: 'sent',
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
             relationships: {
               flow: getRelationship(testFlow),
@@ -695,6 +701,7 @@ context('patient flow page', function() {
       .find('.table-list__item')
       .first()
       .should($action => {
+        expect($action.find('.table-list__icon--large .action-icon--red .fa-caret-down')).to.exist;
         expect($action.find('.fa-circle-exclamation')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('NUR');
         expect($action.find('[data-due-date-region] .is-overdue')).to.exist;
@@ -710,6 +717,7 @@ context('patient flow page', function() {
       .first()
       .next()
       .should($action => {
+        expect($action.find('.table-list__icon--large .fa-file-lines')).to.exist;
         expect($action.find('.fa-circle-dot')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('OT');
         expect($action.find('.fa-paperclip')).to.not.exist;
@@ -721,6 +729,7 @@ context('patient flow page', function() {
       .find('.table-list__item')
       .last()
       .should($action => {
+        expect($action.find('.table-list__icon--large .fa-share-from-square')).to.exist;
         expect($action.find('.fa-circle-check')).to.exist;
         expect($action.find('[data-owner-region]')).to.contain('OT');
         expect($action.find('[data-owner-region] button')).to.be.disabled;

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -754,6 +754,11 @@ context('worklist page', function() {
           due_date: testDate(),
           due_time: '06:01:00',
           updated_at: testTs(),
+          options: {
+            icon: 'caret-down',
+            iconType: 'fas',
+            color: 'red',
+          },
         },
         relationships: {
           state: getRelationship(stateTodo),
@@ -849,13 +854,27 @@ context('worklist page', function() {
       .find('.table-list__item')
       .first()
       .as('firstRow')
-      .should('contain', 'First In List')
-      .should('contain', 'Test Flow')
       .should('have.class', 'is-selected')
-      .next()
+      .should('contain', 'Test Flow')
+      .should('contain', 'First In List')
+      .find('.worklist-list__action-icon')
+      .find('.action-icon--red .fa-caret-down');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .eq(1)
       .should('contain', 'Second In List')
-      .next()
-      .should('contain', 'Last In List');
+      .find('.worklist-list__action-icon')
+      .find('.fa-file-lines');
+
+    cy
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .last()
+      .should('contain', 'Last In List')
+      .find('.worklist-list__action-icon')
+      .find('.fa-share-from-square');
 
     cy
       .get('@firstRow')

--- a/test/integration/programs/program/program-flow.js
+++ b/test/integration/programs/program/program-flow.js
@@ -347,6 +347,11 @@ context('program flow page', function() {
             attributes: {
               sequence: 2,
               name: 'Third In List',
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
           }),
           mergeJsonApi(testProgramFlowActions[2], {
@@ -398,6 +403,12 @@ context('program flow page', function() {
       .first()
       .next()
       .find('.fa-file-lines');
+
+    cy
+      .get('.table-list__item')
+      .last()
+      .find('.table-list__icon--large')
+      .find('.action-icon--red .fa-caret-down');
 
     cy
       .get('.js-draggable')

--- a/test/integration/programs/program/workflows.js
+++ b/test/integration/programs/program/workflows.js
@@ -44,6 +44,11 @@ context('program workflows page', function() {
             attributes: {
               name: 'Third In List',
               updated_at: testTsSubtract(2),
+              options: {
+                icon: 'caret-down',
+                iconType: 'fas',
+                color: 'red',
+              },
             },
           }),
           getProgramAction({
@@ -92,12 +97,26 @@ context('program workflows page', function() {
       .get('.table-list__list')
       .find('.table-list__item')
       .first()
-      .should('contain', 'First In List')
-      .next()
-      .should('contain', 'Second In List')
-      .next()
+      .should('contain', 'First In List');
+
+    cy
+      .get('.table-list__list')
+      .find('.table-list__item')
+      .eq(1)
+      .should('contain', 'Second In List');
+
+    cy
+      .get('.table-list__list')
+      .find('.table-list__item')
+      .eq(2)
       .should('contain', 'Third In List')
-      .next()
+      .find('.table-list__icon--large')
+      .find('.action-icon--red .fa-caret-down');
+
+    cy
+      .get('.table-list__list')
+      .find('.table-list__item')
+      .last()
       .should('contain', 'Fourth In List');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-65369]

If a program/patient action contains custom icon data, display that instead of the default action icon. Which is `options.icon`, `options.iconType`, & `options.color`.

Pages it was implemented for:

1. Worklists
2. Patient flow
3. Patient dashboard/archive
4. Program workflows
5. Program flow

Some feature history: this was originally implemented in https://github.com/RoundingWell/care-ops-frontend/pull/1555, but was reverted in https://github.com/RoundingWell/care-ops-frontend/pull/1560 and was re-done in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom colored action icons across patient and program views (red, green, orange, purple, grey, black options).
  * Introduced two new chart icons: "chart-line-down" and "chart-line-up" for use throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->