### PR TITLE
fix(forms): scope iframe postMessage listeners

### DIFF
--- a/src/js/behaviors/iframe-form.cy.js
+++ b/src/js/behaviors/iframe-form.cy.js
@@ -1,0 +1,88 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+import hbs from 'handlebars-inline-precompile';
+import $ from 'jquery';
+import { View } from 'marionette';
+
+import IframeFormBehavior from './iframe-form';
+
+const IframeView = View.extend({
+  behaviors: [IframeFormBehavior],
+  template: hbs`<iframe></iframe>`,
+});
+
+const ParentView = View.extend({
+  template: hbs`
+    <div data-first-region></div>
+    <div data-second-region></div>
+  `,
+  regions: {
+    first: '[data-first-region]',
+    second: '[data-second-region]',
+  },
+  onRender() {
+    this.showChildView('first', new IframeView({
+      model: new Backbone.Model({ id: '1' }),
+    }));
+    this.showChildView('second', new IframeView({
+      model: new Backbone.Model({ id: '2' }),
+    }));
+  },
+});
+
+context('Iframe Form Behavior', function() {
+  afterEach(function() {
+    Radio.channel('form1').reset();
+    Radio.channel('form2').reset();
+  });
+
+  specify('routes postMessage events only to the matching iframe channel', function() {
+    const requests = [];
+
+    Radio.reply('form1', 'fetch:form:data', (...args) => requests.push(['form1', ...args]));
+    Radio.reply('form2', 'fetch:form:data', (...args) => requests.push(['form2', ...args]));
+
+    cy
+      .mount(() => new ParentView())
+      .get('iframe')
+      .should('have.length', 2);
+
+    cy.window().then(win => {
+      const [firstIframe, secondIframe] = win.document.querySelectorAll('iframe');
+
+      $(win).trigger($.Event('message', {
+        originalEvent: {
+          data: {
+            message: 'fetch:form:data',
+            args: { patientId: 'patient-1' },
+            requestId: 'req_1',
+          },
+          origin: win.origin,
+          source: firstIframe.contentWindow,
+        },
+      }));
+
+      expect(requests).to.deep.equal([
+        ['form1', { patientId: 'patient-1' }, 'req_1'],
+      ]);
+
+      requests.length = 0;
+
+      $(win).trigger($.Event('message', {
+        originalEvent: {
+          data: {
+            message: 'fetch:form:data',
+            args: { patientId: 'patient-2' },
+            requestId: 'req_2',
+          },
+          origin: win.origin,
+          source: secondIframe.contentWindow,
+        },
+      }));
+
+      expect(requests).to.deep.equal([
+        ['form2', { patientId: 'patient-2' }, 'req_2'],
+      ]);
+    });
+  });
+});

--- a/src/js/behaviors/iframe-form.js
+++ b/src/js/behaviors/iframe-form.js
@@ -22,16 +22,19 @@ export default Behavior.extend({
   onAttach() {
     this.channel.reply(this.replies, this);
 
-    $(window).on('message', ({ originalEvent }) => {
+    this.messageHandler = ({ originalEvent }) => {
       const { data, origin } = originalEvent;
+      const iframeWindow = this.ui.iframe[0].contentWindow;
       /* istanbul ignore next: security check */
-      if (origin !== window.origin || !data || !data.message) return;
+      if (origin !== window.origin || originalEvent.source !== iframeWindow || !data || !data.message) return;
 
       this.channel.request(data.message, data.args, data.requestId);
-    });
+    };
+
+    $(window).on('message', this.messageHandler);
   },
   onBeforeDetach() {
-    $(window).off('message');
+    $(window).off('message', this.messageHandler);
     this.channel.stopReplying(keys(this.replies).join(' '));
   },
 });

--- a/src/js/services/forms.cy.js
+++ b/src/js/services/forms.cy.js
@@ -1,0 +1,44 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+
+import FormsService from './forms';
+
+context('Forms Service', function() {
+  let formService;
+
+  beforeEach(function() {
+    Radio.reply('bootstrap', 'currentUser', new Backbone.Model({ id: 'current-user' }));
+  });
+
+  afterEach(function() {
+    if (formService && !formService.isDestroyed()) formService.destroy();
+    Radio.reset();
+    Radio.channel('bootstrap').reset();
+  });
+
+  specify('uses the form id channel', function() {
+    formService = new FormsService({
+      form: new Backbone.Model({ id: '1' }),
+      patient: new Backbone.Model({ id: 'patient-1' }),
+    });
+
+    expect(formService.channelName()).to.equal('form1');
+  });
+
+  specify('resets its channel when destroyed', function() {
+    formService = new FormsService({
+      form: new Backbone.Model({ id: '1' }),
+      patient: new Backbone.Model({ id: 'patient-1' }),
+    });
+
+    const channel = formService.getChannel();
+    cy.spy(channel, 'reset').as('reset');
+
+    cy.then(() => {
+      formService.destroy();
+      formService = null;
+    });
+
+    cy.get('@reset').should('have.been.calledOnce');
+  });
+});

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -43,6 +43,7 @@ export default App.extend({
   onBeforeDestroy() {
     this.updateDraft.cancel();
     this.refreshForm.cancel();
+    this.getChannel().reset();
   },
   radioRequests: {
     'ready:form': 'readyForm',

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -1881,9 +1881,9 @@ context('Patient Action Form', function() {
       .should('have.length', 2);
 
     cy
-      .window()
-      .then(win => {
-        win.postMessage({ message: 'focus' }, win.origin);
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('focus');
       });
 
     cy


### PR DESCRIPTION
Closes FE-113

Fixed the host-side iframe `postMessage` crosstalk in `app-frontend`.

The bug was not caused by two instances of the same form. The actual failure was that the host listener in `src/js/behaviors/iframe-form.js` was global across all form iframes, so messages from one iframe could be handled by another. That led to `Unhandled postMessage: fetch:form:data` and `Unhandled postMessage: fetch:form:definition` when multiple different forms were open.

The fix scopes incoming `message` events to the owning iframe `contentWindow` and keeps cleanup local to the behavior instance. I kept the existing form-id Radio channel because distinct forms already have distinct channels, and the problem was listener routing, not channel naming.

Validation:
- Added regression specs for source-scoped message routing and Radio cleanup
- Ran `npx cypress run --component --spec 'src/js/behaviors/iframe-form.cy.js,src/js/services/forms.cy.js'`
- Ran `npx eslint src/js/behaviors/iframe-form.js src/js/services/forms.js src/js/apps/forms/form/form_app.js src/js/apps/forms/form/form-patient_app.js src/js/services/modal.js src/js/outreach/apps/form_app.js src/js/behaviors/iframe-form.cy.js src/js/services/forms.cy.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the host-side iframe postMessage listener to its owning iframe to prevent cross-talk between forms. Fixes FE-113 and removes "Unhandled postMessage: fetch:form:data/definition" when multiple forms are open.

- **Bug Fixes**
  - Gate message events by origin and require `originalEvent.source === iframe.contentWindow` so only the correct iframe routes.
  - Use a per-instance `messageHandler`; detach with `off('message', handler)` on teardown, call `stopReplying`, and reset the per-form channel. Also reset the Forms service channel on destroy.
  - Added Cypress specs to verify source-scoped routing and channel cleanup.

<sup>Written for commit 511dd9a69b40e516f5cc527dce928167a35c876c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

