### PR TITLE
refactor(i18n): replace handlebars-intl adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/care-ops-ringcentral"
       ],
       "dependencies": {
+        "@formatjs/intl": "^4.1.8",
         "@fortawesome/fontawesome-svg-core": "^7.1.0",
         "@roundingwell/care-ops-auth": "workspace:*",
         "@roundingwell/care-ops-config": "workspace:*",
@@ -32,7 +33,6 @@
         "backbone.store": "^1.1.1",
         "dayjs": "^1.10.6",
         "handlebars": "^4.7.9",
-        "handlebars-intl": "^1.1.2",
         "jquery": "^4.0.0",
         "libphonenumber-js": "^1.10.38",
         "marionette.toolkit": "^6.2.0",
@@ -3868,6 +3868,38 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
         "npm": ">=10"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.3.tgz",
+      "integrity": "sha512-Ocd1vPuD68rW6BJDuAOtnnc1GPeVepY5kZXML1psGVFQ+1Q8CfkftT3Tnam+Mxx97Pz08jIEDCotl/GV+Naccg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.6.tgz",
+      "integrity": "sha512-04ZjRIeQCnR/h32wBP9/S7rkyy1hLAs2fXJcNwc7hseJd//K9TMBqK0ukb4dXqnALKQ9m5ruZeOD2qqEkK9ixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.6"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.6.tgz",
+      "integrity": "sha512-9f1VQ2kaaLHK0WPU1OrAmiNKCKJwyoDmwNzQXbUa6XtFBOgHZ4YZURE8sSedHmMr0kvpB75OtplB0hMYkfdwfg==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.8.tgz",
+      "integrity": "sha512-ikDo41921J++o+fMjl7Qd1QxGiYqnBbMhBbDfzlwlfq0CQIuhF/BU/SZosZEGgpTqOa0VUhLCbOYC7wjtXb1tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.3",
+        "@formatjs/icu-messageformat-parser": "3.5.6",
+        "intl-messageformat": "11.2.3"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -9855,17 +9887,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars-intl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars-intl/-/handlebars-intl-1.1.2.tgz",
-      "integrity": "sha512-XjamtPHDO56u/iI37UAl8bKJjzCtfDJJzx1QW+OlUm8dYqAKJ2RKjoI9qAdDrwORpiMjA4olqjWnQlJ9P5GFWw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "intl-format-cache": "2.0.5",
-        "intl-messageformat": "1.1.0",
-        "intl-relativeformat": "1.1.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -10199,36 +10220,14 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/intl-format-cache": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.0.5.tgz",
-      "integrity": "sha512-xYPMygEcyGQvCsSKtpJz5ftsqLBID8t4p+ZqMLmwiE6pxkIVfTHOPF/jAA+X+bJzAnjBMps/GelH8eO9eYovRQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/intl-messageformat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-1.1.0.tgz",
-      "integrity": "sha512-uw+PsxKM1i0Bj3bd8Y0Rkfm6SYtl9TucmslrUDIHHhz3sKKUs6sdRX+0OOx/cV9cHwAQ0hzGg0A0nswT6ZWFTA==",
-      "license": "BSD",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.3.tgz",
+      "integrity": "sha512-kZthTU+3WLcoWoRg5j6LOkN1TeUBtmkX0OIwSAbcHVIfQAEbGVdmANM8u6GL3eUDOqLwheYoXMUshAh1UdeXlQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "intl-messageformat-parser": "1.1.0"
-      }
-    },
-    "node_modules/intl-messageformat-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.1.0.tgz",
-      "integrity": "sha512-Dy5x2puv9ne6KUvEkZGq781p8iA4nB8BUrRUnacrgCeLv39KAGLPTiGf+18OLxa+PJ8cXnEyiGSSlIku3ZTuUA==",
-      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
-      "license": "BSD"
-    },
-    "node_modules/intl-relativeformat": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-1.1.0.tgz",
-      "integrity": "sha512-JLYCMrLbSbI2lDAJ2/LQ8UXR/Yu2gJ3G7g4ZRoyCljeYfVRu+PbXrpO31wOrcmdc2O+bluBOi+it/EirMxbIaw==",
-      "deprecated": "This package has been deprecated, please see migration guide at 'https://github.com/formatjs/formatjs/tree/master/packages/intl-relativeformat#migration-guide'",
-      "license": "BSD",
-      "dependencies": {
-        "intl-messageformat": "1.1.0"
+        "@formatjs/fast-memoize": "3.1.3",
+        "@formatjs/icu-messageformat-parser": "3.5.6"
       }
     },
     "node_modules/is-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "yaml": "^2.1.1"
   },
   "dependencies": {
+    "@formatjs/intl": "^4.1.8",
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
     "@roundingwell/care-ops-auth": "workspace:*",
     "@roundingwell/care-ops-config": "workspace:*",
@@ -131,7 +132,6 @@
     "backbone.store": "^1.1.1",
     "dayjs": "^1.10.6",
     "handlebars": "^4.7.9",
-    "handlebars-intl": "^1.1.2",
     "jquery": "^4.0.0",
     "libphonenumber-js": "^1.10.38",
     "marionette.toolkit": "^6.2.0",

--- a/src/js/base/helpers.cy.js
+++ b/src/js/base/helpers.cy.js
@@ -1,9 +1,12 @@
 import { View } from 'marionette';
 
 import hbs from 'handlebars-inline-precompile';
+import Handlebars from 'handlebars/dist/cjs/handlebars';
 
 import { testTs } from 'helpers/test-timestamp';
 import formatDate from 'helpers/format-date';
+import { renderTemplate } from 'js/i18n';
+import { registerWith } from 'js/i18n/intl';
 
 context('Handlebars helpers', function() {
   specify('Match text formatting', function() {
@@ -86,6 +89,169 @@ context('Handlebars helpers', function() {
       .get('@root')
       .find('.test-default-html')
       .should('contain', 'No Date Available');
+  });
+
+  specify('Intl formatting', function() {
+    const testDate = '2026-05-05T12:00:00Z';
+    const IntlView = View.extend({
+      template: hbs`
+        {{#intl formats=formats}}
+          <div class="test-date-format">{{formatDate testDate "short"}}</div>
+        {{/intl}}
+        <div class="test-date-options">{{formatDate testDate year="numeric" month="short" day="numeric" timeZone="UTC"}}</div>
+        <div class="test-intlname">{{formatMessage intlName="patients.shared.components.durationComponent.mins" min=4}}</div>
+        <div class="test-function">{{formatMessage functionMessage name="Patient"}}</div>
+        <div class="test-message">{{formatMessage (intlGet "patients.shared.components.durationComponent.mins") min=2}}</div>
+        <div class="test-select">{{formatMessage (intlGet "patients.shared.components.dateFilterComponent.dateTypes") type="created_at"}}</div>
+        <div class="test-number-select">{{formatMessage (intlGet "patients.shared.listViews.countView.maximumListCount") maximumCount=50 totalInDb=1000 isFlowList=false}}</div>
+        <div class="test-html">{{formatHTMLMessage "<strong>{ name }</strong>" name=name}}</div>
+        <div class="test-html-safe">{{formatHTMLMessage "{ name }" name=(matchText "Patient Name" "Patient")}}</div>
+        <div class="test-escaped">{{formatHTMLMessage "{ name }" name=name}}</div>
+      `,
+      templateContext() {
+        return {
+          testDate,
+          formats: {
+            date: {
+              short: {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                timeZone: 'UTC',
+              },
+            },
+          },
+          functionMessage({ name }) {
+            return `Function ${ name }`;
+          },
+          name: '<script>alert("bad")</script>',
+        };
+      },
+    });
+
+    cy
+      .mount(() => {
+        return new IntlView();
+      })
+      .as('root');
+
+    cy
+      .get('@root')
+      .find('.test-date-format')
+      .should('contain', '05/05/2026');
+
+    cy
+      .get('@root')
+      .find('.test-date-options')
+      .should('contain', 'May 5, 2026');
+
+    cy
+      .get('@root')
+      .find('.test-intlname')
+      .should('contain', '4 mins');
+
+    cy
+      .get('@root')
+      .find('.test-function')
+      .should('contain', 'Function Patient');
+
+    cy
+      .get('@root')
+      .find('.test-message')
+      .should('contain', '2 mins');
+
+    cy
+      .get('@root')
+      .find('.test-select')
+      .should('contain', 'Added');
+
+    cy
+      .get('@root')
+      .find('.test-number-select')
+      .should('contain', 'Showing 50 of 1,000 Actions.');
+
+    cy
+      .get('@root')
+      .find('.test-html')
+      .should('contain', '<script>alert("bad")</script>')
+      .and('not.contain', '{ name }')
+      .find('strong')
+      .should('exist');
+
+    cy
+      .get('@root')
+      .find('.test-html-safe')
+      .find('strong')
+      .should('contain', 'Patient');
+
+    cy
+      .get('@root')
+      .find('.test-escaped script')
+      .should('not.exist');
+  });
+
+  specify('Intl formatting defaults', function() {
+    const localHandlebars = Handlebars.create();
+    registerWith(localHandlebars);
+
+    const template = localHandlebars.compile(`
+      {{#intl locales="en-US"}}
+        <div class="test-block">{{formatMessage "{ value }" value=false}}</div>
+      {{/intl}}
+      <div class="test-default-message">{{formatMessage "{ name }" name="Patient"}}</div>
+      <div class="test-default-date">{{formatDate "2026-05-05T12:00:00Z" year="numeric" month="2-digit" day="2-digit" timeZone="UTC"}}</div>
+      <div class="test-default-html">{{formatHTMLMessage "{ name }" name=safeName count=count}}</div>
+    `);
+    const html = template({
+      count: 0,
+      safeName: new localHandlebars.SafeString('<strong>Patient</strong>'),
+    });
+
+    expect(html).to.contain('<div class="test-block"></div>');
+    expect(html).to.contain('<div class="test-default-message">Patient</div>');
+    expect(html).to.contain('<div class="test-default-date">05/05/2026</div>');
+    expect(html).to.contain('<div class="test-default-html"><strong>Patient</strong></div>');
+  });
+
+  specify('Intl formatting rejects invalid input', function() {
+    const localHandlebars = Handlebars.create();
+    registerWith(localHandlebars);
+
+    const BadIntlTemplate = hbs`{{intl}}`;
+    const BadLocalIntlGetTemplate = localHandlebars.compile('{{intlGet "not.found"}}');
+    const BadIntlGetTemplate = hbs`{{intlGet "not.found"}}`;
+    const BadDateTemplate = hbs`{{formatDate null}}`;
+    const BadDateValueTemplate = hbs`{{formatDate "not-a-date"}}`;
+    const BadMessageMissingTemplate = hbs`{{formatMessage}}`;
+    const BadMessageTemplate = hbs`{{formatMessage message}}`;
+
+    expect(() => {
+      renderTemplate(BadIntlTemplate);
+    }).to.throw('{{#intl}} must be invoked as a block helper');
+
+    expect(() => {
+      BadLocalIntlGetTemplate();
+    }).to.throw('Could not find Intl object: not.found');
+
+    expect(() => {
+      renderTemplate(BadIntlGetTemplate);
+    }).to.throw('Could not find Intl object: not.found');
+
+    expect(() => {
+      renderTemplate(BadDateTemplate);
+    }).to.throw('A date or timestamp must be provided to {{formatDate}}');
+
+    expect(() => {
+      renderTemplate(BadDateValueTemplate);
+    }).to.throw('A date or timestamp must be provided to {{formatDate}}');
+
+    expect(() => {
+      renderTemplate(BadMessageMissingTemplate);
+    }).to.throw('{{formatMessage}} must be provided a message or intlName');
+
+    expect(() => {
+      renderTemplate(BadMessageTemplate, { message: { text: 'Bad Message' } });
+    }).to.throw('{{formatMessage}} must be provided a message or intlName');
   });
 
   specify('Phone number formatting', function() {

--- a/src/js/i18n/README.md
+++ b/src/js/i18n/README.md
@@ -2,9 +2,9 @@
 
 ## formatjs
 
-For the provider app we are using Yahoo's [formatjs](https://formatjs.io/) through the
-[handlebars-intl](https://formatjs.io/handlebars/) lib. Our translation will be key based
-and found in the directory [`/assets/js/i18n`](https://github.com/RoundingWell/app-frontend/tree/develop/src/js/i18n).
+For the provider app we use [FormatJS](https://formatjs.io/) directly through a small
+Handlebars adapter in `src/js/i18n/intl.js`. Our translation will be key based and found
+in the directory [`/assets/js/i18n`](https://github.com/RoundingWell/app-frontend/tree/develop/src/js/i18n).
 
 The key naming strategy currently under consideration is:
 `view.directory.fileViews.viewName.stringContextName` where the first part is the

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -383,7 +383,7 @@ careOptsFrontend:
             addButton: Added
             dueButton: Due
             updateButton: Updated
-          dateTypes: "{type, select, created_at {Added} due_date {Due} updated_at {Updated}}"
+          dateTypes: "{type, select, created_at {Added} due_date {Due} updated_at {Updated} other {}}"
           relativeDate: "{relativeTo, select,
               alltime {All Time}
               calendar {Select from calendar...}
@@ -392,7 +392,8 @@ careOptsFrontend:
               thisweek {This Week}
               lastweek {Last Week}
               today {Today}
-              yesterday {Yesterday}}"
+              yesterday {Yesterday}
+              other {}}"
         dialerComponent:
           callLabel: Call
           defaultText: Call Number...
@@ -433,8 +434,8 @@ careOptsFrontend:
         countView:
           actionsCount: "{itemCount, plural, one {# Action} other {# Actions}}"
           flowsCount: "{itemCount, plural, one {# Flow} other {# Flows}}"
-          maximumListCount: Showing {maximumCount} of {totalInDb, number} {isFlowList, select, true {Flows} false {Actions}}.
-          maximumListCountNarrowed: Showing {itemCount} of {maximumCount} {isFlowList, select, true {Flows} false {Actions}}.
+          maximumListCount: Showing {maximumCount} of {totalInDb, number} {isFlowList, select, true {Flows} false {Actions} other {}}.
+          maximumListCountNarrowed: Showing {itemCount} of {maximumCount} {isFlowList, select, true {Flows} false {Actions} other {}}.
           narrowFilters: Try narrowing your filters.
       readOnlyViews:
         readOnlyDurationView:
@@ -617,6 +618,7 @@ careOptsFrontend:
             active {Active}
             inactive {Inactive}
             archived {Archived}
+            other {}
           }
     worklist:
       actionViews:
@@ -628,6 +630,7 @@ careOptsFrontend:
             new_past_day {Actions added in the last 24 hours.}
             updated_past_three_days {Actions updated in the last 3 days.}
             done_last_thirty_days {Actions completed in the last 30 days.}
+            other {}
           }
       flowViews:
         flowEmptyView: No Flows
@@ -638,6 +641,7 @@ careOptsFrontend:
             new_past_day {Flows added in the last 24 hours.}
             updated_past_three_days {Flows updated in the last 3 days.}
             done_last_thirty_days {Flows completed in the last 30 days.}
+            other {}
           }
       tableHeaderTemplate:
         actionHeader: Action
@@ -665,6 +669,7 @@ careOptsFrontend:
               new_past_day {New < 1 Day: }
               updated_past_three_days {Updated < 3 Days: }
               done_last_thirty_days {Done < 30 Days: }
+              other {}
             }
           listTitles: |
             {title, select,
@@ -673,6 +678,7 @@ careOptsFrontend:
               new_past_day {New < 24 hrs: { owner }}
               updated_past_three_days {Updated < 3 Days: {owner}}
               done_last_thirty_days {Done < 30 Days: {owner}}
+              other {}
             }
         noOwnerToggleView:
           noOwner: No Owner
@@ -723,6 +729,7 @@ careOptsFrontend:
             {published, select,
               true {On}
               false {Off}
+              other {}
             }
           state: Program State
         sidebarViews:
@@ -751,6 +758,7 @@ careOptsFrontend:
           {published, select,
             true {On}
             false {Off}
+            other {}
           }
       layoutView:
         title: Programs
@@ -791,6 +799,7 @@ careOptsFrontend:
             {status, select,
               true {On}
               false {Off}
+              other {}
             }
     sidebar:
       action:

--- a/src/js/i18n/index.js
+++ b/src/js/i18n/index.js
@@ -2,10 +2,10 @@ import { extend, isString, keys, reduce } from 'underscore';
 import dayjs from 'dayjs';
 import Handlebars from 'handlebars/dist/cjs/handlebars';
 import HandlebarsRuntime from 'handlebars/runtime';
-import HandlebarsIntl from 'handlebars-intl';
 import { setRenderer } from 'marionette';
 
 import localEnUs from './en-US.yml';
+import { registerWith } from './intl';
 
 const localeKey = 'careOptsFrontend';
 
@@ -32,8 +32,8 @@ function setLocale(locale = 'en-US') {
 
 setLocale();
 
-HandlebarsIntl.registerWith(Handlebars);
-HandlebarsIntl.registerWith(HandlebarsRuntime);
+registerWith(Handlebars);
+registerWith(HandlebarsRuntime);
 
 setRenderer(renderTemplate);
 

--- a/src/js/i18n/intl.js
+++ b/src/js/i18n/intl.js
@@ -1,0 +1,144 @@
+import { createIntl, createIntlCache } from '@formatjs/intl';
+
+const cache = createIntlCache();
+
+function registerWith(Handlebars) {
+  const { SafeString, Utils: { escapeExpression }, createFrame } = Handlebars;
+
+  function intl(options) {
+    if (!options.fn) {
+      throw new Error('{{#intl}} must be invoked as a block helper');
+    }
+
+    const data = createFrame(options.data);
+    data.intl = { ...data.intl, ...options.hash };
+
+    return options.fn(this, { data });
+  }
+
+  function formatHTMLMessage(...args) {
+    const options = args[args.length - 1];
+
+    Object.keys(options.hash).forEach(key => {
+      const value = options.hash[key];
+
+      if (typeof value === 'string') {
+        options.hash[key] = escapeExpression(value);
+      }
+    });
+
+    return new SafeString(String(formatMessage(...args)));
+  }
+
+  Handlebars.registerHelper({
+    intl,
+    intlGet,
+    formatDate,
+    formatMessage,
+    formatHTMLMessage,
+  });
+}
+
+function intlGet(path, options) {
+  let obj = options.data && options.data.intl;
+
+  path.split('.').forEach(pathPart => {
+    obj = obj && obj[pathPart];
+
+    if (obj === undefined) {
+      throw new ReferenceError(`Could not find Intl object: ${ path }`);
+    }
+  });
+
+  return obj;
+}
+
+function formatDate(date, format, options) {
+  assertIsDateInput(date, 'A date or timestamp must be provided to {{formatDate}}');
+
+  const value = new Date(date);
+
+  assertIsDate(value, 'A date or timestamp must be provided to {{formatDate}}');
+
+  if (!options) {
+    options = format;
+    format = null;
+  }
+
+  return getIntl(options).formatDate(value, getFormatOptions('date', format, options));
+}
+
+function formatMessage(message, options) {
+  if (!options) {
+    options = message;
+    message = null;
+  }
+
+  const hash = options.hash;
+
+  if (message == null && hash.intlName) {
+    message = intlGet(hash.intlName, options);
+  }
+
+  if (typeof message === 'function') {
+    return message(hash);
+  }
+
+  if (typeof message !== 'string') {
+    throw new ReferenceError('{{formatMessage}} must be provided a message or intlName');
+  }
+
+  return getIntl(options).formatMessage({
+    id: message,
+    defaultMessage: message,
+  }, normalizeValues(hash), {
+    ignoreTag: true,
+  });
+}
+
+function getIntl(options) {
+  const intlData = options.data.intl || {};
+  const locale = intlData.locales || 'en-US';
+
+  return createIntl({
+    locale,
+    defaultLocale: locale,
+    formats: intlData.formats || {},
+    messages: {},
+  }, cache);
+}
+
+function getFormatOptions(type, format, options) {
+  if (!format) return options.hash;
+
+  return {
+    ...intlGet(`formats.${ type }.${ format }`, options),
+    ...options.hash,
+  };
+}
+
+function normalizeValues(hash) {
+  return Object.keys(hash).reduce((values, key) => {
+    const value = hash[key];
+
+    values[key] = value && typeof value.toHTML === 'function' ? value.toHTML() : value;
+
+    return values;
+  }, {});
+}
+
+function assertIsDateInput(date, errorMessage) {
+  if (date == null) {
+    throw new TypeError(errorMessage);
+  }
+}
+
+function assertIsDate(date, errorMessage) {
+  if (!isFinite(date)) {
+    throw new TypeError(errorMessage);
+  }
+}
+
+export {
+  registerWith,
+};


### PR DESCRIPTION
Closes FE-120

## What
- Replace `handlebars-intl` with `@formatjs/intl`
- Add a local Handlebars i18n adapter for `formatMessage`, `formatDate`, `intlGet`, and `formatHTMLMessage`
- Add component coverage for ICU plural formatting and HTML escaping

## Why
`handlebars-intl` is a thin adapter over FormatJS. Owning the small adapter locally removes an old dependency layer while preserving existing template behavior.

## Testing
- `npx cypress run --component --spec src/js/base/helpers.cy.js`
- `npm run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `handlebars-intl` with a local Handlebars i18n adapter built on `@formatjs/intl`, fixed ICU select handling by adding `other` branches, and preserved HTML message tags with safe escaping. Addresses FE-120 with no template changes and clearer errors for invalid inputs.

- **Refactors**
  - Added `src/js/i18n/intl.js` with `formatMessage`, `formatDate`, `intlGet`, `formatHTMLMessage`, and an `intl` block helper; registered with `handlebars` and `handlebars/runtime`. Updated i18n README.
  - Removed `handlebars-intl` and added `@formatjs/intl`.

- **Bug Fixes**
  - Added `other` branches to ICU selects in `en-US.yml`.
  - Preserved HTML tags while escaping values in `formatHTMLMessage`. Added tests for selects, number formatting, HTML, and invalid input errors.

<sup>Written for commit 96480728214ce60ce56599b815ad233af9600770. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

