### PR TITLE
Fix top portion of fa paperclip icon from being clipped

### DIFF
--- a/packages/care-ops-fontawesome/index.js
+++ b/packages/care-ops-fontawesome/index.js
@@ -12,7 +12,7 @@ function getIconHtml(lib, fonts) {
     const iconName = camelCase(`fa-${ iconClass }`);
     /* eslint-disable-next-line no-console */
     if (!lib[iconName]) console.error('Missing icon:', iconName);
-    return icon(lib[iconName], { symbol: true }).html;
+    return icon(lib[iconName], { symbol: true }).html.map(h => h.replace('<symbol ', '<symbol overflow="visible" '));
   });
 }
 

--- a/src/scss/core/_fontawesome.scss
+++ b/src/scss/core/_fontawesome.scss
@@ -1,3 +1,0 @@
-svg symbol[data-icon] {
-  overflow: visible;
-}

--- a/src/scss/outreach-core.scss
+++ b/src/scss/outreach-core.scss
@@ -2,7 +2,6 @@
 // These are the core styles shared between mobile and desktop
 @forward 'core/reset';
 @forward 'core/flex';
-@forward 'core/fontawesome';
 @forward 'core/fonts';
 @forward 'core/layout';
 @forward 'core/space';

--- a/src/scss/provider-core.scss
+++ b/src/scss/provider-core.scss
@@ -3,7 +3,6 @@
 @forward 'core/reset';
 @forward 'core/base';
 @forward 'core/flex';
-@forward 'core/fontawesome';
 @forward 'core/fonts';
 @forward 'core/layout';
 @forward 'core/space';


### PR DESCRIPTION
Shortcut Story ID: [sc-66750]

<img width="226" height="133" alt="Screenshot 2026-02-25 at 1 41 58 PM" src="https://github.com/user-attachments/assets/14ad09ef-2b9f-4c2a-9c9c-43f812589005" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored FontAwesome icon rendering handling, relocating overflow attribute management to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->