### PR TITLE
Refactor Datadog setup to use stage for env and organization tag

### DIFF
--- a/packages/care-ops-config/index.js
+++ b/packages/care-ops-config/index.js
@@ -26,10 +26,6 @@ function getAppName() {
   return configState.app.name;
 }
 
-function getEnvName() {
-  return `${ configState.app.stage }.${ configState.app.organization }`;
-}
-
 function getAppVersion() {
   return configState.app.version;
 }
@@ -41,17 +37,18 @@ function getDatadogVersion(version) {
 function getDatadogLogsOptions({ service, version } = {}) {
   const datadog = configState.datadog;
   return {
-    env: getEnvName(),
+    env: configState.app.stage,
     service,
     clientToken: datadog.clientToken,
     version: getDatadogVersion(version),
+    organization: configState.app.organization,
   };
 }
 
 function getDatadogRumOptions({ service, version } = {}) {
   const datadog = configState.datadog;
   return {
-    env: getEnvName(),
+    env: configState.app.stage,
     service,
     clientToken: datadog.clientToken,
     version: getDatadogVersion(version),

--- a/packages/care-ops-datadog/index.js
+++ b/packages/care-ops-datadog/index.js
@@ -1,33 +1,31 @@
 import { datadogRum } from '@datadog/browser-rum';
 import { datadogLogs } from '@datadog/browser-logs';
 
-let logsReady = false;
 let rumReady = false;
 
 /**
  * Initialise Datadog Logs.
  * @param {Object} opts
- * @param {string} opts.env          - `${ appConfig.stage }.${ appConfig.organization }`
+ * @param {string} opts.env
  * @param {string} opts.clientToken
  * @param {string} opts.service
  * @param {string} opts.version
+ * @param {string} opts.organization
  */
-export function initLogs({ env, clientToken, service, version }) {
+export function initLogs({ env, clientToken, service, version, organization }) {
   datadogLogs.init({
     env,
     clientToken,
     service,
     version,
+    forwardErrorsToLogs: false,
     useSecureSessionCookie: true,
     usePartitionedCrossSiteSessionCookie: true,
-    beforeSend(log) {
-      const msg = String(log.message);
-      if (msg.includes('Uncaught "[Response]"')) return false;
-      if (msg.includes('Failed to fetch')) return false;
-      return log?.http?.status_code !== 0;
-    },
   });
-  logsReady = true;
+
+  if (organization) {
+    datadogLogs.logger.addTag('organization', organization);
+  }
 }
 
 /**
@@ -64,7 +62,14 @@ export function initRum({
         && event.resource.type === 'fetch'
         && context?.response?.status >= 400
       ) {
-        event.context = { ...event.context, context };
+        const { body } = context.requestInit || {};
+
+        let requestBody;
+        if (typeof body === 'string') {
+          try { requestBody = JSON.parse(body); } catch (e) { requestBody = body; }
+        }
+
+        event.context = { ...event.context, requestBody };
       }
     },
   });
@@ -87,24 +92,4 @@ export function addError(error, context) {
     return;
   }
   datadogRum.addError(error, context);
-}
-
-/**
- * Log a fetch response (clones so you can still read it later).
- */
-export async function logResponse(url, options, response) {
-  if (!logsReady) return;
-
-  const clone = response.clone();
-  const contentType = String(clone.headers.get('Content-Type'));
-  const responseBody = contentType.includes('json') ? await clone.json() : await clone.text();
-  const responseHeads = Object.fromEntries(clone.headers);
-
-  datadogLogs.logger.info(`Response status ${ clone.status }`, {
-    url,
-    options,
-    status: clone.status,
-    responseHeaders: responseHeads,
-    responseBody,
-  });
 }

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -2,8 +2,6 @@
 import { isObject, isArray, defaults, extend, map, flatten, reduce, first, rest, get } from 'underscore';
 import Radio from 'backbone.radio';
 
-import { logResponse } from 'js/datadog';
-
 const fetchers = [];
 
 function registerFetcher(baseUrl, fetcher, controller) {
@@ -156,8 +154,6 @@ export default async(url, options) => {
         }
 
         if (response.status >= 400) {
-          logResponse(url, options, response);
-
           const contentType = String(response.headers.get('Content-Type'));
 
           if (!contentType.includes('json')) {

--- a/src/js/datadog.js
+++ b/src/js/datadog.js
@@ -1,4 +1,4 @@
-import { initLogs, initRum, setUser, startRum, addError, logResponse } from '@roundingwell/care-ops-datadog';
+import { initLogs, initRum, setUser, startRum, addError } from '@roundingwell/care-ops-datadog';
 
 import { getDatadogLogsOptions, getDatadogRumOptions } from '@roundingwell/care-ops-config';
 
@@ -17,5 +17,4 @@ export {
   setUser,
   startRum,
   addError,
-  logResponse,
 };


### PR DESCRIPTION
Closes FE-95

Once released we'll want to revert https://github.com/RoundingWell/ops-terraform/pull/89

## Summary
Refactor the frontend Datadog setup so `env` uses `appConfig.stage` and organization is tracked as a separate tag.

## Changes
- set Datadog `env` to `appConfig.stage` instead of a `stage.organization` composite
- add an `organization` tag to Logs
- remove the unused `getEnvName` helper from `care-ops-config`
- disable handled error forwarding to logs and remove dead `beforeSend` filters
- make RUM `beforeSend` only keep serializable request body
- remove manual fetch response logging now that RUM covers this path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined error response logging in monitoring integration to improve system performance and reduce overhead.
  * Updated environment and organization tagging in observability systems to ensure accurate attribution of system events and errors.
  * Simplified monitoring configuration for cleaner implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->