### PR TITLE
Improve CircleCI deploy marker fan-out for stage-wide deploys

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -114,9 +114,6 @@ jobs:
               deploy_organization=""
             fi
 
-            marker_env_slug="${target_env//:/-}"
-            marker_env_slug="${marker_env_slug//\*/all}"
-            marker_name="deploy-${marker_env_slug}-${target_version}"
             deploy_run_url="${CIRCLE_BUILD_URL:-https://app.circleci.com/pipelines/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PIPELINE_ID}}"
 
             {
@@ -124,10 +121,34 @@ jobs:
               echo "export DEPLOY_TARGET_VERSION=$target_version"
               echo "export DEPLOY_STAGE=$deploy_stage"
               echo "export DEPLOY_ORGANIZATION=$deploy_organization"
-              echo "export DEPLOY_MARKER_NAME=$marker_name"
               echo "export DEPLOY_RUN_URL=$deploy_run_url"
             } >> "$BASH_ENV"
       - setup-aws-oidc
+      - run:
+          name: Resolve deploy marker environments
+          command: |
+            set -euo pipefail
+
+            deploy_tmp_dir="$(mktemp -d)"
+            marker_env_file="$deploy_tmp_dir/deploy-marker-environments.txt"
+            deploy_targets_file="$deploy_tmp_dir/deploy-targets.json"
+            deploy_marker_status_file="$deploy_tmp_dir/deploy-marker-status.json"
+
+            if [ -n "$DEPLOY_ORGANIZATION" ]; then
+              npm run deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
+            else
+              npm run deploy -- --stage="$DEPLOY_STAGE" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
+            fi
+
+            if [ ! -s "$marker_env_file" ]; then
+              echo "No deploy marker environments were resolved"
+              exit 1
+            fi
+
+            printf 'export DEPLOY_TMP_DIR=%q\n' "$deploy_tmp_dir" >> "$BASH_ENV"
+            printf 'export DEPLOY_MARKER_ENV_FILE=%q\n' "$marker_env_file" >> "$BASH_ENV"
+            printf 'export DEPLOY_MARKER_STATUS_FILE=%q\n' "$deploy_marker_status_file" >> "$BASH_ENV"
+            printf 'export DEPLOY_TARGETS_FILE=%q\n' "$deploy_targets_file" >> "$BASH_ENV"
       - run:
           name: Download release artifact
           no_output_timeout: 5m
@@ -149,31 +170,41 @@ jobs:
           name: CircleCI Deploy Marker Plan
           command: |
             set -euo pipefail
-            circleci run release plan "$DEPLOY_MARKER_NAME" \
-              --environment-name="$DEPLOY_TARGET_ENV" \
+            node scripts/deploy-markers.js plan \
               --component-name="app-frontend" \
+              --env-file="$DEPLOY_MARKER_ENV_FILE" \
               --target-version="$DEPLOY_TARGET_VERSION"
       - run:
           name: Deploy selected target
           command: |
             set -euo pipefail
             if [ -n "$DEPLOY_ORGANIZATION" ]; then
-              npm run deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION"
+              npm run deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --read-targets-file="$DEPLOY_TARGETS_FILE" --marker-status-file="$DEPLOY_MARKER_STATUS_FILE"
             else
-              npm run deploy -- --stage="$DEPLOY_STAGE"
+              npm run deploy -- --stage="$DEPLOY_STAGE" --read-targets-file="$DEPLOY_TARGETS_FILE" --marker-status-file="$DEPLOY_MARKER_STATUS_FILE"
             fi
       - run:
           name: CircleCI Deploy Marker Success
           when: on_success
           command: |
             set -euo pipefail
-            circleci run release update "$DEPLOY_MARKER_NAME" --status=SUCCESS
+            node scripts/deploy-markers.js update \
+              --deploy-result="success" \
+              --env-file="$DEPLOY_MARKER_ENV_FILE" \
+              --status-file="$DEPLOY_MARKER_STATUS_FILE" \
+              --target-environment="$DEPLOY_TARGET_ENV" \
+              --target-version="$DEPLOY_TARGET_VERSION"
       - run:
           name: CircleCI Deploy Marker Failure
           when: on_fail
           command: |
             set -euo pipefail
-            circleci run release update "$DEPLOY_MARKER_NAME" --status=FAILED
+            node scripts/deploy-markers.js update \
+              --deploy-result="failure" \
+              --env-file="$DEPLOY_MARKER_ENV_FILE" \
+              --status-file="$DEPLOY_MARKER_STATUS_FILE" \
+              --target-environment="$DEPLOY_TARGET_ENV" \
+              --target-version="$DEPLOY_TARGET_VERSION"
       - run:
           name: Notify QA2 E2E repo
           when: on_success

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -134,7 +134,12 @@ The deploy pipeline in [`.circleci/deploy.yml`](../.circleci/deploy.yml):
 ```bash
 npm run deploy -- --stage=<stage> [--organization=<organization>]
 ```
-5. For QA deploys that include `qa2` (`qa:qa2` and `qa:*`), posts `qa2_deploy_succeeded` to `RoundingWell/app-tests`
+5. Writes CircleCI deploy markers for every environment resolved from the deploy target:
+   - specific targets such as `qa:qa2` write one marker for that concrete environment
+   - stage-wide targets such as `qa:*`, `sandbox:*`, and `prod:*` retain the wildcard marker and also write one marker per concrete environment discovered from CloudFormation tags for that stage
+   - stage-wide deploys continue through every resolved environment and fail the job at the end if any targets fail
+   - if a stage-wide deploy partially succeeds, concrete environment markers reflect the per-environment outcomes while the wildcard marker reflects the overall deploy result
+6. For QA deploys that include `qa2` (`qa:qa2` and `qa:*`), posts `qa2_deploy_succeeded` to `RoundingWell/app-tests`
 
 Supported deploy environments:
 - `dev:<organization>`
@@ -187,6 +192,7 @@ npm run release
    - `environment_name=<stage>:<organization|*>`
    - `target_version=<release-tag>`
 4. The deploy pipeline downloads the artifact for that tag and deploys the target environment.
+5. For stage-wide `dev:*`, `qa:*`, `sandbox:*`, and `prod:*` deploys, the pipeline also writes markers for each concrete environment it resolved for that stage so later environment-specific deploys stay visible in CircleCI Deploy.
 
 The AWS account must expose the deploy target to run successfully:
 - Secrets Manager must have a secret named `customer/<stage>/<organization>`

--- a/scripts/deploy-markers.js
+++ b/scripts/deploy-markers.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+export function buildMarkerName(environment, version) {
+  const markerEnvSlug = environment.replaceAll(':', '-').replaceAll('*', 'all');
+  return `deploy-${ markerEnvSlug }-${ version }`;
+}
+
+export function readMarkerEnvironments(envFile) {
+  return fs.readFileSync(envFile, 'utf8')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+export function readMarkerStatus(statusFile) {
+  if (!statusFile || !fs.existsSync(statusFile)) {
+    return {
+      successfulEnvironments: [],
+      failedEnvironments: [],
+    };
+  }
+
+  return JSON.parse(fs.readFileSync(statusFile, 'utf8'));
+}
+
+export function buildMarkerUpdates({
+  deployResult,
+  failedEnvironments,
+  plannedEnvironments,
+  successfulEnvironments,
+  targetEnvironment,
+}) {
+  if (deployResult === 'success') {
+    return plannedEnvironments.map(environment => ({
+      environment,
+      status: 'SUCCESS',
+    }));
+  }
+
+  const updates = Object.create(null);
+  const addUpdate = (environment, status) => {
+    if (!environment || Object.hasOwn(updates, environment)) return;
+    updates[environment] = status;
+  };
+
+  if (targetEnvironment.endsWith(':*')) {
+    addUpdate(targetEnvironment, 'FAILED');
+  }
+
+  for (const environment of successfulEnvironments) {
+    addUpdate(environment, 'SUCCESS');
+  }
+
+  for (const environment of failedEnvironments) {
+    addUpdate(environment, 'FAILED');
+  }
+
+  if (!failedEnvironments.length && !successfulEnvironments.length) {
+    addUpdate(targetEnvironment, 'FAILED');
+  }
+
+  return Object.entries(updates)
+    .map(([environment, status]) => ({ environment, status }));
+}
+
+function runCircleCi(args) {
+  execFileSync('circleci', args, { stdio: 'inherit' });
+}
+
+function planMarkers({ componentName, envFile, targetVersion }) {
+  for (const environment of readMarkerEnvironments(envFile)) {
+    runCircleCi([
+      'run',
+      'release',
+      'plan',
+      buildMarkerName(environment, targetVersion),
+      `--environment-name=${ environment }`,
+      `--component-name=${ componentName }`,
+      `--target-version=${ targetVersion }`,
+    ]);
+  }
+}
+
+function updateMarkers({
+  deployResult,
+  envFile,
+  statusFile,
+  targetEnvironment,
+  targetVersion,
+}) {
+  const plannedEnvironments = readMarkerEnvironments(envFile);
+  const {
+    failedEnvironments = [],
+    successfulEnvironments = [],
+  } = readMarkerStatus(statusFile);
+  const updates = buildMarkerUpdates({
+    deployResult,
+    failedEnvironments,
+    plannedEnvironments,
+    successfulEnvironments,
+    targetEnvironment,
+  });
+
+  for (const { environment, status } of updates) {
+    runCircleCi([
+      'run',
+      'release',
+      'update',
+      buildMarkerName(environment, targetVersion),
+      `--status=${ status }`,
+    ]);
+  }
+}
+
+function main() {
+  const { positionals, values } = parseArgs({
+    allowPositionals: true,
+    options: {
+      'component-name': { type: 'string' },
+      'deploy-result': { type: 'string' },
+      'env-file': { type: 'string' },
+      'status-file': { type: 'string' },
+      'target-environment': { type: 'string' },
+      'target-version': { type: 'string' },
+    },
+  });
+
+  const [command] = positionals;
+
+  if (!command) {
+    throw new Error('Expected a command: plan or update');
+  }
+
+  if (!values['env-file'] || !values['target-version']) {
+    throw new Error('--env-file and --target-version are required');
+  }
+
+  if (command === 'plan') {
+    if (!values['component-name']) {
+      throw new Error('--component-name is required for plan');
+    }
+
+    planMarkers({
+      componentName: values['component-name'],
+      envFile: values['env-file'],
+      targetVersion: values['target-version'],
+    });
+    return;
+  }
+
+  if (command === 'update') {
+    if (!values['deploy-result'] || !values['target-environment']) {
+      throw new Error('--deploy-result and --target-environment are required for update');
+    }
+
+    updateMarkers({
+      deployResult: values['deploy-result'],
+      envFile: values['env-file'],
+      statusFile: values['status-file'],
+      targetEnvironment: values['target-environment'],
+      targetVersion: values['target-version'],
+    });
+    return;
+  }
+
+  throw new Error(`Unsupported command: ${ command }`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/deploy-markers.test.js
+++ b/scripts/deploy-markers.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildMarkerName, buildMarkerUpdates } from './deploy-markers.js';
+
+test('buildMarkerName normalizes wildcard environments', () => {
+  assert.equal(buildMarkerName('qa:*', 'v260406.1'), 'deploy-qa-all-v260406.1');
+  assert.equal(buildMarkerName('qa:quality-assurance', 'v260406.1'), 'deploy-qa-quality-assurance-v260406.1');
+});
+
+test('buildMarkerUpdates marks every planned environment successful on complete success', () => {
+  assert.deepEqual(
+    buildMarkerUpdates({
+      deployResult: 'success',
+      failedEnvironments: [],
+      plannedEnvironments: ['qa:*', 'qa:qa2', 'qa:quality-assurance'],
+      successfulEnvironments: ['qa:qa2', 'qa:quality-assurance'],
+      targetEnvironment: 'qa:*',
+    }),
+    [
+      { environment: 'qa:*', status: 'SUCCESS' },
+      { environment: 'qa:qa2', status: 'SUCCESS' },
+      { environment: 'qa:quality-assurance', status: 'SUCCESS' },
+    ],
+  );
+});
+
+test('buildMarkerUpdates preserves partial success for stage-wide failures', () => {
+  assert.deepEqual(
+    buildMarkerUpdates({
+      deployResult: 'failure',
+      failedEnvironments: ['qa:quality-assurance'],
+      plannedEnvironments: ['qa:*', 'qa:qa2', 'qa:quality-assurance'],
+      successfulEnvironments: ['qa:qa2'],
+      targetEnvironment: 'qa:*',
+    }),
+    [
+      { environment: 'qa:*', status: 'FAILED' },
+      { environment: 'qa:qa2', status: 'SUCCESS' },
+      { environment: 'qa:quality-assurance', status: 'FAILED' },
+    ],
+  );
+});
+
+test('buildMarkerUpdates marks a failed specific environment when nothing succeeded', () => {
+  assert.deepEqual(
+    buildMarkerUpdates({
+      deployResult: 'failure',
+      failedEnvironments: [],
+      plannedEnvironments: ['prod:demonstration'],
+      successfulEnvironments: [],
+      targetEnvironment: 'prod:demonstration',
+    }),
+    [
+      { environment: 'prod:demonstration', status: 'FAILED' },
+    ],
+  );
+});
+
+test('buildMarkerUpdates marks every failed concrete environment after a continued stage-wide rollout', () => {
+  assert.deepEqual(
+    buildMarkerUpdates({
+      deployResult: 'failure',
+      failedEnvironments: ['qa:qa2', 'qa:quality-assurance'],
+      plannedEnvironments: ['qa:*', 'qa:qa2', 'qa:quality-assurance', 'qa:qa3'],
+      successfulEnvironments: ['qa:qa3'],
+      targetEnvironment: 'qa:*',
+    }),
+    [
+      { environment: 'qa:*', status: 'FAILED' },
+      { environment: 'qa:qa3', status: 'SUCCESS' },
+      { environment: 'qa:qa2', status: 'FAILED' },
+      { environment: 'qa:quality-assurance', status: 'FAILED' },
+    ],
+  );
+});

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,6 +4,7 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { parseArgs } from 'node:util';
+import fsSync from 'node:fs';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -319,30 +320,121 @@ export function formatNoOrganizationsError(stage, filterOrganization) {
   return `No environments found for stage=${ stage }${ organizationMsg }\n`;
 }
 
+export function buildDeployMarkerEnvironments(stage, filterOrganization, organizations) {
+  if (filterOrganization) {
+    return [`${ stage }:${ filterOrganization }`];
+  }
+
+  const concreteEnvironments = [...organizations]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b))
+    .map(organization => `${ stage }:${ organization }`);
+
+  return [`${ stage }:*`, ...concreteEnvironments];
+}
+
+export function writeDeployMarkerStatus(statusFile, markerStatus) {
+  if (!statusFile) return;
+  fsSync.writeFileSync(statusFile, `${ JSON.stringify(markerStatus, null, 2) }\n`);
+}
+
+export function readResolvedDeployTargets(targetsFile) {
+  if (!targetsFile) {
+    throw new Error('Resolved deploy targets file path is required.');
+  }
+
+  if (!fsSync.existsSync(targetsFile)) {
+    throw new Error(`Resolved deploy targets file not found: ${ targetsFile }`);
+  }
+
+  let payload;
+
+  try {
+    payload = JSON.parse(fsSync.readFileSync(targetsFile, 'utf8'));
+  } catch {
+    throw new Error(`Resolved deploy targets file is not valid JSON: ${ targetsFile }`);
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error(`Resolved deploy targets payload must be a JSON object: ${ targetsFile }`);
+  }
+
+  const { organizationBuckets } = payload;
+
+  if (!Array.isArray(organizationBuckets)) {
+    throw new Error(`Resolved deploy targets payload must include an organizationBuckets array: ${ targetsFile }`);
+  }
+
+  const hasInvalidEntry = organizationBuckets.some(entry => !Array.isArray(entry) || entry.length !== 2);
+
+  if (hasInvalidEntry) {
+    throw new Error(`Resolved deploy targets organizationBuckets must be an array of [key, value] entries: ${ targetsFile }`);
+  }
+
+  return new Map(organizationBuckets);
+}
+
+export function writeResolvedDeployTargets(targetsFile, organizationBuckets) {
+  if (!targetsFile) return;
+  fsSync.writeFileSync(targetsFile, `${ JSON.stringify({
+    organizationBuckets: [...organizationBuckets.entries()],
+  }, null, 2) }\n`);
+}
+
+export function formatFailedDeploymentsError(failedEnvironments) {
+  return `Deployment failed for environments: ${ failedEnvironments.join(', ') }`;
+}
+
 /**
  * Main deployment function.
  */
 async function main() {
   const { values } = parseArgs({
     options: {
+      'read-targets-file': { type: 'string' },
+      'marker-status-file': { type: 'string' },
       'stage': { type: 'string' },
       'organization': { type: 'string' },
+      'list-marker-environments': { type: 'boolean' },
+      'write-targets-file': { type: 'string' },
     },
   });
 
   const { stage, filterOrganization } = resolveDeployInputs(values);
   const organizationFilter = formatOrganizationFilter(filterOrganization);
-
+  const isListingMarkerEnvironments = values['list-marker-environments'];
   const clients = createAwsClients();
 
-  process.stdout.write(`Querying CloudFormation organizations by tags for stage: ${ stage }${ organizationFilter }\n`);
-
-  const organizationBuckets = await listStageOrganizations(clients.cloudFormation, stage, filterOrganization);
+  let organizationBuckets;
+  if (values['read-targets-file']) {
+    organizationBuckets = readResolvedDeployTargets(values['read-targets-file']);
+    if (!isListingMarkerEnvironments) {
+      process.stdout.write(`Loaded deploy targets from ${ values['read-targets-file'] }\n`);
+    }
+  } else {
+    if (!isListingMarkerEnvironments) {
+      process.stdout.write(`Querying CloudFormation organizations by tags for stage: ${ stage }${ organizationFilter }\n`);
+    }
+    organizationBuckets = await listStageOrganizations(clients.cloudFormation, stage, filterOrganization);
+    writeResolvedDeployTargets(values['write-targets-file'], organizationBuckets);
+  }
 
   if (organizationBuckets.size === 0) {
     process.stderr.write(formatNoOrganizationsError(stage, filterOrganization));
     process.exit(1);
   }
+
+  if (isListingMarkerEnvironments) {
+    const environments = buildDeployMarkerEnvironments(stage, filterOrganization, organizationBuckets.keys());
+    process.stdout.write(`${ environments.join('\n') }\n`);
+    return;
+  }
+
+  const markerStatus = {
+    failedEnvironments: [],
+    successfulEnvironments: [],
+  };
+  writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
 
   process.stdout.write(`Found ${ organizationBuckets.size } organizations to deploy:\n`);
   organizationBuckets.forEach((bucketName, organization) => {
@@ -352,7 +444,21 @@ async function main() {
   const distDir = path.join(__dirname, '../dist');
 
   for (const [organization, bucketName] of organizationBuckets) {
-    await deployToOrganization(clients, stage, organization, bucketName, distDir);
+    const environment = `${ stage }:${ organization }`;
+
+    try {
+      await deployToOrganization(clients, stage, organization, bucketName, distDir);
+      markerStatus.successfulEnvironments.push(environment);
+      writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
+    } catch (error) {
+      markerStatus.failedEnvironments.push(environment);
+      writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
+      process.stderr.write(`Deployment failed for ${ environment }: ${ error.message }\n`);
+    }
+  }
+
+  if (markerStatus.failedEnvironments.length) {
+    throw new Error(formatFailedDeploymentsError(markerStatus.failedEnvironments));
   }
 
   process.stdout.write('\nAll deployments complete!\n');

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  buildDeployMarkerEnvironments,
+  formatFailedDeploymentsError,
+  readResolvedDeployTargets,
+  writeDeployMarkerStatus,
+  writeResolvedDeployTargets,
+} from './deploy.js';
+
+test('buildDeployMarkerEnvironments retains wildcard and adds sorted concrete environments', () => {
+  assert.deepEqual(
+    buildDeployMarkerEnvironments('qa', '', ['quality-assurance', 'qa2']),
+    ['qa:*', 'qa:qa2', 'qa:quality-assurance'],
+  );
+});
+
+test('buildDeployMarkerEnvironments keeps wildcard when there are no concrete environments', () => {
+  assert.deepEqual(
+    buildDeployMarkerEnvironments('sandbox', '', []),
+    ['sandbox:*'],
+  );
+});
+
+test('buildDeployMarkerEnvironments returns only the requested concrete environment for single-target deploys', () => {
+  assert.deepEqual(
+    buildDeployMarkerEnvironments('prod', 'demonstration', ['demonstration', 'other']),
+    ['prod:demonstration'],
+  );
+});
+
+test('writeDeployMarkerStatus persists marker deployment progress', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-marker-status-'));
+  const statusFile = path.join(tempDir, 'status.json');
+
+  writeDeployMarkerStatus(statusFile, {
+    failedEnvironments: ['qa:quality-assurance'],
+    successfulEnvironments: ['qa:qa2'],
+  });
+
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(statusFile, 'utf8')),
+    {
+      failedEnvironments: ['qa:quality-assurance'],
+      successfulEnvironments: ['qa:qa2'],
+    },
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('formatFailedDeploymentsError summarizes all failed environments', () => {
+  assert.equal(
+    formatFailedDeploymentsError(['qa:qa2', 'qa:quality-assurance']),
+    'Deployment failed for environments: qa:qa2, qa:quality-assurance',
+  );
+});
+
+test('writeResolvedDeployTargets persists the resolved deploy target snapshot', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-targets-'));
+  const targetsFile = path.join(tempDir, 'targets.json');
+  const organizationBuckets = new Map([
+    ['qa2', 'bucket-a'],
+    ['quality-assurance', 'bucket-b'],
+  ]);
+
+  writeResolvedDeployTargets(targetsFile, organizationBuckets);
+
+  assert.deepEqual(
+    [...readResolvedDeployTargets(targetsFile).entries()],
+    [...organizationBuckets.entries()],
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('readResolvedDeployTargets requires a file path', () => {
+  assert.throws(
+    () => readResolvedDeployTargets(''),
+    /Resolved deploy targets file path is required/,
+  );
+});
+
+test('readResolvedDeployTargets reports a missing snapshot file clearly', () => {
+  const targetsFile = path.join(os.tmpdir(), `missing-deploy-targets-${ process.pid }.json`);
+
+  assert.throws(
+    () => readResolvedDeployTargets(targetsFile),
+    new RegExp(`Resolved deploy targets file not found: ${ targetsFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') }`),
+  );
+});
+
+test('readResolvedDeployTargets rejects malformed snapshot payloads', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invalid-deploy-targets-'));
+  const targetsFile = path.join(tempDir, 'targets.json');
+  fs.writeFileSync(targetsFile, JSON.stringify({ organizationBuckets: [['qa2']] }));
+
+  assert.throws(
+    () => readResolvedDeployTargets(targetsFile),
+    /organizationBuckets must be an array of \[key, value\] entries/,
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
Shortcut Story ID: [sc-new-story]

## Summary

Improve CircleCI deploy markers for stage-wide deploys.

## Changes

- keep the wildcard marker for `qa:*`, `sandbox:*`, and `prod:*`
- fan out concrete environment markers from the same resolved target snapshot used by the deploy
- continue through all resolved environments and fail at the end if any target fails
- preserve per-environment marker outcomes on partial success
- add focused tests and update deploy docs

## Why

A stage-wide deploy should update the wildcard marker and the concrete environment markers it actually touched.

This keeps CircleCI Deploy closer to the real rollout state, especially when a stage-wide deploy only partially succeeds.

## Validation

- `node --test scripts/deploy.test.js scripts/deploy-markers.test.js scripts/dispatch-qa2-e2e.test.js scripts/lib/appconfig.test.js`
- CircleCI config validated for `.circleci/deploy.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified deploy runbook: stage-wide deploys emit per-environment markers; semantics for partial/total success and overall stage reporting are defined.

* **New Features**
  * Deploys now record and publish per-environment outcomes for both stage-wide and specific targets, improving visibility of successes/failures.

* **Tests**
  * Added unit tests covering marker naming, update logic, and deploy-target/status persistence.

* **Chores**
  * CI deploy workflow updated to resolve marker environments and expose marker/status artifacts for downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->