### PR TITLE
ci: add deploy markers for tag deploy workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,12 @@ jobs:
       deploy-name:
         type: string
         default: Deploy to S3
+      marker-environment:
+        type: string
+        default: unknown
+      marker-deployment-name:
+        type: string
+        default: deploy
     steps:
       - checkout
       - attach_workspace:
@@ -213,8 +219,40 @@ jobs:
       - restore-npm-cache
       - install-dependencies
       - run:
+          name: CircleCI Deploy Marker Plan
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping deploy marker plan"
+              exit 0
+            fi
+            circleci run release plan "<< parameters.marker-deployment-name >>" \
+              --environment-name="<< parameters.marker-environment >>" \
+              --component-name="app-frontend" \
+              --target-version="<< pipeline.git.tag >>"
+      - run:
           name: << parameters.deploy-name >>
           command: npm run deploy -- --stage=<< parameters.stage >>
+      - run:
+          name: CircleCI Deploy Marker Success
+          when: on_success
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping deploy marker success"
+              exit 0
+            fi
+            circleci run release update "<< parameters.marker-deployment-name >>" --status=SUCCESS
+      - run:
+          name: CircleCI Deploy Marker Failure
+          when: on_fail
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping deploy marker failure"
+              exit 0
+            fi
+            circleci run release update "<< parameters.marker-deployment-name >>" --status=FAILED
 
 # ------------------------------------------------------------
 # WORKFLOWS
@@ -341,6 +379,8 @@ workflows:
           name: deploy sandboxes
           stage: sandbox
           deploy-name: Deploy assets to sandbox stacks
+          marker-environment: sandbox
+          marker-deployment-name: deploy-sandbox
 
   deploy-prod:
     when: *when-release
@@ -358,3 +398,5 @@ workflows:
           name: deploy prod
           stage: prod
           deploy-name: Deploy assets to production stacks
+          marker-environment: prod
+          marker-deployment-name: deploy-prod


### PR DESCRIPTION
Shortcut Story ID: [sc-66560]

## Summary
Add CircleCI Deploy Marker wiring around the existing deploy execution for tag-triggered deploy workflows, as groundwork for Deploy/Rollback pipelines.

## What Changed
- Updated `/Users/paulfalgout/Projects/care-ops-frontend/.circleci/config.yml` `deploy` job to include marker metadata params:
  - `marker-environment` (default `unknown`)
  - `marker-deployment-name` (default `deploy`)
- Added deploy marker steps that wrap the real deploy command:
  - `circleci run release plan ...` immediately before `npm run deploy -- --stage=...`
  - `circleci run release update ... --status=SUCCESS` on success
  - `circleci run release update ... --status=FAILED` on failure
- Kept `set -euo pipefail` and tag guards (`<< pipeline.git.tag >>`) in marker steps.
- Wired workflow-specific marker params:
  - `deploy-sandboxes` -> `marker-environment: sandbox`, `marker-deployment-name: deploy-sandbox`
  - `deploy-prod` -> `marker-environment: prod`, `marker-deployment-name: deploy-prod`

## Marker Values
- `component-name`: `app-frontend`
- `environment-name`: `sandbox` / `prod`
- `target-version`: `<< pipeline.git.tag >>`
- deployment names: `deploy-sandbox` / `deploy-prod`

## What Stayed Unchanged
- Actual deploy behavior (`npm run deploy -- --stage=...`)
- Approval gate, contexts, tag filters, tag regex, and overall workflow shape

## Validation
- YAML syntax check passed for `/Users/paulfalgout/Projects/care-ops-frontend/.circleci/config.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment tracking and monitoring. Added automated deployment markers that monitor and report deployment status (success/failure) for sandbox and production environments when deploying tagged releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->