### PR TITLE
Remove `eslint.experimental.useFlatConfig` from `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,6 @@
   "github.copilot.chat.scopeSelection": true,
 
   // Keep VS Code aligned with repo tooling
-  "eslint.experimental.useFlatConfig": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",


### PR DESCRIPTION
This was breaking the auto-fix on save. Since we use eslint v10, we shouldn't need this anymore. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->