### PR TITLE
Add `max-height` to base dialer element, not only when `.is-open`

### DIFF
--- a/packages/care-ops-five9/five9.scss
+++ b/packages/care-ops-five9/five9.scss
@@ -20,12 +20,12 @@ $five9-call-ended-hover: color(red, dark);
   display: flex;
   flex-direction: column;
   height: 36px;
+  max-height: 760px;
   overflow: hidden;
   transition: height 0.2s ease;
 
   .five9-wrapper.is-open & {
     height: 80vh;
-    max-height: 760px;
   }
 }
 

--- a/packages/care-ops-ringcentral/ringcentral.scss
+++ b/packages/care-ops-ringcentral/ringcentral.scss
@@ -20,12 +20,12 @@ $ringcentral-call-ended-hover: color(red, dark);
   display: flex;
   flex-direction: column;
   height: 36px;
+  max-height: 760px;
   overflow: hidden;
   transition: height 0.2s ease;
 
   .ringcentral-wrapper.is-open & {
     height: 80vh;
-    max-height: 760px;
   }
 }
 


### PR DESCRIPTION
Refs FE-106

The `max-height` css property in https://github.com/RoundingWell/app-frontend/pull/1666 was added to the wrong spot.

As a result, the max-height briefly gets switched to none when closing the panel. Which makes the panel height flash upwards before closing:

https://github.com/user-attachments/assets/1d1998c3-d67a-4a3a-aba2-81180b328a89

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply max-height to the base dialer element for Five9 and RingCentral to prevent the panel from flashing taller during close. This keeps the 760px cap consistent through the animation.

- **Bug Fixes**
  - Moved `max-height: 760px` from the `.is-open` state to the base dialer in `care-ops-five9/five9.scss` and `care-ops-ringcentral/ringcentral.scss`.
  - Stops max-height from briefly resetting to none on close, eliminating the height jump.

<sup>Written for commit 3a25ef421cfc1c5826f8e86b03f1d3d352daa9cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

