### PR TITLE
Fix deploy marker environment capture

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -135,9 +135,9 @@ jobs:
             deploy_marker_status_file="$deploy_tmp_dir/deploy-marker-status.json"
 
             if [ -n "$DEPLOY_ORGANIZATION" ]; then
-              npm run deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
+              npm run --silent deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
             else
-              npm run deploy -- --stage="$DEPLOY_STAGE" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
+              npm run --silent deploy -- --stage="$DEPLOY_STAGE" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
             fi
 
             if [ ! -s "$marker_env_file" ]; then


### PR DESCRIPTION
Shortcut Story ID: [sc-###]

## Summary
<img width="788" height="442" alt="Screenshot 2026-04-08 at 2 41 27 AM" src="https://github.com/user-attachments/assets/d3771c0d-5528-48ad-854a-ae1393377512" />

Fixes bogus CircleCI deploy markers created from `npm run` banner output.

## Issue

The `Resolve deploy marker environments` step redirected stdout from `npm run deploy -- ... --list-marker-environments` into `$marker_env_file`.

That meant npm’s own script banner lines, such as `> app-frontend@1.0.0 deploy` and `> node scripts/deploy.js ...`, were written into `deploy-marker-environments.txt` alongside real environment lines. The deploy marker plan step then treated those banner lines as environment names, which created odd deploy markers in CircleCI.

## Fix

Use `npm run --silent deploy -- ...` only in the machine-readable marker-environment resolution step. This suppresses npm’s banner output while preserving the deploy script’s stdout, so the marker file contains only real environments such as `qa:*`, `qa:qa2`, or `prod:<org>`.

The actual deploy step is unchanged, so normal deploy logging remains visible.

## Validation

- `npm run --silent deploy -- --stage=qa --read-targets-file=<tmp> --list-marker-environments`
- `node --test scripts/deploy.test.js scripts/deploy-markers.test.js`
- `circleci config validate .circleci/deploy.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to suppress npm output during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->