### PR TITLE
Add a max height css property to dialer element

### DIFF
--- a/packages/care-ops-five9/five9.scss
+++ b/packages/care-ops-five9/five9.scss
@@ -25,6 +25,7 @@ $five9-call-ended-hover: color(red, dark);
 
   .five9-wrapper.is-open & {
     height: 80vh;
+    max-height: 760px;
   }
 }
 

--- a/packages/care-ops-ringcentral/ringcentral.scss
+++ b/packages/care-ops-ringcentral/ringcentral.scss
@@ -25,6 +25,7 @@ $ringcentral-call-ended-hover: color(red, dark);
 
   .ringcentral-wrapper.is-open & {
     height: 80vh;
+    max-height: 760px;
   }
 }
 


### PR DESCRIPTION
Refs FE-106



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 760px max-height to the open dialers in `care-ops-five9` and `care-ops-ringcentral` to prevent oversized panels on tall screens, while keeping 80vh on smaller screens. Addresses FE-106.

<sup>Written for commit dc97a3ad78db010aca23c4f982fe705dbdcb0df6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

