### PR TITLE
fix(ui): overflow ellipsis not working on custom filter buttons

### DIFF
--- a/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
+++ b/src/js/views/patients/sidebar/filters/filters-sidebar_views.js
@@ -30,7 +30,7 @@ const CustomFilterDropList = Droplist.extend({
     return this.getView().$el.outerWidth();
   },
   viewOptions: {
-    className: 'button-secondary w-100 flex',
+    className: 'button-secondary w-100',
     template: hbs`{{ value }}{{#unless value}}{{ defaultText }}{{/unless}}`,
     templateContext: {
       defaultText: i18n.customFilterView.defaultText,


### PR DESCRIPTION
Closes FE-127

To fix text ellipsis overflow not working in the custom filters dropdown buttons:

<img width="353" height="53" alt="Screenshot 2026-05-13 at 2 42 08 PM" src="https://github.com/user-attachments/assets/e5ca6b04-34af-4743-8e1f-69856608031a" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix overflow ellipsis on custom filter dropdown buttons so long labels truncate instead of wrapping, addressing FE-127. Removes the `flex` class from the button, which blocked `text-overflow: ellipsis` in production.

<sup>Written for commit 6d86ea60cd97c43ea89e439f3e29ccda9034845a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

