### PR TITLE
Implement `subscriptionVersion` on web socket messages

### DIFF
--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -98,18 +98,6 @@ context('WS Service', function() {
 
     const closedTest = { id: 'foo', type: 'bar' };
 
-    const notification = {
-      state: {},
-      data: {
-        name: 'Subscribe',
-        data: {
-          clientKey,
-          workspace,
-          resources: [closedTest],
-        },
-      },
-    };
-
     cy
       .startService()
       .then(() => {
@@ -127,7 +115,18 @@ context('WS Service', function() {
       .should('be.calledTwice')
       .then(spy => {
         const secondCall = spy.getCall(1);
-        expect(secondCall.args[0]).to.deep.equal(notification);
+        expect(secondCall.args[0]).to.deep.equal({
+          state: {},
+          data: {
+            name: 'Subscribe',
+            data: {
+              clientKey,
+              workspace,
+              resources: [closedTest],
+              subscriptionVersion: service.subscriptionVersion,
+            },
+          },
+        });
       });
   });
 
@@ -147,7 +146,13 @@ context('WS Service', function() {
       });
 
     cy
-      .sendWs({ category: 'Test', resource: { id: 'id', type: 'flows' } })
+      .then(() =>
+        cy.sendWs({
+          category: 'Test',
+          resource: { id: 'id', type: 'flows' },
+          subscription_version: service.subscriptionVersion,
+        }),
+      )
       .then(() => {
         expect(handler).to.be.calledOnce;
         const callArgs = handler.getCall(0).args;
@@ -156,11 +161,33 @@ context('WS Service', function() {
         expect(handler2).to.be.calledOnce;
       });
 
+    // subscription_version intentially left undefined to test that message is still handled
     cy
-      .sendWs({ category: 'Test' })
       .then(() => {
-        expect(handler).to.be.calledTwice;
-        expect(handler2).to.be.calledOnce;
+        handler.reset();
+        handler2.reset();
+
+        cy.sendWs({ category: 'Test' });
+      })
+      .then(() => {
+        expect(handler).to.be.calledOnce;
+        expect(handler2).to.not.be.called;
+      });
+
+    // should not handle this message because subscription_version doesn't match
+    cy
+      .then(() => {
+        handler.reset();
+        handler2.reset();
+
+        cy.sendWs({
+          category: 'Test',
+          subscription_version: 'stale-version',
+        });
+      })
+      .then(() => {
+        expect(handler).to.not.be.called;
+        expect(handler2).to.not.be.called;
       });
   });
 
@@ -191,6 +218,7 @@ context('WS Service', function() {
           clientKey,
           workspace,
           resources,
+          subscriptionVersion: Cypress.sinon.match.string,
         },
       };
     }

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -1,6 +1,7 @@
 import { each, map, values, isArray } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import { v4 as uuid } from 'uuid';
 
 import App from 'js/base/app';
 
@@ -64,6 +65,8 @@ export default App.extend({
   },
 
   _subscribe() {
+    this.subscriptionVersion = uuid();
+
     const currentUser = Radio.request('bootstrap', 'currentUser');
     const currentWorkspace = Radio.request('workspace', 'current');
 
@@ -71,6 +74,7 @@ export default App.extend({
       clientKey: currentUser.clientKey,
       workspace: currentWorkspace.id,
       resources: this.resources.toJSON(),
+      subscriptionVersion: this.subscriptionVersion,
     };
 
     if (this.filters) data.filters = this.filters;
@@ -159,6 +163,8 @@ export default App.extend({
     const data = JSON.parse(event.data);
 
     if (!data.category || data.name === 'pong') return;
+
+    if (data.subscription_version && data.subscription_version !== this.subscriptionVersion) return;
 
     if (!data.resource) {
       this.triggerMessage(data);


### PR DESCRIPTION
Shortcut Story ID: [sc-66686]

To fix a race condition bug where we were receiving ws messages from stale ws subscriptions.

1. When FE sends "Subscribe" ws message, create a uuid that is cached on the ws service and include that on the subscription data sent to the BE.
2. BE stores that and attaches it to future ws messages sent to the FE.
3. When FE receives ws messages, don't handle messages if the version is set on the message AND doesn't match what's cached on ws service. (if no `subscription_version` is set, handle message)

Corresponding BE PR: https://github.com/RoundingWell/app-backend/pull/10556

To do:

- [x] Implement `subscriptionVersion`
- [x] Modify component test
- [x] Test that it works on my dev sandbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WebSocket reliability by implementing subscription version tracking to prevent processing of outdated or mismatched messages.

* **Tests**
  * Added comprehensive tests for subscription version validation in WebSocket messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->