### PR TITLE
chore(deploy): upload cutover files last

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -147,6 +147,29 @@ function shouldSkipUploadEntry(entryName) {
   return entryName.startsWith('.');
 }
 
+const FINAL_UPLOAD_ORDER = new Map([
+  ['appconfig.json', 1],
+  ['index.html', 2],
+  ['sw.js', 3],
+]);
+
+function compareUploadEntries(a, b, prefix = '') {
+  const aPriority = prefix === '' ? (FINAL_UPLOAD_ORDER.get(a.name) || 0) : 0;
+  const bPriority = prefix === '' ? (FINAL_UPLOAD_ORDER.get(b.name) || 0) : 0;
+
+  // Hold back the stable root files that act as rollout cutover points.
+  if (aPriority !== bPriority) return aPriority - bPriority;
+  if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+
+  return a.name.localeCompare(b.name);
+}
+
+export function sortUploadEntries(entries, prefix = '') {
+  return [...entries]
+    .filter(entry => !shouldSkipUploadEntry(entry.name))
+    .sort((a, b) => compareUploadEntries(a, b, prefix));
+}
+
 /**
  * Upload a single file to S3.
  * @param {S3Client} s3Client - S3 client instance
@@ -176,11 +199,12 @@ async function uploadFile(s3Client, bucketName, filePath, key) {
  * @param {string} prefix - The S3 key prefix
  */
 async function uploadDirectory(s3Client, bucketName, dirPath, prefix = '') {
-  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const entries = sortUploadEntries(
+    await fs.readdir(dirPath, { withFileTypes: true }),
+    prefix,
+  );
 
   for (const entry of entries) {
-    if (shouldSkipUploadEntry(entry.name)) continue;
-
     const fullPath = path.join(dirPath, entry.name);
     const s3Key = prefix ? `${ prefix }/${ entry.name }` : entry.name;
 


### PR DESCRIPTION
This changes the deploy upload order so the stable cutover files are published last during an S3 deploy.

Previously, deploys uploaded dist/ in raw directory order, which meant appconfig.json, index.html, or sw.js could be pushed before the rest of the release finished uploading. That created a mixed-version window where clients could see new entrypoint files pointing at a release that was still only partially present in S3.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roundingwell/app-frontend/pull/1635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved deployment reliability by implementing deterministic upload ordering for directory contents, ensuring consistent and predictable file delivery sequence during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->