### PR TITLE
Configure `settings` service to use `currentClinician.settings`

### DIFF
--- a/src/js/services/settings.cy.js
+++ b/src/js/services/settings.cy.js
@@ -2,6 +2,7 @@ import Radio from 'backbone.radio';
 
 import SettingsService from './settings';
 
+import { Model as Clinician } from 'js/entities-service/entities/clinicians';
 import { Model as Workspace } from 'js/entities-service/entities/workspaces';
 import { Collection as Settings } from 'js/entities-service/entities/settings';
 
@@ -9,19 +10,25 @@ context('Settings Service', function() {
   let service;
 
   beforeEach(function() {
-    const currentWorkspace = new Workspace({ settings: { bar: 1 } });
+    const currentUser = new Clinician({ settings: { baz: 'clinician' } });
+
+    Radio.reply('bootstrap', 'currentUser', () => currentUser);
+
+    const currentWorkspace = new Workspace({ settings: { bar: 1, baz: 'workspace' } });
 
     Radio.reply('workspace', 'current', () => currentWorkspace);
 
     const settings = new Settings([
       { id: 'foo', value: 'value' },
       { id: 'bar', value: 2 },
+      { id: 'baz', value: 'organization' },
     ]);
 
     service = new SettingsService({ settings });
   });
 
   afterEach(function() {
+    Radio.reset('bootstrap');
     Radio.reset('workspace');
     service.destroy();
   });
@@ -36,5 +43,11 @@ context('Settings Service', function() {
     const setting = Radio.request('settings', 'get', 'bar');
 
     expect(setting).to.equal(1);
+  });
+
+  specify('Get Clinician Setting', function() {
+    const setting = Radio.request('settings', 'get', 'baz');
+
+    expect(setting).to.equal('clinician');
   });
 });

--- a/src/js/services/settings.js
+++ b/src/js/services/settings.js
@@ -12,6 +12,12 @@ export default App.extend({
     this.settings = settings;
   },
   getSetting(settingName) {
+    const currentUser = Radio.request('bootstrap', 'currentUser');
+    const clinicianSettings = currentUser.get('settings');
+    const clinicianSetting = get(clinicianSettings, settingName);
+
+    if (!isUndefined(clinicianSetting)) return clinicianSetting;
+
     const currentWorkspace = Radio.request('workspace', 'current');
     const workspaceSettings = currentWorkspace.get('settings');
     const workspaceSetting = get(workspaceSettings, settingName);


### PR DESCRIPTION
Shortcut Story ID: [sc-67178]

If setting is found in `currentClinician.settings: []`, that value should take priority over the same setting set on the workspace & organization level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings management now supports clinician-specific overrides that automatically take priority over workspace defaults. Individual clinicians can maintain personalized preferences while workspace defaults continue to serve as fallbacks for settings not customized at the individual level.

* **Tests**
  * Expanded test suite to validate clinician-specific setting retrieval and ensure proper priority ordering between clinician and workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->