### PR TITLE
fix(ci): upload coveralls before failing coverage checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,11 +250,14 @@ jobs:
 
             npx nyc merge /tmp/cypress-coverage .nyc_output/out.json
             npm run coverage:merge
-            npm run coverage:check:baseline
-            npm run coverage:check:migrated
             npm run coverage:report:ci
       - coveralls/upload:
           fail_on_error: false
+      - run:
+          name: Enforce coverage thresholds
+          command: |
+            npm run coverage:check:baseline
+            npm run coverage:check:migrated
 
   build:
     docker:
@@ -406,6 +409,8 @@ workflows:
           should_build: false
           cypress_command: >
             npx cypress run --component
+            --record
+            --group care-ops-component
 
       - run-unit:
           filters:


### PR DESCRIPTION
Refs FE-103.

## Summary
- upload the coverage report to Coveralls before enforcing the 100% coverage gates
- keep the coverage job failing after upload when baseline or migrated coverage checks fail
- record the PR component Cypress run as `care-ops-component` so the expected GitHub status is published

## Validation
- CircleCI config validates successfully
- pipeline not rerun locally from Codex
- next CI run should confirm:
  - Coveralls receives the report even when coverage is below 100%
  - `cypress: care-ops-component` no longer stays `Expected`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD pipeline configuration to improve test coverage reporting and Cypress test recording processes.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->