### PR TITLE
fix(auth): handle AuthKit refresh failures

### DIFF
--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -165,6 +165,11 @@ export class WorkosAuthProvider extends AuthProvider {
 
         success();
       },
+      onRefreshFailure() {
+        authProvider.authEvent('AUTH_REFRESH_FAILED', { reason: 'refresh_failed' });
+        if (!navigator.onLine) return;
+        authProvider.beginReauth('auth_refresh_failed');
+      },
       ...this.config.createClientOptions,
     };
 

--- a/src/js/auth/workos.cy.js
+++ b/src/js/auth/workos.cy.js
@@ -11,6 +11,13 @@ function setOnline(value) {
   });
 }
 
+function mockAccessToken({ iat = Date.now() / 1000, exp = Date.now() / 1000 + 3600 } = {}) {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ sid: 'session', iat, exp }));
+
+  return `${ header }.${ payload }.signature`;
+}
+
 function expectAuthEvent(trackAuthEvent, name, context) {
   const match = trackAuthEvent
     .getCalls()
@@ -33,6 +40,7 @@ context('WorkosAuthProvider', function() {
 
   afterEach(function() {
     document.cookie = 'workos-has-session=; Max-Age=0; path=/';
+    localStorage.removeItem('workos:refresh-token:client');
     window.history.pushState({}, '', '/');
     setOnline(true);
   });
@@ -326,6 +334,63 @@ context('WorkosAuthProvider', function() {
       expect(provider.reauthPending).to.be.true;
       expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT', {
         reason: 'auth_recovery_failed',
+        pathname: '/',
+        online: true,
+      });
+    });
+  });
+
+  specify('starts re-auth when AuthKit background refresh fails', function() {
+    const now = Date.now() / 1000;
+    const provider = new WorkosAuthProvider({
+      createClientOptions: {
+        apiHostname: location.hostname,
+        port: Number(location.port),
+        https: false,
+        devMode: true,
+      },
+    }, null, trackAuthEvent);
+    let refreshCount = 0;
+
+    localStorage.setItem('workos:refresh-token:client', 'refresh-token');
+    cy.intercept('POST', '**/user_management/authenticate', req => {
+      refreshCount += 1;
+      req.reply(refreshCount === 1 ?
+        {
+          statusCode: 200,
+          body: {
+            user: { id: 'user' },
+            access_token: mockAccessToken({ iat: now, exp: now }),
+            refresh_token: 'refresh-token',
+          },
+        } :
+        {
+          statusCode: 400,
+          body: {
+            error: 'invalid_grant',
+            error_description: 'Session has already ended.',
+          },
+        });
+    }).as('authRefresh');
+
+    cy.wrap(provider._initClient('client', cy.stub()))
+      .then(client => {
+        provider.client = client;
+        cy.stub(client, 'signIn').as('signIn');
+      });
+
+    cy.wait('@authRefresh');
+    cy.wait('@authRefresh');
+    cy.get('@signIn').should('have.been.calledWith', { state: '/' });
+
+    cy.then(() => {
+      expectAuthEvent(trackAuthEvent, 'AUTH_REFRESH_FAILED', {
+        reason: 'refresh_failed',
+        pathname: '/',
+        online: true,
+      });
+      expectAuthEvent(trackAuthEvent, 'AUTH_LOGIN_PROMPT', {
+        reason: 'auth_refresh_failed',
         pathname: '/',
         online: true,
       });


### PR DESCRIPTION
Closes FE-117

## What
- Add a WorkOS `onRefreshFailure` handler for AuthKit background refresh failures.
- Emit `AUTH_REFRESH_FAILED` and start the existing re-auth flow with `auth_refresh_failed`.
- Cover the refresh-failure re-auth path in `workos.cy.js`.

## Why
AuthKit can fail background refresh before the next app API request. Without this hook, the app may not begin re-auth until a later 401.

## Testing
- `npx cypress run --component --spec "src/js/auth/workos.cy.js"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start re-auth immediately when AuthKit reports a background refresh failure, and emit `AUTH_REFRESH_FAILED` so the earlier failure is visible in Datadog. Skip starting re-auth when offline. Addresses FE-117 to avoid delayed re-auth that waits for a later 401.

- **Bug Fixes**
  - Added `onRefreshFailure` to the WorkOS client to emit `AUTH_REFRESH_FAILED` and call `beginReauth('auth_refresh_failed')` when online.
  - Expanded the Cypress spec to simulate an expired token and a 400 refresh response, validating the real `onRefreshFailure` path triggers early re-auth and events.

<sup>Written for commit aee5cee015b1456a069c2030b30dbc491cfd37b3. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1681?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

