### PR TITLE
Remove whitespace between due date & time components for some action list items

### DIFF
--- a/src/js/views/patients/patient/archive/action-item.hbs
+++ b/src/js/views/patients/patient/archive/action-item.hbs
@@ -11,7 +11,7 @@
   <span data-state-region></span>
   <span data-owner-region></span>
   <span>
-    <span data-due-date-region></span>
+    <span data-due-date-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>
   </span>
   <span data-form-region></span>

--- a/src/js/views/patients/patient/dashboard/action-item.hbs
+++ b/src/js/views/patients/patient/dashboard/action-item.hbs
@@ -15,7 +15,7 @@
   <span data-state-region></span>
   <span data-owner-region></span>
   <span>
-    <span data-due-date-region></span>
+    <span data-due-date-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>
   </span>
   <span data-form-region></span>

--- a/src/js/views/patients/patient/flow/action-item.hbs
+++ b/src/js/views/patients/patient/flow/action-item.hbs
@@ -15,7 +15,7 @@
   <span data-state-region></span>
   <span data-owner-region></span>
   <span>
-    <span data-due-date-region></span>
+    <span data-due-date-region></span>{{~ remove_whitespace ~}}
     <span data-due-time-region></span>
   </span>
   <span data-form-region></span>

--- a/src/js/views/patients/worklist/action-item.hbs
+++ b/src/js/views/patients/worklist/action-item.hbs
@@ -23,7 +23,10 @@
   <span class="worklist-list__details-icon" data-details-region></span>
   <span><span data-state-region></span><span class="worklist-list__search-helper">&#8203;{{ state }}&#8203;</span></span>
   <span><span data-owner-region></span><span class="worklist-list__search-helper">&#8203;{{ owner }}&#8203;</span></span>
-  <span><span data-due-date-region></span><span data-due-time-region></span></span>
+  <span>
+    <span data-due-date-region></span>{{~ remove_whitespace ~}}
+    <span data-due-time-region></span>
+  </span>
   <span><span data-form-region></span>&#8203;</span>
   {{#if hasAttachments}}
     <span class="worklist__action-display-icon">{{far "paperclip"}}</span>


### PR DESCRIPTION
Shortcut Story ID: [sc-66754]

Effects action list items on the worklist, patient dashboard, archive, and flow pages.

Removes the whitespace shown here:

<img width="188" height="74" alt="Screenshot 2026-02-24 at 12 57 57 PM" src="https://github.com/user-attachments/assets/9346e103-d7b9-4d3f-9813-90b7898e0fd4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified markup for patient action items across multiple views and adjusted whitespace handling between due date and due time.
  * Results: date/time displays render without extra gaps while preserving existing content and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->