### PR TITLE
chore(deps): update backbone.store to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "backbone.eventrouter": "^1.0.1",
         "backbone.marionette": "^4.1.2",
         "backbone.radio": "^2.0.0",
-        "backbone.store": "^1.1.1",
+        "backbone.store": "^2.0.0",
         "dayjs": "^1.10.6",
         "handlebars": "^4.7.9",
         "jquery": "^4.0.0",
@@ -7480,9 +7480,9 @@
       }
     },
     "node_modules/backbone.store": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/backbone.store/-/backbone.store-1.1.1.tgz",
-      "integrity": "sha512-WqqGSqKs5SHmDtCI4DfatJSRxRtBbcCmR6lGr8o3Lcxy2IKFvpb07lYBjElax2nWqgTC2BFrv7ymkbqRU3quOA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/backbone.store/-/backbone.store-2.0.0.tgz",
+      "integrity": "sha512-c/oPRLoDnoVvg6zRmvIBYRwc6Qa/btBPQiA6Apz6RbyNK2bs0g1ZHr9T427NOg4zL4CWuHB/AiUv31Xd0A+UTw==",
       "license": "MIT",
       "peerDependencies": {
         "backbone": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "backbone.eventrouter": "^1.0.1",
     "backbone.marionette": "^4.1.2",
     "backbone.radio": "^2.0.0",
-    "backbone.store": "^1.1.1",
+    "backbone.store": "^2.0.0",
     "dayjs": "^1.10.6",
     "handlebars": "^4.7.9",
     "jquery": "^4.0.0",


### PR DESCRIPTION
Closes FE-130

## What
- Bump `backbone.store` from `^1.1.1` to `^2.0.0`.
- Refresh `package-lock.json` to resolve `backbone.store@2.0.0`.
- Keep app cache behavior unchanged.

## Why
- Pulls in the v2 package/runtime hardening while keeping this PR dependency-only.

## Scope
- Impacts the frontend dependency graph.
- Does not change entity-service, model-cache usage, websocket handling, or runtime cache semantics.

## Deployment Impact
- Normal app deployment only.

## Testing
- `npm install backbone.store@^2.0.0`
- `node -e "import('backbone.store').then(m=>console.log(m.default && typeof m.default, m.ModelCache && typeof m.ModelCache))"`
- `npx vite build --mode test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `backbone.store` from `^1.1.1` to `^2.0.0` to adopt v2 hardening with no behavior changes. Aligns with FE-130; lockfile refreshed and normal deploy only.

<sup>Written for commit f2a82c3e47447b3c8a888a727e0d635e8c7cd309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

