### PR TITLE
Remove use of form `published_at` attribute

### DIFF
--- a/src/js/views/programs/shared/components/form_component.js
+++ b/src/js/views/programs/shared/components/form_component.js
@@ -28,8 +28,6 @@ let formsCollection;
 function getForms(workspace) {
   if (formsCollection) return formsCollection;
   formsCollection = workspace.getForms();
-  const formModels = formsCollection.reject({ published_at: null });
-  formsCollection.reset(formModels);
   return formsCollection;
 }
 

--- a/test/integration/programs/sidebar/action-sidebar.js
+++ b/test/integration/programs/sidebar/action-sidebar.js
@@ -340,20 +340,12 @@ context('program action sidebar', function() {
       getForm(testForm),
       getForm({
         attributes: {
-          name: 'C Form',
-          published_at: null,
-        },
-      }),
-      getForm({
-        attributes: {
           name: 'B Form',
-          published_at: testTs(),
         },
       }),
       getForm({
         attributes: {
           name: 'A Form',
-          published_at: testTs(),
         },
       }),
     ];
@@ -686,8 +678,6 @@ context('program action sidebar', function() {
     cy
       .get('.picklist')
       .find('.js-picklist-item')
-      .should('not.contain', 'C Form')
-      .eq(1)
       .should('contain', 'A Form')
       .next()
       .should('contain', 'B Form')


### PR DESCRIPTION
Shortcut Story ID: [sc-65926]

Removed by BE in https://github.com/RoundingWell/care-ops-backend/pull/10358.

Only used by FE in the form droplist component for program actions, to filter out unpublished forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Forms that were previously filtered out are now included in form lists.

* **Tests**
  * Updated test cases to reflect changes in form handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->