### PR TITLE
Fix logout hard-route

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -62,6 +62,11 @@ export class WorkosAuthProvider extends AuthProvider {
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
+      try {
+        await this.client.getAccessToken();
+      } catch {
+        // Ignore bootstrap failures and let signOut() handle the no-session case.
+      }
       this.client.signOut({ returnTo: location.origin });
       return;
     }


### PR DESCRIPTION
authkit 0.19 fixed session clean up, but in the case where the logout is reached from a hard refresh (which is how we've been testing), authkit assumes the client is unauthed without a local token and redirects as if already signed out.  Requesting the token seems to allow the signOut, and now that the sessions is cleaned up it actually goes to the login screen

Shortcut Story ID: [sc-65433]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logout process to gracefully handle edge cases where sessions may not exist, ensuring users can reliably sign out even in uncommon authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->