### PR TITLE
chore(tests): ignore `|| []` branch in coverage in filters sidebar app

### DIFF
--- a/src/js/apps/patients/sidebar/filters-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/filters-sidebar_app.js
@@ -53,7 +53,7 @@ export default App.extend(extend({
     });
   },
   showCustomFiltersView() {
-    Promise.allSettled(this.fetchFilters() || [])
+    Promise.allSettled(this.fetchFilters() || /* istanbul ignore next */ [])
       .then(() => {
         if (!this.isRunning()) return;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore the unreachable `|| []` fallback in `src/js/apps/patients/sidebar/filters-sidebar_app.js` from coverage using `/* istanbul ignore next */`. This stabilizes coverage and does not change runtime behavior.

<sup>Written for commit fe17309bf2894b3e9afa9770d9d28204d8413cb8. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1695?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

