### PR TITLE
Add `shouldDelay` of `200ms` option to tooltip component

### DIFF
--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -15,6 +15,7 @@ const CLASS_OPTIONS = [
   'messageHtml',
   'orientation',
   'position',
+  'shouldDelay',
   'uiView',
   'ui',
 ];
@@ -32,7 +33,12 @@ const TooltipView = View.extend({
 export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
-  delay: 0,
+  delay() {
+    if (_TEST_) return 0;
+
+    /* istanbul ignore next */
+    return this.shouldDelay ? 200 : 0;
+  },
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 

--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -32,7 +32,7 @@ const TooltipView = View.extend({
 export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
-  delay: /* istanbul ignore next: Branch only for testing */ _TEST_ ? 0 : 200,
+  delay: 0,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 

--- a/src/js/components/tooltip/index.js
+++ b/src/js/components/tooltip/index.js
@@ -15,7 +15,6 @@ const CLASS_OPTIONS = [
   'messageHtml',
   'orientation',
   'position',
-  'shouldShowOnClick',
   'uiView',
   'ui',
 ];
@@ -34,7 +33,6 @@ export default Component.extend({
   ViewClass: TooltipView,
   className: 'tooltip',
   delay: /* istanbul ignore next: Branch only for testing */ _TEST_ ? 0 : 200,
-  shouldShowOnClick: true,
   constructor: function(options) {
     this.mergeOptions(options, CLASS_OPTIONS);
 
@@ -51,11 +49,7 @@ export default Component.extend({
 
     this.ui.on('mouseleave.tooltip', bind(this.hideTooltip, this));
 
-    const shouldShowOnClick = result(this, 'shouldShowOnClick');
-
-    if (shouldShowOnClick) {
-      this.ui.on('pointerdown.tooltip', bind(this.showTooltip, this));
-    }
+    this.ui.on('pointerdown.tooltip', bind(this.showTooltip, this));
   },
   showTooltip() {
     clearTimeout(this.delayTimeout);

--- a/src/js/components/tooltip/tooltip.cy.js
+++ b/src/js/components/tooltip/tooltip.cy.js
@@ -203,44 +203,4 @@ context('Tooltip', function() {
       .get('.tooltip')
       .should('not.exist');
   });
-
-  specify('shouldShowOnClick option', function() {
-    const NoClickView = View.extend({
-      tagName: 'button',
-      className: 'button--blue',
-      template: hbs`No Pointer Down Listener`,
-      attributes: {
-        style: 'margin: 20px;',
-      },
-      ui: {
-        'button': 'button',
-      },
-      onRender() {
-        new Tooltip({
-          message: 'Not shown on pointerdown event',
-          uiView: this,
-          ui: this.$el,
-          ignoreEl: this.el,
-          shouldShowOnClick: false,
-        });
-      },
-    });
-
-    cy
-      .mount(rootView => {
-        Tooltip.setRegion(rootView.getRegion('tooltip'));
-        return new NoClickView();
-      })
-      .as('root');
-
-    cy
-      .get('@root')
-      .contains('No Pointer Down Listener')
-      .trigger('pointerdown')
-      .wait(200); // account for 200ms delay when showing tooltips
-
-    cy
-      .get('.tooltip')
-      .should('not.exist');
-  });
 });

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -105,7 +105,6 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.sidebarButton,
-      shouldShowOnClick: false,
     });
   },
   renderExpandTooltip() {
@@ -116,7 +115,6 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.expandButton,
-      shouldShowOnClick: false,
     });
   },
   renderHistoryTooltip() {
@@ -127,7 +125,6 @@ const FormStateActionsView = View.extend({
       message,
       uiView: this,
       ui: this.ui.historyButton,
-      shouldShowOnClick: false,
     });
   },
 });

--- a/src/js/views/patients/schedule/schedule_views.js
+++ b/src/js/views/patients/schedule/schedule_views.js
@@ -102,6 +102,7 @@ const ScheduleTitleView = View.extend({
       uiView: this,
       ui: this.ui.tooltip,
       orientation: 'vertical',
+      shouldDelay: true,
     });
   },
   showLabel() {

--- a/src/js/views/patients/shared/actions_views.js
+++ b/src/js/views/patients/shared/actions_views.js
@@ -51,6 +51,7 @@ const DetailsTooltip = View.extend({
       }),
       uiView: this,
       ui: this.$el,
+      shouldDelay: true,
     });
   },
   _formatDetails(details) {

--- a/src/js/views/patients/worklist/worklist_views.js
+++ b/src/js/views/patients/worklist/worklist_views.js
@@ -184,6 +184,7 @@ const ListTitleView = View.extend({
       uiView: this,
       ui: this.ui.tooltip,
       orientation: 'vertical',
+      shouldDelay: true,
     });
   },
   showLabel() {


### PR DESCRIPTION
Shortcut Story ID: [sc-65602]

Default delay of `0` for all tooltips. if `shouldDelay: true` is passed as an option to a tooltip, it will have a `200ms` delay before being shown.

In cypress tests, delay is always `0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable display delay option for tooltips to improve visibility timing.

* **Refactor**
  * Standardized tooltip behavior across the application by transitioning from click-triggered to delay-based display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->