### PR TITLE
FE-93 remove legacy appconfig compatibility output

### DIFF
--- a/scripts/lib/appconfig.js
+++ b/scripts/lib/appconfig.js
@@ -61,24 +61,6 @@ function addAuthProvider(config, secrets) {
     createAuth0AuthConfig(secrets);
 }
 
-function addLegacyAuthKeys(config) {
-  if (!config.auth || !config.auth.provider) return;
-  const legacyAuth = {
-    provider: config.auth.provider,
-    disableLoginPrompt: config.auth.disableLoginPrompt,
-    ...(config.auth.config || {}),
-  };
-
-  if (config.auth.provider === 'workos') {
-    config.workos = legacyAuth;
-    return;
-  }
-
-  if (config.auth.provider === 'auth0') {
-    config.auth0 = legacyAuth;
-  }
-}
-
 /**
  * Remove null/undefined values from object (matches PHP nullifyAny)
  * @param {Object} obj - Object to clean
@@ -139,20 +121,6 @@ export function buildAppConfig({
 
   // Add WorkOS or Auth0 (WorkOS takes priority)
   addAuthProvider(config, secrets);
-
-  // TEMP legacy compatibility block.
-  // Remove after downstream consumers fully migrate away from
-  // app.env/app.stack/app.disableLoginPrompt and versions.frontend.
-  config.app.env = `${ stage }.${ organization }`;
-  config.app.stack = organization;
-  config.app.disableLoginPrompt = config.auth.disableLoginPrompt;
-  config.versions = {
-    frontend: version,
-  };
-
-  // TEMP legacy auth compatibility keys.
-  // Remove after downstream consumers fully migrate to the `auth` block.
-  addLegacyAuthKeys(config);
 
   // Remove null values (matches PHP nullifyAny)
   return removeNullValues(config);

--- a/scripts/lib/appconfig.test.js
+++ b/scripts/lib/appconfig.test.js
@@ -26,14 +26,8 @@ test('buildAppConfig returns auth.provider=auth0 when WorkOS client id is missin
     app: {
       stage: 'prod',
       organization: 'customer-a',
-      stack: 'customer-a',
       version: 'abc1234',
-      env: 'prod.customer-a',
       name: 'Acme',
-      disableLoginPrompt: true,
-    },
-    versions: {
-      frontend: 'abc1234',
     },
     datadog: {
       applicationId: 'dd-app',
@@ -57,19 +51,6 @@ test('buildAppConfig returns auth.provider=auth0 when WorkOS client id is missin
         useRefreshTokens: true,
         cacheLocation: 'localstorage',
       },
-    },
-    auth0: {
-      provider: 'auth0',
-      disableLoginPrompt: true,
-      domain: 'acme.auth0.com',
-      clientId: 'auth0-client',
-      authorizationParams: {
-        connection: 'Username-Password-Authentication',
-        organization: 'org_123',
-        audience: 'care-ops-backend',
-      },
-      useRefreshTokens: true,
-      cacheLocation: 'localstorage',
     },
   });
 });
@@ -98,14 +79,8 @@ test('buildAppConfig prioritizes WorkOS and sets auth.provider=workos', () => {
     app: {
       stage: 'qa',
       organization: 'qa2',
-      stack: 'qa2',
       version: 'def5678',
-      env: 'qa.qa2',
       name: 'Acme',
-      disableLoginPrompt: false,
-    },
-    versions: {
-      frontend: 'def5678',
     },
     datadog: {
       applicationId: 'dd-app',
@@ -126,15 +101,6 @@ test('buildAppConfig prioritizes WorkOS and sets auth.provider=workos', () => {
         },
       },
     },
-    workos: {
-      provider: 'workos',
-      disableLoginPrompt: false,
-      clientId: 'workos-client',
-      createClientOptions: {
-        apiHostname: 'workos.example.com',
-        devMode: true,
-      },
-    },
   });
 });
 
@@ -153,5 +119,4 @@ test('buildAppConfig omits WorkOS devMode outside dev and qa', () => {
   });
 
   assert.equal(config.auth.config.createClientOptions.devMode, undefined);
-  assert.equal(config.workos.createClientOptions.devMode, undefined);
 });


### PR DESCRIPTION
Closes FE-93

Can just wait to merge this until after the release goes out for convenience. 

## Summary
Remove the legacy `appconfig.json` compatibility output now that the app has migrated to the nested config format.

## What changed
- stopped generating legacy `app.env`, `app.stack`, and `app.disableLoginPrompt`
- stopped generating `versions.frontend`
- stopped generating top-level `auth0` and `workos` compatibility blocks
- kept the nested `auth` block unchanged
- updated unit tests to assert the new shape and verify the legacy keys are absent

## Verification
- `node --test /Users/paulfalgout/Projects/care-ops-frontend/scripts/lib/appconfig.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy configuration compatibility layer and deprecated fields to simplify the application configuration process and reduce technical debt.

* **Tests**
  * Updated test assertions to validate removal of deprecated configuration fields and ensure correct behavior of the streamlined configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->