### PR TITLE
ci: allow dev deploy targets

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -87,7 +87,7 @@ jobs:
             if [[ "$target_env" != *:* ]]; then
               echo "Unsupported deploy environment: $target_env"
               echo "Expected format: <stage>:<organization>"
-              echo "Examples: qa:*, sandbox:*, prod:*, qa:qa2, sandbox:banana, prod:apple"
+              echo "Examples: dev:nick, qa:*, sandbox:banana, prod:apple"
               exit 1
             fi
 
@@ -95,11 +95,11 @@ jobs:
             deploy_organization="${target_env#*:}"
 
             case "$deploy_stage" in
-              qa|sandbox|prod)
+              dev|qa|sandbox|prod)
                 ;;
               *)
                 echo "Unsupported deploy stage: $deploy_stage"
-                echo "Supported stages: qa, sandbox, prod"
+                echo "Supported stages: dev, qa, sandbox, prod"
                 exit 1
                 ;;
             esac
@@ -173,16 +173,16 @@ jobs:
             circleci run release update "$DEPLOY_MARKER_NAME" --status=FAILED
 
 workflows:
-  deploy-qa:
+  deploy-dev:
     when:
       matches:
-        pattern: '^qa:[a-z0-9*-]+$'
+        pattern: '^(dev|qa):[a-z0-9*-]+$'
         value: << pipeline.deploy.environment_name >>
     jobs:
       - deploy-from-artifact:
           context: aws-dev
 
-  deploy-non-qa:
+  deploy-prod:
     when:
       matches:
         pattern: '^(sandbox|prod):[a-z0-9*-]+$'

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -136,14 +136,20 @@ npm run deploy -- --stage=<stage> [--organization=<organization>]
 ```
 
 Supported deploy environments:
+- `dev:<organization>`
+- `dev:*`
 - `qa:*`
 - `sandbox:*`
 - `prod:*`
-- specific environments such as `qa:qa2`, `sandbox:banana`, `prod:apple`
+- specific environments such as `dev:nick`, `qa:qa2`, `sandbox:banana`, `prod:apple`
 
-Role selection:
-- `qa:*` deploys assume the dev account role
-- `sandbox:*` and `prod:*` deploys assume the prod account role
+Dev-account deploys:
+- `dev:<organization>` or `dev:*`
+- `qa:*`
+
+Prod-account deploys:
+- `sandbox:*`
+- `prod:*`
 
 Artifact ownership:
 - the release artifact is published to the dev-account bucket


### PR DESCRIPTION
We might as well allow deploying to dev environments from circleci.  I just tried it and forget it didn't work
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roundingwell/app-frontend/pull/1636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deploying to a new "dev" stage alongside existing stages; deployment routing and validation updated to recognize dev targets.

* **Documentation**
  * Updated deployment docs and examples to include dev targets and clarify which environment patterns use the dev account vs the prod account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->