### PR TITLE
Downgrade `@workos-inc/authkit-js` to `0.17.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4412,12 +4412,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@workos-inc/authkit-js": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.18.0.tgz",
-      "integrity": "sha512-/X4P3N0Zo2fbb4PXzE3vx9IXZFGvu3y7hYADI4UoHEZmUE9W9QBoEKjLMOZzT23Wr+jknuus6qOgkQ181bI8mg==",
-      "license": "MIT"
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -13752,8 +13746,14 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
-        "@workos-inc/authkit-js": "^0.18.0"
+        "@workos-inc/authkit-js": "^0.17.0"
       }
+    },
+    "packages/care-ops-auth/node_modules/@workos-inc/authkit-js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.17.0.tgz",
+      "integrity": "sha512-3PKSf59M/IU4YzmeQs2brTe2pctvpTXbvci05BL+sk0unhqYs30zZzsha+6/9IYiaMVtCZWPdL5lrqIPA4echw==",
+      "license": "MIT"
     },
     "packages/care-ops-config": {
       "name": "@roundingwell/care-ops-config",

--- a/packages/care-ops-auth/package.json
+++ b/packages/care-ops-auth/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@kinde-oss/kinde-auth-pkce-js": "^4.2.0",
-    "@workos-inc/authkit-js": "^0.18.0"
+    "@workos-inc/authkit-js": "^0.17.0"
   }
 }


### PR DESCRIPTION
The fix for the `/logout` redirect issue we upgraded the package for in https://github.com/RoundingWell/care-ops-frontend/pull/1577 did not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication library dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->