### PR TITLE
fix(coverage): ignore coverage for `getFormUrl()`

### DIFF
--- a/src/js/entities-service/entities/forms.js
+++ b/src/js/entities-service/entities/forms.js
@@ -18,7 +18,7 @@ const _Model = BaseModel.extend({
   isSubmitHidden() {
     return get(this.get('options'), 'submit_hidden');
   },
-  getFormUrl(params = {}) {
+  getFormUrl(/* istanbul ignore next */params = {}) {
     const baseUrl = this.get('url') || '/forms/formio/index.html';
     const url = new URL(baseUrl, window.location.origin);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude getFormUrl() from Istanbul coverage by adding /* istanbul ignore next */, preventing flaky coverage caused by browser-only APIs (window.location, URL).

<sup>Written for commit 49f9498f821ffed24aff9d170cf6e7418a199f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

