### PR TITLE
fix(work): include program relationships on action and flow fetches

### DIFF
--- a/src/js/apps/patients/patient/archive/archive_app.js
+++ b/src/js/apps/patients/patient/archive/archive_app.js
@@ -4,6 +4,9 @@ import { NIL as NIL_UUID } from 'uuid';
 
 import App from 'js/base/app';
 
+import { ACTION_INCLUDE } from 'js/entities-service/actions';
+import { FLOW_INCLUDE } from 'js/entities-service/flows';
+
 import { LayoutView, ListView } from 'js/views/patients/patient/archive/archive_views';
 
 export default App.extend({
@@ -41,7 +44,7 @@ export default App.extend({
     Radio.request('ws', 'subscribe', this.collection.models, {
       filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
-    Radio.request('ws', 'manage:add', this, this.collection, 'flows');
-    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions');
+    Radio.request('ws', 'manage:add', this, this.collection, 'flows', { include: FLOW_INCLUDE });
+    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions', { include: ACTION_INCLUDE });
   },
 });

--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -4,6 +4,9 @@ import { NIL as NIL_UUID } from 'uuid';
 
 import App from 'js/base/app';
 
+import { ACTION_INCLUDE } from 'js/entities-service/actions';
+import { FLOW_INCLUDE } from 'js/entities-service/flows';
+
 import AddWorkflowApp from './add-workflow_app';
 
 import { LayoutView, ListView } from 'js/views/patients/patient/dashboard/dashboard_views';
@@ -57,8 +60,8 @@ export default App.extend({
     Radio.request('ws', 'subscribe', this.collection.models, {
       filters: { actions: { ...filters, flow: NIL_UUID }, flows: filters },
     });
-    Radio.request('ws', 'manage:add', this, this.collection, 'flows');
-    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions');
+    Radio.request('ws', 'manage:add', this, this.collection, 'flows', { include: FLOW_INCLUDE });
+    Radio.request('ws', 'manage:add', this, this.collection, 'patient-actions', { include: ACTION_INCLUDE });
   },
   startAddWorkflow() {
     if (!this.currentUser.can('work:own')) return;

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -7,6 +7,8 @@ import handleErrors from 'js/utils/handle-errors';
 
 import SubRouterApp from 'js/base/subrouterapp';
 
+import { ACTION_INCLUDE } from 'js/entities-service/actions';
+
 import StateModel from './flow_state';
 
 import BulkEditActionsApp from 'js/apps/patients/sidebar/bulk-edit-actions_app';
@@ -105,7 +107,7 @@ export default SubRouterApp.extend({
   subscribe() {
     const filters = { actions: { flow: this.flow.id } };
     Radio.request('ws', 'subscribe', [this.flow, ...this.actions.models], { filters });
-    Radio.request('ws', 'manage:add', this, this.actions, 'patient-actions');
+    Radio.request('ws', 'manage:add', this, this.actions, 'patient-actions', { include: ACTION_INCLUDE });
   },
   _setFlowProgress() {
     const complete = this.actions.filter(action => action.isDone()).length;

--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -1,6 +1,11 @@
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/actions';
 
+export const ACTION_INCLUDE = [
+  'program-action.program',
+  'flow.program-flow.program',
+].join();
+
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
@@ -13,16 +18,11 @@ const Entity = BaseEntity.extend({
     'fetch:actions:collection:byFlow': 'fetchActionsByFlow',
   },
   fetchAction(id) {
-    const include = [
-      'program-action.program',
-      'flow.program-flow.program',
-    ].join();
-
-    return this.fetchModel(id, { data: { include } });
+    return this.fetchModel(id, { data: { include: ACTION_INCLUDE } });
   },
   fetchActionWithResponses(id) {
     const data = {
-      include: ['form-responses'],
+      include: [ACTION_INCLUDE, 'form-responses'].join(),
       fields: {
         'form-responses': ['status', 'updated_at', 'editor'],
       },
@@ -37,9 +37,10 @@ const Entity = BaseEntity.extend({
     return this.fetchCollection({ url, data });
   },
   fetchActionsByFlow(flowId) {
+    const data = { include: ACTION_INCLUDE };
     const url = `/api/flows/${ flowId }/relationships/actions`;
 
-    return this.fetchCollection({ url });
+    return this.fetchCollection({ url, data });
   },
 });
 

--- a/src/js/entities-service/flows.js
+++ b/src/js/entities-service/flows.js
@@ -1,6 +1,12 @@
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/flows';
 
+export const FLOW_INCLUDE = [
+  'program-flow',
+  'program-flow.program',
+  'program-flow.program-actions',
+].join();
+
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
@@ -11,12 +17,7 @@ const Entity = BaseEntity.extend({
     'fetch:flows:collection:byPatient': 'fetchFlowsByPatient',
   },
   fetchFlow(id) {
-    const include = [
-      'program-flow',
-      'program-flow.program',
-      'program-flow.program-actions',
-    ].join();
-    return this.fetchModel(id, { data: { include } });
+    return this.fetchModel(id, { data: { include: FLOW_INCLUDE } });
   },
   fetchFlowsByPatient({ patientId, filter }) {
     const data = { filter };

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -138,7 +138,7 @@ Cypress.Commands.add('routeFlowActions', (mutator = routeFlowActions) => {
   const included = [];
 
   cy
-    .intercept('GET', '/api/flows/**/relationships/actions', {
+    .intercept('GET', '/api/flows/**/relationships/actions*', {
       body: mutator({ data, included }),
     })
     .as('routeFlowActions');


### PR DESCRIPTION
Closes FE-136

## What
- Export canonical `ACTION_INCLUDE` and `FLOW_INCLUDE` constants from the entity service.
- Apply them to every action/flow fetch path (single model, `byPatient`, `byFlow`) and every `manage:add` websocket refetch on the dashboard, flow page, and archive.
- Update the `/api/flows/**/relationships/actions` Cypress route stub so its glob matches the new `?include=…` query string.

## Why
Production Datadog errors showed `getUserWorkspaces` being read from an undefined program while rendering action and flow owners. Root cause: `fetchActionsByPatient`, `fetchActionsByFlow`, `fetchFlowsByPatient`, and the `manage:add` refetches on the patient surfaces were not requesting the `program-action.program` / `program-flow.program` chain, so the program model in the store was only partially hydrated by the time views called `program.getUserWorkspaces()`.

The fix is purely on the request side — model and view code is unchanged.

## Scope
- `src/js/entities-service/actions.js`, `src/js/entities-service/flows.js` — central include constants.
- `src/js/apps/patients/patient/{dashboard,flow,archive}/*_app.js` — import and pass the constants on `manage:add`.
- `test/support/api/actions.js` — Cypress glob fix only.

No changes to entity model methods, view components, or production behavior for fully-hydrated payloads.

## Deployment Impact
No form redeploy. Ships through normal app-frontend deployment. Affects only data-request shape (additional `include` query params), so all consumers see fully-hydrated program data instead of partial models.

## Testing
- `npm run lint`
- `npx cypress run --spec "test/integration/patients/patient/dashboard.js,test/integration/patients/patient/patient-flow.js,test/integration/patients/patient/archive.js"` — 29 passing.
- Coverage on changed entity-service files: 100% lines / 100% branches.