### PR TITLE
fix(auth): harden WorkOS token refresh

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -16,6 +16,7 @@ export class WorkosAuthProvider extends AuthProvider {
     super(config, LoginView);
     this.trackAuthEvent = trackAuthEvent;
     this.recoveryPromise = null;
+    this.tokenPromise = null;
     this.reauthPending = false;
   }
 
@@ -31,8 +32,9 @@ export class WorkosAuthProvider extends AuthProvider {
     if (!this.client) return;
     if (!navigator.onLine) return this.token;
     if (this.reauthPending) return null;
+    if (this.tokenPromise) return this.tokenPromise;
 
-    return this.client
+    this.tokenPromise = this.client
       .getAccessToken(options)
       .then(token => {
         this.token = `Bearer ${ token }`;
@@ -53,7 +55,12 @@ export class WorkosAuthProvider extends AuthProvider {
         }
 
         return null;
+      })
+      .finally(() => {
+        this.tokenPromise = null;
       });
+
+    return this.tokenPromise;
   }
 
   async recoverToken() {
@@ -102,7 +109,15 @@ export class WorkosAuthProvider extends AuthProvider {
       return;
     }
 
-    super.loginPrompt(path);
+    try {
+      super.loginPrompt(path);
+    } catch (error) {
+      this.authEvent('AUTH_LOGIN_PROMPT_FAILED', {
+        reason: 'render_failed',
+        error: error?.message,
+      });
+      this.login(path);
+    }
   }
 
   async handleUnauthorized(retry) {

--- a/src/js/auth/workos.cy.js
+++ b/src/js/auth/workos.cy.js
@@ -105,6 +105,48 @@ context('WorkosAuthProvider', function() {
     });
   });
 
+  specify('coalesces concurrent getToken calls into a single AuthKit request', function() {
+    let resolveToken;
+    const tokenPromise = new Promise(resolve => {
+      resolveToken = resolve;
+    });
+    const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
+    provider.client = {
+      getAccessToken: cy.stub().returns(tokenPromise),
+    };
+
+    const first = provider.getToken();
+    const second = provider.getToken();
+    const third = provider.getToken();
+
+    resolveToken('new-token');
+
+    return Promise.all([first, second, third]).then(tokens => {
+      expect(tokens).to.deep.equal([
+        'Bearer new-token',
+        'Bearer new-token',
+        'Bearer new-token',
+      ]);
+      expect(provider.client.getAccessToken).to.have.been.calledOnce;
+    });
+  });
+
+  specify('clears the in-flight token promise after completion', function() {
+    const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
+    provider.client = {
+      getAccessToken: cy.stub()
+        .onFirstCall().resolves('first-token')
+        .onSecondCall().resolves('second-token'),
+    };
+
+    return provider.getToken()
+      .then(() => provider.getToken())
+      .then(token => {
+        expect(token).to.equal('Bearer second-token');
+        expect(provider.client.getAccessToken).to.have.been.calledTwice;
+      });
+  });
+
   specify('does not keep retrying normal token reads while re-auth is pending', function() {
     const provider = new WorkosAuthProvider({}, null, trackAuthEvent);
     provider.reauthPending = true;
@@ -225,6 +267,32 @@ context('WorkosAuthProvider', function() {
         expect(provider.client.getAccessToken).to.have.been.calledOnce;
         expect(provider.client.signIn).to.have.been.calledOnce;
       });
+  });
+
+  specify('falls back to direct sign-in when the login prompt view fails to render', function() {
+    function ThrowingLoginView() {
+      this.on = () => {};
+      this.render = () => {
+        throw new TypeError('e.querySelectorAll is not a function');
+      };
+    }
+
+    const provider = new WorkosAuthProvider({}, ThrowingLoginView, trackAuthEvent);
+    provider.client = {
+      getAccessToken: cy.stub().rejects(new LoginRequiredError()),
+      signIn: cy.stub(),
+    };
+
+    return provider.getToken().then(token => {
+      expect(token).to.be.null;
+      expect(provider.client.signIn).to.have.been.calledWith({ state: '/' });
+      expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT_FAILED', {
+        reason: 'render_failed',
+        error: 'e.querySelectorAll is not a function',
+        pathname: '/',
+        online: true,
+      });
+    });
   });
 
   specify('prompts for login when 401 recovery fails', function() {


### PR DESCRIPTION
## Summary
- Coalesce concurrent WorkOS AuthKit token requests so callers share one in-flight refresh.
- Clear the in-flight token slot after completion so later refreshes can run normally.
- Fall back to direct WorkOS sign-in and emit `AUTH_LOGIN_PROMPT_FAILED` if the re-auth prompt fails to render.

## Test plan
- `npm run lint`
- `npx cypress run --component --spec "src/js/auth/workos.cy.js"`

Follow-up structural fix: [FE-115](https://linear.app/roundingwell/issue/FE-115/fix-workos-re-auth-prompt-root-view-collision).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened WorkOS token refresh to stop race conditions and added a safe fallback when the re-auth prompt can’t render. Improves stability of `care-ops-auth` login flows.

- **Bug Fixes**
  - Coalesce concurrent AuthKit `getAccessToken` calls into one in-flight promise, then clear it after completion.
  - On login prompt render failure, emit `AUTH_LOGIN_PROMPT_FAILED` and fall back to direct WorkOS `signIn` with the current path.
  - Mitigates the re-auth prompt/root view collision noted in Linear FE-115; the structural fix remains tracked in that issue.

<sup>Written for commit bddf225507ddafdd1b954dfa3ac52b6b1478826f. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1679?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

