### PR TITLE
Dialer UI updates

### DIFF
--- a/packages/care-ops-five9/five9_views.js
+++ b/packages/care-ops-five9/five9_views.js
@@ -67,12 +67,11 @@ const PatientButtonItemView = View.extend({
 
 const PatientButtonsView = CollectionView.extend({
   childView: PatientButtonItemView,
-  initialize() {
-    this.listenTo(Radio.channel('history'), 'change:route', this.render);
+  collectionEvents: {
+    'change:currentPatientId': 'render',
   },
   viewFilter({ model }) {
-    const currentUrl = window.location.href;
-    return !currentUrl.includes(model.id);
+    return this.collection.currentPatientId !== model.id;
   },
 });
 

--- a/packages/care-ops-ringcentral/ringcentral_app.js
+++ b/packages/care-ops-ringcentral/ringcentral_app.js
@@ -46,20 +46,20 @@ export default App.extend({
 
       // when an inbound call is ringing
       if (data.type === 'rc-call-ring-notify') {
-        if (['active', 'transferred'].includes(this.getState('callState'))) return;
+        if (this.getState('callState') === 'active') return;
 
         this.setState('callState', 'ringing');
       }
 
       // when a user accepts a ringing inbound call or outbound call is connected
       if (data.type === 'rc-call-start-notify') {
-        const isTransferredCall = data.call?.direction === 'Inbound' && data.call?.isForwarded === true;
+        const isInboundCall = data.call?.direction === 'Inbound';
 
-        this.setState('callState', isTransferredCall ? 'transferred' : 'active');
+        this.setState('callState', 'active');
 
         Radio.request('dialer', 'showPatientLinks', {
           actionId: this.getState('actionId'),
-          number: isTransferredCall ? data.call?.from : data.call?.to,
+          number: isInboundCall ? data.call?.from : data.call?.to,
         });
       }
 
@@ -78,7 +78,7 @@ export default App.extend({
     this.setState('isOpen', true);
 
     // If there's an active call, only show the panel
-    if (['active', 'transferred'].includes(this.getState('callState'))) return;
+    if (this.getState('callState') === 'active') return;
 
     this.setState('pendingCall', number);
     this.setState('actionId', action.id);

--- a/packages/care-ops-ringcentral/ringcentral_app.js
+++ b/packages/care-ops-ringcentral/ringcentral_app.js
@@ -44,6 +44,13 @@ export default App.extend({
         this.setState('actionId', null);
       }
 
+      // when an inbound call is ringing
+      if (data.type === 'rc-call-ring-notify') {
+        if (['active', 'transferred'].includes(this.getState('callState'))) return;
+
+        this.setState('callState', 'ringing');
+      }
+
       // when a user accepts a ringing inbound call or outbound call is connected
       if (data.type === 'rc-call-start-notify') {
         const isTransferredCall = data.call?.direction === 'Inbound' && data.call?.isForwarded === true;

--- a/packages/care-ops-ringcentral/ringcentral_views.js
+++ b/packages/care-ops-ringcentral/ringcentral_views.js
@@ -125,7 +125,7 @@ const LayoutView = View.extend({
   showCallState() {
     const callState = this.model.get('callState');
 
-    this.ui.header.toggleClass('is-call-active', callState === 'active' || callState === 'transferred');
+    this.ui.header.toggleClass('is-call-active', callState === 'ringing' || callState === 'active' || callState === 'transferred');
 
     if (callState === 'active') {
       this.showChildView('heading', new TimerView());
@@ -134,6 +134,11 @@ const LayoutView = View.extend({
 
     if (callState === 'transferred') {
       this.showChildView('heading', new View({ template: hbs`Transferred Call` }));
+      return;
+    }
+
+    if (callState === 'ringing') {
+      this.showChildView('heading', new View({ template: hbs`Incoming Call` }));
       return;
     }
 

--- a/packages/care-ops-ringcentral/ringcentral_views.js
+++ b/packages/care-ops-ringcentral/ringcentral_views.js
@@ -50,12 +50,11 @@ const PatientButtonItemView = View.extend({
 
 const PatientButtonsView = CollectionView.extend({
   childView: PatientButtonItemView,
-  initialize() {
-    this.listenTo(Radio.channel('history'), 'change:route', this.render);
+  collectionEvents: {
+    'change:currentPatientId': 'render',
   },
   viewFilter({ model }) {
-    const currentUrl = window.location.href;
-    return !currentUrl.includes(model.id);
+    return this.collection.currentPatientId !== model.id;
   },
 });
 

--- a/packages/care-ops-ringcentral/ringcentral_views.js
+++ b/packages/care-ops-ringcentral/ringcentral_views.js
@@ -125,20 +125,15 @@ const LayoutView = View.extend({
   showCallState() {
     const callState = this.model.get('callState');
 
-    this.ui.header.toggleClass('is-call-active', callState === 'ringing' || callState === 'active' || callState === 'transferred');
-
-    if (callState === 'active') {
-      this.showChildView('heading', new TimerView());
-      return;
-    }
-
-    if (callState === 'transferred') {
-      this.showChildView('heading', new View({ template: hbs`Transferred Call` }));
-      return;
-    }
+    this.ui.header.toggleClass('is-call-active', callState === 'ringing' || callState === 'active');
 
     if (callState === 'ringing') {
       this.showChildView('heading', new View({ template: hbs`Incoming Call` }));
+      return;
+    }
+
+    if (callState === 'active') {
+      this.showChildView('heading', new TimerView());
       return;
     }
 

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -66,6 +66,9 @@ export default SubRouterApp.extend({
     this.currentRoute = currentRoute;
     this.editableCollection = actions.clone();
     this.patient = patient;
+
+    Radio.trigger('dialer', 'change:currentPatientId', patient.id);
+
     this.addOpts = this.getAddOpts(this.flow.getProgramFlow());
 
     this.subscribe();

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -62,6 +62,19 @@ export default RouterApp.extend({
     },
   },
 
+  onBeforeAppRoute(event, patientId) {
+    // if routing to flow route, currentPatientId is set by flow_app's onStart()
+    if (event.startsWith('flow')) return;
+
+    // determines if dialer patient buttons are shown or hidden
+    const isPatientRoute = event.startsWith('patient');
+    Radio.trigger('dialer', 'change:currentPatientId', isPatientRoute ? patientId : null);
+  },
+
+  onStop() {
+    Radio.trigger('dialer', 'change:currentPatientId', null);
+  },
+
   showPatient(patientId) {
     this.startRoute('patient', { patientId });
   },

--- a/src/js/apps/patients/reduced-patients-main_app.js
+++ b/src/js/apps/patients/reduced-patients-main_app.js
@@ -1,3 +1,5 @@
+import Radio from 'backbone.radio';
+
 import RouterApp from 'js/base/routerapp';
 
 import FlowApp from 'js/apps/patients/patient/flow/flow_app';
@@ -44,6 +46,18 @@ export default RouterApp.extend({
       action: 'showFlow',
       route: 'flow/:id/action/:id',
     },
+  },
+
+  onBeforeAppRoute(event, patientId) {
+    // if routing to flow route, currentPatientId is set by flow_app's onStart()
+    if (event.startsWith('flow')) return;
+
+    // determines if dialer patient buttons are shown or hidden
+    const isPatientRoute = event.startsWith('patient');
+    Radio.trigger('dialer', 'change:currentPatientId', isPatientRoute ? patientId : null);
+  },
+  onStop() {
+    Radio.trigger('dialer', 'change:currentPatientId', null);
   },
   showPatient(patientId) {
     this.startRoute('patient', { patientId });

--- a/src/js/services/dialer.js
+++ b/src/js/services/dialer.js
@@ -15,6 +15,13 @@ export default App.extend({
     'five9Call': 'five9Call',
     'ringcentralCall': 'ringcentralCall',
   },
+  radioEvents: {
+    'change:currentPatientId': 'updateCurrentPatientId',
+  },
+  updateCurrentPatientId(patientId) {
+    patients.currentPatientId = patientId;
+    patients.trigger('change:currentPatientId');
+  },
   async init() {
     /* istanbul ignore next: prevent re-initialization */
     if (this._call) return;

--- a/src/js/services/dialer.test.js
+++ b/src/js/services/dialer.test.js
@@ -135,6 +135,21 @@ describe('Dialer Service', () => {
     expect(ringcentralInit).not.toHaveBeenCalled();
   });
 
+  it('updates currentPatientId on the patients collection', async() => {
+    Radio.reply('settings', 'get', () => 'five9');
+    Radio.reply('bootstrap', 'organization', () => ({ get: () => 'RoundingWell' }));
+
+    await service.init();
+
+    const { patients } = five9Init.mock.calls[0][0];
+    const triggerSpy = vi.spyOn(patients, 'trigger');
+
+    Radio.trigger('dialer', 'change:currentPatientId', 'patient-1');
+
+    expect(patients.currentPatientId).toBe('patient-1');
+    expect(triggerSpy).toHaveBeenCalledWith('change:currentPatientId');
+  });
+
   it('clears patient links when no call data is provided', () => {
     const patient = new Backbone.Model({
       id: 'patient-1',

--- a/test/integration/services/dialer.js
+++ b/test/integration/services/dialer.js
@@ -5,81 +5,105 @@ import { getPatient } from 'support/api/patients';
 import { getFlow } from 'support/api/flows';
 import { stateTodo } from 'support/api/states';
 import { getCurrentClinician } from 'support/api/clinicians';
+import { workspaceOne } from 'support/api/workspaces';
+import { roleReducedEmployee } from 'support/api/roles';
+
+const STATE_VERSION = 'v6';
+
+const testPatient = getPatient({
+  attributes: {
+    first_name: 'Test',
+    last_name: 'Patient',
+  },
+});
+
+const otherTestPatient = getPatient({
+  attributes: {
+    first_name: 'Other',
+    last_name: 'Patient',
+  },
+});
+
+const testFlow = getFlow({
+  attributes: {
+    name: 'Test Flow',
+  },
+  relationships: {
+    state: getRelationship(stateTodo),
+    patient: getRelationship(testPatient),
+  },
+});
+
+const testAction = getAction({
+  attributes: {
+    name: 'Test Action',
+  },
+  relationships: {
+    state: getRelationship(stateTodo),
+    flow: getRelationship(testFlow),
+    patient: getRelationship(testPatient),
+  },
+});
+
+const searchResults = [
+  {
+    id: testPatient.id,
+    type: 'patient-search-results',
+    attributes: {
+      ...testPatient.attributes,
+      match: {
+        label: 'Phone Number',
+        value: '+16513216543',
+      },
+    },
+    relationships: {
+      patient: getRelationship(testPatient, 'patients'),
+    },
+  },
+  {
+    id: otherTestPatient.id,
+    type: 'patient-search-results',
+    attributes: {
+      ...otherTestPatient.attributes,
+      match: {
+        label: 'Phone Number',
+        value: '+16513216543',
+      },
+    },
+    relationships: {
+      patient: getRelationship(otherTestPatient, 'patients'),
+    },
+  },
+];
 
 context('Dialer Service', function() {
   specify('five9 - patient dashboard buttons', function() {
-    const testPatient = getPatient({
+    const currentClinician = getCurrentClinician({
       attributes: {
-        first_name: 'Test',
-        last_name: 'Patient',
+        settings: { dialer: 'five9' },
       },
     });
 
-    const otherTestPatient = getPatient({
-      attributes: {
-        first_name: 'Other',
-        last_name: 'Patient',
-      },
-    });
-
-    const testFlow = getFlow({
-      attributes: {
-        name: 'Test Flow',
-      },
-      relationships: {
-        state: getRelationship(stateTodo),
-      },
-    });
-
-    const testAction = getAction({
-      attributes: {
-        name: 'Test Action',
-      },
-      relationships: {
-        'flow': getRelationship(testFlow),
-        'patient': getRelationship(testPatient),
-      },
-    });
-
-    const searchResults = [
-      {
-        id: testPatient.id,
-        type: 'patient-search-results',
-        attributes: {
-          ...testPatient.attributes,
-          match: {
-            label: 'Phone Number',
-            value: '+16513216543',
-          },
-        },
-        relationships: {
-          patient: getRelationship(testPatient, 'patients'),
-        },
-      },
-      {
-        id: otherTestPatient.id,
-        type: 'patient-search-results',
-        attributes: {
-          ...otherTestPatient.attributes,
-          match: {
-            label: 'Phone Number',
-            value: '+16513216543',
-          },
-        },
-        relationships: {
-          patient: getRelationship(otherTestPatient, 'patients'),
-        },
-      },
-    ];
+    localStorage.setItem(`owned-by_${ currentClinician.id }_${ workspaceOne.id }-${ STATE_VERSION }`, JSON.stringify({
+      id: 'owned-by',
+      listType: 'flows',
+      flowsSortId: 'sortCreatedDesc',
+      clinicianId: currentClinician.id,
+      states: [stateTodo],
+      customFilters: {},
+    }));
 
     cy
       .routesForPatientAction()
       .routeCurrentClinician(fx => {
-        fx.data = getCurrentClinician({
-          attributes: {
-            settings: { dialer: 'five9' },
-          },
-        });
+        fx.data = currentClinician;
+
+        return fx;
+      })
+      .routeFlows(fx => {
+        fx.data = [testFlow];
+
+        fx.included.push(testPatient);
 
         return fx;
       })
@@ -87,7 +111,7 @@ context('Dialer Service', function() {
         fx.data = testFlow;
 
         return fx;
-      })
+      }, { delay: 200 })
       .routeFlowActions(fx => {
         fx.data = [testAction];
 
@@ -95,8 +119,8 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routePatientByFlow(fx => {
-        fx.data = testPatient;
+      .routeAction(fx => {
+        fx.data = testAction;
 
         return fx;
       })
@@ -105,7 +129,22 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routeActionActivity()
+      .routePatientByFlow(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [testFlow];
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [testAction];
+
+        return fx;
+      })
+      .routeDashboards()
       .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -113,6 +152,15 @@ context('Dialer Service', function() {
       .wait('@routeActionActivity')
       .wait('@routeActionComments')
       .wait('@routeActionFiles');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Owned By')
+      .as('navOwnedByLink')
+      .click()
+      .wait('@routeFlows');
 
     cy
       .get('.five9-wrapper')
@@ -134,7 +182,9 @@ context('Dialer Service', function() {
       .should('have.length', 1)
       .should('contain', 'Test Patient')
       .click()
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
 
     cy
       .get('@patientButtons')
@@ -153,19 +203,87 @@ context('Dialer Service', function() {
       .should('have.length', 0);
 
     cy
-      .go('back');
+      .get('.patient__tabs')
+      .find('.js-archive')
+      .click()
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.patient__tabs')
+      .find('.js-dashboard')
+      .click()
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy
+      .get('@navOwnedByLink')
+      .click()
+      .wait('@routeFlows');
 
     cy
       .get('@patientButtons')
       .should('have.length', 1);
 
     cy
+      .get('.table-list__item')
+      .contains('Test Flow')
+      .click()
+      .wait('@routeFlow');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
       .getRadio(Radio => {
         Radio.request('dialer', 'showPatientLinks', {
           actionId: testAction.id,
           number: null,
         });
       });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.patient-flow__context-trail .js-patient')
+      .click()
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.table-list__item')
+      .contains('Test Flow')
+      .click();
+
+    cy
+      .get('@patientButtons', { timeout: 0 })
+      .should('have.length', 0);
+
+    cy
+      .wait('@routeFlow');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.app-nav')
+      .find('.app-nav__bottom')
+      .contains('Dashboards')
+      .click()
+      .wait('@routeDashboards');
 
     cy
       .get('@patientButtons')
@@ -220,78 +338,19 @@ context('Dialer Service', function() {
   });
 
   specify('RingCentral - patient dashboard buttons', function() {
-    const testPatient = getPatient({
+    const currentClinician = getCurrentClinician({
       attributes: {
-        first_name: 'Test',
-        last_name: 'Patient',
-      },
-    });
-
-    const otherTestPatient = getPatient({
-      attributes: {
-        first_name: 'Other',
-        last_name: 'Patient',
-      },
-    });
-
-    const testFlow = getFlow({
-      attributes: {
-        name: 'Test Flow',
+        settings: { dialer: 'ringcentral' },
       },
       relationships: {
-        state: getRelationship(stateTodo),
+        role: getRelationship(roleReducedEmployee),
       },
     });
-
-    const testAction = getAction({
-      attributes: {
-        name: 'Test Action',
-      },
-      relationships: {
-        'flow': getRelationship(testFlow),
-        'patient': getRelationship(testPatient),
-      },
-    });
-
-    const searchResults = [
-      {
-        id: testPatient.id,
-        type: 'patient-search-results',
-        attributes: {
-          ...testPatient.attributes,
-          match: {
-            label: 'Phone Number',
-            value: '+16513216543',
-          },
-        },
-        relationships: {
-          patient: getRelationship(testPatient, 'patients'),
-        },
-      },
-      {
-        id: otherTestPatient.id,
-        type: 'patient-search-results',
-        attributes: {
-          ...otherTestPatient.attributes,
-          match: {
-            label: 'Phone Number',
-            value: '+16513216543',
-          },
-        },
-        relationships: {
-          patient: getRelationship(otherTestPatient, 'patients'),
-        },
-      },
-    ];
 
     cy
       .routesForPatientAction()
       .routeCurrentClinician(fx => {
-        fx.data = getCurrentClinician({
-          attributes: {
-            settings: { dialer: 'ringcentral' },
-          },
-        });
+        fx.data = currentClinician;
 
         return fx;
       })
@@ -299,7 +358,7 @@ context('Dialer Service', function() {
         fx.data = testFlow;
 
         return fx;
-      })
+      }, { delay: 200 })
       .routeFlowActions(fx => {
         fx.data = [testAction];
 
@@ -307,8 +366,16 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routePatientByFlow(fx => {
-        fx.data = testPatient;
+      .routeActions(fx => {
+        fx.data = [testAction];
+
+        fx.included.push(testFlow);
+        fx.included.push(testPatient);
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testAction;
 
         return fx;
       })
@@ -317,7 +384,22 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routeActionActivity()
+      .routePatientByFlow(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [testFlow];
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [testAction];
+
+        return fx;
+      })
+      .routeDashboards()
       .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeFlow')
       .wait('@routePatientByFlow')
@@ -325,6 +407,15 @@ context('Dialer Service', function() {
       .wait('@routeActionActivity')
       .wait('@routeActionComments')
       .wait('@routeActionFiles');
+
+    cy
+      .get('[data-nav-content-region]')
+      .find('[data-worklists-region]')
+      .find('.app-nav__link')
+      .contains('Schedule')
+      .as('navScheduleLink')
+      .click()
+      .wait('@routeActions');
 
     cy
       .get('.ringcentral-wrapper')
@@ -346,7 +437,9 @@ context('Dialer Service', function() {
       .should('have.length', 1)
       .should('contain', 'Test Patient')
       .click()
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
 
     cy
       .get('@patientButtons')
@@ -365,11 +458,45 @@ context('Dialer Service', function() {
       .should('have.length', 0);
 
     cy
-      .go('back');
+      .get('.patient__tabs')
+      .find('.js-archive')
+      .click()
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
 
     cy
       .get('@patientButtons')
-      .should('have.length', 1);
+      .should('have.length', 0);
+
+    cy
+      .get('.patient__tabs')
+      .find('.js-dashboard')
+      .click()
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy
+      .get('@navScheduleLink')
+      .click()
+      .wait('@routeActions');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 1)
+      .click()
+      .wait('@routePatient')
+      .wait('@routePatientFlows')
+      .wait('@routePatientActions');
+
+    cy
+      .get('.table-list__item')
+      .contains('Test Flow')
+      .click()
+      .wait('@routeFlow');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
 
     cy
       .getRadio(Radio => {
@@ -378,6 +505,44 @@ context('Dialer Service', function() {
           number: null,
         });
       });
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.patient-flow__context-trail .js-patient')
+      .click()
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.table-list__item')
+      .contains('Test Flow')
+      .click();
+
+    cy
+      .get('@patientButtons', { timeout: 0 })
+      .should('have.length', 0);
+
+    cy
+      .wait('@routeFlow');
+
+    cy
+      .get('@patientButtons')
+      .should('have.length', 0);
+
+    cy
+      .get('.app-nav')
+      .find('.app-nav__bottom')
+      .contains('Dashboards')
+      .click()
+      .wait('@routeDashboards');
 
     cy
       .get('@patientButtons')

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -44,7 +44,7 @@ export function getFlows({ attributes, relationships, meta } = {}, { sample = 3,
   return _.times(sample, () => getFlow({ attributes, relationships, meta }, { depth }));
 }
 
-Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
+Cypress.Commands.add('routeFlow', (mutator = _.identity, options = {}) => {
   const program = getProgram();
   const programActions = getProgramActions({});
   const programFlow = getProgramFlow({
@@ -67,6 +67,7 @@ Cypress.Commands.add('routeFlow', (mutator = _.identity) => {
   cy
     .intercept('GET', '/api/flows/*', {
       body: mutator({ data, included }),
+      ...options,
     })
     .as('routeFlow');
 });


### PR DESCRIPTION
Shortcut Story ID: [sc-67722] [sc-67702]

Summary of changes in this PR:

* `RingCentral`: show "Incoming Call" in UI panel when incoming call is ringing.
* `RingCentral`: fixed issue where patient jump buttons not shown on inbound calls.
* `RingCentral`/`five9`: don't show patient jump buttons on flows that belong to the current patient id/s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced call state detection to distinguish transferred calls from regular inbound calls
  * Improved patient tracking when navigating between patient flows

* **Bug Fixes**
  * Fixed call state display logic to properly show ringing and active states
  * Improved patient button filtering to avoid duplicate display in flow views

* **Tests**
  * Expanded integration tests for dialer functionality with flow patient tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->