### PR TITLE
Force a login to ensure a correct session id

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -24,16 +24,22 @@ export class WorkosAuthProvider extends AuthProvider {
   }
 
   async _initClient(clientId, success) {
+    const authProvider = this;
     const clientConfig = {
       redirectUri: location.origin + AuthProvider.PATH_AUTHD,
-      onRedirectCallback: ({ user, state }) => {
+      onRedirectCallback({ user, state }) {
         const path = state;
-        if (!user) {
-          this.loginPrompt(path);
+        if (path === AuthProvider.PATH_LOGOUT) {
+          this.signOut({ returnTo: location.origin });
           return;
         }
 
-        this.handleAuthedPath(path);
+        if (!user) {
+          authProvider.loginPrompt(path);
+          return;
+        }
+
+        authProvider.handleAuthedPath(path);
 
         success();
       },
@@ -62,12 +68,8 @@ export class WorkosAuthProvider extends AuthProvider {
 
     if (pathName === AuthProvider.PATH_LOGOUT) {
       this.token = null;
-      try {
-        await this.client.getAccessToken();
-      } catch {
-        // Ignore bootstrap failures and let signOut() handle the no-session case.
-      }
-      this.client.signOut({ returnTo: location.origin });
+      // Force a login to ensure the correct session id is logged out
+      this.client.signIn({ state: AuthProvider.PATH_LOGOUT });
       return;
     }
 


### PR DESCRIPTION
`await this.client.getAccessToken();` wasn’t always enough to ensure a session id.

I've tested this on QA2.  I think it covers all the edge-cases.  We'll see if this is something authkit will fix.  We don't _have_ to have a logout route causing the hard-refresh edge case..  I think auth0 needed one at one point or something.. But it'd be a pain to work around it.  User experience here is relatively painless.. url flips around a bit and then you're back at the login screen.

But this _actually_ fixes the issue

https://github.com/workos/authkit-js/issues/109#issuecomment-4084403206

Shortcut Story ID: [sc-65433]



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roundingwell/app-frontend/pull/1629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication callback handling and session management reliability.
  * Enhanced logout flow to ensure proper session cleanup and state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->