### PR TITLE
Add RingCX embeddable example package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "packages/care-ops-datadog",
     "packages/care-ops-five9",
     "packages/care-ops-fontawesome",
+    "packages/care-ops-ringcx",
     "packages/care-ops-ringcentral"
   ],
   "scripts": {

--- a/packages/care-ops-ringcx/README.md
+++ b/packages/care-ops-ringcx/README.md
@@ -1,0 +1,65 @@
+# RingCX Embeddable Example Package
+
+This package shows what a RingCX integration would look like in the same shape as the existing dialer packages, but using the RingCX Embeddable iframe and documented `postMessage` transport.
+
+## What it implements
+
+- `init(options)` to mount the RingCX panel in a Marionette region
+- `call(number, action)` to queue and send a documented `rc-ev-clickToDial` message
+- Service registration on the documented `rc-ev-init` event
+- Request handlers for:
+  - `rc-ev-logCall`
+  - `rc-ev-matchContacts`
+  - `rc-ev-matchCallLogs`
+  - `rc-ev-viewLead`
+- Push event listeners for:
+  - `rc-ev-ringCall`
+  - `rc-ev-newCall`
+  - `rc-ev-endCall`
+- Preserves the full RingCX `rc-ev-logCall` payload so callers can read `task.dispositionId` and `task.notes`
+- Keeps the ended-call UI visible until the RingCX `rc-ev-logCall` request arrives with disposition data
+- Marks transferred calls when `call.session.transferSessions[call.session.sessionId]` is present in the RingCX call payload
+
+## Usage
+
+```javascript
+import { init, call } from '@roundingwell/care-ops-ringcx';
+
+init({
+  region,
+  widgetUrl: 'https://cdn.labs.ringcentral.com/ringcx-embeddable/1.0.0/app.html',
+  serviceName: 'CareOps',
+  onCallLog(callLog, { actionId }) {
+    console.log('log call', actionId, callLog.task.dispositionId, callLog.task.notes);
+  },
+  onTransferredCall(call) {
+    console.log('transferred call', call.session.transferSessions[call.session.sessionId]);
+  },
+  onMatchContacts(queries) {
+    return {};
+  },
+  onMatchCallLogs(queries) {
+    return {};
+  },
+  onViewLead(lead) {
+    console.log('view lead', lead);
+  },
+});
+
+call('+16599999999', { id: 'action-123' });
+```
+
+## Notes
+
+- This package uses the iframe/message-transport path from the RingCX docs, not the `RCAdapter` global.
+- The callback hooks are intentionally app-specific extension points. RingCX documents the request names and transport shape, but not your CRM's storage model.
+- The default widget URL matches the current RingCX Embeddable 1.0.0 beta README.
+- The earlier `app-frontend` RingCentral PR got stuck because it modeled state off `rc-call-end-notify` and had no verified disposition-complete signal. This example uses the RingCX `rc-ev-logCall` request, whose source payload includes `task.dispositionId` and `task.notes`.
+- RingCX exposes transfer state in call/session data, but the public parent-to-widget message types do not expose a documented transfer command. This package can detect transferred calls; it does not claim to initiate transfers from the outer app UI.
+
+## Sources
+
+- https://github.com/ringcentral/engage-voice-embeddable
+- https://github.com/ringcentral/engage-voice-embeddable/blob/1.x/docs/api.md
+- https://github.com/ringcentral/engage-voice-embeddable/blob/1.x/docs/message-transport.md
+- https://github.com/ringcentral/engage-voice-embeddable/blob/1.x/docs/call-events.md

--- a/packages/care-ops-ringcx/index.js
+++ b/packages/care-ops-ringcx/index.js
@@ -1,0 +1,14 @@
+import RingCXApp from './ringcx_app';
+
+let dialerApp;
+
+function call(number, action) {
+  return dialerApp?.call(number, action);
+}
+
+function init(options) {
+  dialerApp = new RingCXApp(options);
+  return dialerApp;
+}
+
+export { call, init };

--- a/packages/care-ops-ringcx/package.json
+++ b/packages/care-ops-ringcx/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@roundingwell/care-ops-ringcx",
+  "version": "1.0.0",
+  "description": "RingCX Embeddable integration example",
+  "main": "index.js",
+  "type": "module",
+  "private": true
+}

--- a/packages/care-ops-ringcx/ringcx.scss
+++ b/packages/care-ops-ringcx/ringcx.scss
@@ -1,0 +1,71 @@
+$ringcx-color: #f58220;
+$ringcx-color-hover: #d66c16;
+$ringcx-call-active: color(green);
+$ringcx-call-active-hover: color(green, dark);
+
+.ringcx-wrapper {
+  border-radius: 8px 8px 0 0;
+  bottom: 0;
+  position: fixed;
+  right: 40px;
+  width: 300px;
+}
+
+.ringcx-panel {
+  background: white;
+  border-radius: 8px 8px 0 0;
+  box-shadow: 0 4px 10px rgb(0 0 0 / 20%);
+  display: flex;
+  flex-direction: column;
+  height: 36px;
+  overflow: hidden;
+  transition: height 0.2s ease;
+
+  .ringcx-wrapper.is-open & {
+    height: 80vh;
+  }
+}
+
+.ringcx-panel__header {
+  align-items: center;
+  background-color: $ringcx-color;
+  border: 0;
+  border-radius: 8px 8px 0 0;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  flex: 0 0 auto;
+  font-weight: bold;
+  justify-content: space-between;
+  padding: 8px 16px;
+  transition: background-color 0.15s linear;
+
+  .ringcx-wrapper.is-open &.is-call-active,
+  &.is-call-active {
+    background-color: $ringcx-call-active;
+
+    &:hover {
+      background-color: $ringcx-call-active-hover;
+    }
+  }
+
+  &:hover {
+    background-color: $ringcx-color-hover;
+  }
+
+  .icon.fa-window-minimize {
+    transform: translateY(-4px);
+  }
+}
+
+.ringcx-panel__iframe {
+  min-height: 0;
+  pointer-events: none;
+  visibility: hidden;
+
+  .ringcx-wrapper.is-open & {
+    flex: 1 1 auto;
+    pointer-events: auto;
+    visibility: visible;
+  }
+}

--- a/packages/care-ops-ringcx/ringcx_app.js
+++ b/packages/care-ops-ringcx/ringcx_app.js
@@ -1,0 +1,240 @@
+import dayjs from 'dayjs';
+
+import App from 'js/base/app';
+
+import RingCXTransport from './ringcx_transport';
+import { LayoutView } from './ringcx_views';
+
+const DEFAULT_FRAME_ID = 'care-ops-ringcx-frame';
+const DEFAULT_SERVICE_NAME = 'CareOps';
+const DEFAULT_WIDGET_URL = 'https://cdn.labs.ringcentral.com/ringcx-embeddable/1.0.0/app.html';
+
+function getOrigin(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '*';
+  }
+}
+
+export default App.extend({
+  stateEvents: {
+    'change:isReady': 'onReadyChange',
+  },
+  initialize({
+    frameId = DEFAULT_FRAME_ID,
+    serviceName = DEFAULT_SERVICE_NAME,
+    service = {},
+    widgetUrl = DEFAULT_WIDGET_URL,
+    onCallLog,
+    onMatchContacts,
+    onMatchCallLogs,
+    onViewLead,
+    onPushEvent,
+    onTransferredCall,
+  } = {}) {
+    this.frameId = frameId;
+    this.service = {
+      name: serviceName,
+      callLoggerEnabled: true,
+      contactMatcherEnabled: true,
+      callLogMatcherEnabled: true,
+      ...service,
+    };
+    this.widgetUrl = widgetUrl;
+    this.onCallLog = onCallLog;
+    this.onMatchContacts = onMatchContacts;
+    this.onMatchCallLogs = onMatchCallLogs;
+    this.onViewLead = onViewLead;
+    this.onPushEvent = onPushEvent;
+    this.onTransferredCall = onTransferredCall;
+    this.transport = new RingCXTransport({
+      frameId,
+      widgetOrigin: getOrigin(widgetUrl),
+      onInit: this._handleInit.bind(this),
+      onPush: this._handlePush.bind(this),
+      onRequest: this._handleRequest.bind(this),
+    });
+  },
+  startAfterInitialized: true,
+  onStart() {
+    this.showView(new LayoutView({
+      model: this.getState(),
+      frameId: this.frameId,
+      widgetUrl: this.widgetUrl,
+    }));
+  },
+  onBeforeDestroy() {
+    this.transport?.destroy();
+  },
+  onReadyChange() {
+    this._call();
+  },
+  call(number, action) {
+    if (!number) return false;
+
+    this.setState({
+      actionId: action?.id || null,
+      isOpen: true,
+      pendingCall: number,
+    });
+
+    return this._call();
+  },
+  _call() {
+    const number = this.getState('pendingCall');
+
+    if (!this.getState('isReady') || !number) return false;
+
+    const didSend = this.transport.clickToDial(number);
+
+    if (didSend) {
+      this.setState('pendingCall', null);
+    }
+
+    return didSend;
+  },
+  _handleInit() {
+    this.transport.registerService(this.service);
+    this.setState({
+      isOpen: true,
+      isReady: true,
+    });
+  },
+  _handlePush(payload = {}) {
+    const currentCall = payload.call || null;
+
+    this.onPushEvent?.(payload, this);
+
+    if (payload.type === 'rc-ev-ringCall') {
+      this.setState({
+        currentCall,
+        isCallEnded: false,
+        isOpen: true,
+        isRinging: true,
+        isTransferredCall: this._isTransferredCall(currentCall),
+      });
+      this._notifyTransferredCall(currentCall);
+      return;
+    }
+
+    if (payload.type === 'rc-ev-newCall') {
+      this.setState({
+        callTime: dayjs(),
+        currentCall,
+        isCallEnded: false,
+        isCalling: true,
+        isOpen: true,
+        isRinging: false,
+        isTransferredCall: this._isTransferredCall(currentCall),
+      });
+      this._notifyTransferredCall(currentCall);
+      return;
+    }
+
+    if (payload.type === 'rc-ev-endCall') {
+      this.setState({
+        currentCall,
+        isCallEnded: true,
+        isCalling: false,
+        isRinging: false,
+        isTransferredCall: this._isTransferredCall(currentCall),
+      });
+      this._notifyTransferredCall(currentCall);
+    }
+  },
+  async _handleRequest(message = {}) {
+    const { payload = {}, requestId } = message;
+    const context = this._getRequestContext();
+
+    try {
+      if (payload.requestType === 'rc-ev-logCall') {
+        await this._handleLogCallRequest({ context, payload, requestId });
+        return;
+      }
+
+      if (payload.requestType === 'rc-ev-matchContacts') {
+        await this._handleMatchContactsRequest({ context, payload, requestId });
+        return;
+      }
+
+      if (payload.requestType === 'rc-ev-matchCallLogs') {
+        await this._handleMatchCallLogsRequest({ context, payload, requestId });
+        return;
+      }
+
+      if (payload.requestType === 'rc-ev-viewLead') {
+        await this._handleViewLeadRequest({ context, payload, requestId });
+        return;
+      }
+
+      this._respondUnsupportedRequest({ requestId, requestType: payload.requestType });
+    } catch(error) {
+      this.transport.respond({
+        requestId,
+        error: error.message,
+      });
+    }
+  },
+  _getRequestContext() {
+    return {
+      actionId: this.getState('actionId'),
+      app: this,
+    };
+  },
+  async _handleLogCallRequest({ context, payload, requestId }) {
+    this.setState(this._getLogCallState(payload.data));
+    await this.onCallLog?.(payload.data, context);
+    this._notifyTransferredCall(payload.data?.call);
+    this.transport.respond({ requestId, result: 'ok' });
+  },
+  _getLogCallState(data) {
+    const state = {
+      actionId: this.getState('actionId'),
+      callLogData: data,
+      callTime: this.getState('callTime'),
+      currentCall: data?.call || this.getState('currentCall'),
+      isCallEnded: this.getState('isCallEnded'),
+      isTransferredCall: this._isTransferredCall(data?.call),
+    };
+
+    if (!data?.task?.dispositionId) return state;
+
+    state.actionId = null;
+    state.callTime = null;
+    state.isCallEnded = false;
+
+    return state;
+  },
+  async _handleMatchContactsRequest({ context, payload, requestId }) {
+    const result = await this.onMatchContacts?.(payload.data, context);
+
+    this.transport.respond({ requestId, result: result || {} });
+  },
+  async _handleMatchCallLogsRequest({ context, payload, requestId }) {
+    const result = await this.onMatchCallLogs?.(payload.data, context);
+
+    this.transport.respond({ requestId, result: result || {} });
+  },
+  async _handleViewLeadRequest({ context, payload, requestId }) {
+    await this.onViewLead?.(payload.data, context);
+    this.transport.respond({ requestId, result: 'ok' });
+  },
+  _respondUnsupportedRequest({ requestId, requestType }) {
+    this.transport.respond({
+      requestId,
+      error: `Unsupported request type: ${ requestType }`,
+    });
+  },
+  _isTransferredCall(call) {
+    const sessionId = call?.session?.sessionId;
+
+    if (!sessionId) return false;
+
+    return !!call.session.transferSessions?.[sessionId];
+  },
+  _notifyTransferredCall(call) {
+    if (!this._isTransferredCall(call)) return;
+    this.onTransferredCall?.(call, { actionId: this.getState('actionId'), app: this });
+  },
+});

--- a/packages/care-ops-ringcx/ringcx_transport.js
+++ b/packages/care-ops-ringcx/ringcx_transport.js
@@ -1,0 +1,98 @@
+const PUSH_MESSAGE_TYPE = 'MessageTransport-push';
+const REQUEST_MESSAGE_TYPE = 'MessageTransport-request';
+const RESPONSE_MESSAGE_TYPE = 'MessageTransport-response';
+
+export default class RingCXTransport {
+  constructor({
+    frameId,
+    widgetOrigin = '*',
+    onInit = () => {},
+    onPush = () => {},
+    onRequest = () => {},
+  }) {
+    this.frameId = frameId;
+    this.widgetOrigin = widgetOrigin;
+    this.onInit = onInit;
+    this.onPush = onPush;
+    this.onRequest = onRequest;
+
+    this._onMessage = this._onMessage.bind(this);
+    window.addEventListener('message', this._onMessage);
+  }
+
+  destroy() {
+    window.removeEventListener('message', this._onMessage);
+  }
+
+  clickToDial(phoneNumber) {
+    return this.send({
+      type: 'rc-ev-clickToDial',
+      phoneNumber,
+    });
+  }
+
+  registerService(service) {
+    return this.send({
+      type: 'rc-ev-register',
+      service,
+    });
+  }
+
+  respond({ requestId, result, error }) {
+    const frame = this.getFrame();
+
+    if (!frame?.contentWindow) return false;
+
+    frame.contentWindow.postMessage({
+      type: RESPONSE_MESSAGE_TYPE,
+      requestId,
+      result,
+      error,
+    }, this.widgetOrigin);
+
+    return true;
+  }
+
+  send(payload) {
+    const frame = this.getFrame();
+
+    if (!frame?.contentWindow) return false;
+
+    frame.contentWindow.postMessage({
+      type: PUSH_MESSAGE_TYPE,
+      payload,
+    }, this.widgetOrigin);
+
+    return true;
+  }
+
+  getFrame() {
+    return document.getElementById(this.frameId);
+  }
+
+  _isWidgetMessage(event) {
+    if (!event?.data) return false;
+    if (this.widgetOrigin === '*') return true;
+    return event.origin === this.widgetOrigin;
+  }
+
+  _onMessage(event) {
+    if (!this._isWidgetMessage(event)) return;
+
+    const { data } = event;
+
+    if (data.type === 'rc-ev-init') {
+      this.onInit(data);
+      return;
+    }
+
+    if (data.type === PUSH_MESSAGE_TYPE) {
+      this.onPush(data.payload);
+      return;
+    }
+
+    if (data.type === REQUEST_MESSAGE_TYPE) {
+      this.onRequest(data);
+    }
+  }
+}

--- a/packages/care-ops-ringcx/ringcx_views.js
+++ b/packages/care-ops-ringcx/ringcx_views.js
@@ -1,0 +1,154 @@
+import { delay } from 'underscore';
+import dayjs from 'dayjs';
+
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import './ringcx.scss';
+
+function timeSince(startTime) {
+  const now = dayjs();
+  const diff = now.diff(startTime);
+  const minutes = Math.floor(diff / 60000);
+  const seconds = Math.floor((diff % 60000) / 1000);
+
+  return {
+    minutes: String(minutes).padStart(2, '0'),
+    seconds: String(seconds).padStart(2, '0'),
+  };
+}
+
+const TimerView = View.extend({
+  initialize({ startTime }) {
+    this.startTime = startTime;
+  },
+  onRender() {
+    delay(() => this.render(), 1000);
+  },
+  template: hbs`Call: {{ minutes }}:{{ seconds }}`,
+  templateContext() {
+    return timeSince(this.startTime);
+  },
+});
+
+const CallEndedView = View.extend({
+  initialize({ startTime }) {
+    this.startTime = startTime;
+  },
+  template: hbs`Call Ended: {{ minutes }}:{{ seconds }}`,
+  templateContext() {
+    return timeSince(this.startTime);
+  },
+});
+
+const HeadingView = View.extend({
+  getTemplate() {
+    if (!this.model.get('isReady')) return hbs`Connecting`;
+    if (this.model.get('isCallEnded')) return hbs`Call Ended`;
+    if (this.model.get('isTransferredCall')) return hbs`Transferred Call`;
+    if (this.model.get('isRinging')) return hbs`Ringing`;
+    if (this.model.get('pendingCall')) return hbs`Dialing`;
+    return hbs`RingCX`;
+  },
+});
+
+const StatusView = View.extend({
+  getTemplate() {
+    if (!this.model.get('isOpen')) return hbs`{{far "window-maximize"}}`;
+    return hbs`{{far "window-minimize"}}`;
+  },
+});
+
+const LayoutView = View.extend({
+  className: 'ringcx-wrapper',
+  template: hbs`
+    <div class="ringcx-panel">
+      <div class="ringcx-panel__header js-header">
+        {{fas "phone"}}
+        <span data-heading-region></span>
+        <span data-status-region></span>
+      </div>
+      <iframe
+        id="{{ frameId }}"
+        class="ringcx-panel__iframe"
+        src="{{ widgetUrl }}"
+        title="RingCX Dialer"
+        allow="microphone"
+        loading="lazy"
+        referrerpolicy="no-referrer"
+        sandbox="allow-scripts allow-forms allow-same-origin allow-popups">
+      </iframe>
+    </div>
+  `,
+  regions: {
+    heading: '[data-heading-region]',
+    status: '[data-status-region]',
+  },
+  modelEvents: {
+    'change:callTime': 'showHeading',
+    'change:isCallEnded': 'showHeading',
+    'change:isCalling': 'showHeading',
+    'change:isOpen': 'onChangeIsOpen',
+    'change:isReady': 'showHeading',
+    'change:isRinging': 'showHeading',
+    'change:isTransferredCall': 'showHeading',
+    'change:pendingCall': 'showHeading',
+  },
+  ui: {
+    header: '.js-header',
+  },
+  triggers: {
+    'click @ui.header': 'click:header',
+  },
+  templateContext() {
+    return {
+      frameId: this.getOption('frameId'),
+      widgetUrl: this.getOption('widgetUrl'),
+    };
+  },
+  onClickHeader() {
+    this.model.set('isOpen', !this.model.get('isOpen'));
+  },
+  onChangeIsOpen() {
+    this.togglePanel();
+    this.showPanelStatus();
+  },
+  onRender() {
+    this.togglePanel();
+    this.showHeading();
+    this.showPanelStatus();
+  },
+  togglePanel() {
+    this.$el.toggleClass('is-open', this.model.get('isOpen'));
+  },
+  showHeading() {
+    if (this.model.get('isCallEnded') && this.model.get('callTime')) {
+      this.showChildView('heading', new CallEndedView({
+        startTime: this.model.get('callTime'),
+      }));
+      return;
+    }
+
+    if (
+      this.model.get('isCalling')
+      && this.model.get('callTime')
+      && !this.model.get('isTransferredCall')
+    ) {
+      this.showChildView('heading', new TimerView({
+        startTime: this.model.get('callTime'),
+      }));
+      return;
+    }
+
+    this.showChildView('heading', new HeadingView({ model: this.model }));
+  },
+  showPanelStatus() {
+    this.showChildView('status', new StatusView({ model: this.model }));
+  },
+});
+
+export {
+  CallEndedView,
+  LayoutView,
+  TimerView,
+};


### PR DESCRIPTION
I haven't reviewed this much, but I gave codex the other PR and the disposition issue we're having there and told it to read the docs.  here's how it explained the work:

This PR adds a separate example package at packages/care-ops-ringcx instead of reworking the existing packages/care-ops-ringcentral. The package shows what a RingCX integration should look like when modeled after our real Five9 package shape: init() and call() exports, an embeddable iframe panel, documented message transport, call-state handling, and callback hooks for call logging, contact matching, call-log matching, and lead viewing. It also preserves the full RingCX logCall payload so the caller can read disposition data from task.dispositionId and task.notes, and it detects transferred calls from the RingCX session metadata.

I got to this result by comparing our current Five9 integration with the current RingCentral package, then checking the RingCX embeddable docs and source rather than guessing. The key detail came from the RingCX source and your prior PR review on [#1633](https://github.com/RoundingWell/app-frontend/pull/1633#pullrequestreview-4049797259): the older RingCentral embeddable notify events did not give a trustworthy disposition-complete signal, which is why that effort stalled. For RingCX, the correct terminal event is the documented rc-ev-logCall request, whose source payload includes { call, task, sessionId }, so this example keeps ended-call state until that request arrives instead of clearing on an arbitrary timeout. I did not implement outer-UI-triggered transfer because the public RingCX parent/iframe message contract does not document a transfer command; the example only handles transferred-call detection, which is the part the docs and source actually support.
