### PR TITLE
Add Datadog version override support for forms

### DIFF
--- a/packages/care-ops-config/index.js
+++ b/packages/care-ops-config/index.js
@@ -34,23 +34,27 @@ function getAppVersion() {
   return configState.app.version;
 }
 
-function getDatadogLogsOptions(service) {
+function getDatadogVersion(version) {
+  return version || getAppVersion();
+}
+
+function getDatadogLogsOptions({ service, version } = {}) {
   const datadog = configState.datadog;
   return {
     env: getEnvName(),
     service,
     clientToken: datadog.clientToken,
-    version: getAppVersion(),
+    version: getDatadogVersion(version),
   };
 }
 
-function getDatadogRumOptions(service) {
+function getDatadogRumOptions({ service, version } = {}) {
   const datadog = configState.datadog;
   return {
     env: getEnvName(),
     service,
     clientToken: datadog.clientToken,
-    version: getAppVersion(),
+    version: getDatadogVersion(version),
     applicationId: datadog.applicationId,
   };
 }

--- a/packages/care-ops-forms/index.js
+++ b/packages/care-ops-forms/index.js
@@ -44,13 +44,14 @@ function postFormsVersion(targetWindow = parent, targetOrigin = window.origin) {
 function initFormsDatadog({
   isPdfPrinter,
   service,
+  version,
 }) {
   if (location.hostname === 'localhost') return Promise.resolve();
 
   if (!formsDatadogPromise) {
     formsDatadogPromise = fetchFormsConfig()
       .then(() => {
-        const logOptions = getDatadogLogsOptions(service);
+        const logOptions = getDatadogLogsOptions({ service, version });
 
         if (!logOptions.clientToken) return;
 
@@ -58,7 +59,7 @@ function initFormsDatadog({
 
         if (isPdfPrinter) return;
 
-        const rumOptions = getDatadogRumOptions(service);
+        const rumOptions = getDatadogRumOptions({ service, version });
 
         if (!rumOptions.applicationId) return;
 
@@ -76,6 +77,7 @@ function initFormsDatadog({
 
 async function initFormServices({
   ddService = 'customer-forms',
+  ddVersion,
   targetWindow = parent,
   targetOrigin = window.origin,
 } = {}) {
@@ -85,6 +87,7 @@ async function initFormServices({
   await initFormsDatadog({
     isPdfPrinter: isPdfFormRequest(),
     service: ddService,
+    version: ddVersion,
   });
 }
 

--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -8,8 +8,8 @@ function initDataDog() {
 
   const service = 'app-frontend';
 
-  initLogs(getDatadogLogsOptions(service));
-  initRum(getDatadogRumOptions(service));
+  initLogs(getDatadogLogsOptions({ service }));
+  initRum(getDatadogRumOptions({ service }));
 }
 
 export {


### PR DESCRIPTION
Shortcut Story ID: [sc-new-story]

## Summary
Allows forms consumers to pass a Datadog release version that differs from `appConfig.json`, while preserving the existing fallback to `app.version`.  Needed so that async deployment of forms and formio can send map files to datadog.

## Changes
- update Datadog config helpers to accept `{ service, version }`
- add optional `ddVersion` passthrough in `care-ops-forms`
- update frontend Datadog bootstrap to the new helper signature

## Validation
- `npx eslint packages/care-ops-config/index.js packages/care-ops-forms/index.js src/js/datadog.js`
- `npm run build:shared-runtime`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal Datadog configuration system to accept optional version parameters alongside service names, improving configuration flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->