### PR TITLE
fix(auth): coordinate WorkOS re-auth on login required

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -1,6 +1,6 @@
 import { AuthProvider } from '../AuthProvider.js';
 
-import { createClient } from '@workos-inc/authkit-js';
+import { createClient, LoginRequiredError } from '@workos-inc/authkit-js';
 
 function hasWorkosSessionCookie(clientId) {
   // Mirrors AuthKit's internal hasSessionCookie() check; no public helper is exported.
@@ -16,7 +16,7 @@ export class WorkosAuthProvider extends AuthProvider {
     super(config, LoginView);
     this.trackAuthEvent = trackAuthEvent;
     this.recoveryPromise = null;
-    this.loginPrompted = false;
+    this.reauthPending = false;
   }
 
   authEvent(name, context = {}) {
@@ -30,32 +30,47 @@ export class WorkosAuthProvider extends AuthProvider {
   async getToken(options) {
     if (!this.client) return;
     if (!navigator.onLine) return this.token;
+    if (this.reauthPending) return null;
 
     return this.client
       .getAccessToken(options)
       .then(token => {
         this.token = `Bearer ${ token }`;
+        this.reauthPending = false;
         return this.token;
       })
       .catch(error => {
         if (!navigator.onLine) return;
 
         this.authEvent('AUTH_GET_TOKEN_FAILED', {
-          reason: 'get_access_token_failed',
+          reason: error instanceof LoginRequiredError ? 'login_required' : 'get_access_token_failed',
           error: error?.message,
         });
         this.token = null;
-        throw error;
+
+        if (error instanceof LoginRequiredError) {
+          this.beginReauth('auth_login_required');
+        }
+
+        return null;
       });
   }
 
   async recoverToken() {
-    return this.getToken({ forceRefresh: true });
+    if (!this.client) {
+      throw new LoginRequiredError();
+    }
+
+    const token = await this.client.getAccessToken({ forceRefresh: true });
+
+    this.token = `Bearer ${ token }`;
+    this.reauthPending = false;
+
+    return this.token;
   }
 
   async recoverAuth() {
     if (!this.recoveryPromise) {
-      this.loginPrompted = false;
       this.recoveryPromise = Promise.resolve()
         // Clear the app bearer so concurrent callers don't reuse a stale header while AuthKit refreshes.
         .then(() => this.clearToken())
@@ -72,15 +87,21 @@ export class WorkosAuthProvider extends AuthProvider {
     this.client.signIn({ state: path });
   }
 
-  loginPromptOnce(reason) {
-    if (this.loginPrompted) return;
+  beginReauth(reason, path = location.pathname) {
+    if (this.reauthPending) return;
 
-    this.loginPrompted = true;
-    this.loginPrompt(location.pathname, reason);
+    this.loginPrompt(path, reason);
   }
 
   loginPrompt(path, reason = 'auth_required') {
+    this.reauthPending = true;
     this.authEvent('AUTH_LOGIN_PROMPT', { reason });
+
+    if (!this.client) {
+      this.replaceState(AuthProvider.PATH_LOGIN);
+      return;
+    }
+
     super.loginPrompt(path);
   }
 
@@ -88,18 +109,21 @@ export class WorkosAuthProvider extends AuthProvider {
     this.authEvent('AUTH_401', { reason: 'api_unauthorized' });
 
     if (!navigator.onLine) return;
+    if (this.reauthPending) return;
 
     try {
       await this.recoverAuth();
-    } catch {
-      this.loginPromptOnce('auth_recovery_failed');
+    } catch (error) {
+      if (error instanceof LoginRequiredError) {
+        this.beginReauth('auth_recovery_failed');
+      }
       return;
     }
 
     const response = await retry();
 
     if (response.status === 401) {
-      this.loginPromptOnce('auth_retry_unauthorized');
+      this.beginReauth('auth_retry_unauthorized');
     }
 
     return response;
@@ -121,6 +145,7 @@ export class WorkosAuthProvider extends AuthProvider {
           return;
         }
 
+        authProvider.reauthPending = false;
         authProvider.handleAuthedPath(path);
 
         success();
@@ -194,12 +219,15 @@ export class WorkosAuthProvider extends AuthProvider {
       this.replaceState(AuthProvider.PATH_ROOT);
     }
 
+    this.reauthPending = false;
+
     // If we're already authenticated and at the right path
     success();
   }
 
   async logout(reason = 'user') {
     this.token = null;
+    this.reauthPending = false;
 
     this.authEvent('AUTH_LOGOUT', { reason });
 

--- a/src/js/auth/workos.cy.js
+++ b/src/js/auth/workos.cy.js
@@ -1,5 +1,6 @@
 import { AuthProvider } from '@roundingwell/care-ops-auth/AuthProvider.js';
 import { WorkosAuthProvider } from '@roundingwell/care-ops-auth/workos.js';
+import { LoginRequiredError } from '@workos-inc/authkit-js';
 
 function setOnline(value) {
   Object.defineProperty(navigator, 'onLine', {
@@ -36,31 +37,56 @@ context('WorkosAuthProvider', function() {
     setOnline(true);
   });
 
-  specify('clears the local token and throws when token acquisition fails', function() {
+  specify('starts re-auth and returns null when token acquisition requires login', function() {
+    const error = new LoginRequiredError();
+    const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
+    provider.token = 'Bearer old-token';
+    provider.client = {
+      getAccessToken: cy.stub().rejects(error),
+      signIn: cy.stub(),
+    };
+    provider.logout = cy.stub();
+
+    return provider.getToken().then(token => {
+      expect(token).to.be.null;
+      expect(provider.token).to.be.null;
+      expect(provider.client.getAccessToken).to.have.been.calledOnce;
+      expect(provider.client.signIn).to.have.been.calledWith({ state: '/' });
+      expectAuthEvent(trackAuthEvent, 'AUTH_GET_TOKEN_FAILED', {
+        reason: 'login_required',
+        error: 'No access token available',
+        pathname: '/',
+        online: true,
+      });
+      expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT', {
+        reason: 'auth_login_required',
+        pathname: '/',
+        online: true,
+      });
+      expect(provider.logout).not.to.have.been.called;
+    });
+  });
+
+  specify('returns null without prompting for non-login token failures', function() {
     const error = new Error('token failed');
     const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
     provider.token = 'Bearer old-token';
     provider.client = {
       getAccessToken: cy.stub().rejects(error),
+      signIn: cy.stub(),
     };
-    provider.logout = cy.stub();
 
-    return provider.getToken().then(
-      () => {
-        throw new Error('Expected getToken to reject');
-      },
-      rejectedError => {
-        expect(rejectedError).to.equal(error);
-        expect(provider.token).to.be.null;
-        expectAuthEvent(trackAuthEvent, 'AUTH_GET_TOKEN_FAILED', {
-          reason: 'get_access_token_failed',
-          error: 'token failed',
-          pathname: '/',
-          online: true,
-        });
-        expect(provider.logout).not.to.have.been.called;
-      },
-    );
+    return provider.getToken().then(token => {
+      expect(token).to.be.null;
+      expect(provider.token).to.be.null;
+      expect(provider.client.signIn).not.to.have.been.called;
+      expectAuthEvent(trackAuthEvent, 'AUTH_GET_TOKEN_FAILED', {
+        reason: 'get_access_token_failed',
+        error: 'token failed',
+        pathname: '/',
+        online: true,
+      });
+    });
   });
 
   specify('does nothing when token acquisition is requested offline', function() {
@@ -76,6 +102,19 @@ context('WorkosAuthProvider', function() {
       expect(token).to.be.null;
       expect(provider.client.getAccessToken).not.to.have.been.called;
       expect(provider.logout).not.to.have.been.called;
+    });
+  });
+
+  specify('does not keep retrying normal token reads while re-auth is pending', function() {
+    const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
+    provider.reauthPending = true;
+    provider.client = {
+      getAccessToken: cy.stub(),
+    };
+
+    return provider.getToken().then(token => {
+      expect(token).to.be.null;
+      expect(provider.client.getAccessToken).not.to.have.been.called;
     });
   });
 
@@ -173,7 +212,7 @@ context('WorkosAuthProvider', function() {
     });
   });
 
-  specify('allows independent recovery cycles to prompt independently', function() {
+  specify('does not keep retrying recovery while re-auth is pending', function() {
     const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
     provider.client = {
       getAccessToken: cy.stub().resolves('new-token'),
@@ -183,8 +222,8 @@ context('WorkosAuthProvider', function() {
     return provider.handleUnauthorized(cy.stub().resolves({ status: 401 }))
       .then(() => provider.handleUnauthorized(cy.stub().resolves({ status: 401 })))
       .then(() => {
-        expect(provider.client.getAccessToken).to.have.been.calledTwice;
-        expect(provider.client.signIn).to.have.been.calledTwice;
+        expect(provider.client.getAccessToken).to.have.been.calledOnce;
+        expect(provider.client.signIn).to.have.been.calledOnce;
       });
   });
 
@@ -192,7 +231,7 @@ context('WorkosAuthProvider', function() {
     const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
     const retry = cy.stub();
     provider.client = {
-      getAccessToken: cy.stub().rejects(new Error('recovery failed')),
+      getAccessToken: cy.stub().rejects(new LoginRequiredError()),
       signIn: cy.stub(),
     };
 
@@ -200,6 +239,23 @@ context('WorkosAuthProvider', function() {
       expect(response).to.be.undefined;
       expect(retry).not.to.have.been.called;
       expect(provider.client.signIn).to.have.been.calledWith({ state: '/' });
+      expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT', {
+        reason: 'auth_recovery_failed',
+        pathname: '/',
+        online: true,
+      });
+    });
+  });
+
+  specify('prompts for login when 401 recovery runs before client init', function() {
+    const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
+    const retry = cy.stub();
+
+    return provider.handleUnauthorized(retry).then(response => {
+      expect(response).to.be.undefined;
+      expect(retry).not.to.have.been.called;
+      expect(provider.token).to.be.null;
+      expect(provider.reauthPending).to.be.true;
       expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT', {
         reason: 'auth_recovery_failed',
         pathname: '/',


### PR DESCRIPTION
Closes FE-111
Follow-up to CS-32 / WorkOS auth recovery.

When AuthKit `getAccessToken()` throws `LoginRequiredError` during normal app use, the frontend should treat that as a coordinated re-auth state instead of repeatedly surfacing token failures while the user clicks around.

## Requirements

- Catch `LoginRequiredError` specifically
- Do not hard logout or clear the WorkOS session as part of this path
- Stop repeated normal `getAccessToken()` retries while re-auth is pending
- Route the user into one login prompt / `signIn()` flow with the current return path
- Keep ordinary network/server token failures distinct from login-required failures
- Verify Datadog no longer shows repeated raw `No access token available` source errors during this state

## Notes

- This is a follow-up UX fix, not a rollback of the Phase 1 session-revocation fix
- The goal is re-auth without session revocation or repeated token-failure thrash

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinate WorkOS re-auth when login is required to stop repeated token failures and trigger a single sign-in with the current return path. Addresses FE-111; follow-up to CS-32.

- **Bug Fixes**
  - Catch `LoginRequiredError` from `@workos-inc/authkit-js`; start one `signIn()` with state, log `login_required`, and return null without clearing the WorkOS session.
  - Add `reauthPending` to block repeated `getAccessToken()` calls and 401 recovery while re-auth runs; return null immediately when pending.
  - Keep non-login token errors separate: return null and don’t prompt; on 401, begin re-auth only when refresh throws `LoginRequiredError` or the client isn’t initialized.
  - Reset `reauthPending` on successful refresh/auth and on logout; set it false after token refresh and on authed path handling; update tests for login-required token failure, non-login no-prompt, no-retry while pending, and pre-init 401 recovery.

<sup>Written for commit c743e0f84d0f75811b706f0f3c7e4f3074a84ec6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

