### PR TITLE
fix(ci): upload all datadog sourcemaps

### DIFF
--- a/vite.shared.config.js
+++ b/vite.shared.config.js
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
     publicDir: false,
     build: {
       target,
-      sourcemap: true,
+      sourcemap: 'hidden',
       emptyOutDir: false,
       minify: 'esbuild',
       outDir: sharedRuntimeDir,


### PR DESCRIPTION
Closes FE-110

## What
- Change the shared runtime Vite build from visible sourcemaps to hidden sourcemaps.
- Align shared runtime sourcemap output with the main app build so Datadog CLI uploads all sibling `*.js.map` files.

## Why
Datadog CLI was detecting `sourceMappingURL` comments on the shared runtime bundles and only uploading those three maps. The main app maps were built but skipped because the app bundles use hidden sourcemaps.

## Scope
- `vite.shared.config.js`
- Shared runtime build output behavior only
- Release sourcemap upload behavior for app-frontend

## Deployment Impact
- No app runtime behavior change.
- Future release artifact publishes should upload all app-frontend sourcemaps to Datadog.
- No form or app redeploy is required outside the normal release flow.

## Testing
- `npm run build`
- Datadog dry run:
  `DATADOG_API_KEY=fake npx --yes @datadog/datadog-ci@5.8.0 sourcemaps upload dist --service=app-frontend --release-version=v260421.1 --minified-path-prefix=/ --dry-run`
- Dry run handled 29 sourcemaps instead of 3.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `sourcemap: 'hidden'` in the shared runtime Vite build to match the main app build, so `@datadog/datadog-ci` uploads all app-frontend `*.js.map` files. Addresses FE-110 with no runtime impact.

<sup>Written for commit e900319250d6a93d0cefe37d94447716c5aa39a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

