### PR TITLE
test(local-store): cover undefined-value and unexpected-error branches

### DIFF
--- a/src/js/utils/local-store.cy.js
+++ b/src/js/utils/local-store.cy.js
@@ -24,6 +24,12 @@ context('localStore', function() {
     expect(localStore.get('my-key')).to.deep.equal({ a: 1 });
   });
 
+  specify('set with undefined removes the key', function() {
+    localStore.set('rm-key', 'value');
+    localStore.set('rm-key', undefined);
+    expect(localStore.get('rm-key')).to.be.undefined;
+  });
+
   specify('set does not throw when storage is unavailable', function() {
     cy.stub(localStorage, 'setItem').throws(new DOMException('blocked', 'SecurityError'));
     expect(() => localStore.set('key', 'val')).not.to.throw();
@@ -32,6 +38,11 @@ context('localStore', function() {
   specify('set rethrows QuotaExceededError', function() {
     cy.stub(localStorage, 'setItem').throws(new DOMException('quota', 'QuotaExceededError'));
     expect(() => localStore.set('key', 'val')).to.throw('quota');
+  });
+
+  specify('set rethrows unexpected errors', function() {
+    cy.stub(localStorage, 'setItem').throws(new Error('unexpected'));
+    expect(() => localStore.set('key', 'val')).to.throw('unexpected');
   });
 
   specify('remove deletes the key', function() {


### PR DESCRIPTION
Follow up work for https://github.com/RoundingWell/app-frontend/pull/1694.

To fix coverage drops: https://coveralls.io/builds/79687943/source?filename=src%2Fjs%2Futils%2Flocal-store.js#L11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tests for `localStore.set` to cover undefined-value removal and unexpected error rethrow. Restores coverage for `local-store.js` and confirms correct behavior in these edge cases.

<sup>Written for commit 0bce9846ae42dfea772a1e81f2482105f117aa35. Summary will update on new commits. <a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved local storage utility test coverage with additional validation scenarios.

---

**Note:** This release includes internal quality assurance improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RoundingWell/app-frontend/pull/1703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->