### PR TITLE
Disable `pointerdown` show event on additional tooltips

### DIFF
--- a/src/js/views/patients/shared/components/date-filter/date-filter_views.js
+++ b/src/js/views/patients/shared/components/date-filter/date-filter_views.js
@@ -118,12 +118,14 @@ const ControllerView = View.extend({
       message: tooltipMessages.prevMessage,
       uiView: this,
       ui: this.ui.prev,
+      shouldShowOnClick: false,
     });
 
     new Tooltip({
       message: tooltipMessages.nextMessage,
       uiView: this,
       ui: this.ui.next,
+      shouldShowOnClick: false,
     });
   },
   getTooltipMessages() {

--- a/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
+++ b/src/js/views/patients/sidebar/action/action-sidebar-activity-views.js
@@ -157,6 +157,7 @@ const CommentView = View.extend({
       messageHtml: renderTemplate(template, { edited }),
       uiView: this,
       ui: this.ui.edit,
+      shouldShowOnClick: false,
     });
   },
   onClickEdit() {


### PR DESCRIPTION
Shortcut Story ID: [sc-65591]

Additional follow up work from https://github.com/RoundingWell/care-ops-frontend/pull/1568/.

Screen recordings of the current tooltip behaviors on the shortcut story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted tooltip interaction behavior in date filters and activity comment sections—tooltips will no longer respond to clicks, improving interaction consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->