### PR TITLE
Fix bug where add workflow droplist input filter is not working

### DIFF
--- a/src/js/components/optionlist/index.js
+++ b/src/js/components/optionlist/index.js
@@ -32,6 +32,7 @@ export default Picklist.extend({
     'close': 'close',
   },
   viewEvents: {
+    'watch:change': 'onWatchChange',
     'picklist:item:select': 'onPicklistSelect',
   },
   position() {

--- a/src/js/components/optionlist/optionlist.cy.js
+++ b/src/js/components/optionlist/optionlist.cy.js
@@ -20,6 +20,7 @@ context('Optionlist', function() {
         ui: this.ui.button,
         uiView: this,
         lists: [{ collection: this.collection }],
+        isSelectlist: true,
       });
 
       optionlist.show();
@@ -88,5 +89,20 @@ context('Optionlist', function() {
     cy
       .get('.picklist')
       .should('not.exist');
+
+    cy
+      .get('@root')
+      .contains('Test Menu')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-input')
+      .type('Test 1');
+
+    cy
+      .get('.picklist')
+      .find('.picklist__item')
+      .should('have.length', 1);
   });
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-65497]

Caused by [this change](https://github.com/RoundingWell/care-ops-frontend/commit/90a0ea93201e411ecbb0eff53f506afa8c27f138#diff-fab3cde5629392f2a3d9cf9dbe2c6a74f43e38465db2cc18b29a6e44ac2b84fbR34-R36).

Setting a `viewEvents` on the `OptionList` overrides the `viewEvents` on the `Picklist` component. So we lost the `'watch:change': 'onWatchChange',` listener.