### PR TITLE
Fix alignment of minimize icon in five9 panel header

### DIFF
--- a/packages/care-ops-five9/five9.scss
+++ b/packages/care-ops-five9/five9.scss
@@ -43,6 +43,10 @@ $five9-call-ended-hover: color(red, dark);
   transition: background-color 0.15s;
   transition-timing-function: linear;
 
+  .icon.fa-window-minimize {
+    transform: translateY(-4px);
+  }
+
   &:hover {
     background-color: $five9-color-hover;
   }


### PR DESCRIPTION
Before:

<img width="313" height="68" alt="Screenshot 2026-04-02 at 2 13 50 PM" src="https://github.com/user-attachments/assets/211d415a-8f7f-4cbd-9e81-09e2e1257f67" />

After:

<img width="324" height="63" alt="Screenshot 2026-04-02 at 2 13 59 PM" src="https://github.com/user-attachments/assets/b2eb52f6-ce7b-4884-8ddc-4830f1be2dfd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the visual positioning of the minimize icon in the Five9 panel header for improved alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->