### PR TITLE
In dialer service, handle `null`/`undefined` phone numbers in `showPatientLinks()`

### DIFF
--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -48,6 +48,8 @@ export default App.extend({
       return;
     }
 
+    if (!number) return;
+
     const phone = parsePhoneNumber(number, 'US');
 
     if (phone && phone.isValid()) {

--- a/test/integration/services/dialer.js
+++ b/test/integration/services/dialer.js
@@ -164,6 +164,18 @@ context('Dialer Service', function() {
 
     cy
       .getRadio(Radio => {
+        Radio.request('dialer', 'showPatientLinks', {
+          actionId: null,
+          number: null,
+        });
+      });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 1);
+
+    cy
+      .getRadio(Radio => {
         Radio.request('dialer', 'showPatientLinks', null);
       });
 
@@ -185,7 +197,7 @@ context('Dialer Service', function() {
       .getRadio(Radio => {
         Radio.request('dialer', 'showPatientLinks', {
           actionId: null,
-          number: '+16513216543 ',
+          number: '+16513216543',
         });
       });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-66108]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the dialer service when phone numbers are not provided
  * The dialer now gracefully handles null or missing phone number parameters

* **Tests**
  * Added test coverage for edge case scenarios where the dialer is called without phone number data
  * Normalized test data for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->