### PR TITLE
fix(worklist): keep websocket action subscriptions current

### DIFF
--- a/src/js/apps/patients/patient/dashboard/dashboard_app.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard_app.js
@@ -81,6 +81,7 @@ export default App.extend({
     const action = programAction.createAction({ patient: this.patient });
     action.saveAll().then(() => {
       this.collection.unshift(action);
+      Radio.request('ws', 'add', action);
 
       Radio.trigger('event-router', 'patient:action', this.patient.id, action.id);
     });

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -258,6 +258,7 @@ export default SubRouterApp.extend({
     const action = programAction.createAction({ flow: this.flow });
     action.saveAll().then(() => {
       this.actions.add(action);
+      Radio.request('ws', 'add', action);
 
       Radio.trigger('event-router', 'flow:action', this.flow.id, action.id);
     });

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -13,6 +13,7 @@ const AdderApp = App.extend({
   onStart({ model, collection }) {
     collection.add(model);
     Radio.request('ws', 'add', model);
+    this.destroy();
   },
 });
 

--- a/test/integration/patients/patient/dashboard.js
+++ b/test/integration/patients/patient/dashboard.js
@@ -1037,6 +1037,17 @@ context('patient dashboard page', function() {
       });
 
     cy
+      .get('@wsHandleMessage')
+      .should(stub => {
+        const subscribedResources = _.flatten(stub.getCalls().map(call => call.args[0].data.resources));
+
+        expect(subscribedResources).to.deep.include({
+          id: testOne,
+          type: 'patient-actions',
+        });
+      });
+
+    cy
       .url()
       .should('contain', `patient/${ testPatient.id }/action/${ testOne }`);
 

--- a/test/integration/patients/patient/patient-flow.js
+++ b/test/integration/patients/patient/patient-flow.js
@@ -1082,6 +1082,17 @@ context('patient flow page', function() {
       });
 
     cy
+      .get('@wsHandleMessage')
+      .should(stub => {
+        const subscribedResources = _.flatten(stub.getCalls().map(call => call.args[0].data.resources));
+
+        expect(subscribedResources).to.deep.include({
+          id: conditionalAction.id,
+          type: conditionalAction.type,
+        });
+      });
+
+    cy
       .url()
       .should('contain', `flow/${ testFlow.id }/action/${ conditionalAction.id }`);
 

--- a/test/integration/patients/worklist/worklist.js
+++ b/test/integration/patients/worklist/worklist.js
@@ -1610,6 +1610,48 @@ context('worklist page', function() {
       .get('@firstRow')
       .find('[data-state-region] .fa-circle-check');
 
+    cy.sendWs({
+      category: 'ResourceDeleted',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .get('[data-count-region]')
+      .should('contain', '1 Action');
+
+    cy
+      .routeAction(fx => {
+        fx.data = testNewSocketAction;
+
+        return fx;
+      });
+
+    cy.sendWs({
+      category: 'ResourceCreated',
+      resource: {
+        type: testNewSocketAction.type,
+        id: testNewSocketAction.id,
+      },
+      payload: {},
+    });
+
+    cy
+      .wait('@routeAction')
+      .its('request.url')
+      .should('contain', testNewSocketAction.id);
+
+    cy
+      .get('[data-count-region]')
+      .should('contain', '2 Actions');
+
+    cy
+      .get('@firstRow')
+      .should('contain', 'New Action - Created Elsewhere');
+
     cy
       .routeAction(fx => {
         fx.data = testNewStateSocketAction;


### PR DESCRIPTION
Closes FE-140
Closes FE-142

## What
- Register locally-created dashboard and flow patient actions with the websocket resource subscription.
- Destroy one-shot websocket adder child apps after they add and subscribe the incoming model.
- Add Cypress coverage inside existing dashboard, flow, and worklist specs for websocket subscription and same-id re-add behavior.

## Why
Locally-created patient actions were inserted into frontend collections without being added to the websocket Resources set, so later state changes from another session could be missed until reload. Worklist websocket adder child apps also stayed alive after one add, which could block a same-id resource from being re-added after it left the collection and matched again.

## Scope
Impacts patient dashboard action creation, patient flow action creation, and shared websocket manage:add handling. No worklist filter state or count refresh logic is changed.

## Deployment Impact
No form bundle redeploy is needed. This is normal app frontend deployment only.

## Testing
- npx eslint src/js/services/ws.js src/js/apps/patients/patient/dashboard/dashboard_app.js src/js/apps/patients/patient/flow/flow_app.js test/integration/patients/patient/dashboard.js test/integration/patients/patient/patient-flow.js test/integration/patients/worklist/worklist.js --max-warnings=0
- npm run build -- --mode test
- npx cypress run --spec test/integration/patients/patient/dashboard.js,test/integration/patients/patient/patient-flow.js,test/integration/patients/worklist/worklist.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures locally created patient actions are subscribed to websockets and keeps worklist subscriptions current to prevent missed updates. Addresses FE-140 and FE-142.

- **Bug Fixes**
  - Register new dashboard and flow actions with websockets by calling `Radio.request('ws', 'add', action)` after save.
  - Destroy the websocket `AdderApp` after it adds/subscribes a model to allow same-id re-adds after removal.
  - Extend Cypress coverage in dashboard, flow, and worklist to verify new IDs are subscribed and delete+recreate flows re-add and update.

<sup>Written for commit d1b6050e75fc6acb52c78186b6e7b9982e31ed37. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1702?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

