### PR TITLE
Add bulk edit `applyOwner` listener to schedule & patient flow apps

### DIFF
--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -199,6 +199,9 @@ export default SubRouterApp.extend({
     });
 
     this.listenTo(app, {
+      'applyOwner'(owner) {
+        this.selected.applyOwner(owner);
+      },
       'save'(saveData) {
         const itemCount = this.selected.length;
 

--- a/src/js/apps/patients/schedule/schedule_app.js
+++ b/src/js/apps/patients/schedule/schedule_app.js
@@ -233,6 +233,9 @@ export default App.extend({
     });
 
     this.listenTo(app, {
+      'applyOwner'(owner) {
+        this.selected.applyOwner(owner);
+      },
       'save'(saveData) {
         const itemCount = this.selected.length;
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1999,6 +1999,13 @@ context('patient flow page', function() {
       .should('contain', 'Multiple Durations...');
 
     cy
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlowOwner');
+
+    cy
       .intercept('PATCH', `/api/actions/${ testFlowActions[0].id }`, {
         statusCode: 204,
         body: {},
@@ -2109,8 +2116,20 @@ context('patient flow page', function() {
 
     cy
       .get('@bulkEditSidebar')
+      .find('.js-apply-owner')
+      .click();
+
+    cy
+      .get('@bulkEditSidebar')
       .find('.js-submit')
       .click();
+
+    cy
+      .wait('@patchFlowOwner')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.relationships.owner.data.id).to.equal(teamNurse.id);
+      });
 
     cy
       .wait('@patchAction1')

--- a/test/integration/patients/worklist/schedule.js
+++ b/test/integration/patients/worklist/schedule.js
@@ -755,6 +755,7 @@ context('schedule page', function() {
         relationships: {
           owner: getRelationship(currentClinician),
           state: getRelationship(index % 2 ? stateTodo : stateInProgress),
+          flow: getRelationship(testFlow),
         },
       });
     });
@@ -777,6 +778,8 @@ context('schedule page', function() {
     cy
       .routeActions(fx => {
         fx.data = testActions;
+
+        fx.included.push(testFlow);
 
         return fx;
       })
@@ -870,6 +873,13 @@ context('schedule page', function() {
       .should('contain', 'Edit 20 Actions');
 
     cy
+      .intercept('PATCH', '/api/flows/*', {
+        statusCode: 204,
+        body: {},
+      })
+      .as('patchFlowOwner');
+
+    cy
       .intercept('PATCH', '/api/actions/*', {
         statusCode: 204,
         body: {},
@@ -924,8 +934,14 @@ context('schedule page', function() {
 
     cy
       .get('@bulkEditSidebar')
+      .find('.js-apply-owner')
+      .click();
+
+    cy
+      .get('@bulkEditSidebar')
       .find('.js-submit')
       .click()
+      .wait('@patchFlowOwner')
       .wait('@patchAction');
 
     cy


### PR DESCRIPTION
Shortcut Story ID: [sc-65441]

Follow up work for https://github.com/RoundingWell/care-ops-frontend/pull/1569. Need to have the `applyOwner` listener on the patient flow and schedule apps. So when bulk editing actions on those pages, the owner can be applied to the parent flow/s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled bulk assignment of flow owners in patient and schedule applications, allowing users to apply ownership changes to multiple flows simultaneously.

* **Tests**
  * Added comprehensive integration tests to validate flow owner assignment during bulk edit workflows, ensuring proper synchronization of ownership updates across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->