### PR TITLE
Utilize circleci deploy / rollback pipelines for frontend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,6 @@ aliases:
           pattern: '^v[0-9]{8}\.[0-9]+$'
           value: << pipeline.git.tag >>
 
-  prod-deploy-job: &prod-deploy-job
-    context: aws-prod
-    requires:
-      - release-approval
-
 commands:
   setup-fa-auth:
     steps:
@@ -253,6 +248,38 @@ jobs:
             fi
             circleci run release update "<< parameters.marker-deployment-name >>" --status=FAILED
 
+  publish-build-artifact:
+    docker:
+      - image: *node-image
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore-npm-cache
+      - install-dependencies
+      - run:
+          name: Package build artifact
+          command: |
+            set -euo pipefail
+            tag="<< pipeline.git.tag >>"
+            if [ -z "$tag" ]; then
+              echo "No pipeline.git.tag; refusing to publish artifact"
+              exit 1
+            fi
+
+            tar -C dist -czf /tmp/dist.tar.gz .
+            sha256sum /tmp/dist.tar.gz > /tmp/dist.tar.gz.sha256
+      - run:
+          name: Upload build artifact once per tag
+          command: |
+            set -euo pipefail
+            npm run artifact:publish -- \
+              --bucket=rw-frontend-artifacts \
+              --prefix=app-frontend \
+              --tag="<< pipeline.git.tag >>" \
+              --artifact=/tmp/dist.tar.gz \
+              --checksum=/tmp/dist.tar.gz.sha256
+
 # ------------------------------------------------------------
 # WORKFLOWS
 # ------------------------------------------------------------
@@ -360,40 +387,14 @@ workflows:
             --group edge-component
             --config retries=4
 
-  deploy-sandboxes:
+  release-artifact:
     when: *when-release
     jobs:
       - build:
           <<: *tag-filter
-          context: aws-prod
-      - release-approval:
+      - publish-build-artifact:
           <<: *tag-filter
-          type: approval
+          name: publish release artifact
+          context: aws-prod
           requires:
             - build
-      - deploy:
-          <<: [*tag-filter, *prod-deploy-job]
-          name: deploy sandboxes
-          stage: sandbox
-          deploy-name: Deploy assets to sandbox stacks
-          marker-environment: sandbox
-          marker-deployment-name: deploy-sandbox
-
-  deploy-prod:
-    when: *when-release
-    jobs:
-      - build:
-          <<: *tag-filter
-          context: aws-prod
-      - release-approval:
-          <<: *tag-filter
-          type: approval
-          requires:
-            - build
-      - deploy:
-          <<: [*tag-filter, *prod-deploy-job]
-          name: deploy prod
-          stage: prod
-          deploy-name: Deploy assets to production stacks
-          marker-environment: prod
-          marker-deployment-name: deploy-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,10 +273,6 @@ jobs:
           name: CircleCI Release Marker Plan
           command: |
             set -euo pipefail
-            if [ -z "<< pipeline.git.tag >>" ]; then
-              echo "No pipeline.git.tag; skipping release marker plan"
-              exit 0
-            fi
             circleci run release plan "release-<< pipeline.git.tag >>" \
               --environment-name="release" \
               --component-name="app-frontend" \
@@ -289,27 +285,18 @@ jobs:
               --bucket=rw-frontend-artifacts \
               --prefix=app-frontend \
               --tag="<< pipeline.git.tag >>" \
-              --artifact=/tmp/dist.tar.gz \
-              --checksum=/tmp/dist.tar.gz.sha256
+              --artifact=/tmp/dist.tar.gz
       - run:
           name: CircleCI Release Marker Success
           when: on_success
           command: |
             set -euo pipefail
-            if [ -z "<< pipeline.git.tag >>" ]; then
-              echo "No pipeline.git.tag; skipping release marker success"
-              exit 0
-            fi
             circleci run release update "release-<< pipeline.git.tag >>" --status=SUCCESS
       - run:
           name: CircleCI Release Marker Failure
           when: on_fail
           command: |
             set -euo pipefail
-            if [ -z "<< pipeline.git.tag >>" ]; then
-              echo "No pipeline.git.tag; skipping release marker failure"
-              exit 0
-            fi
             circleci run release update "release-<< pipeline.git.tag >>" --status=FAILED
 
 # ------------------------------------------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,18 @@ jobs:
             tar -C dist -czf /tmp/dist.tar.gz .
             sha256sum /tmp/dist.tar.gz > /tmp/dist.tar.gz.sha256
       - run:
+          name: CircleCI Release Marker Plan
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping release marker plan"
+              exit 0
+            fi
+            circleci run release plan "release-<< pipeline.git.tag >>" \
+              --environment-name="release" \
+              --component-name="app-frontend" \
+              --target-version="<< pipeline.git.tag >>"
+      - run:
           name: Upload build artifact once per tag
           command: |
             set -euo pipefail
@@ -279,6 +291,26 @@ jobs:
               --tag="<< pipeline.git.tag >>" \
               --artifact=/tmp/dist.tar.gz \
               --checksum=/tmp/dist.tar.gz.sha256
+      - run:
+          name: CircleCI Release Marker Success
+          when: on_success
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping release marker success"
+              exit 0
+            fi
+            circleci run release update "release-<< pipeline.git.tag >>" --status=SUCCESS
+      - run:
+          name: CircleCI Release Marker Failure
+          when: on_fail
+          command: |
+            set -euo pipefail
+            if [ -z "<< pipeline.git.tag >>" ]; then
+              echo "No pipeline.git.tag; skipping release marker failure"
+              exit 0
+            fi
+            circleci run release update "release-<< pipeline.git.tag >>" --status=FAILED
 
 # ------------------------------------------------------------
 # WORKFLOWS

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -59,45 +59,38 @@ jobs:
               exit 1
             fi
 
-            deploy_stage=""
-            deploy_stack=""
+            if [[ "$target_env" != *:* ]]; then
+              echo "Unsupported deploy environment: $target_env"
+              echo "Expected format: <stage>:<stack>"
+              echo "Examples: qa:*, sandbox:*, prod:*, qa:qa2, sandbox:banana, prod:apple"
+              exit 1
+            fi
 
-            case "$target_env" in
-              qa)
-                deploy_stage="qa"
-                deploy_stack="quality-assurance"
-                ;;
-              qa2)
-                deploy_stage="qa"
-                deploy_stack="qa2"
-                ;;
-              all-sandboxes|sandbox)
-                deploy_stage="sandbox"
-                ;;
-              all-prod|prod)
-                deploy_stage="prod"
-                ;;
-              *-sandbox)
-                deploy_stage="sandbox"
-                deploy_stack="${target_env%-sandbox}"
-                ;;
-              *-prod)
-                deploy_stage="prod"
-                deploy_stack="${target_env%-prod}"
+            deploy_stage="${target_env%%:*}"
+            deploy_stack="${target_env#*:}"
+
+            case "$deploy_stage" in
+              qa|sandbox|prod)
                 ;;
               *)
-                echo "Unsupported deploy environment: $target_env"
-                echo "Supported: qa, qa2, all-sandboxes, all-prod, <stack>-sandbox, <stack>-prod"
+                echo "Unsupported deploy stage: $deploy_stage"
+                echo "Supported stages: qa, sandbox, prod"
                 exit 1
                 ;;
             esac
 
-            if [ -n "$deploy_stack" ] && [ "$deploy_stack" = "$target_env" ]; then
-              echo "Invalid deploy stack parsed from environment: $target_env"
+            if [ -z "$deploy_stack" ]; then
+              echo "Deploy stack segment cannot be empty in target environment: $target_env"
               exit 1
             fi
 
-            marker_name="deploy-${target_env}-${target_version}"
+            if [ "$deploy_stack" = "*" ] || [ "$deploy_stack" = "all" ]; then
+              deploy_stack=""
+            fi
+
+            marker_env_slug="${target_env//:/-}"
+            marker_env_slug="${marker_env_slug//\*/all}"
+            marker_name="deploy-${marker_env_slug}-${target_version}"
 
             {
               echo "DEPLOY_TARGET_ENV=$target_env"

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -1,0 +1,160 @@
+version: 2.1
+
+aliases:
+  .node-image: &node-image cimg/node:22.16
+
+commands:
+  setup-fa-auth:
+    steps:
+      - run:
+          name: Configure npm registry auth
+          command: |
+            cat > ~/.npmrc \<< EOF
+            # Pro Font Awesome registry
+            @fortawesome:registry=https://npm.fontawesome.com/
+            //npm.fontawesome.com/:_authToken=${FONTAWESOME}
+            EOF
+            echo "Created ~/.npmrc"
+
+  install-dependencies:
+    steps:
+      - run:
+          name: Verify Node version matches .nvmrc
+          command: |
+            expected="$(tr -d '[:space:]' < .nvmrc | sed 's/^v//')"
+            expected_major_minor="$(echo "$expected" | cut -d. -f1,2)"
+            image_version="$(node -v)"
+            image_version="${image_version#v}"
+            if [[ "$image_version" != "$expected_major_minor".* ]]; then
+              echo "Node version mismatch: .nvmrc=${expected_major_minor}, image=${image_version}"
+              exit 1
+            fi
+      - setup-fa-auth
+      - run:
+          name: Install dependencies
+          command: npm ci --prefer-offline --no-audit
+
+jobs:
+  deploy-from-artifact:
+    docker:
+      - image: *node-image
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Resolve deploy target
+          command: |
+            set -euo pipefail
+
+            target_env="<< pipeline.deploy.target_environment_name >>"
+            target_version="<< pipeline.deploy.target_version >>"
+
+            if [ -z "$target_env" ]; then
+              echo "Deploy target environment is required"
+              exit 1
+            fi
+
+            if [ -z "$target_version" ]; then
+              echo "Deploy target version is required"
+              exit 1
+            fi
+
+            deploy_stage=""
+            deploy_stack=""
+
+            case "$target_env" in
+              qa)
+                deploy_stage="qa"
+                deploy_stack="quality-assurance"
+                ;;
+              qa2)
+                deploy_stage="qa"
+                deploy_stack="qa2"
+                ;;
+              all-sandboxes|sandbox)
+                deploy_stage="sandbox"
+                ;;
+              all-prod|prod)
+                deploy_stage="prod"
+                ;;
+              *-sandbox)
+                deploy_stage="sandbox"
+                deploy_stack="${target_env%-sandbox}"
+                ;;
+              *-prod)
+                deploy_stage="prod"
+                deploy_stack="${target_env%-prod}"
+                ;;
+              *)
+                echo "Unsupported deploy environment: $target_env"
+                echo "Supported: qa, qa2, all-sandboxes, all-prod, <stack>-sandbox, <stack>-prod"
+                exit 1
+                ;;
+            esac
+
+            if [ -n "$deploy_stack" ] && [ "$deploy_stack" = "$target_env" ]; then
+              echo "Invalid deploy stack parsed from environment: $target_env"
+              exit 1
+            fi
+
+            marker_name="deploy-${target_env}-${target_version}"
+
+            {
+              echo "DEPLOY_TARGET_ENV=$target_env"
+              echo "DEPLOY_TARGET_VERSION=$target_version"
+              echo "DEPLOY_STAGE=$deploy_stage"
+              echo "DEPLOY_STACK=$deploy_stack"
+              echo "DEPLOY_MARKER_NAME=$marker_name"
+            } >> "$BASH_ENV"
+      - run:
+          name: Download release artifact
+          command: |
+            set -euo pipefail
+            npm run artifact:download -- \
+              --bucket=rw-frontend-artifacts \
+              --prefix=app-frontend \
+              --tag="$DEPLOY_TARGET_VERSION" \
+              --artifact=/tmp/dist.tar.gz \
+              --checksum=/tmp/dist.tar.gz.sha256
+      - run:
+          name: Unpack release artifact
+          command: |
+            set -euo pipefail
+            rm -rf dist
+            mkdir -p dist
+            tar -C dist -xzf /tmp/dist.tar.gz
+      - run:
+          name: CircleCI Deploy Marker Plan
+          command: |
+            set -euo pipefail
+            circleci run release plan "$DEPLOY_MARKER_NAME" \
+              --environment-name="$DEPLOY_TARGET_ENV" \
+              --component-name="app-frontend" \
+              --target-version="$DEPLOY_TARGET_VERSION"
+      - run:
+          name: Deploy selected target
+          command: |
+            set -euo pipefail
+            if [ -n "$DEPLOY_STACK" ]; then
+              npm run deploy -- --stage="$DEPLOY_STAGE" --stack="$DEPLOY_STACK"
+            else
+              npm run deploy -- --stage="$DEPLOY_STAGE"
+            fi
+      - run:
+          name: CircleCI Deploy Marker Success
+          when: on_success
+          command: |
+            set -euo pipefail
+            circleci run release update "$DEPLOY_MARKER_NAME" --status=SUCCESS
+      - run:
+          name: CircleCI Deploy Marker Failure
+          when: on_fail
+          command: |
+            set -euo pipefail
+            circleci run release update "$DEPLOY_MARKER_NAME" --status=FAILED
+
+workflows:
+  deploy:
+    jobs:
+      - deploy-from-artifact:
+          context: aws-prod

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -108,14 +108,14 @@ jobs:
             } >> "$BASH_ENV"
       - run:
           name: Download release artifact
+          no_output_timeout: 5m
           command: |
             set -euo pipefail
             npm run artifact:download -- \
               --bucket=rw-frontend-artifacts \
               --prefix=app-frontend \
               --tag="$DEPLOY_TARGET_VERSION" \
-              --artifact=/tmp/dist.tar.gz \
-              --checksum=/tmp/dist.tar.gz.sha256
+              --artifact=/tmp/dist.tar.gz
       - run:
           name: Unpack release artifact
           command: |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "analyze": "npx vite-bundle-visualizer",
     "build": "vite build",
     "deploy": "node scripts/deploy.js",
+    "artifact:publish": "node scripts/publish-artifact.js",
     "predeploy:dev": "npm run build",
     "deploy:dev": "node --env-file=.env scripts/deploy.js",
     "predeploy:qa": "npm run build",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "vite build",
     "deploy": "node scripts/deploy.js",
     "artifact:publish": "node scripts/publish-artifact.js",
+    "artifact:download": "node scripts/download-artifact.js",
     "predeploy:dev": "npm run build",
     "deploy:dev": "node --env-file=.env scripts/deploy.js",
     "predeploy:qa": "npm run build",

--- a/scripts/download-artifact.js
+++ b/scripts/download-artifact.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { parseArgs } from 'node:util';
+import { getCredentials, getRegion } from './lib/aws.js';
+
+function resolveInputs(values) {
+  const bucket = values.bucket || process.env.ARTIFACT_BUCKET || 'rw-frontend-artifacts';
+  const prefix = values.prefix || process.env.ARTIFACT_PREFIX || 'app-frontend';
+  const tag = values.tag || process.env.ARTIFACT_TAG;
+  const artifactPath = values.artifact || process.env.ARTIFACT_PATH || '/tmp/dist.tar.gz';
+  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || '/tmp/dist.tar.gz.sha256';
+
+  if (!tag) {
+    throw new Error('Tag is required (--tag or ARTIFACT_TAG)');
+  }
+
+  return {
+    bucket,
+    prefix,
+    tag,
+    artifactPath,
+    checksumPath,
+  };
+}
+
+async function ensureParentDirectory(filePath) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function downloadObject(s3Client, bucket, key, destinationPath) {
+  const response = await s3Client.send(new GetObjectCommand({
+    Bucket: bucket,
+    Key: key,
+  }));
+
+  if (!response.Body) {
+    throw new Error(`Empty S3 response body for s3://${ bucket }/${ key }`);
+  }
+
+  await ensureParentDirectory(destinationPath);
+  await pipeline(response.Body, createWriteStream(destinationPath));
+}
+
+async function calculateSha256(filePath) {
+  const hash = createHash('sha256');
+  const stream = createReadStream(filePath);
+
+  for await (const chunk of stream) {
+    hash.update(chunk);
+  }
+
+  return hash.digest('hex');
+}
+
+function parseChecksumFile(content) {
+  return content.trim().split(/\s+/)[0];
+}
+
+async function verifyChecksum(artifactPath, checksumPath) {
+  const checksumContent = await fs.readFile(checksumPath, 'utf8');
+  const expectedChecksum = parseChecksumFile(checksumContent);
+  const actualChecksum = await calculateSha256(artifactPath);
+
+  if (actualChecksum !== expectedChecksum) {
+    throw new Error(`Artifact checksum mismatch: expected=${ expectedChecksum }, actual=${ actualChecksum }`);
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      bucket: { type: 'string' },
+      prefix: { type: 'string' },
+      tag: { type: 'string' },
+      artifact: { type: 'string' },
+      checksum: { type: 'string' },
+    },
+  });
+
+  const inputs = resolveInputs(values);
+  const artifactFileName = path.basename(inputs.artifactPath);
+  const checksumFileName = path.basename(inputs.checksumPath);
+  const artifactKey = `${ inputs.prefix }/${ inputs.tag }/${ artifactFileName }`;
+  const checksumKey = `${ inputs.prefix }/${ inputs.tag }/${ checksumFileName }`;
+
+  const s3Client = new S3Client({
+    region: getRegion(),
+    credentials: getCredentials(),
+  });
+
+  await downloadObject(s3Client, inputs.bucket, artifactKey, inputs.artifactPath);
+  await downloadObject(s3Client, inputs.bucket, checksumKey, inputs.checksumPath);
+  await verifyChecksum(inputs.artifactPath, inputs.checksumPath);
+
+  process.stdout.write(`Downloaded and verified: s3://${ inputs.bucket }/${ artifactKey }\n`);
+}
+
+main().catch(error => {
+  process.stderr.write(`Artifact download failed: ${ error.message }\n`);
+  process.exit(1);
+});

--- a/scripts/download-artifact.js
+++ b/scripts/download-artifact.js
@@ -14,7 +14,7 @@ function resolveInputs(values) {
   const prefix = values.prefix || process.env.ARTIFACT_PREFIX || 'app-frontend';
   const tag = values.tag || process.env.ARTIFACT_TAG;
   const artifactPath = values.artifact || process.env.ARTIFACT_PATH || '/tmp/dist.tar.gz';
-  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || '/tmp/dist.tar.gz.sha256';
+  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || `${ artifactPath }.sha256`;
 
   if (!tag) {
     throw new Error('Tag is required (--tag or ARTIFACT_TAG)');

--- a/scripts/publish-artifact.js
+++ b/scripts/publish-artifact.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { createReadStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+import { getCredentials, getRegion } from './lib/aws.js';
+
+function resolveInputs(values) {
+  const bucket = values.bucket || process.env.ARTIFACT_BUCKET || 'rw-frontend-artifacts';
+  const prefix = values.prefix || process.env.ARTIFACT_PREFIX || 'app-frontend';
+  const tag = values.tag || process.env.ARTIFACT_TAG;
+  const artifactPath = values.artifact || process.env.ARTIFACT_PATH || '/tmp/dist.tar.gz';
+  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || '/tmp/dist.tar.gz.sha256';
+
+  if (!tag) {
+    throw new Error('Tag is required (--tag or ARTIFACT_TAG)');
+  }
+
+  return {
+    bucket,
+    prefix,
+    tag,
+    artifactPath,
+    checksumPath,
+  };
+}
+
+function isNotFoundError(error) {
+  return error.name === 'NotFound'
+    || error.name === 'NoSuchKey'
+    || error.$metadata?.httpStatusCode === 404;
+}
+
+async function objectExists(s3Client, bucket, key) {
+  try {
+    await s3Client.send(new HeadObjectCommand({
+      Bucket: bucket,
+      Key: key,
+    }));
+    return true;
+  } catch(error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function assertReadable(filePath) {
+  try {
+    await fs.access(filePath);
+  } catch {
+    throw new Error(`File not found: ${ filePath }`);
+  }
+}
+
+async function uploadFile(s3Client, bucket, key, filePath, contentType) {
+  await s3Client.send(new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: createReadStream(filePath),
+    ContentType: contentType,
+  }));
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      bucket: { type: 'string' },
+      prefix: { type: 'string' },
+      tag: { type: 'string' },
+      artifact: { type: 'string' },
+      checksum: { type: 'string' },
+    },
+  });
+
+  const inputs = resolveInputs(values);
+  await assertReadable(inputs.artifactPath);
+  await assertReadable(inputs.checksumPath);
+
+  const artifactFileName = path.basename(inputs.artifactPath);
+  const checksumFileName = path.basename(inputs.checksumPath);
+  const artifactKey = `${ inputs.prefix }/${ inputs.tag }/${ artifactFileName }`;
+  const checksumKey = `${ inputs.prefix }/${ inputs.tag }/${ checksumFileName }`;
+
+  const s3Client = new S3Client({
+    region: getRegion(),
+    credentials: getCredentials(),
+  });
+
+  const artifactAlreadyExists = await objectExists(s3Client, inputs.bucket, artifactKey);
+  if (artifactAlreadyExists) {
+    throw new Error(`Artifact already exists for tag ${ inputs.tag }: s3://${ inputs.bucket }/${ artifactKey }`);
+  }
+
+  await uploadFile(s3Client, inputs.bucket, artifactKey, inputs.artifactPath, 'application/gzip');
+  await uploadFile(s3Client, inputs.bucket, checksumKey, inputs.checksumPath, 'text/plain');
+
+  process.stdout.write(`Uploaded artifact: s3://${ inputs.bucket }/${ artifactKey }\n`);
+}
+
+main().catch(error => {
+  process.stderr.write(`Artifact publish failed: ${ error.message }\n`);
+  process.exit(1);
+});

--- a/scripts/publish-artifact.js
+++ b/scripts/publish-artifact.js
@@ -12,7 +12,7 @@ function resolveInputs(values) {
   const prefix = values.prefix || process.env.ARTIFACT_PREFIX || 'app-frontend';
   const tag = values.tag || process.env.ARTIFACT_TAG;
   const artifactPath = values.artifact || process.env.ARTIFACT_PATH || '/tmp/dist.tar.gz';
-  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || '/tmp/dist.tar.gz.sha256';
+  const checksumPath = values.checksum || process.env.ARTIFACT_CHECKSUM_PATH || `${ artifactPath }.sha256`;
 
   if (!tag) {
     throw new Error('Tag is required (--tag or ARTIFACT_TAG)');

--- a/scripts/publish-artifact.js
+++ b/scripts/publish-artifact.js
@@ -91,8 +91,15 @@ async function main() {
   });
 
   const artifactAlreadyExists = await objectExists(s3Client, inputs.bucket, artifactKey);
-  if (artifactAlreadyExists) {
-    throw new Error(`Artifact already exists for tag ${ inputs.tag }: s3://${ inputs.bucket }/${ artifactKey }`);
+  const checksumAlreadyExists = await objectExists(s3Client, inputs.bucket, checksumKey);
+
+  if (artifactAlreadyExists || checksumAlreadyExists) {
+    const existingKeys = [
+      artifactAlreadyExists ? `s3://${ inputs.bucket }/${ artifactKey }` : null,
+      checksumAlreadyExists ? `s3://${ inputs.bucket }/${ checksumKey }` : null,
+    ].filter(Boolean).join(', ');
+
+    throw new Error(`Artifact publish blocked for immutable tag ${ inputs.tag }; existing object(s): ${ existingKeys }`);
   }
 
   await uploadFile(s3Client, inputs.bucket, artifactKey, inputs.artifactPath, 'application/gzip');


### PR DESCRIPTION
Shortcut Story ID: [sc-66559]

I think this needs to be merged for me to fully test it.

Currently I have release artifacts saving to S3 and showing up in the deploy ui.

This will allow us to promote releases to any non-dev environment or all sandboxes/prod at once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm commands to publish and download release artifacts with checksum verification.

* **Chores**
  * Switched CI release flow to publish and manage packaged build artifacts and release markers instead of direct deploy steps.
  * Added an artifact-based deploy path that downloads, verifies, and deploys packaged artifacts, with status updates for success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->