### PR TITLE
fix(sw): exclude icon modules from script cache

### DIFF
--- a/src/js/sw.js
+++ b/src/js/sw.js
@@ -5,6 +5,7 @@ import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { PrecacheFallbackPlugin, precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching';
 
 const SHARED_RUNTIME_PREFIX = '/shared/';
+const ICONS_PREFIX = '/icons/';
 
 // Ensure that updates to the underlying service worker take effect immediately
 // for both the current client and all other active clients.
@@ -58,10 +59,11 @@ if (self.location.hostname !== 'localhost') {
 
   deleteHashedCache();
 
-  const staticHashedAssetsRoute = new Route(({ request }) => {
+  const staticHashedAssetsRoute = new Route(({ request, url }) => {
     return (
       ['script', 'style'].includes(request.destination)
-      && !new URL(request.url).pathname.startsWith(SHARED_RUNTIME_PREFIX)
+      && !url.pathname.startsWith(SHARED_RUNTIME_PREFIX)
+      && !url.pathname.startsWith(ICONS_PREFIX)
     );
   }, new CacheFirst({ cacheName: getHashedCacheName('static-hashed-assets') }));
 


### PR DESCRIPTION
Closes FE-137

## What
- Exclude `/icons/` requests from the service worker hashed script/style `CacheFirst` route.
- Reuse the parsed request pathname for the existing `/shared/` exclusion and the new icon-module exclusion.

## Why
QA intermittently hit `Failed to load module script` for `/icons/icons.js` when a browser received an HTML fallback response instead of JavaScript. The live icon bundle now serves `application/javascript`, but the service worker could retain a prior fallback response as a script cache entry.

## Scope
- Impacts app-frontend service worker caching behavior.
- Does not change customer icon bundle generation or deployment.
- Does not change `/shared/` runtime caching behavior beyond using the parsed pathname once.

## Deployment Impact
A normal app-frontend deployment is needed so clients receive the updated service worker. No form bundle redeploy is required. Existing affected browsers may still need the updated service worker to activate or manual site-data clearing if they already cached the bad response.

## Testing
- `npm exec -- eslint src/js/sw.js --max-warnings=0`
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents intermittent “Failed to load module script” by excluding `/icons/` from the service worker’s script/style `CacheFirst` route. Fixes FE-137.

- **Bug Fixes**
  - Skip caching icon modules under `/icons/` in the hashed assets route.
  - Use the route’s `url.pathname` once for both `/shared/` and `/icons/` exclusions.

- **Migration**
  - Deploy app-frontend to ship the updated service worker.
  - Some affected browsers may need the new worker to activate or manual site-data clearing.

<sup>Written for commit 95ca73e08af507c6f4e90c5074824612840874c6. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service worker caching configuration to optimize handling of icon assets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RoundingWell/app-frontend/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->