### PR TITLE
For workos auth, handle redirecting after `/logout`

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -74,7 +74,8 @@ export class WorkosAuthProvider extends AuthProvider {
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
-      this.client.signOut({ returnTo: location.origin });
+      await this.client.signOut({ navigate: false });
+      window.location = AuthProvider.PATH_LOGIN;
       return;
     }
 


### PR DESCRIPTION
Shortcut Story ID: [sc-65433]

Instead of passing a URL to the `workos` sdk and having them do the redirect.

To fix a bug with the current implementation. Where the `/logout` page is being loaded and doesn't redirect, showing a blank screen to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout flow and navigation handling to ensure proper redirection after sign-out.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->