### PR TITLE
perf(boot): preload startup resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,13 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
     <link rel="mask-icon" href="/rwell-logo.svg" color="#0582da">
+    <link rel="preconnect" href="https://login.roundingwell.com" crossorigin>
+    <link rel="preload" href="/appconfig.json" as="fetch">
+    <link rel="modulepreload" href="/shared/config.js" crossorigin>
+    <link rel="modulepreload" href="/shared/datadog.js" crossorigin>
+    <link rel="prefetch" href="/shared/forms.js" as="script" crossorigin>
+    <link rel="preload" href="/fonts/ProximaSoft/3955CC_4_0.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/ProximaSoft/3955CC_1_0.woff2" as="font" type="font/woff2" crossorigin>
     <meta name="msapplication-TileColor" content="#0582da">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=1200, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "vite-plugin-pwa": "^1.0.0",
         "workbox-cacheable-response": "^7.3.0",
         "workbox-core": "^7.3.0",
+        "workbox-navigation-preload": "^7.3.0",
         "workbox-precaching": "^7.3.0",
         "workbox-routing": "^7.3.0",
         "workbox-strategies": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "vite-plugin-pwa": "^1.0.0",
     "workbox-cacheable-response": "^7.3.0",
     "workbox-core": "^7.3.0",
+    "workbox-navigation-preload": "^7.3.0",
     "workbox-precaching": "^7.3.0",
     "workbox-routing": "^7.3.0",
     "workbox-strategies": "^7.3.0",

--- a/packages/care-ops-config/index.js
+++ b/packages/care-ops-config/index.js
@@ -1,7 +1,7 @@
 const configState = {};
 
 function fetchConfig() {
-  return fetch('/appconfig.json', { cache: 'no-store' })
+  return fetch('/appconfig.json', { cache: 'no-cache' })
     .then(response => response.json())
     .then(config => {
       configState.app = config.app || {};

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,8 +21,11 @@ async function startAuth() {
   await auth();
 }
 
-async function start() {
-  const { startApp } = await import('./app');
+async function loadApp() {
+  return import('./app');
+}
+
+async function start({ startApp }) {
   startApp();
 }
 
@@ -40,7 +43,10 @@ document.addEventListener('DOMContentLoaded', async() => {
 
   initDataDog();
 
-  await startAuth();
+  const authPromise = startAuth();
+  const appPromise = loadApp();
 
-  await start();
+  const [, appModule] = await Promise.all([authPromise, appPromise]);
+
+  await start(appModule);
 });

--- a/src/js/sw.js
+++ b/src/js/sw.js
@@ -1,5 +1,6 @@
 import { clientsClaim } from 'workbox-core';
 import { registerRoute, Route } from 'workbox-routing';
+import { enable as enableNavigationPreload } from 'workbox-navigation-preload';
 import { NetworkOnly, NetworkFirst, CacheFirst } from 'workbox-strategies';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { PrecacheFallbackPlugin, precacheAndRoute, cleanupOutdatedCaches } from 'workbox-precaching';
@@ -16,6 +17,7 @@ if (self.location.hostname !== 'localhost') {
   cleanupOutdatedCaches();
 
   precacheAndRoute(self.__WB_MANIFEST);
+  enableNavigationPreload();
 
   // Any navigation loads the precached index.html
   const networkOnlyNavigationRoute = new Route(({ request }) => {

--- a/src/js/views/globals/prelogin/prelogin.scss
+++ b/src/js/views/globals/prelogin/prelogin.scss
@@ -1,6 +1,7 @@
 // NOTE: Not using sass to prevent overriding form.io with base sass reset :-/
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: normal;
   font-weight: normal;
@@ -8,6 +9,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: normal;
   font-weight: bold;

--- a/src/scss/core/_fonts.scss
+++ b/src/scss/core/_fonts.scss
@@ -35,6 +35,7 @@
 */
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: normal;
   font-weight: normal;
@@ -42,6 +43,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: italic;
   font-weight: normal;
@@ -49,6 +51,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: normal;
   font-weight: 600;
@@ -56,6 +59,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: italic;
   font-weight: 600;
@@ -63,6 +67,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: normal;
   font-weight: bold;
@@ -70,6 +75,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: ProximaSoft;
   font-style: italic;
   font-weight: bold;

--- a/vite.config.js
+++ b/vite.config.js
@@ -64,6 +64,45 @@ function sharedRuntimeDevPlugin() {
   };
 }
 
+function modulePreloadEntryPlugin(moduleIds) {
+  const normalizedModuleIds = moduleIds.map(moduleId => moduleId.replace(/^\//, ''));
+
+  return {
+    name: 'module-preload-entry-plugin',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html, ctx) {
+        const bundle = ctx.bundle;
+        if (!bundle) return html;
+
+        const tags = Object.values(bundle)
+          .filter(chunk => {
+            if (chunk.type !== 'chunk') return false;
+            const chunkModuleIds = [chunk.facadeModuleId, ...chunk.moduleIds]
+              .filter(Boolean)
+              .map(chunkModuleId => path.relative(process.cwd(), chunkModuleId).split(path.sep).join('/'));
+
+            return normalizedModuleIds.some(moduleId => {
+              return chunkModuleIds.includes(moduleId);
+            });
+          })
+          .map(chunk => ({
+            tag: 'link',
+            attrs: {
+              rel: 'modulepreload',
+              crossorigin: true,
+              href: `/${ chunk.fileName }`,
+            },
+            injectTo: 'head',
+          }));
+
+        return tags;
+      },
+    },
+  };
+}
+
 const css = {
   preprocessorOptions: {
     scss: {
@@ -131,6 +170,13 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [
       sharedRuntimeDevPlugin(),
+      modulePreloadEntryPlugin([
+        '/src/js/auth.js',
+        '/src/js/app.js',
+        '/src/js/apps/globals/app-frame_app.js',
+        '/packages/care-ops-auth/AuthProvider.js',
+        '/packages/care-ops-auth/providers/workos.js',
+      ]),
       fontawesome(),
       isTest && babelPlugin,
       inlineHbsCompile(),


### PR DESCRIPTION
Closes FE-141

## What
- Preload boot-critical shared/runtime modules, first-route chunks, app config, and first-paint fonts.
- Fetch `appconfig.json` with revalidation so the head preload can satisfy boot config without weakening version freshness.
- Enable service worker navigation preload for document navigations.

## Why
QA boot timing showed avoidable startup latency before auth and app data loading could begin. The app config fetch was a serial blocker, and boot chunk/font discovery could start earlier during HTML parsing.

## Scope
Impacts global app startup resource loading, shared config fetching, font loading, Vite production HTML generation, and service worker navigation handling.

Intentionally not included: temporary boot timing instrumentation, `docs/perf-plan.md`, bootstrap data-loading changes, workspace data-loading changes, and dialer deferral.

## Deployment Impact
No forms redeploy beyond the normal app deployment is needed. `@roundingwell/care-ops-config` is a shared runtime module, so both the app and embedded forms continue using the same `fetchConfig()` contract.

## Testing
- `npx eslint packages/care-ops-config/index.js`
- `npm run build`
- Deployed the timing build to `qa:quality-assurance` and measured three route-complete runs. `config.fetch` median dropped from roughly 627ms to roughly 8ms after the `appconfig.json` preload plus `cache: no-cache` change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads boot-critical resources and runs auth and app import in parallel to cut startup time and unblock earlier data loading. Aligns with FE-141 by making config, modules, and fonts available during HTML parse and enabling navigation preload.

- **Performance**
  - Preload `/appconfig.json` (`as=fetch`) and fetch with `cache: 'no-cache'` so the head preload satisfies `fetchConfig()` while preserving ETag freshness; QA median dropped from ~627ms to ~8ms.
  - Add modulepreload for first-route/runtime chunks via a `vite` plugin and `index.html` tags; prefetch the shared forms chunk.
  - Preconnect to `https://login.roundingwell.com` and enable service worker navigation preload.
  - Preload first-paint fonts and set `font-display: swap`.
  - Import the app in parallel with auth and start once both are ready.

- **Dependencies**
  - Add `workbox-navigation-preload`.

<sup>Written for commit 05f4c91a72846b236ea1919e065d90da6bb934de. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1700?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Faster startup by loading authentication and app modules concurrently
  * Improved resource hints (preconnect, preload, prefetch, modulepreload) for quicker asset delivery
  * Navigation preload enabled to speed up page transitions

* **Style**
  * Improved font loading behavior (font-display: swap) for better text rendering during load

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RoundingWell/app-frontend/pull/1700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->