### PR TITLE
Support both DistroId and DistroID for CloudFront invalidation

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -89,7 +89,7 @@ This resolves CloudFormation stack:
 And then:
 1. Generates `dist/appconfig.json` from Secrets Manager secret `customer/<stage>/<stack-id>`
 2. Uploads `dist/` to the stack's WebsiteBucket
-3. Invalidates CloudFront if the secret contains `DistroId`
+3. Invalidates CloudFront if the secret contains `DistroId` or `DistroID`
 
 ## Local Deploy: All Stacks In A Stage
 
@@ -138,4 +138,4 @@ npm run release
   - Verify SSO login and `AWS_PROFILE`.
 
 - `No CloudFront distribution found, skipping invalidation`
-  - Expected when `DistroId` is absent from stack secret.
+  - Expected when both `DistroId` and `DistroID` are absent from stack secret.

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -219,8 +219,9 @@ async function deployToStack(clients, stage, stack, bucketName, distDir) {
   // Invalidate CloudFront if distribution exists
   try {
     const secrets = await fetchStackSecrets(clients.secretsManager, stage, stack);
-    if (secrets.DistroId) {
-      await invalidateCloudFront(clients.cloudFront, stack, secrets.DistroId);
+    const distroId = secrets.DistroId || secrets.DistroID;
+    if (distroId) {
+      await invalidateCloudFront(clients.cloudFront, stack, distroId);
     } else {
       process.stdout.write('No CloudFront distribution found, skipping invalidation\n');
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment flexibility to recognize alternate naming conventions for CloudFront distribution configuration.

* **Documentation**
  * Updated troubleshooting guide to reflect expanded configuration options for distribution setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->