### PR TITLE
Handle legacy formio PDF requests

### DIFF
--- a/src/js/formservice.js
+++ b/src/js/formservice.js
@@ -8,23 +8,27 @@ import App from 'js/base/app';
 
 import 'js/entities-service';
 
-// TODO: Move definition request to optional
+// TODO: remove after the last Form.io PDF is replaced.
+function isFormIo() {
+  return document.referrer.includes('formio');
+}
+
 const ActionFormApp = App.extend({
   beforeStart({ actionId }) {
     return [
       Radio.request('entities', 'fetch:forms:byAction', actionId),
-      Radio.request('entities', 'fetch:forms:definition:byAction', actionId),
       Radio.request('entities', 'fetch:forms:data', actionId),
       Radio.request('entities', 'fetch:actions:model', actionId),
+      isFormIo() && Radio.request('entities', 'fetch:forms:definition:byAction', actionId),
     ];
   },
-  onStart(opts, form, definition, data, action) {
+  onStart(opts, form, data, action, definition) {
     const filter = this._getPrefillFilters(form, action);
 
     return Promise.resolve(Radio.request('entities', 'fetch:formResponses:byPatient', filter))
       .then(response => {
         parent.postMessage({ message: 'form:pdf', args: { value: {
-          definition,
+          ...(definition && { definition }),
           formData: data.attributes,
           responseData: response.getFormData(),
           formSubmission: response.getResponse(),
@@ -50,14 +54,14 @@ const FormApp = App.extend({
   beforeStart({ formId, patientId, responseId }) {
     return [
       Radio.request('entities', 'fetch:forms:model', formId),
-      Radio.request('entities', 'fetch:forms:definition', formId),
       Radio.request('entities', 'fetch:forms:data', null, patientId, formId),
       Radio.request('entities', 'fetch:formResponses:model', responseId),
+      isFormIo() && Radio.request('entities', 'fetch:forms:definition', formId),
     ];
   },
-  onStart(opts, form, definition, data, response) {
+  onStart(opts, form, data, response, definition) {
     parent.postMessage({ message: 'form:pdf', args: { value: {
-      definition,
+      ...(definition && { definition }),
       formData: data.attributes,
       responseData: response.getFormData(),
       formSubmission: response.getResponse(),

--- a/test/fixtures/formservice-parent.html
+++ b/test/fixtures/formservice-parent.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <script>
+    window.addEventListener('load', function() {
+      const params = new URLSearchParams(window.location.search);
+      const iframe = document.createElement('iframe');
+      const origin = window.location.origin;
+
+      iframe.src = origin + params.get('serviceUrl');
+      document.body.appendChild(iframe);
+    });
+  </script>
+</body>
+</html>

--- a/test/integration/formservice/formservice.js
+++ b/test/integration/formservice/formservice.js
@@ -3,7 +3,55 @@ import { getFormResponse } from 'support/api/form-responses';
 import { getForm } from 'support/api/forms';
 
 context('Formservice', function() {
-  specify('action formservice iframe makes correct api requests', function() {
+  specify('action formservice makes correct api requests', function() {
+    cy
+      .intercept('GET', '/api/actions/1/form', {
+        statusCode: 200,
+        body: { data: getForm({
+          attributes: {
+            options: {
+              is_report: true,
+            },
+          },
+        }) },
+      })
+      .as('routeFormModelByAction');
+
+    cy
+      .intercept('GET', '/api/actions/1/form/fields', {
+        statusCode: 200,
+        body: { data: [] },
+      })
+      .as('routeActionFormFields');
+
+    cy
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 200,
+        body: { data: getAction() },
+      })
+      .as('routeAction');
+
+    cy
+      .intercept('GET', '/api/patients/**/form-responses/submitted*', {
+        statusCode: 200,
+        body: { data: getFormResponse() },
+      })
+      .as('routeLatestFormSubmission');
+
+    cy
+      .intercept('GET', '/forms/custom/pdf.html*', { fixture: 'formservice-parent.html' });
+
+    cy
+      .visit('/forms/custom/pdf.html?serviceUrl=%2Fformservice%2Faction%2F1', { noWait: true, isRoot: true });
+
+    cy
+      .wait('@routeFormModelByAction')
+      .wait('@routeActionFormFields')
+      .wait('@routeAction')
+      .wait('@routeLatestFormSubmission');
+  });
+
+  specify('action formservice adds form definition for formio', function() {
     cy
       .intercept('GET', '/api/actions/1/form', {
         statusCode: 200,
@@ -46,7 +94,12 @@ context('Formservice', function() {
       .as('routeLatestFormSubmission');
 
     cy
-      .visit('/formservice/action/1', { noWait: true, isRoot: true })
+      .intercept('GET', '/forms/formio/pdf.html*', { fixture: 'formservice-parent.html' });
+
+    cy
+      .visit('/forms/formio/pdf.html?serviceUrl=%2Fformservice%2Faction%2F1', { noWait: true, isRoot: true });
+
+    cy
       .wait('@routeFormModelByAction')
       .wait('@routeFormDefinitionByAction')
       .wait('@routeActionFormFields')
@@ -54,7 +107,7 @@ context('Formservice', function() {
       .wait('@routeLatestFormSubmission');
   });
 
-  specify('formservice iframe makes correct api requests', function() {
+  specify('formservice adds form definition for formio', function() {
     cy
       .intercept('GET', '/api/forms/1', {
         statusCode: 200,
@@ -84,7 +137,12 @@ context('Formservice', function() {
       .as('routeFormResponse');
 
     cy
-      .visit('/formservice/1/1/1', { noWait: true, isRoot: true })
+      .intercept('GET', '/forms/formio/pdf.html*', { fixture: 'formservice-parent.html' });
+
+    cy
+      .visit('/forms/formio/pdf.html?serviceUrl=%2Fformservice%2F1%2F1%2F1', { noWait: true, isRoot: true });
+
+    cy
       .wait('@routeFormModel')
       .wait('@routeFormDefinition')
       .wait('@routeFormFields')


### PR DESCRIPTION
Closes FE-91

This updates the PDF formservice iframe flow so it can support both current Form.io-backed forms and the newer non-Form.io forms.

The service now detects legacy Form.io mode from the parent page URL and only requests definition for the legacy path. The standard form path no longer pulls or sends that extra payload. The Form.io branch is intentionally left in place for now with a TODO to remove it after the last Form.io PDF is replaced.

The formservice integration tests were reshaped accordingly: the generic action flow stays generic, and the legacy Form.io route is the only test that asserts the definition request.

Validation

npm run eslint -- src/js/formservice.js test/integration/formservice/formservice.js
npx cypress run --spec test/integration/formservice/formservice.js --config baseUrl=http://localhost:4178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized form definition loading by fetching definitions only when embedded in a Form.io context.
  * Improved cross-frame messaging to include form definition only when available.

* **Tests**
  * Updated and expanded integration tests to cover embedded form flows and parent-frame loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->