### PR TITLE
For actions bulk edit, add option to apply owner to parent flows

### DIFF
--- a/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
+++ b/src/js/apps/patients/sidebar/bulk-edit-actions_app.js
@@ -149,6 +149,11 @@ export default App.extend({
 
     this.modal.showSavingFooter();
 
+    const applyOwner = !!this.getState('applyOwner');
+    if (applyOwner) {
+      this.triggerMethod('applyOwner', this.getState('owner'));
+    }
+
     this.triggerMethod('save', this.getState().getData());
   },
   onStop() {

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -237,6 +237,13 @@ const _Model = BaseModel.extend({
       },
     });
   },
+  applyOwner(owner) {
+    const flow = this.getFlow();
+
+    if (!flow) return;
+
+    return flow.saveOwner(owner);
+  },
   saveOwner(owner) {
     return this.save({ _owner: owner.getResource() }, {
       relationships: {
@@ -288,7 +295,10 @@ const Collection = BaseCollection.extend({
   url: '/api/actions',
   model: Model,
   save(attrs) {
-    return this.batchInvoke('saveAll', 25, attrs);
+    return this.batchInvoke('saveAll', 20, attrs);
+  },
+  applyOwner(owner) {
+    return this.batchInvoke('applyOwner', 20, owner);
   },
   groupByDate() {
     const groupedCollection = this.groupBy('due_date');

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -327,6 +327,7 @@ careOptsFrontend:
             headingText: "{itemCount, plural, one {Edit # Action} other {Edit # Actions}}"
           bulkEditActionsSuccess: "{itemCount, plural, one {# Action has been updated} other {# Actions have been updated}}"
           bulkEditActionBodyTemplate:
+            applyOwnerLabel: Apply Owner to Flows
             dueDateLabel: Due
             durationLabel: Duration
             ownerLabel: Owner

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit-action-body.hbs
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit-action-body.hbs
@@ -7,3 +7,4 @@
   </div>
 </div>
 <div class="flex u-margin--t-8"><h4 class="sidebar__label u-margin--t-8">{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditActionBodyTemplate.durationLabel }}</h4><div class="flex-grow" data-duration-region></div></div>
+<div class="flex u-margin--t-16 u-margin--b-8"><div class="sidebar__label u-margin--t-8"></div><div class="flex-grow" data-apply-owner-region></div></div>

--- a/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
+++ b/src/js/views/patients/shared/bulk-edit/bulk-edit_views.js
@@ -142,6 +142,7 @@ const BulkEditActionsBodyView = View.extend({
     dueDate: '[data-due-date-region]',
     dueTime: '[data-due-time-region]',
     duration: '[data-duration-region]',
+    applyOwner: '[data-apply-owner-region]',
   },
   onRender() {
     this.isSaving = this.model.get('isSaving');
@@ -150,6 +151,7 @@ const BulkEditActionsBodyView = View.extend({
     this.showOwner();
     this.showDueDateTime();
     this.showDuration();
+    this.showApplyOwner();
   },
   getStateComponent() {
     const isDisabled = this.isSaving;
@@ -312,6 +314,12 @@ const BulkEditActionsBodyView = View.extend({
 
     this.showChildView('duration', durationComponent);
   },
+  showApplyOwner() {
+    this.showChildView('applyOwner', new ApplyOwnerView({
+      model: this.model,
+      isForFlows: false,
+    }));
+  },
 });
 
 const ApplyOwnerView = View.extend({
@@ -323,14 +331,22 @@ const ApplyOwnerView = View.extend({
   template: hbs`
     <button class="button--checkbox js-apply-owner"{{#if isDisabled}} disabled{{/if}}>
       {{#if applyOwner}}{{fas "square-check"}}{{else}}{{fal "square"}}{{/if~}}
-      <span>{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.applyOwnerLabel }}</span>
+      {{#if isForFlows}}
+        <span>{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditFlowBodyTemplate.applyOwnerLabel }}</span>
+      {{else}}
+        <span>{{ @intl.patients.shared.bulkEdit.bulkEditViews.bulkEditActionBodyTemplate.applyOwnerLabel }}</span>
+      {{/if}}
     </button>`,
   triggers: {
     'click .js-apply-owner': 'click:select',
   },
+  initialize({ isForFlows }) {
+    this.isForFlows = isForFlows;
+  },
   templateContext() {
     return {
       isDisabled: this.model.get('ownerMulti') || this.model.get('isSaving'),
+      isForFlows: this.isForFlows,
     };
   },
   onClickSelect() {
@@ -420,6 +436,7 @@ const BulkEditFlowsBodyView = View.extend({
   showApplyOwner() {
     this.showChildView('applyOwner', new ApplyOwnerView({
       model: this.model,
+      isForFlows: true,
     }));
   },
 });

--- a/test/integration/patients/worklist/bulk-edit.js
+++ b/test/integration/patients/worklist/bulk-edit.js
@@ -544,6 +544,12 @@ context('Worklist bulk editing', function() {
   });
 
   specify('bulk actions editing', function() {
+    const testFlow = getFlow({
+      relationships: {
+        state: getRelationship(stateTodo),
+      },
+    });
+
     const testActions = [
       getAction({
         attributes: {
@@ -556,6 +562,7 @@ context('Worklist bulk editing', function() {
         relationships: {
           owner: getRelationship(getCurrentClinician()),
           state: getRelationship(stateTodo),
+          flow: getRelationship(testFlow),
         },
       }),
       getAction({
@@ -566,6 +573,7 @@ context('Worklist bulk editing', function() {
         },
         relationships: {
           state: getRelationship(stateTodo),
+          flow: getRelationship(testFlow),
         },
       }),
       getAction({
@@ -580,6 +588,7 @@ context('Worklist bulk editing', function() {
           owner: getRelationship(teamCoordinator),
           state: getRelationship(stateTodo),
           form: getRelationship(testForm),
+          flow: getRelationship(testFlow),
         },
       }),
       getAction({
@@ -588,6 +597,7 @@ context('Worklist bulk editing', function() {
         },
         relationships: {
           state: getRelationship(stateInProgress),
+          flow: getRelationship(),
         },
       }),
     ];
@@ -595,6 +605,8 @@ context('Worklist bulk editing', function() {
     cy
       .routeActions(fx => {
         fx.data = testActions;
+
+        fx.included.push(testFlow);
 
         return fx;
       })
@@ -675,6 +687,13 @@ context('Worklist bulk editing', function() {
       .get('@bulkEditSidebar')
       .find('[data-duration-region]')
       .should('contain', 'Multiple Durations...');
+
+    cy
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlowOwner');
 
     cy
       .intercept('PATCH', `/api/actions/${ testActions[0].id }`, {
@@ -792,6 +811,11 @@ context('Worklist bulk editing', function() {
 
     cy
       .get('@bulkEditSidebar')
+      .find('.js-apply-owner')
+      .click();
+
+    cy
+      .get('@bulkEditSidebar')
       .find('.js-submit')
       .click();
 
@@ -822,9 +846,24 @@ context('Worklist bulk editing', function() {
 
     cy
       .get('@bulkEditSidebar')
+      .find('[data-apply-owner-region] button')
+      .should('be.disabled');
+
+    cy
+      .get('@bulkEditSidebar')
       .find('[data-footer-region] button')
       .should('not.have.class', 'js-submit')
       .should('be.disabled');
+
+    cy
+      .wait(['@patchFlowOwner', '@patchFlowOwner', '@patchFlowOwner'])
+      .get('@patchFlowOwner.all').should('have.length', 3);
+
+    cy
+      .get('@patchFlowOwner.all')
+      .each(interception => {
+        expect(interception.request.body.data.relationships.owner.data.id).to.equal(teamNurse.id);
+      });
 
     cy
       .wait('@patchAction1')


### PR DESCRIPTION
Shortcut Story ID: [sc-65441]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply owner to multiple flows during bulk editing; new UI control appears alongside existing bulk edit actions and adapts its label when targeting flows.

* **Documentation**
  * Added localization for the new "Apply Owner to Flows" label.

* **Tests**
  * Integration tests added to validate UI flows and backend requests for bulk flow ownership updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->