### PR TITLE
fix(deploy): deploy demonstration with sandbox rollouts

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -146,7 +146,7 @@ jobs:
               exit 1
             fi
 
-            if [ "$DEPLOY_TARGET_ENV" = "sandbox:*" ]; then
+            if [ "$DEPLOY_STAGE" = "sandbox" ] && [ -z "$DEPLOY_ORGANIZATION" ]; then
               npm run --silent deploy -- --stage="prod" --organization="demonstration" --write-targets-file="$prod_demonstration_targets_file" --list-marker-environments >> "$marker_env_file"
               printf 'export DEPLOY_PROD_DEMONSTRATION_TARGETS_FILE=%q\n' "$prod_demonstration_targets_file" >> "$BASH_ENV"
             fi

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -133,6 +133,7 @@ jobs:
             marker_env_file="$deploy_tmp_dir/deploy-marker-environments.txt"
             deploy_targets_file="$deploy_tmp_dir/deploy-targets.json"
             deploy_marker_status_file="$deploy_tmp_dir/deploy-marker-status.json"
+            prod_demonstration_targets_file="$deploy_tmp_dir/prod-demonstration-targets.json"
 
             if [ -n "$DEPLOY_ORGANIZATION" ]; then
               npm run --silent deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --write-targets-file="$deploy_targets_file" --list-marker-environments > "$marker_env_file"
@@ -143,6 +144,11 @@ jobs:
             if [ ! -s "$marker_env_file" ]; then
               echo "No deploy marker environments were resolved"
               exit 1
+            fi
+
+            if [ "$DEPLOY_TARGET_ENV" = "sandbox:*" ]; then
+              npm run --silent deploy -- --stage="prod" --organization="demonstration" --write-targets-file="$prod_demonstration_targets_file" --list-marker-environments >> "$marker_env_file"
+              printf 'export DEPLOY_PROD_DEMONSTRATION_TARGETS_FILE=%q\n' "$prod_demonstration_targets_file" >> "$BASH_ENV"
             fi
 
             printf 'export DEPLOY_TMP_DIR=%q\n' "$deploy_tmp_dir" >> "$BASH_ENV"
@@ -182,6 +188,10 @@ jobs:
               npm run deploy -- --stage="$DEPLOY_STAGE" --organization="$DEPLOY_ORGANIZATION" --read-targets-file="$DEPLOY_TARGETS_FILE" --marker-status-file="$DEPLOY_MARKER_STATUS_FILE"
             else
               npm run deploy -- --stage="$DEPLOY_STAGE" --read-targets-file="$DEPLOY_TARGETS_FILE" --marker-status-file="$DEPLOY_MARKER_STATUS_FILE"
+            fi
+
+            if [ -n "${DEPLOY_PROD_DEMONSTRATION_TARGETS_FILE:-}" ]; then
+              npm run deploy -- --stage="prod" --organization="demonstration" --read-targets-file="$DEPLOY_PROD_DEMONSTRATION_TARGETS_FILE" --marker-status-file="$DEPLOY_MARKER_STATUS_FILE"
             fi
       - run:
           name: CircleCI Deploy Marker Success

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -137,6 +137,8 @@ npm run deploy -- --stage=<stage> [--organization=<organization>]
 5. Writes CircleCI deploy markers for every environment resolved from the deploy target:
    - specific targets such as `qa:qa2` write one marker for that concrete environment
    - stage-wide targets such as `qa:*`, `sandbox:*`, and `prod:*` retain the wildcard marker and also write one marker per concrete environment discovered from CloudFormation tags for that stage
+   - `sandbox:*` also deploys `prod:demonstration` from the same artifact and writes a marker for that environment
+   - `prod:*` excludes `prod:demonstration`; deploy it explicitly or through `sandbox:*`
    - stage-wide deploys continue through every resolved environment and fail the job at the end if any targets fail
    - if a stage-wide deploy partially succeeds, concrete environment markers reflect the per-environment outcomes while the wildcard marker reflects the overall deploy result
 6. For QA deploys that include `qa2` (`qa:qa2` and `qa:*`), posts `qa2_deploy_succeeded` to `RoundingWell/app-tests`
@@ -161,8 +163,8 @@ Dev-account deploys:
 - `qa:*`
 
 Prod-account deploys:
-- `sandbox:*`
-- `prod:*`
+- `sandbox:*` plus `prod:demonstration`
+- `prod:*` excluding `prod:demonstration`
 
 Artifact ownership:
 - the release artifact is published to the dev-account bucket

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -19,6 +19,7 @@ const DEPLOYABLE_STATUSES = new Set([
   'UPDATE_ROLLBACK_COMPLETE',
 ]);
 const SHARED_RUNTIME_CACHE_CONTROL = 'no-cache';
+const PROD_WILDCARD_EXCLUDED_ORGANIZATIONS = new Set(['demonstration']);
 
 function isMainModule() {
   if (!process.argv[1]) {
@@ -61,6 +62,13 @@ function matchesOrganizationTarget(deploymentTarget, stage, filterOrganization) 
   return true;
 }
 
+export function shouldIncludeDeployTarget(stage, filterOrganization, organizationIdentifier) {
+  if (filterOrganization) return true;
+  if (stage !== 'prod') return true;
+
+  return !PROD_WILDCARD_EXCLUDED_ORGANIZATIONS.has(organizationIdentifier);
+}
+
 /**
  * Get all organizations for a stage with their website buckets by CloudFormation tags.
  * @param {CloudFormationClient} cfClient - CloudFormation client instance
@@ -100,6 +108,8 @@ function addOrganizationsFromPage(organizationBuckets, response, stage, filterOr
 
     const bucketName = getWebsiteBucketOutput(deploymentTarget);
     const organizationIdentifier = getTagValue(deploymentTarget, 'organization');
+
+    if (!shouldIncludeDeployTarget(stage, filterOrganization, organizationIdentifier)) continue;
 
     if (!bucketName) {
       throw new Error(
@@ -338,6 +348,17 @@ export function writeDeployMarkerStatus(statusFile, markerStatus) {
   fsSync.writeFileSync(statusFile, `${ JSON.stringify(markerStatus, null, 2) }\n`);
 }
 
+export function readDeployMarkerStatus(statusFile) {
+  if (!statusFile || !fsSync.existsSync(statusFile)) {
+    return {
+      failedEnvironments: [],
+      successfulEnvironments: [],
+    };
+  }
+
+  return JSON.parse(fsSync.readFileSync(statusFile, 'utf8'));
+}
+
 export function readResolvedDeployTargets(targetsFile) {
   if (!targetsFile) {
     throw new Error('Resolved deploy targets file path is required.');
@@ -430,10 +451,7 @@ async function main() {
     return;
   }
 
-  const markerStatus = {
-    failedEnvironments: [],
-    successfulEnvironments: [],
-  };
+  const markerStatus = readDeployMarkerStatus(values['marker-status-file']);
   writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
 
   process.stdout.write(`Found ${ organizationBuckets.size } organizations to deploy:\n`);

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -349,14 +349,31 @@ export function writeDeployMarkerStatus(statusFile, markerStatus) {
 }
 
 export function readDeployMarkerStatus(statusFile) {
+  const defaultStatus = {
+    failedEnvironments: [],
+    successfulEnvironments: [],
+  };
+
   if (!statusFile || !fsSync.existsSync(statusFile)) {
-    return {
-      failedEnvironments: [],
-      successfulEnvironments: [],
-    };
+    return defaultStatus;
   }
 
-  return JSON.parse(fsSync.readFileSync(statusFile, 'utf8'));
+  let payload;
+
+  try {
+    payload = JSON.parse(fsSync.readFileSync(statusFile, 'utf8'));
+  } catch (error) {
+    throw new Error(`Deploy marker status file is not valid JSON: ${ statusFile }. Delete it and retry. ${ error.message }`);
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return defaultStatus;
+  }
+
+  return {
+    failedEnvironments: Array.isArray(payload.failedEnvironments) ? payload.failedEnvironments : [],
+    successfulEnvironments: Array.isArray(payload.successfulEnvironments) ? payload.successfulEnvironments : [],
+  };
 }
 
 export function readResolvedDeployTargets(targetsFile) {

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -6,7 +6,9 @@ import test from 'node:test';
 import {
   buildDeployMarkerEnvironments,
   formatFailedDeploymentsError,
+  readDeployMarkerStatus,
   readResolvedDeployTargets,
+  shouldIncludeDeployTarget,
   writeDeployMarkerStatus,
   writeResolvedDeployTargets,
 } from './deploy.js';
@@ -32,6 +34,13 @@ test('buildDeployMarkerEnvironments returns only the requested concrete environm
   );
 });
 
+test('shouldIncludeDeployTarget excludes demonstration only from prod wildcard deploys', () => {
+  assert.equal(shouldIncludeDeployTarget('prod', '', 'demonstration'), false);
+  assert.equal(shouldIncludeDeployTarget('prod', 'demonstration', 'demonstration'), true);
+  assert.equal(shouldIncludeDeployTarget('prod', '', 'apple'), true);
+  assert.equal(shouldIncludeDeployTarget('sandbox', '', 'demonstration'), true);
+});
+
 test('writeDeployMarkerStatus persists marker deployment progress', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-marker-status-'));
   const statusFile = path.join(tempDir, 'status.json');
@@ -50,6 +59,36 @@ test('writeDeployMarkerStatus persists marker deployment progress', () => {
   );
 
   fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('readDeployMarkerStatus preserves existing marker deployment progress', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-marker-status-'));
+  const statusFile = path.join(tempDir, 'status.json');
+
+  fs.writeFileSync(statusFile, JSON.stringify({
+    failedEnvironments: [],
+    successfulEnvironments: ['sandbox:apple'],
+  }));
+
+  assert.deepEqual(
+    readDeployMarkerStatus(statusFile),
+    {
+      failedEnvironments: [],
+      successfulEnvironments: ['sandbox:apple'],
+    },
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('readDeployMarkerStatus defaults missing marker deployment progress', () => {
+  assert.deepEqual(
+    readDeployMarkerStatus(''),
+    {
+      failedEnvironments: [],
+      successfulEnvironments: [],
+    },
+  );
 });
 
 test('formatFailedDeploymentsError summarizes all failed environments', () => {

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -91,6 +91,57 @@ test('readDeployMarkerStatus defaults missing marker deployment progress', () =>
   );
 });
 
+test('readDeployMarkerStatus reports invalid marker deployment progress JSON', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invalid-deploy-marker-status-'));
+  const statusFile = path.join(tempDir, 'status.json');
+
+  fs.writeFileSync(statusFile, '');
+
+  assert.throws(
+    () => readDeployMarkerStatus(statusFile),
+    new RegExp(`Deploy marker status file is not valid JSON: ${ statusFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') }\\. Delete it and retry\\.`),
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('readDeployMarkerStatus normalizes malformed marker deployment progress payloads', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'malformed-deploy-marker-status-'));
+  const statusFile = path.join(tempDir, 'status.json');
+
+  fs.writeFileSync(statusFile, JSON.stringify({ successfulEnvironments: ['sandbox:apple'] }));
+
+  assert.deepEqual(
+    readDeployMarkerStatus(statusFile),
+    {
+      failedEnvironments: [],
+      successfulEnvironments: ['sandbox:apple'],
+    },
+  );
+
+  fs.writeFileSync(statusFile, JSON.stringify({ failedEnvironments: 'sandbox:apple' }));
+
+  assert.deepEqual(
+    readDeployMarkerStatus(statusFile),
+    {
+      failedEnvironments: [],
+      successfulEnvironments: [],
+    },
+  );
+
+  fs.writeFileSync(statusFile, JSON.stringify([]));
+
+  assert.deepEqual(
+    readDeployMarkerStatus(statusFile),
+    {
+      failedEnvironments: [],
+      successfulEnvironments: [],
+    },
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
 test('formatFailedDeploymentsError summarizes all failed environments', () => {
   assert.equal(
     formatFailedDeploymentsError(['qa:qa2', 'qa:quality-assurance']),


### PR DESCRIPTION
Closes FE-138

## What
- Adds `prod:demonstration` as an additional deploy target when CircleCI deploys `sandbox:*`.
- Excludes `prod:demonstration` from `prod:*` wildcard deploy resolution while keeping explicit `prod:demonstration` deploys supported.
- Preserves deploy marker status across the sandbox deploy and the additional demonstration deploy, and updates deploy docs/tests.

## Why
`prod:demonstration` should follow sandbox rollouts from the same release artifact, but production wildcard deploys should no longer send to demonstration.

## Scope
- Impacted areas: CircleCI deploy workflow, deploy target resolution, deploy marker status handling, and deploy documentation.
- `prod:*` still deploys the other prod organizations discovered from CloudFormation tags.
- Explicit org-scoped prod deploy behavior remains supported.

## Deployment Impact
- No form redeploy is required.
- This changes future CircleCI deploy behavior for `sandbox:*` and `prod:*` in `app-frontend`.
- Normal app deployment is sufficient for the script/workflow changes to take effect once merged.

## Testing
- `node --test scripts/deploy.test.js scripts/deploy-markers.test.js`
- `node --check scripts/deploy.js`
- `circleci config validate .circleci/deploy.yml`
- `git diff --check -- .circleci/deploy.yml docs/deploy.md scripts/deploy.js scripts/deploy.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically deploys `prod:demonstration` from the same artifact when `sandbox:*` rolls out, and prevents `prod:*` wildcards from targeting `demonstration`. Persists and reuses deploy marker status across both runs. Aligns with FE-138 (demonstration follows sandbox; excluded from prod wildcards).

- **New Features**
  - Excludes `demonstration` from `prod:*` wildcard resolution; explicit `prod:demonstration` still works.
  - For `sandbox:*`, generates targets for `prod:demonstration` and runs a second deploy using the same marker status file.
  - Adds `readDeployMarkerStatus` with validation and tests; updates docs to note `sandbox:*` also deploys `prod:demonstration` and `prod:*` excludes it.

<sup>Written for commit 3c4a44a73f0f1282927eb83efb40a7ac0ba30c97. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox deployments now support "production demonstration" environment, while production wildcard deployments explicitly exclude this environment.
  * Deployment system can now resume from previously saved deployment state.

* **Documentation**
  * Updated deployment documentation to reflect production demonstration environment handling and deployment marker behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RoundingWell/app-frontend/pull/1699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->