### PR TITLE
fix(actions): keep created program local

### DIFF
--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -52,9 +52,9 @@ const _Model = BaseModel.extend({
       },
       _program_action: this.getResource(),
     };
-
     if (patient) attrs._patient = patient.getResource();
     if (flow) attrs._flow = flow.getResource();
+    attrs._program = this.getProgram().getResource();
 
     return Radio.request('entities', 'actions:model', attrs);
   },


### PR DESCRIPTION
Closes FE-136

## What
- Preserve the program relationship on locally-created patient action models.
- Set `_program` from the selected program action during `createAction()`.
- Keep action save serialization unchanged; this does not send `relationships.program` in the POST.

## Why
New actions are inserted into local patient action collections immediately after save. Keeping `_program` on the local model prevents owner rendering from losing program context before the next full fetch/subscription refresh.

## Scope
- Patient dashboard action creation.
- Patient flow action creation.
- Does not change websocket subscription registration; FE-140 remains a separate subscription gap.
- Does not change the action create API payload shape.

## Deployment Impact
No form redeploy is needed. This is app-frontend shared JavaScript behavior and ships with the normal app deployment.

## Testing
- `npm run lint -- src/js/entities-service/entities/program-actions.js test/integration/patients/patient/patient-flow.js test/integration/patients/patient/dashboard.js`
- `npm run build -- --mode test`
- `npx cypress run --spec test/integration/patients/patient/patient-flow.js,test/integration/patients/patient/dashboard.js`
- Checked coverage counters for the changed `createAction()` line.