### PR TITLE
ci(linear): wire Linear release pipeline to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,19 +70,6 @@ commands:
           role_arn: ${AWS_ROLE_ARN}
           role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
-  download-linear-release:
-    steps:
-      - run:
-          name: Download Linear Release CLI
-          command: |
-            set -euo pipefail
-            linear_release_version="v0.7.0"
-            linear_release_sha256="c82e10e79ac54bfa5efff69124add2aa793d91b0d5e32c1ed56ab856eb2a7e79"
-            linear_release_url="https://github.com/linear/linear-release/releases/download/${linear_release_version}/linear-release-linux-x64"
-            curl -fsSL "$linear_release_url" -o /tmp/linear-release
-            echo "${linear_release_sha256}  /tmp/linear-release" | sha256sum -c -
-            chmod +x /tmp/linear-release
-
 # ------------------------------------------------------------
 # EXECUTOR  –  Node 22 LTS image with Chrome 137, FF 139, Edge 137
 # ------------------------------------------------------------
@@ -287,18 +274,20 @@ jobs:
           command: |
             set -euo pipefail
             circleci run release update "release-<< pipeline.git.tag >>" --status=FAILED
-      - download-linear-release
       - run:
           name: Sync Linear release
           when: on_success
           command: |
-            set -euo pipefail
-            git fetch --force --tags origin
-            /tmp/linear-release sync \
-              --release-version="<< pipeline.git.tag >>"
-            /tmp/linear-release update \
-              --release-version="<< pipeline.git.tag >>" \
-              --stage="Started"
+            set -uo pipefail
+            {
+              ./scripts/download-linear-release.sh
+              git fetch --force --tags origin
+              /tmp/linear-release sync \
+                --release-version="<< pipeline.git.tag >>"
+              /tmp/linear-release update \
+                --release-version="<< pipeline.git.tag >>" \
+                --stage="Started"
+            } || echo "Linear release sync failed; artifact published. Sync manually if needed."
 
 # ------------------------------------------------------------
 # WORKFLOWS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,19 @@ commands:
           role_arn: ${AWS_ROLE_ARN}
           role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
+  download-linear-release:
+    steps:
+      - run:
+          name: Download Linear Release CLI
+          command: |
+            set -euo pipefail
+            linear_release_version="v0.7.0"
+            linear_release_sha256="c82e10e79ac54bfa5efff69124add2aa793d91b0d5e32c1ed56ab856eb2a7e79"
+            linear_release_url="https://github.com/linear/linear-release/releases/download/${linear_release_version}/linear-release-linux-x64"
+            curl -fsSL "$linear_release_url" -o /tmp/linear-release
+            echo "${linear_release_sha256}  /tmp/linear-release" | sha256sum -c -
+            chmod +x /tmp/linear-release
+
 # ------------------------------------------------------------
 # EXECUTOR  –  Node 22 LTS image with Chrome 137, FF 139, Edge 137
 # ------------------------------------------------------------
@@ -274,6 +287,18 @@ jobs:
           command: |
             set -euo pipefail
             circleci run release update "release-<< pipeline.git.tag >>" --status=FAILED
+      - download-linear-release
+      - run:
+          name: Sync Linear release
+          when: on_success
+          command: |
+            set -euo pipefail
+            git fetch --force --tags origin
+            /tmp/linear-release sync \
+              --release-version="<< pipeline.git.tag >>"
+            /tmp/linear-release update \
+              --release-version="<< pipeline.git.tag >>" \
+              --stage="Started"
 
 # ------------------------------------------------------------
 # WORKFLOWS
@@ -428,6 +453,8 @@ workflows:
       - publish-build-artifact:
           <<: *tag-filter
           name: publish release artifact
-          context: aws-dev
+          context:
+            - aws-dev
+            - linear-secrets
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,14 +279,16 @@ jobs:
           when: on_success
           command: |
             set -uo pipefail
-            {
-              ./scripts/download-linear-release.sh
-              git fetch --force --tags origin
-              /tmp/linear-release sync \
-                --release-version="<< pipeline.git.tag >>"
-              /tmp/linear-release update \
-                --release-version="<< pipeline.git.tag >>" \
-                --stage="Started"
+            # set -e is suspended on the left side of `||`, so chain commands
+            # with `&&` to short-circuit on the first failure and let the
+            # group's exit code reflect the actual outcome.
+            { ./scripts/download-linear-release.sh \
+                && git fetch --force --tags origin \
+                && /tmp/linear-release sync \
+                     --release-version="<< pipeline.git.tag >>" \
+                && /tmp/linear-release update \
+                     --release-version="<< pipeline.git.tag >>" \
+                     --stage="Started"
             } || echo "Linear release sync failed; artifact published. Sync manually if needed."
 
 # ------------------------------------------------------------

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -275,16 +275,17 @@ jobs:
               *) exit 0 ;;
             esac
 
-            {
-              ./scripts/download-linear-release.sh
-              git fetch --force --tags origin
-              /tmp/linear-release update \
-                --release-version="$DEPLOY_TARGET_VERSION" \
-                --stage="$linear_stage"
-              if [ "$DEPLOY_STAGE" = "prod" ]; then
-                /tmp/linear-release complete \
-                  --release-version="$DEPLOY_TARGET_VERSION"
-              fi
+            # set -e is suspended on the left side of `||`, so chain commands
+            # with `&&` to short-circuit on the first failure and let the
+            # group's exit code reflect the actual outcome.
+            { ./scripts/download-linear-release.sh \
+                && git fetch --force --tags origin \
+                && /tmp/linear-release update \
+                     --release-version="$DEPLOY_TARGET_VERSION" \
+                     --stage="$linear_stage" \
+                && { [ "$DEPLOY_STAGE" != "prod" ] \
+                     || /tmp/linear-release complete \
+                          --release-version="$DEPLOY_TARGET_VERSION"; }
             } || echo "Linear release update failed; deploy succeeded. Sync manually if needed."
 
 workflows:

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -58,19 +58,6 @@ commands:
           role_arn: ${AWS_ROLE_ARN}
           role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
-  download-linear-release:
-    steps:
-      - run:
-          name: Download Linear Release CLI
-          command: |
-            set -euo pipefail
-            linear_release_version="v0.7.0"
-            linear_release_sha256="c82e10e79ac54bfa5efff69124add2aa793d91b0d5e32c1ed56ab856eb2a7e79"
-            linear_release_url="https://github.com/linear/linear-release/releases/download/${linear_release_version}/linear-release-linux-x64"
-            curl -fsSL "$linear_release_url" -o /tmp/linear-release
-            echo "${linear_release_sha256}  /tmp/linear-release" | sha256sum -c -
-            chmod +x /tmp/linear-release
-
 jobs:
   deploy-from-artifact:
     docker:
@@ -218,36 +205,6 @@ jobs:
               --status-file="$DEPLOY_MARKER_STATUS_FILE" \
               --target-environment="$DEPLOY_TARGET_ENV" \
               --target-version="$DEPLOY_TARGET_VERSION"
-      - download-linear-release
-      - run:
-          name: Update Linear release stage
-          when: on_success
-          command: |
-            set -euo pipefail
-
-            case "$DEPLOY_STAGE" in
-              qa)      linear_stage="QA" ;;
-              sandbox) linear_stage="Sandbox" ;;
-              prod)
-                if [ "$DEPLOY_ORGANIZATION" = "demonstration" ]; then
-                  echo "Skipping Linear release update for prod:demonstration"
-                  exit 0
-                fi
-                linear_stage="Released"
-                ;;
-              *)       exit 0 ;;
-            esac
-
-            git fetch --force --tags origin
-
-            /tmp/linear-release update \
-              --release-version="$DEPLOY_TARGET_VERSION" \
-              --stage="$linear_stage"
-
-            if [ "$DEPLOY_STAGE" = "prod" ]; then
-              /tmp/linear-release complete \
-                --release-version="$DEPLOY_TARGET_VERSION"
-            fi
       - run:
           name: Notify QA2 E2E repo
           when: on_success
@@ -296,12 +253,56 @@ jobs:
                 }
               ]
             }
+      - run:
+          name: Update Linear release stage
+          when: on_success
+          command: |
+            set -uo pipefail
+
+            case "$DEPLOY_STAGE" in
+              qa)      linear_stage="QA" ;;
+              sandbox) linear_stage="Sandbox" ;;
+              prod)
+                # Only the wildcard prod:* deploy represents a real release
+                # event. Org-scoped prod deploys (e.g. prod:demonstration,
+                # prod:apple) must not advance or complete the Linear release.
+                if [ -n "$DEPLOY_ORGANIZATION" ]; then
+                  echo "Skipping Linear release update for prod:$DEPLOY_ORGANIZATION"
+                  exit 0
+                fi
+                linear_stage="Released"
+                ;;
+              *) exit 0 ;;
+            esac
+
+            {
+              ./scripts/download-linear-release.sh
+              git fetch --force --tags origin
+              /tmp/linear-release update \
+                --release-version="$DEPLOY_TARGET_VERSION" \
+                --stage="$linear_stage"
+              if [ "$DEPLOY_STAGE" = "prod" ]; then
+                /tmp/linear-release complete \
+                  --release-version="$DEPLOY_TARGET_VERSION"
+              fi
+            } || echo "Linear release update failed; deploy succeeded. Sync manually if needed."
 
 workflows:
   deploy-dev:
     when:
       matches:
-        pattern: '^(dev|qa):[a-z0-9*-]+$'
+        pattern: '^dev:[a-z0-9*-]+$'
+        value: << pipeline.deploy.environment_name >>
+    jobs:
+      - deploy-from-artifact:
+          context:
+            - aws-dev
+            - slack-secrets
+
+  deploy-qa:
+    when:
+      matches:
+        pattern: '^qa:[a-z0-9*-]+$'
         value: << pipeline.deploy.environment_name >>
     jobs:
       - deploy-from-artifact:

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -58,6 +58,19 @@ commands:
           role_arn: ${AWS_ROLE_ARN}
           role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
+  download-linear-release:
+    steps:
+      - run:
+          name: Download Linear Release CLI
+          command: |
+            set -euo pipefail
+            linear_release_version="v0.7.0"
+            linear_release_sha256="c82e10e79ac54bfa5efff69124add2aa793d91b0d5e32c1ed56ab856eb2a7e79"
+            linear_release_url="https://github.com/linear/linear-release/releases/download/${linear_release_version}/linear-release-linux-x64"
+            curl -fsSL "$linear_release_url" -o /tmp/linear-release
+            echo "${linear_release_sha256}  /tmp/linear-release" | sha256sum -c -
+            chmod +x /tmp/linear-release
+
 jobs:
   deploy-from-artifact:
     docker:
@@ -205,6 +218,36 @@ jobs:
               --status-file="$DEPLOY_MARKER_STATUS_FILE" \
               --target-environment="$DEPLOY_TARGET_ENV" \
               --target-version="$DEPLOY_TARGET_VERSION"
+      - download-linear-release
+      - run:
+          name: Update Linear release stage
+          when: on_success
+          command: |
+            set -euo pipefail
+
+            case "$DEPLOY_STAGE" in
+              qa)      linear_stage="QA" ;;
+              sandbox) linear_stage="Sandbox" ;;
+              prod)
+                if [ "$DEPLOY_ORGANIZATION" = "demonstration" ]; then
+                  echo "Skipping Linear release update for prod:demonstration"
+                  exit 0
+                fi
+                linear_stage="Released"
+                ;;
+              *)       exit 0 ;;
+            esac
+
+            git fetch --force --tags origin
+
+            /tmp/linear-release update \
+              --release-version="$DEPLOY_TARGET_VERSION" \
+              --stage="$linear_stage"
+
+            if [ "$DEPLOY_STAGE" = "prod" ]; then
+              /tmp/linear-release complete \
+                --release-version="$DEPLOY_TARGET_VERSION"
+            fi
       - run:
           name: Notify QA2 E2E repo
           when: on_success
@@ -265,6 +308,7 @@ workflows:
           context:
             - aws-dev
             - slack-secrets
+            - linear-secrets
 
   deploy-prod:
     when:
@@ -276,3 +320,4 @@ workflows:
           context:
             - aws-prod
             - slack-secrets
+            - linear-secrets

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -140,6 +140,12 @@ npm run deploy -- --stage=<stage> [--organization=<organization>]
    - stage-wide deploys continue through every resolved environment and fail the job at the end if any targets fail
    - if a stage-wide deploy partially succeeds, concrete environment markers reflect the per-environment outcomes while the wildcard marker reflects the overall deploy result
 6. For QA deploys that include `qa2` (`qa:qa2` and `qa:*`), posts `qa2_deploy_succeeded` to `RoundingWell/app-tests`
+7. Updates the Linear release stage by running the pinned `linear/linear-release` CLI:
+   - `qa` deploys → `update --stage=QA`
+   - `sandbox` deploys → `update --stage=Sandbox`
+   - `prod` deploys → `update --stage=Released`, then `complete`
+   - `prod:demonstration` deploys are skipped (demo org, not a real release event)
+   - `dev` deploys are skipped
 
 Supported deploy environments:
 - `dev:<organization>`
@@ -166,6 +172,11 @@ Additional CircleCI secrets for the QA2 E2E dispatch step:
 - `GH_APP_ID`
 - `GH_APP_PRIVATE_KEY`
 - `GH_APP_INSTALLATION_ID`
+
+CircleCI context for the Linear release steps:
+- `linear-secrets` context, providing `LINEAR_ACCESS_KEY` (Linear release pipeline access key)
+- attached to the `release-artifact` workflow in [`.circleci/config.yml`](../.circleci/config.yml) (sync + `Started` stage on tag build) and to both deploy workflows in [`.circleci/deploy.yml`](../.circleci/deploy.yml) (per-stage `update` and final `complete`)
+- the Linear release pipeline is configured as **scheduled**; stages used: built-in `Started`, custom `QA` (frozen) and `Sandbox`, and built-in terminal `Released`. CI also calls `complete` after a successful prod deploy.
 
 For QA deploys that include `qa2`, [`.circleci/deploy.yml`](../.circleci/deploy.yml) resolves the release SHA, passes the release tag, SHA, and a CircleCI run URL to [`scripts/dispatch-qa2-e2e.js`](../scripts/dispatch-qa2-e2e.js), and that script uses the GitHub App credentials above plus the `app-tests` installation id to mint a short-lived installation token before posting `repository_dispatch` with this payload:
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -140,12 +140,13 @@ npm run deploy -- --stage=<stage> [--organization=<organization>]
    - stage-wide deploys continue through every resolved environment and fail the job at the end if any targets fail
    - if a stage-wide deploy partially succeeds, concrete environment markers reflect the per-environment outcomes while the wildcard marker reflects the overall deploy result
 6. For QA deploys that include `qa2` (`qa:qa2` and `qa:*`), posts `qa2_deploy_succeeded` to `RoundingWell/app-tests`
-7. Updates the Linear release stage by running the pinned `linear/linear-release` CLI:
-   - `qa` deploys → `update --stage=QA`
-   - `sandbox` deploys → `update --stage=Sandbox`
-   - `prod` deploys → `update --stage=Released`, then `complete`
-   - `prod:demonstration` deploys are skipped (demo org, not a real release event)
+7. Updates the Linear release stage by running the pinned `linear/linear-release` CLI (downloaded by [`scripts/download-linear-release.sh`](../scripts/download-linear-release.sh)):
+   - `qa:*` and specific `qa:<organization>` deploys → `update --stage=QA`
+   - `sandbox:*` and specific `sandbox:<organization>` deploys → `update --stage=Sandbox`
+   - `prod:*` (wildcard only) → `update --stage=Released`, then `complete`
+   - org-scoped `prod:<organization>` deploys (e.g. `prod:demonstration`, `prod:apple`) are skipped — only the wildcard prod deploy represents a release event
    - `dev` deploys are skipped
+   - the step is failure-tolerant (`|| echo …`); a Linear API or download failure does not fail the deploy job
 
 Supported deploy environments:
 - `dev:<organization>`
@@ -175,7 +176,7 @@ Additional CircleCI secrets for the QA2 E2E dispatch step:
 
 CircleCI context for the Linear release steps:
 - `linear-secrets` context, providing `LINEAR_ACCESS_KEY` (Linear release pipeline access key)
-- attached to the `release-artifact` workflow in [`.circleci/config.yml`](../.circleci/config.yml) (sync + `Started` stage on tag build) and to both deploy workflows in [`.circleci/deploy.yml`](../.circleci/deploy.yml) (per-stage `update` and final `complete`)
+- attached to the `release-artifact` workflow in [`.circleci/config.yml`](../.circleci/config.yml) (sync + `Started` stage on tag build), and to the `deploy-qa` and `deploy-prod` workflows in [`.circleci/deploy.yml`](../.circleci/deploy.yml). The `deploy-dev` workflow does not have access to the Linear secret.
 - the Linear release pipeline is configured as **scheduled**; stages used: built-in `Started`, custom `QA` (frozen) and `Sandbox`, and built-in terminal `Released`. CI also calls `complete` after a successful prod deploy.
 
 For QA deploys that include `qa2`, [`.circleci/deploy.yml`](../.circleci/deploy.yml) resolves the release SHA, passes the release tag, SHA, and a CircleCI run URL to [`scripts/dispatch-qa2-e2e.js`](../scripts/dispatch-qa2-e2e.js), and that script uses the GitHub App credentials above plus the `app-tests` installation id to mint a short-lived installation token before posting `repository_dispatch` with this payload:

--- a/scripts/download-linear-release.sh
+++ b/scripts/download-linear-release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Download and verify the linear/linear-release CLI to /tmp/linear-release.
+# Single source of truth for the pinned version + sha256 used by both
+# .circleci/config.yml (release-artifact workflow) and .circleci/deploy.yml
+# (deploy workflows). Prints the binary path on success.
+
+set -euo pipefail
+
+linear_release_version="v0.7.0"
+linear_release_sha256="c82e10e79ac54bfa5efff69124add2aa793d91b0d5e32c1ed56ab856eb2a7e79"
+linear_release_url="https://github.com/linear/linear-release/releases/download/${linear_release_version}/linear-release-linux-x64"
+linear_release_bin="${LINEAR_RELEASE_BIN:-/tmp/linear-release}"
+
+curl -fsSL "$linear_release_url" -o "$linear_release_bin"
+echo "${linear_release_sha256}  ${linear_release_bin}" | sha256sum -c -
+chmod +x "$linear_release_bin"
+echo "$linear_release_bin"


### PR DESCRIPTION
Closes FE-119

Add Linear release stage updates to the tag-build artifact pipeline and the deploy pipeline. Tag artifact upload syncs the release and moves it to Started; qa/sandbox/prod deploys advance through QA, Sandbox, and Released stages, with complete called after a successful prod deploy. Skips dev deploys and prod:demonstration. Pinned CLI binary v0.7.0 with sha256 verification, scoped via the linear-secrets CircleCI context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the Linear release pipeline into CircleCI so release stages update automatically from tag builds and deploys. Implements FE-119 by syncing on tag builds and advancing stages on QA, Sandbox, and wildcard Prod; steps use `&&` chaining and are failure-tolerant so they won’t block deploys.

- **New Features**
  - Tag artifact upload syncs the release for the tag and sets stage to Started.
  - Deploys update stages: QA → QA, Sandbox → Sandbox, `prod:*` → Released, then `complete`; skips `dev` and org-scoped `prod:<org>`; runs after deploy notifications and chains commands with `&&` to surface failures while keeping deploys/artifacts green.
  - `linear-secrets` context added to tag-build, `deploy-qa`, and `deploy-prod` (not `deploy-dev`).

- **Dependencies**
  - Adds pinned `linear/linear-release` CLI v0.7.0 with SHA256 verification, downloaded via `scripts/download-linear-release.sh`.
  - Updates `docs/deploy.md` with stage mapping and required `LINEAR_ACCESS_KEY` in `linear-secrets`.

<sup>Written for commit 50eb96ae3d5549e51c6c0d9ec34bad03c5e22a2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

