### PR TITLE
Use devMode for dev and qa stage builds

### DIFF
--- a/public/appconfig.json
+++ b/public/appconfig.json
@@ -5,7 +5,7 @@
     "name": "Salvation Clinic",
     "version": "dev"
   },
-  "auth": {
+  "~auth": {
     "provider": "auth0",
     "disableLoginPrompt": true,
     "config": {
@@ -19,12 +19,14 @@
       "useRefreshTokens": true
     }
   },
-  "~auth": {
+  "auth": {
     "provider": "workos",
     "disableLoginPrompt": false,
     "config": {
       "clientId": "client_01J7M1FVZZMHM6KTVTN5ZKRME1",
-      "createClientOptions": {}
+      "createClientOptions": {
+        "devMode": true
+      }
     }
   },
   "datadog": {

--- a/scripts/lib/appconfig.js
+++ b/scripts/lib/appconfig.js
@@ -2,12 +2,17 @@ function getDisableLoginPrompt(secrets) {
   return String(secrets.DisableLoginPrompt ?? '').toLowerCase() === 'true';
 }
 
+function shouldEnableWorkOsDevMode(stage) {
+  return stage === 'dev' || stage === 'qa';
+}
+
 /**
  * Create auth config for WorkOS
  * @param {Object} secrets - Stack secrets
+ * @param {string} stage - Deployed stage
  * @returns {Object}
  */
-function createWorkOsAuthConfig(secrets) {
+function createWorkOsAuthConfig(secrets, stage) {
   return {
     provider: 'workos',
     disableLoginPrompt: getDisableLoginPrompt(secrets),
@@ -15,6 +20,7 @@ function createWorkOsAuthConfig(secrets) {
       clientId: secrets.WorkOsClientId || '',
       createClientOptions: {
         apiHostname: secrets.WorkOsApiDomain || 'login.roundingwell.com',
+        ...(shouldEnableWorkOsDevMode(stage) ? { devMode: true } : {}),
       },
     },
   };
@@ -51,7 +57,7 @@ function createAuth0AuthConfig(secrets) {
  */
 function addAuthProvider(config, secrets) {
   config.auth = secrets.WorkOsClientId ?
-    createWorkOsAuthConfig(secrets) :
+    createWorkOsAuthConfig(secrets, config.app.stage) :
     createAuth0AuthConfig(secrets);
 }
 

--- a/scripts/lib/appconfig.test.js
+++ b/scripts/lib/appconfig.test.js
@@ -122,6 +122,7 @@ test('buildAppConfig prioritizes WorkOS and sets auth.provider=workos', () => {
         clientId: 'workos-client',
         createClientOptions: {
           apiHostname: 'workos.example.com',
+          devMode: true,
         },
       },
     },
@@ -131,7 +132,26 @@ test('buildAppConfig prioritizes WorkOS and sets auth.provider=workos', () => {
       clientId: 'workos-client',
       createClientOptions: {
         apiHostname: 'workos.example.com',
+        devMode: true,
       },
     },
   });
+});
+
+test('buildAppConfig omits WorkOS devMode outside dev and qa', () => {
+  const config = buildAppConfig({
+    secrets: {
+      OrganizationName: 'Acme',
+      WorkOsClientId: 'workos-client',
+      WorkOsApiDomain: 'workos.example.com',
+    },
+    stage: 'prod',
+    organization: 'customer-a',
+    version: 'ghi9012',
+    deploymentTime: '2026-02-12T08:00:00-06:00',
+    deploymentSource: 'Continuous Integration',
+  });
+
+  assert.equal(config.auth.config.createClientOptions.devMode, undefined);
+  assert.equal(config.workos.createClientOptions.devMode, undefined);
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-67281]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated authentication provider configuration to enable WorkOS development mode in development and QA environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roundingwell/app-frontend/pull/1631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
