### PR TITLE
chore: replace `store` npm package with app-owned storage helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "libphonenumber-js": "^1.10.38",
         "marionette.toolkit": "^6.2.0",
         "sortablejs": "^1.14.0",
-        "store": "^2.0.12",
         "underscore": "^1.13.1",
         "uuid": "^14.0.0"
       },
@@ -14383,15 +14382,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/store": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
-      "integrity": "sha512-eO9xlzDpXLiMr9W1nQ3Nfp9EzZieIQc10zPPMP5jsVV7bLOziSFFBP0XoDXACEIFtdI+rIz0NwWVA/QVJ8zJtw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "libphonenumber-js": "^1.10.38",
     "marionette.toolkit": "^6.2.0",
     "sortablejs": "^1.14.0",
-    "store": "^2.0.12",
     "underscore": "^1.13.1",
     "uuid": "^14.0.0"
   },

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -1,6 +1,7 @@
 import { extend } from 'underscore';
 import Radio from 'backbone.radio';
-import store from 'store';
+
+import localStore from 'js/utils/local-store';
 
 import App from 'js/base/app';
 
@@ -34,7 +35,7 @@ export default App.extend({
     },
   },
   initFormState() {
-    const storedState = store.get(`form-state_${ this.currentUser.id }`);
+    const storedState = localStore.get(`form-state_${ this.currentUser.id }`);
 
     this.setState(extend({ isExpanded: true, saveButtonType: 'save' }, storedState));
   },
@@ -123,7 +124,7 @@ export default App.extend({
     'change:isExpanded': 'showSidebar',
   },
   onChangeState(state) {
-    store.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
+    localStore.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
   },
   showStateActions() {
     const actionsView = new FormStateActionsView({

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -1,6 +1,7 @@
 import { extend, get } from 'underscore';
 import Radio from 'backbone.radio';
-import store from 'store';
+
+import localStore from 'js/utils/local-store';
 
 import App from 'js/base/app';
 
@@ -41,7 +42,7 @@ export default App.extend({
     actionSidebar: ActionSiderbarApp,
   },
   initFormState() {
-    const storedState = store.get(`form-state_${ this.currentUser.id }`);
+    const storedState = localStore.get(`form-state_${ this.currentUser.id }`);
 
     this.setState(extend({
       responseId: null,
@@ -172,7 +173,7 @@ export default App.extend({
     'change:responseId': 'onChangeResponseId',
   },
   onChangeState(state) {
-    store.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
+    localStore.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
   },
   onChangeResponseId() {
     this.showFormActions();

--- a/src/js/apps/globals/nav_app.js
+++ b/src/js/apps/globals/nav_app.js
@@ -2,7 +2,7 @@ import { compact, isEqual, noop, partial, defer } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
-import store from 'store';
+import localStore from 'js/utils/local-store';
 
 import RouterApp from 'js/base/routerapp';
 
@@ -229,7 +229,7 @@ export default RouterApp.extend({
     const currentAppName = this.getState('currentApp');
     this.setSelectedAdminNavItem(currentAppName);
 
-    store.set('isNavMenuMinimized', this.getState('isMinimized'));
+    localStore.set('isNavMenuMinimized', this.getState('isMinimized'));
   },
   getNavMatch(appName, event, eventArgs) {
     return this._navMatch(patientsAppWorkflowsNav, event, eventArgs);
@@ -240,14 +240,14 @@ export default RouterApp.extend({
     });
   },
   onBeforeStart() {
-    const storedState = store.get('isNavMenuMinimized');
+    const storedState = localStore.get('isNavMenuMinimized');
 
     if (storedState) {
       this.setState('isMinimized', storedState);
       return;
     }
 
-    store.set('isNavMenuMinimized', this.getState('isMinimized'));
+    localStore.set('isNavMenuMinimized', this.getState('isMinimized'));
   },
   onStart() {
     const currentUser = Radio.request('bootstrap', 'currentUser');

--- a/src/js/apps/patients/schedule/schedule_state.js
+++ b/src/js/apps/patients/schedule/schedule_state.js
@@ -1,10 +1,11 @@
 import { clone, extend, omit, reduce } from 'underscore';
 import dayjs from 'dayjs';
-import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
 
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+
+import localStore from 'js/utils/local-store';
 
 import MultiselectStateMixin from 'js/mixins/multiselect-state_mixin';
 
@@ -53,13 +54,13 @@ const StateModel = Backbone.Model.extend({
     return `schedule_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
   },
   getStore() {
-    return store.get(this.getStoreKey());
+    return localStore.get(this.getStoreKey());
   },
   removeStore() {
-    store.remove(this.getStoreKey());
+    localStore.remove(this.getStoreKey());
   },
   onChange() {
-    store.set(this.getStoreKey(), omit(this.attributes, 'filtersCount', 'lastSelectedIndex', 'searchQuery'));
+    localStore.set(this.getStoreKey(), omit(this.attributes, 'filtersCount', 'lastSelectedIndex', 'searchQuery'));
   },
   setSearchQuery(searchQuery = '') {
     return this.set({

--- a/src/js/apps/patients/worklist/worklist_state.js
+++ b/src/js/apps/patients/worklist/worklist_state.js
@@ -1,10 +1,11 @@
 import { clone, extend, omit, reduce } from 'underscore';
 import dayjs from 'dayjs';
-import store from 'store';
 import { NIL as NIL_UUID } from 'uuid';
 
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+
+import localStore from 'js/utils/local-store';
 
 import MultiselectStateMixin from 'js/mixins/multiselect-state_mixin';
 
@@ -68,13 +69,13 @@ const StateModel = Backbone.Model.extend({
     return `${ id }_${ this.currentClinician.id }_${ this.currentWorkspace.id }-${ STATE_VERSION }`;
   },
   getStore(id) {
-    return store.get(this.getStoreKey(id));
+    return localStore.get(this.getStoreKey(id));
   },
   removeStore() {
-    store.remove(this.getStoreKey(this.id));
+    localStore.remove(this.getStoreKey(this.id));
   },
   onChange() {
-    store.set(this.getStoreKey(this.id), omit(this.attributes, 'lastSelectedIndex', 'searchQuery'));
+    localStore.set(this.getStoreKey(this.id), omit(this.attributes, 'lastSelectedIndex', 'searchQuery'));
   },
   setClinicianId(clinicianId) {
     if (clinicianId) return this.set({ clinicianId });

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -1,8 +1,8 @@
 import { map, get, debounce } from 'underscore';
 import dayjs from 'dayjs';
-import store from 'store';
-
 import Radio from 'backbone.radio';
+
+import localStore from 'js/utils/local-store';
 
 import App from 'js/base/app';
 
@@ -96,7 +96,7 @@ export default App.extend({
     if (this.isReadOnly()) return {};
 
     const draft = this.getLatestDraft();
-    const localDraft = store.get(this.getStoreId()) || {};
+    const localDraft = localStore.get(this.getStoreId()) || {};
 
     if (draft.updated && (!localDraft.updated || dayjs(draft.updated).isAfter(localDraft.updated))) {
       this.trigger('update:submission', draft.updated);
@@ -116,13 +116,13 @@ export default App.extend({
     this._draft = submission;
 
     try {
-      store.set(this.getStoreId(), { submission, updated });
+      localStore.set(this.getStoreId(), { submission, updated });
       this.trigger('update:submission', updated);
     } catch /* istanbul ignore next: Tested locally, test runner borks on CI */ {
-      store.each((value, key) => {
-        if (String(key).startsWith('form-subm-')) store.remove(key);
+      localStore.each((value, key) => {
+        if (String(key).startsWith('form-subm-')) localStore.remove(key);
       });
-      store.set(this.getStoreId(), { submission, updated });
+      localStore.set(this.getStoreId(), { submission, updated });
     }
 
     this.updateDraft();
@@ -130,7 +130,7 @@ export default App.extend({
   },
   clearStoredSubmission() {
     this.latestResponse = null;
-    store.remove(this.getStoreId());
+    localStore.remove(this.getStoreId());
     this.trigger('update:submission');
   },
   fetchField({ fieldName }, requestId) {

--- a/src/js/services/workspace.js
+++ b/src/js/services/workspace.js
@@ -1,6 +1,7 @@
 import { get } from 'underscore';
 import Radio from 'backbone.radio';
-import store from 'store';
+
+import localStore from 'js/utils/local-store';
 
 import App from 'js/base/app';
 
@@ -17,14 +18,14 @@ export default App.extend({
     if (!workspaces.length) throw 'No workspaces found';
 
     return workspaces.find({ slug })
-      || workspaces.find({ id: store.get('currentWorkspace') })
+      || workspaces.find({ id: localStore.get('currentWorkspace') })
       || workspaces.at(0);
   },
   _setCurrentWorkspace(route) {
     const workspace = this._getWorkspace(route);
 
     if (workspace.id !== get(this.currentWorkspace, 'id')) {
-      store.set('currentWorkspace', workspace.id);
+      localStore.set('currentWorkspace', workspace.id);
       this.currentWorkspace = workspace;
       this.getChannel().trigger('change:workspace', workspace);
     }

--- a/src/js/utils/local-store.cy.js
+++ b/src/js/utils/local-store.cy.js
@@ -24,10 +24,25 @@ context('localStore', function() {
     expect(localStore.get('my-key')).to.deep.equal({ a: 1 });
   });
 
+  specify('set does not throw when storage is unavailable', function() {
+    cy.stub(localStorage, 'setItem').throws(new DOMException('blocked', 'SecurityError'));
+    expect(() => localStore.set('key', 'val')).not.to.throw();
+  });
+
+  specify('set rethrows QuotaExceededError', function() {
+    cy.stub(localStorage, 'setItem').throws(new DOMException('quota', 'QuotaExceededError'));
+    expect(() => localStore.set('key', 'val')).to.throw('quota');
+  });
+
   specify('remove deletes the key', function() {
     localStore.set('del-key', 'value');
     localStore.remove('del-key');
     expect(localStore.get('del-key')).to.be.undefined;
+  });
+
+  specify('remove does not throw when storage is unavailable', function() {
+    cy.stub(localStorage, 'removeItem').throws(new DOMException('blocked', 'SecurityError'));
+    expect(() => localStore.remove('key')).not.to.throw();
   });
 
   specify('each iterates all entries with (value, key)', function() {
@@ -54,5 +69,10 @@ context('localStore', function() {
     expect(localStore.get('form-subm-a')).to.be.undefined;
     expect(localStore.get('form-subm-b')).to.be.undefined;
     expect(localStore.get('keep')).to.equal('yes');
+  });
+
+  specify('each does not throw when storage is unavailable', function() {
+    cy.stub(localStorage, 'key').throws(new DOMException('blocked', 'SecurityError'));
+    expect(() => localStore.each(() => {})).not.to.throw();
   });
 });

--- a/src/js/utils/local-store.cy.js
+++ b/src/js/utils/local-store.cy.js
@@ -1,0 +1,58 @@
+import localStore from './local-store';
+
+context('localStore', function() {
+  beforeEach(function() {
+    localStorage.clear();
+  });
+
+  specify('get returns parsed value for existing key', function() {
+    localStorage.setItem('test-key', JSON.stringify({ foo: 'bar' }));
+    expect(localStore.get('test-key')).to.deep.equal({ foo: 'bar' });
+  });
+
+  specify('get returns undefined for missing key', function() {
+    expect(localStore.get('no-such-key')).to.be.undefined;
+  });
+
+  specify('get returns undefined for invalid JSON', function() {
+    localStorage.setItem('bad-json', '{not valid}');
+    expect(localStore.get('bad-json')).to.be.undefined;
+  });
+
+  specify('set stores value readable by get', function() {
+    localStore.set('my-key', { a: 1 });
+    expect(localStore.get('my-key')).to.deep.equal({ a: 1 });
+  });
+
+  specify('remove deletes the key', function() {
+    localStore.set('del-key', 'value');
+    localStore.remove('del-key');
+    expect(localStore.get('del-key')).to.be.undefined;
+  });
+
+  specify('each iterates all entries with (value, key)', function() {
+    localStore.set('k1', 1);
+    localStore.set('k2', 2);
+
+    const seen = {};
+    localStore.each((value, key) => {
+      seen[key] = value;
+    });
+
+    expect(seen).to.deep.equal({ k1: 1, k2: 2 });
+  });
+
+  specify('each is safe when callback removes keys', function() {
+    localStore.set('form-subm-a', { submission: 'a' });
+    localStore.set('form-subm-b', { submission: 'b' });
+    localStore.set('keep', 'yes');
+
+    localStore.each((value, key) => {
+      if (String(key).startsWith('form-subm-')) localStore.remove(key);
+    });
+
+    expect(localStore.get('form-subm-a')).to.be.undefined;
+    expect(localStore.get('form-subm-b')).to.be.undefined;
+    expect(localStore.get('keep')).to.equal('yes');
+  });
+});

--- a/src/js/utils/local-store.js
+++ b/src/js/utils/local-store.js
@@ -1,0 +1,25 @@
+const localStore = {
+  get(key) {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw === null ? undefined : JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+  },
+  set(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+  remove(key) {
+    localStorage.removeItem(key);
+  },
+  each(callback) {
+    const keys = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      keys.push(localStorage.key(i));
+    }
+    keys.forEach(key => callback(this.get(key), key));
+  },
+};
+
+export default localStore;

--- a/src/js/utils/local-store.js
+++ b/src/js/utils/local-store.js
@@ -8,16 +8,31 @@ const localStore = {
     }
   },
   set(key, value) {
-    localStorage.setItem(key, JSON.stringify(value));
+    if (value === undefined) return this.remove(key);
+
+    const serialized = JSON.stringify(value);
+
+    try {
+      localStorage.setItem(key, serialized);
+    } catch(error) {
+      if (error?.name === 'QuotaExceededError') throw error;
+      if (error?.name !== 'SecurityError') throw error;
+    }
   },
   remove(key) {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch { /* storage unavailable */ }
   },
   each(callback) {
     const keys = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      keys.push(localStorage.key(i));
-    }
+
+    try {
+      for (let i = 0; i < localStorage.length; i++) {
+        keys.push(localStorage.key(i));
+      }
+    } catch { /* storage unavailable */ }
+
     keys.forEach(key => callback(this.get(key), key));
   },
 };


### PR DESCRIPTION
Closes FE-132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the third-party `store` package with an app-owned `localStore` utility to standardize local storage and handle blocked storage/quota errors. Aligns with FE-132 by consolidating persistence logic and adding tests.

- New Features
  - Added `js/utils/local-store` with get, set, remove, each; safe JSON parsing; rethrows `QuotaExceededError`; no-ops on `SecurityError`; `each` is safe while deleting keys.
  - Replaced all `store` usages in forms, nav, schedule/worklist state, and workspace services; added `js/utils/local-store.cy.js` covering quota, blocked storage, iteration, and JSON cases.

- Dependencies
  - Removed `store` from `package.json` and the lockfile.

<sup>Written for commit fa0f75ac4f2816e543af67b43aa637c401789d3f. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1694?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

