### PR TITLE
Fix some flakey integration tests

### DIFF
--- a/test/integration/patients/patient/archive.js
+++ b/test/integration/patients/patient/archive.js
@@ -379,10 +379,6 @@ context('patient archive page', function() {
       });
 
     cy
-      .get('@flowItem')
-      .find('.fa-circle-exclamation');
-
-    cy
       .get('.list-page__list')
       .find('.table-list__item')
       .should('have.lengthOf', 3);

--- a/test/integration/programs/programs-all.js
+++ b/test/integration/programs/programs-all.js
@@ -35,7 +35,8 @@ context('program all list', function() {
 
         return fx;
       })
-      .visit('/programs');
+      .visit('/programs')
+      .wait('@routePrograms');
 
     cy
       .get('.table-list__item')

--- a/test/integration/programs/sidebar/flow-sidebar.js
+++ b/test/integration/programs/sidebar/flow-sidebar.js
@@ -183,7 +183,8 @@ context('program flow sidebar', function() {
         updated_at: testTs(),
       },
       relationships: {
-        'program': getRelationship(testProgram),
+        program: getRelationship(testProgram),
+        owner: getRelationship(null),
       },
     });
 


### PR DESCRIPTION
Shortcut Story ID: [sc-66815]

These three:

* `patient archive page` => `action, flow and events list` ([link](https://cloud.cypress.io/projects/ep9zr6/analytics/flaky-tests/ab10d331-6e7c-05f1-71f4-0bcdcef358b3-2bb9a684-996d-0e1d-59af-5415302a7724))
* `program flow sidebar` => `display flow sidebar` ([link](https://cloud.cypress.io/projects/ep9zr6/analytics/flaky-tests/523546be-36df-f9dd-e26a-7beeb4a3bd09-eede2a71-acba-4da2-7809-a34eff6aee1c))
* `program all list` => `display programs list` ([link](https://cloud.cypress.io/projects/ep9zr6/analytics/flaky-tests/6a813f57-1a4b-7e17-3323-3cbeac647722-9539766b-3288-0ae5-6f96-2e86a8648eaf))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed outdated assertion from patient archival integration test
  * Added route synchronization to program tests for improved reliability
  * Updated test data structure for program flow sidebar relationships

<!-- end of auto-generated comment: release notes by coderabbit.ai -->