### PR TITLE
On five9 inbound/transfer calls, ability to jump to patient dashboard

### DIFF
--- a/packages/care-ops-five9/five9.scss
+++ b/packages/care-ops-five9/five9.scss
@@ -5,23 +5,25 @@ $five9-call-active-hover: color(green, dark);
 $five9-call-ended: color(red);
 $five9-call-ended-hover: color(red, dark);
 
+.five9-wrapper {
+  bottom: 0;
+  position: fixed;
+  right: 40px;
+  width: 300px;
+}
+
 .five9-panel {
   background: white;
-  border: 1px solid #{$black-90};
   border-radius: 8px 8px 0 0;
-  bottom: 0;
   box-shadow: 0 4px 10px rgb(0 0 0 / 20%);
   display: flex;
   flex-direction: column;
   height: 36px;
   overflow: hidden;
-  position: fixed;
-  right: 40px;
   transition: height 0.2s ease;
-  width: 300px;
 
-  &.is-open {
-    height: 90vh;
+  .five9-wrapper.is-open & {
+    height: 80vh;
   }
 }
 
@@ -62,14 +64,12 @@ $five9-call-ended-hover: color(red, dark);
 }
 
 .five9-panel__iframe {
-  flex: 1 1 auto;
-  height: auto;
   min-height: 0;
   pointer-events: none;
   visibility: hidden;
 
-
-  .five9-panel.is-open & {
+  .five9-wrapper.is-open & {
+    flex: 1 1 auto;
     pointer-events: auto;
     visibility: visible;
   }

--- a/packages/care-ops-five9/five9.scss
+++ b/packages/care-ops-five9/five9.scss
@@ -6,6 +6,7 @@ $five9-call-ended: color(red);
 $five9-call-ended-hover: color(red, dark);
 
 .five9-wrapper {
+  border-radius: 8px 8px 0 0;
   bottom: 0;
   position: fixed;
   right: 40px;
@@ -60,6 +61,35 @@ $five9-call-ended-hover: color(red, dark);
     &:hover {
       background-color: $five9-call-ended-hover;
     }
+  }
+}
+
+.five9-panel__patient-btn {
+  align-items: center;
+  background-color: white;
+  border: 1px solid $five9-color;
+  border-radius: 8px;
+  color: $five9-color;
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  font-weight: 600;
+  justify-content: center;
+  margin-bottom: 8px;
+  padding: 8px 16px;
+  text-overflow: ellipsis;
+  transition: background-color 0.15s;
+  transition-timing-function: linear;
+  white-space: nowrap;
+  width: 100%;
+
+  &:hover {
+    background-color: color(light_blue, light);
+  }
+
+  svg {
+    flex-shrink: 0;
+    margin: 0 6px;
   }
 }
 

--- a/packages/care-ops-five9/five9_app.js
+++ b/packages/care-ops-five9/five9_app.js
@@ -52,7 +52,7 @@ export default App.extend({
 
         if (!actionId) return;
 
-        Radio.request('dialer', 'five9CallComplete', callData.interactionId, { actionId });
+        Radio.request('dialer', 'five9Call', { callData, actionId });
 
         await interaction.setCav({
           interactionId: callData.interactionId,
@@ -66,6 +66,7 @@ export default App.extend({
       },
       callAccepted: ({ callData }) => {
         this.setState('callTime', dayjs());
+
         Radio.request('dialer', 'callNumber', { actionId: this.getState('actionId'), number: callData.number });
       },
       callEnded: () => {
@@ -75,7 +76,7 @@ export default App.extend({
       callFinished: ({ callLogData, callData }) => {
         this.setState('isCalling', false);
         this.setState('actionId', null);
-        Radio.request('dialer', 'five9CallComplete', callData.interactionId, { callLog: callLogData });
+        Radio.request('dialer', 'five9Call', { callData, callLogData });
       },
     });
   },

--- a/packages/care-ops-five9/five9_app.js
+++ b/packages/care-ops-five9/five9_app.js
@@ -64,11 +64,13 @@ export default App.extend({
           ],
         });
       },
-      callAccepted: () => {
+      callAccepted: ({ callData }) => {
         this.setState('callTime', dayjs());
+        Radio.request('dialer', 'callNumber', { actionId: this.getState('actionId'), number: callData.number });
       },
       callEnded: () => {
         this.setState('callTime', null);
+        Radio.request('dialer', 'callNumber', null);
       },
       callFinished: ({ callLogData, callData }) => {
         this.setState('isCalling', false);

--- a/packages/care-ops-five9/five9_app.js
+++ b/packages/care-ops-five9/five9_app.js
@@ -14,14 +14,18 @@ export default App.extend({
   stateEvents: {
     'change:isLoggedIn': 'onLoginChange',
   },
-  initialize({ providerName }) {
+  initialize({ providerName, patients }) {
+    this.patients = patients;
     this.registerApi(providerName);
     this.handleLogin();
     this.subscribe();
   },
   startAfterInitialized: true,
   onStart() {
-    this.showView(new LayoutView({ model: this.getState() }));
+    this.showView(new LayoutView({
+      model: this.getState(),
+      collection: this.patients,
+    }));
   },
   onLoginChange() {
     this._call();

--- a/packages/care-ops-five9/five9_app.js
+++ b/packages/care-ops-five9/five9_app.js
@@ -1,5 +1,7 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
+import fetcher, { handleJSON } from 'js/base/fetch';
 import { applicationApi, crmApi, interactionApi } from './sdk/index';
 
 import App from 'js/base/app';
@@ -64,14 +66,16 @@ export default App.extend({
           ],
         });
       },
-      callAccepted: ({ callData }) => {
+      callAccepted: async({ callData }) => {
         this.setState('callTime', dayjs());
 
-        Radio.request('dialer', 'callNumber', { actionId: this.getState('actionId'), number: callData.number });
+        const number = await this._getCallNumber(callData);
+
+        Radio.request('dialer', 'showPatientLinks', { actionId: this.getState('actionId'), number });
       },
       callEnded: () => {
         this.setState('callTime', null);
-        Radio.request('dialer', 'callNumber', null);
+        Radio.request('dialer', 'showPatientLinks', null);
       },
       callFinished: ({ callLogData, callData }) => {
         this.setState('isCalling', false);
@@ -97,5 +101,25 @@ export default App.extend({
     if (!this.getState('isLoggedIn') || !number) return;
     interaction.click2dial({ click2DialData: { clickToDialNumber: number } });
     this.setState('pendingCall', null);
+  },
+  async _getCallNumber(callData) {
+    const { number, agent } = callData;
+
+    if (number.includes('agent:')) {
+      const { data } = await fetcher('/api/artifacts/search', {
+        data: {
+          filter: {
+            type: 'five9-call-log',
+            path: 'callData.agent',
+            term: agent,
+            limit: 1,
+          },
+        },
+      }).then(handleJSON);
+
+      return get(data, '0.attributes.callData.number');
+    }
+
+    return number;
   },
 });

--- a/packages/care-ops-five9/five9_views.js
+++ b/packages/care-ops-five9/five9_views.js
@@ -1,8 +1,9 @@
 import { delay } from 'underscore';
+import Radio from 'backbone.radio';
 import dayjs from 'dayjs';
 
 import hbs from 'handlebars-inline-precompile';
-import { View } from 'marionette';
+import { View, CollectionView } from 'marionette';
 
 import './five9.scss';
 
@@ -48,10 +49,31 @@ const StatusView = View.extend({
   },
 });
 
+const PatientButtonItemView = View.extend({
+  tagName: 'button',
+  className: 'five9-panel__patient-btn',
+  template: hbs`
+    <span>Jump to</span>
+    {{far "address-card"}}
+    <span class="u-text--overflow">{{ name }}</span>
+  `,
+  triggers: {
+    'click': 'click',
+  },
+  onClick() {
+    Radio.trigger('event-router', 'patient:dashboard', this.model.id);
+  },
+});
+
+const PatientButtonsView = CollectionView.extend({
+  childView: PatientButtonItemView,
+});
+
 // https://app.five9.com/clients/integrations/adt.li.main.html?f9crmapi=true&f9verticalthreshold=300px#login/showLogin
 const LayoutView = View.extend({
   className: 'five9-wrapper',
   template: hbs`
+    <div data-patient-buttons-region></div>
     <div class="five9-panel">
       <div class="five9-panel__header js-header">
         {{fas "phone"}}
@@ -69,6 +91,7 @@ const LayoutView = View.extend({
     </div>
   `,
   regions: {
+    patientButtons: '[data-patient-buttons-region]',
     heading: '[data-heading-region]',
     status: '[data-status-region]',
   },
@@ -91,8 +114,14 @@ const LayoutView = View.extend({
     this.showPanelStatus();
   },
   onRender() {
+    this.showPatientButton();
     this.showCallState();
     this.showPanelStatus();
+  },
+  showPatientButton() {
+    this.showChildView('patientButtons', new PatientButtonsView({
+      collection: this.collection,
+    }));
   },
   togglePanel() {
     this.$el.toggleClass('is-open', this.model.get('isOpen'));

--- a/packages/care-ops-five9/five9_views.js
+++ b/packages/care-ops-five9/five9_views.js
@@ -67,6 +67,13 @@ const PatientButtonItemView = View.extend({
 
 const PatientButtonsView = CollectionView.extend({
   childView: PatientButtonItemView,
+  initialize() {
+    this.listenTo(Radio.channel('history'), 'change:route', this.render);
+  },
+  viewFilter({ model }) {
+    const currentUrl = window.location.href;
+    return !currentUrl.includes(model.id);
+  },
 });
 
 // https://app.five9.com/clients/integrations/adt.li.main.html?f9crmapi=true&f9verticalthreshold=300px#login/showLogin

--- a/packages/care-ops-five9/five9_views.js
+++ b/packages/care-ops-five9/five9_views.js
@@ -50,21 +50,23 @@ const StatusView = View.extend({
 
 // https://app.five9.com/clients/integrations/adt.li.main.html?f9crmapi=true&f9verticalthreshold=300px#login/showLogin
 const LayoutView = View.extend({
-  className: 'five9-panel',
+  className: 'five9-wrapper',
   template: hbs`
-    <div class="five9-panel__header js-header">
-      {{fas "phone"}}
-      <span data-heading-region>Five9</span>
-      <span data-status-region></span>
+    <div class="five9-panel">
+      <div class="five9-panel__header js-header">
+        {{fas "phone"}}
+        <span data-heading-region>Five9</span>
+        <span data-status-region></span>
+      </div>
+      <iframe
+        class="five9-panel__iframe"
+        src="https://app.five9.com/clients/integrations/adt.li.main.html?f9crmapi=true&f9verticalthreshold=300px"
+        title="Five9 Dialer"
+        loading="lazy"
+        referrerpolicy="no-referrer"
+        sandbox="allow-scripts allow-forms allow-same-origin allow-popups">
+      </iframe>
     </div>
-    <iframe
-      class="five9-panel__iframe"
-      src="https://app.five9.com/clients/integrations/adt.li.main.html?f9crmapi=true&f9verticalthreshold=300px"
-      title="Five9 Dialer"
-      loading="lazy"
-      referrerpolicy="no-referrer"
-      sandbox="allow-scripts allow-forms allow-same-origin allow-popups">
-    </iframe>
   `,
   regions: {
     heading: '[data-heading-region]',

--- a/packages/care-ops-five9/index.js
+++ b/packages/care-ops-five9/index.js
@@ -6,8 +6,8 @@ function call(number, action) {
   dialerApp.call(number, action);
 }
 
-function init({ region, providerName }) {
-  dialerApp = new Five9App({ region, providerName });
+function init({ region, providerName, patients }) {
+  dialerApp = new Five9App({ region, providerName, patients });
 }
 
 export { call, init };

--- a/src/js/services/dialer.cy.js
+++ b/src/js/services/dialer.cy.js
@@ -16,7 +16,7 @@ context('Dialer Service', function() {
       .as('root');
   });
 
-  specify('five9CallComplete', function() {
+  specify('five9Call', function() {
     cy
       .intercept('PATCH', '/api/artifacts/**', {
         statusCode: 201,
@@ -29,9 +29,14 @@ context('Dialer Service', function() {
     cy
       .get('@root')
       .then(() => {
-        Radio.request('dialer', 'five9CallComplete', 'abc1234', {
-          callDuration: 42,
-          disposition: 'completed',
+        Radio.request('dialer', 'five9Call', {
+          callData: {
+            interactionId: 'abc1234',
+          },
+          callLogData: {
+            callDuration: 42,
+            disposition: 'completed',
+          },
         });
       });
 
@@ -46,8 +51,13 @@ context('Dialer Service', function() {
             artifact: 'five9-call-log',
             identifier: 'abc1234',
             values: {
-              callDuration: 42,
-              disposition: 'completed',
+              callData: {
+                interactionId: 'abc1234',
+              },
+              callLogData: {
+                callDuration: 42,
+                disposition: 'completed',
+              },
             },
           },
         },

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -12,7 +12,7 @@ export default App.extend({
     'call': 'call',
     'init': 'init',
     'callNumber': 'callNumber',
-    'five9CallComplete': 'five9CallComplete',
+    'five9Call': 'five9Call',
   },
   async init() {
     /* istanbul ignore next: prevent re-initialization */
@@ -57,10 +57,12 @@ export default App.extend({
         .then(() => searchCollection.each(this._addPatient, this));
     }
   },
-  five9CallComplete(identifier, values) {
+  five9Call(values) {
+    const { callData } = values;
+
     Radio.request('entities', 'save:artifacts:model', {
       artifact: 'five9-call-log',
-      identifier,
+      identifier: callData.interactionId,
       values,
     });
   },

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -1,5 +1,6 @@
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import parsePhoneNumber from 'libphonenumber-js/min';
 
 import App from 'js/base/app';
 
@@ -47,10 +48,14 @@ export default App.extend({
       return;
     }
 
-    const searchCollection = Radio.request('entities', 'searchPatients:collection');
+    const phone = parsePhoneNumber(number, 'US');
 
-    searchCollection.fetch({ data: { 'filter[search]': number } })
-      .then(() => searchCollection.each(this._addPatient, this));
+    if (phone && phone.isValid()) {
+      const searchCollection = Radio.request('entities', 'searchPatients:collection');
+
+      searchCollection.fetch({ data: { 'filter[search]': number } })
+        .then(() => searchCollection.each(this._addPatient, this));
+    }
   },
   five9CallComplete(identifier, values) {
     Radio.request('entities', 'save:artifacts:model', {

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -1,6 +1,9 @@
+import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
 import App from 'js/base/app';
+
+const patients = new Backbone.Collection([]);
 
 export default App.extend({
   channelName: 'dialer',
@@ -21,7 +24,7 @@ export default App.extend({
 
       const { call, init } = await import('@roundingwell/care-ops-five9');
       this._call = call;
-      init({ region: this.getRegion(), providerName });
+      init({ region: this.getRegion(), providerName, patients });
     }
   },
   call(number, action) {

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -10,6 +10,7 @@ export default App.extend({
   radioRequests: {
     'call': 'call',
     'init': 'init',
+    'callNumber': 'callNumber',
     'five9CallComplete': 'five9CallComplete',
   },
   async init() {
@@ -29,6 +30,44 @@ export default App.extend({
   },
   call(number, action) {
     this._call(number, action);
+  },
+  callNumber(values) {
+    if (!values) {
+      patients.reset();
+      return;
+    }
+
+    const { actionId, number } = values;
+    const currentUrl = window.location.href;
+    const action = Radio.request('entities', 'actions:model', actionId);
+
+    if (action) {
+      const patient = action.getPatient();
+
+      if (patient) {
+        if (!currentUrl.includes(patient.id)) {
+          patients.add({
+            id: patient.id,
+            name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
+          });
+        }
+
+        return;
+      }
+    }
+
+    const searchCollection = Radio.request('entities', 'searchPatients:collection');
+
+    searchCollection.fetch({ data: { 'filter[search]': number } }).then(() => {
+      searchCollection.each(patient => {
+        if (!currentUrl.includes(patient.id)) {
+          patients.add({
+            id: patient.id,
+            name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
+          });
+        }
+      });
+    });
   },
   five9CallComplete(identifier, values) {
     Radio.request('entities', 'save:artifacts:model', {

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -38,15 +38,13 @@ export default App.extend({
     }
 
     const { actionId, number } = values;
+
     const action = Radio.request('entities', 'actions:model', actionId);
+    const patient = action.getPatient();
 
-    if (action) {
-      const patient = action.getPatient();
-
-      if (patient) {
-        this._addPatient(patient);
-        return;
-      }
+    if (patient) {
+      this._addPatient(patient);
+      return;
     }
 
     const searchCollection = Radio.request('entities', 'searchPatients:collection');

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -44,31 +44,27 @@ export default App.extend({
       const patient = action.getPatient();
 
       if (patient) {
-        patients.add({
-          id: patient.id,
-          name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
-        });
-
+        this._addPatient(patient);
         return;
       }
     }
 
     const searchCollection = Radio.request('entities', 'searchPatients:collection');
 
-    searchCollection.fetch({ data: { 'filter[search]': number } }).then(() => {
-      searchCollection.each(patient => {
-        patients.add({
-          id: patient.id,
-          name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
-        });
-      });
-    });
+    searchCollection.fetch({ data: { 'filter[search]': number } })
+      .then(() => searchCollection.each(this._addPatient, this));
   },
   five9CallComplete(identifier, values) {
     Radio.request('entities', 'save:artifacts:model', {
       artifact: 'five9-call-log',
       identifier,
       values,
+    });
+  },
+  _addPatient(patient) {
+    patients.add({
+      id: patient.id,
+      name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
     });
   },
 });

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -11,7 +11,7 @@ export default App.extend({
   radioRequests: {
     'call': 'call',
     'init': 'init',
-    'callNumber': 'callNumber',
+    'showPatientLinks': 'showPatientLinks',
     'five9Call': 'five9Call',
   },
   async init() {
@@ -32,13 +32,13 @@ export default App.extend({
   call(number, action) {
     this._call(number, action);
   },
-  callNumber(values) {
-    if (!values) {
+  showPatientLinks(callData) {
+    if (!callData) {
       patients.reset();
       return;
     }
 
-    const { actionId, number } = values;
+    const { actionId, number } = callData;
 
     const action = Radio.request('entities', 'actions:model', actionId);
     const patient = action.getPatient();

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -38,19 +38,16 @@ export default App.extend({
     }
 
     const { actionId, number } = values;
-    const currentUrl = window.location.href;
     const action = Radio.request('entities', 'actions:model', actionId);
 
     if (action) {
       const patient = action.getPatient();
 
       if (patient) {
-        if (!currentUrl.includes(patient.id)) {
-          patients.add({
-            id: patient.id,
-            name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
-          });
-        }
+        patients.add({
+          id: patient.id,
+          name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
+        });
 
         return;
       }
@@ -60,12 +57,10 @@ export default App.extend({
 
     searchCollection.fetch({ data: { 'filter[search]': number } }).then(() => {
       searchCollection.each(patient => {
-        if (!currentUrl.includes(patient.id)) {
-          patients.add({
-            id: patient.id,
-            name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
-          });
-        }
+        patients.add({
+          id: patient.id,
+          name: `${ patient.get('first_name') } ${ patient.get('last_name') }`,
+        });
       });
     });
   },

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -823,7 +823,7 @@ context('action sidebar', function() {
       .click();
 
     cy
-      .get('.five9-panel')
+      .get('.five9-wrapper')
       .should('have.class', 'is-open');
 
     cy

--- a/test/integration/services/dialer.js
+++ b/test/integration/services/dialer.js
@@ -1,0 +1,200 @@
+import { getRelationship, getResource } from 'helpers/json-api';
+
+import { getAction } from 'support/api/actions';
+import { getPatient } from 'support/api/patients';
+import { getFlow } from 'support/api/flows';
+import { stateTodo } from 'support/api/states';
+
+context('Dialer Service', function() {
+  specify('Patient dashboard buttons', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+    });
+
+    const otherTestPatient = getPatient({
+      attributes: {
+        first_name: 'Other',
+        last_name: 'Patient',
+      },
+    });
+
+    const testFlow = getFlow({
+      attributes: {
+        name: 'Test Flow',
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+      },
+    });
+
+    const testAction = getAction({
+      attributes: {
+        name: 'Test Action',
+      },
+      relationships: {
+        'flow': getRelationship(testFlow),
+        'patient': getRelationship(testPatient),
+      },
+    });
+
+    const searchResults = [
+      {
+        id: testPatient.id,
+        type: 'patient-search-results',
+        attributes: {
+          ...testPatient.attributes,
+          match: {
+            label: 'Phone Number',
+            value: '+16513216543',
+          },
+        },
+        relationships: {
+          patient: getRelationship(testPatient, 'patients'),
+        },
+      },
+      {
+        id: otherTestPatient.id,
+        type: 'patient-search-results',
+        attributes: {
+          ...otherTestPatient.attributes,
+          match: {
+            label: 'Phone Number',
+            value: '+16513216543',
+          },
+        },
+        relationships: {
+          patient: getRelationship(otherTestPatient, 'patients'),
+        },
+      },
+    ];
+
+    cy
+      .routesForPatientAction()
+      .routeSettings('dialer', 'five9')
+      .routeFlow(fx => {
+        fx.data = testFlow;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = [testAction];
+
+        fx.included.push(testFlow);
+
+        return fx;
+      })
+      .routePatientByFlow(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeActionActivity()
+      .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatientByFlow')
+      .wait('@routeFlowActions')
+      .wait('@routeActionActivity')
+      .wait('@routeActionComments')
+      .wait('@routeActionFiles');
+
+    cy
+      .get('.five9-wrapper')
+      .find('[data-patient-buttons-region] button')
+      .should('have.length', 0);
+
+    cy
+      .getRadio(Radio => {
+        Radio.request('dialer', 'callNumber', {
+          actionId: testAction.id,
+          number: null,
+        });
+      });
+
+    cy
+      .get('.five9-wrapper')
+      .find('[data-patient-buttons-region] button')
+      .as('patientButtons')
+      .should('have.length', 1)
+      .should('contain', 'Test Patient')
+      .click()
+      .wait('@routePatient');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .getRadio(Radio => {
+        Radio.request('dialer', 'callNumber', {
+          actionId: testAction.id,
+          number: null,
+        });
+      });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .go('back');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 1);
+
+    cy
+      .getRadio(Radio => {
+        Radio.request('dialer', 'callNumber', {
+          actionId: testAction.id,
+          number: null,
+        });
+      });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 1);
+
+    cy
+      .getRadio(Radio => {
+        Radio.request('dialer', 'callNumber', null);
+      });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy.intercept({
+      method: 'GET',
+      url: '/api/patients?filter*',
+    }, {
+      body: {
+        data: searchResults,
+        included: [getResource(testPatient, 'patients')],
+      },
+    }).as('routePatientSearch');
+
+    cy
+      .getRadio(Radio => {
+        Radio.request('dialer', 'callNumber', {
+          actionId: null,
+          number: '+16513216543 ',
+        });
+      });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 2)
+      .first()
+      .should('contain', 'Test Patient')
+      .next()
+      .should('contain', 'Other Patient');
+  });
+});

--- a/test/integration/services/dialer.js
+++ b/test/integration/services/dialer.js
@@ -112,7 +112,7 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
-        Radio.request('dialer', 'callNumber', {
+        Radio.request('dialer', 'showPatientLinks', {
           actionId: testAction.id,
           number: null,
         });
@@ -133,7 +133,7 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
-        Radio.request('dialer', 'callNumber', {
+        Radio.request('dialer', 'showPatientLinks', {
           actionId: testAction.id,
           number: null,
         });
@@ -152,7 +152,7 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
-        Radio.request('dialer', 'callNumber', {
+        Radio.request('dialer', 'showPatientLinks', {
           actionId: testAction.id,
           number: null,
         });
@@ -164,7 +164,7 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
-        Radio.request('dialer', 'callNumber', null);
+        Radio.request('dialer', 'showPatientLinks', null);
       });
 
     cy
@@ -183,7 +183,7 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
-        Radio.request('dialer', 'callNumber', {
+        Radio.request('dialer', 'showPatientLinks', {
           actionId: null,
           number: '+16513216543 ',
         });


### PR DESCRIPTION
Shortcut Story ID: [sc-65412]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patient "Jump to" buttons added to the call panel (hidden for current patient).
  * Call flow now resolves agent numbers and surfaces matching patients automatically.
  * Init accepts a patient list to drive in-panel patient controls.

* **Bug Fixes / Behavior**
  * Call panel positioning, sizing, visibility, and open/close behavior refined; iframe visibility/pointer handling improved.
  * Patient buttons clear on call end and restore correctly during navigation/back actions.

* **Tests**
  * Integration tests expanded to cover patient-button behaviors and updated call payload shapes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->