### PR TITLE
Shorten tag release and use in appconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ aliases:
   when-release: &when-release
     and:
       - matches:
-          pattern: '^v[0-9]{8}\.[0-9]+$'
+          pattern: '^v[0-9]{6}\.[0-9]+$'
           value: << pipeline.git.tag >>
 
 commands:

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ $ npm run release -- --dry-run
 ```
 
 Tag format:
-- `vYYYYMMDD.N` (UTC date, sequence starts at `1`)
-- Example: `v20260212.1`
+- `vYYMMDD.N` (UTC date, sequence starts at `1`)
+- Example: `v260212.1`
 
 Tag immutability:
 - release tags are treated as immutable

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -104,7 +104,7 @@ This discovers all `careops-<stage>-*` stacks (with pagination) and deploys each
 ## CircleCI Deploys
 
 CircleCI deploy workflows run only for release tags matching:
-- `vYYYYMMDD.N`
+- `vYYMMDD.N`
 
 Current deploy workflows:
 - `deploy-sandboxes` (stage `sandbox`)

--- a/scripts/generate-appconfig.js
+++ b/scripts/generate-appconfig.js
@@ -17,10 +17,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
- * Get the current git commit SHA
+ * Get frontend version for appconfig
+ * Prefers release/tag version when available in CI.
  * @returns {string}
  */
 function getVersion() {
+  const tagVersion = process.env.DEPLOY_TARGET_VERSION || process.env.CIRCLE_TAG;
+  if (tagVersion) {
+    return tagVersion.trim();
+  }
+
   try {
     return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
   } catch {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -182,7 +182,7 @@ function listRemoteTags(tagPattern) {
 }
 
 function computeNextReleaseTag() {
-  const datePart = dayjs.utc().format('YYYYMMDD');
+  const datePart = dayjs.utc().format('YYMMDD');
   const prefix = `v${ datePart }`;
   const matchingTags = listRemoteTags(`refs/tags/${ prefix }.*`)
     .filter(tag => new RegExp(`^${ prefix }\\.\\d+$`).test(tag));


### PR DESCRIPTION
Shortcut Story ID: [sc-###]

reduced version tag length for better circleci ux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release tag format to use a shorter YYMMDD pattern (vYYMMDD.N).
  * Enhanced deployment version detection to prioritize explicit deployment/tag-provided versions.
  * Adjusted deployment workflows and updated documentation to reflect the revised deploy stages and workflow names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->