### PR TITLE
Add `patient:action:archive` route handling to reduced-patients main app

### DIFF
--- a/src/js/apps/patients/reduced-patients-main_app.js
+++ b/src/js/apps/patients/reduced-patients-main_app.js
@@ -34,6 +34,10 @@ export default RouterApp.extend({
       action: 'showPatient',
       route: 'patient/:id/action/:id',
     },
+    'patient:action:archive': {
+      action: 'showPatient',
+      route: 'patient/archive/:id/action/:id',
+    },
     'flow': {
       action: 'showFlow',
       route: 'flow/:id',

--- a/test/integration/patients/worklist/reduced-schedule.js
+++ b/test/integration/patients/worklist/reduced-schedule.js
@@ -252,8 +252,24 @@ context('reduced schedule page', function() {
       .navigate(`/patient/${ testPatient.id }/action/${ testAction.id }`);
 
     cy
+      .get('.sidebar')
+      .find('.action-sidebar__name')
+      .should('contain', 'Test Action');
+
+    cy
+      .navigate(`/patient/archive/${ testPatient.id }`);
+
+    cy
       .get('.patient__context-trail')
       .should('contain', 'First Last');
+
+    cy
+      .navigate(`/patient/archive/${ testPatient.id }/action/${ testAction.id }`);
+
+    cy
+      .get('.sidebar')
+      .find('.action-sidebar__name')
+      .should('contain', 'Test Action');
 
     cy
       .routeFlow()


### PR DESCRIPTION
Refs FE-104.

Reduced schedule role users currently can't open action sidebars on the `/archive` page. Adding this route handling will allow them to do that.

I can't think of a reason we would restrict users from opening an archived action sidebar. And that this is just an oversight. But I may be missing something. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds route handling for archived patient actions so reduced schedule users can open the action sidebar on archive pages. Addresses FE-104 and brings archived pages to parity with active patient routes.

- **Bug Fixes**
  - Map `patient:action:archive` to `showPatient` with route `patient/archive/:id/action/:id`.
  - Extend integration tests to cover archived patient navigation and opening the action sidebar.

<sup>Written for commit b3333ff99e28bcab8f0fbade655152d3084fb46c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing support for patient archive actions, enabling dedicated archive workflow navigation.

* **Tests**
  * Extended test coverage for patient archive functionality, verifying sidebar rendering and navigation across archive-related routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->