### PR TITLE
Optionally disable `pointerdown` tooltip event listener

### DIFF
--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -15,6 +15,7 @@ const CLASS_OPTIONS = [
   'messageHtml',
   'orientation',
   'position',
+  'shouldShowOnClick',
   'uiView',
   'ui',
 ];
@@ -33,6 +34,7 @@ export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
   delay: /* istanbul ignore next: Branch only for testing */ _TEST_ ? 0 : 200,
+  shouldShowOnClick: true,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 
@@ -49,7 +51,11 @@ export default Component.extend({
 
     this.ui.on('mouseleave.tooltip', bind(this.hideTooltip, this));
 
-    this.ui.on('pointerdown.tooltip', bind(this.showTooltip, this));
+    const shouldShowOnClick = result(this, 'shouldShowOnClick');
+
+    if (shouldShowOnClick) {
+      this.ui.on('pointerdown.tooltip', bind(this.showTooltip, this));
+    }
   },
   showTooltip() {
     clearTimeout(this.delayTimeout);

--- a/src/js/components/tooltip/tooltip.cy.js
+++ b/src/js/components/tooltip/tooltip.cy.js
@@ -203,4 +203,44 @@ context('Tooltip', function() {
       .get('.tooltip')
       .should('not.exist');
   });
+
+  specify('shouldShowOnClick option', function() {
+    const NoClickView = View.extend({
+      tagName: 'button',
+      className: 'button--blue',
+      template: hbs`No Pointer Down Listener`,
+      attributes: {
+        style: 'margin: 20px;',
+      },
+      ui: {
+        'button': 'button',
+      },
+      onRender() {
+        new Tooltip({
+          message: 'Not shown on pointerdown event',
+          uiView: this,
+          ui: this.$el,
+          ignoreEl: this.el,
+          shouldShowOnClick: false,
+        });
+      },
+    });
+
+    cy
+      .mount(rootView => {
+        Tooltip.setRegion(rootView.getRegion('tooltip'));
+        return new NoClickView();
+      })
+      .as('root');
+
+    cy
+      .get('@root')
+      .contains('No Pointer Down Listener')
+      .trigger('pointerdown')
+      .wait(200); // account for 200ms delay when showing tooltips
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
+  });
 });

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -105,6 +105,7 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.sidebarButton,
+      shouldShowOnClick: false,
     });
   },
   renderExpandTooltip() {
@@ -115,6 +116,7 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.expandButton,
+      shouldShowOnClick: false,
     });
   },
   renderHistoryTooltip() {
@@ -125,6 +127,7 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.historyButton,
+      shouldShowOnClick: false,
     });
   },
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-65463]

This PR adds a `shouldShowOnClick` option that can be passed to the tooltip component. Set to `true` by default.