### PR TITLE
In add flows/actions picklist, fix name text overflow styling

### DIFF
--- a/src/js/components/picklist/index.js
+++ b/src/js/components/picklist/index.js
@@ -69,7 +69,7 @@ const PicklistEmpty = View.extend({
 const PicklistItem = View.extend({
   tagName: 'li',
   itemTemplate: hbs`
-    <div class="flex-grow">{{#if icon}}{{fa icon.type icon.icon classes=icon.classes}}{{/if}}<span>{{matchText text query}}</span></div>
+    <div class="picklist__item-content">{{#if icon}}{{fa icon.type icon.icon classes=icon.classes}}{{/if}}<span>{{matchText text query}}</span></div>
     {{#if isChecked}}{{fas "check"}}{{/if}}
   `,
   itemClassName() {

--- a/src/js/components/picklist/picklist.scss
+++ b/src/js/components/picklist/picklist.scss
@@ -62,6 +62,15 @@
   }
 }
 
+.picklist__item-content {
+  display: flex;
+  flex-grow: 1;
+
+  .icon {
+    margin-top: 2px;
+  }
+}
+
 .picklist__message {
   color: #{$black-60};
   font-size: 14px;


### PR DESCRIPTION
Shortcut Story ID: [sc-65423]

Current layout when a action/flow name overflows to a second line: [screenshot](https://github.com/user-attachments/assets/8865b4a2-a5b1-4522-b9d7-fee367268741). 

This PR updates the layout to be this in that situation: [screenshot](https://github.com/user-attachments/assets/50420c75-9cbc-44e4-9941-d09f8af2a872).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated picklist item styling for improved visual layout and icon alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->