### PR TITLE
fix(worklist): prevent stale filter sidebar render

### DIFF
--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -53,8 +53,10 @@ export default App.extend(extend({
     });
   },
   showCustomFiltersView() {
-    Promise.allSettled(this.fetchFilters())
+    Promise.allSettled(this.fetchFilters() || [])
       .then(() => {
+        if (!this.isRunning()) return;
+
         this._showCustomFiltersView();
       });
   },

--- a/test/integration/patients/sidebar/filter-sidebar.js
+++ b/test/integration/patients/sidebar/filter-sidebar.js
@@ -1086,6 +1086,44 @@ context('filter sidebar', function() {
       .should('not.exist');
 
     cy
+      .intercept('GET', '/api/filters/team/**', {
+        delay: 1000,
+        body: {
+          data: getFilter({
+            attributes: {
+              name: 'Team',
+              slug: 'team',
+              values: [
+                { value: 'Coordinator', total: 2 },
+                { value: 'Nurse', total: 1 },
+              ],
+            },
+          }),
+          included: [],
+        },
+      })
+      .as('delayedRouteFilterTeam');
+
+    cy
+      .get('.list-page__filters')
+      .find('[data-filters-region]')
+      .find('button')
+      .click();
+
+    cy
+      .get('.app-frame__sidebar .sidebar')
+      .as('filtersSidebar')
+      .find('.js-close')
+      .click();
+
+    cy
+      .wait('@delayedRouteFilterTeam');
+
+    cy
+      .get('@filtersSidebar')
+      .should('not.exist');
+
+    cy
       .get('.list-page__filters')
       .find('[data-filters-region]')
       .find('button')


### PR DESCRIPTION
Closes FE-125

## What
- Guard the worklist filter sidebar custom-filter render path so stale fetch responses do not render after the sidebar app stops.
- Add a Cypress regression that delays `/api/filters/team/**`, clears filters, closes the sidebar, and changes the date filter to `Due > Today`.

## Why
Datadog reported `TypeError: Cannot read properties of undefined (reading 'getChildView')` from `services/sidebar.js`. The root cause was an async custom-filter fetch resolving after the filter sidebar had already been closed/stopped.

## Scope
Impacts the patients worklist filter sidebar custom-filter loading path.
No shared sidebar API changes and no date filter behavior changes.

## Deployment Impact
Normal app deployment only. No form or shared-runtime redeploy required.

## Testing
- Reproduced the failure in Cypress before the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stale custom-filter rendering after the worklist filter sidebar is closed, fixing a TypeError in the patients worklist. Adds a `Cypress` regression test for delayed team filter responses. Closes FE-125.

- **Bug Fixes**
  - Guard rendering with `isRunning()` and default to `Promise.allSettled(this.fetchFilters() || [])` to avoid post-stop renders and handle missing fetches.
  - Add a `Cypress` test that delays `/api/filters/team/**`, closes the sidebar, and verifies no render occurs.

<sup>Written for commit e8f019249ff4b4509cf2c9bd8e60fb9342cf29dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

