### PR TITLE
Set explicit CircleCI AWS role session names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ commands:
     steps:
       - aws-cli/setup:
           role_arn: ${AWS_ROLE_ARN}
+          role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
 # ------------------------------------------------------------
 # EXECUTOR  –  Node 22 LTS image with Chrome 137, FF 139, Edge 137

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -55,6 +55,7 @@ commands:
     steps:
       - aws-cli/setup:
           role_arn: ${AWS_ROLE_ARN}
+          role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
 jobs:
   deploy-from-artifact:


### PR DESCRIPTION
Deploys were failing without setting a session number

Fixed with this:
https://app.circleci.com/pipelines/github/RoundingWell/app-frontend?branch=release%2Foidc-deploy-test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roundingwell/app-frontend/pull/1627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance AWS session management during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->