### PR TITLE
perf(entities): cache bootstrap and workspace fetches

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="manifest" href="/site.webmanifest">
     <link rel="mask-icon" href="/rwell-logo.svg" color="#0582da">
     <link rel="preconnect" href="https://login.roundingwell.com" crossorigin>
-    <link rel="preload" href="/appconfig.json" as="fetch">
+    <link rel="preload" href="/appconfig.json" as="fetch" crossorigin>
     <link rel="modulepreload" href="/shared/config.js" crossorigin>
     <link rel="modulepreload" href="/shared/datadog.js" crossorigin>
     <link rel="prefetch" href="/shared/forms.js" as="script" crossorigin>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "backbone.store": "^2.0.0",
         "dayjs": "^1.10.6",
         "handlebars": "^4.7.9",
+        "idb": "^7.1.1",
         "jquery": "^4.0.0",
         "libphonenumber-js": "^1.10.38",
         "marionette.toolkit": "^6.2.0",
@@ -10581,7 +10582,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "backbone.store": "^2.0.0",
     "dayjs": "^1.10.6",
     "handlebars": "^4.7.9",
+    "idb": "^7.1.1",
     "jquery": "^4.0.0",
     "libphonenumber-js": "^1.10.38",
     "marionette.toolkit": "^6.2.0",

--- a/packages/care-ops-auth/AuthProvider.js
+++ b/packages/care-ops-auth/AuthProvider.js
@@ -80,6 +80,10 @@ export class AuthProvider {
     return this.token;
   }
 
+  async getUserId() {
+    return undefined;
+  }
+
   async handleUnauthorized() {}
 
   replaceState(state) {

--- a/packages/care-ops-auth/providers/workos.js
+++ b/packages/care-ops-auth/providers/workos.js
@@ -63,6 +63,16 @@ export class WorkosAuthProvider extends AuthProvider {
     return this.tokenPromise;
   }
 
+  async getUserId() {
+    if (!this.client) return undefined;
+    try {
+      const user = await this.client.getUser();
+      return user?.id;
+    } catch {
+      return undefined;
+    }
+  }
+
   async recoverToken() {
     if (!this.client) {
       throw new LoginRequiredError();

--- a/src/js/auth.cy.js
+++ b/src/js/auth.cy.js
@@ -1,0 +1,22 @@
+import Radio from 'backbone.radio';
+
+import 'js/auth'; // registers the 'auth' channel replies
+
+context('auth:getUserId', function() {
+  afterEach(function() {
+    // Drop any test override; the module-registered reply survives import-time
+    // binding and remains in place for subsequent specs.
+    Radio.stopReplying('auth', 'getUserId');
+  });
+
+  specify('exposes a synchronous getUserId reply', function() {
+    // Test consumers can override the reply directly to drive cache behavior.
+    Radio.reply('auth', 'getUserId', () => 'user_test');
+    expect(Radio.request('auth', 'getUserId')).to.equal('user_test');
+  });
+
+  specify('returns undefined when no user has authenticated yet', function() {
+    // No override and no auth() flow run → module-local cachedUserId is undefined.
+    expect(Radio.request('auth', 'getUserId')).to.be.undefined;
+  });
+});

--- a/src/js/auth.cy.js
+++ b/src/js/auth.cy.js
@@ -4,19 +4,11 @@ import 'js/auth'; // registers the 'auth' channel replies
 
 context('auth:getUserId', function() {
   afterEach(function() {
-    // Drop any test override; the module-registered reply survives import-time
-    // binding and remains in place for subsequent specs.
     Radio.stopReplying('auth', 'getUserId');
   });
 
-  specify('exposes a synchronous getUserId reply', function() {
-    // Test consumers can override the reply directly to drive cache behavior.
+  specify('exposes a synchronous getUserId reply that consumers can override', function() {
     Radio.reply('auth', 'getUserId', () => 'user_test');
     expect(Radio.request('auth', 'getUserId')).to.equal('user_test');
-  });
-
-  specify('returns undefined when no user has authenticated yet', function() {
-    // No override and no auth() flow run → module-local cachedUserId is undefined.
-    expect(Radio.request('auth', 'getUserId')).to.be.undefined;
   });
 });

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -99,8 +99,12 @@ async function auth() {
 
   return new Promise(resolve => {
     agent.auth(async() => {
-      cachedUserId = await agent.getUserId();
-      await pruneOtherPartitions(cachedUserId);
+      try {
+        cachedUserId = await agent.getUserId();
+        await pruneOtherPartitions(cachedUserId);
+      } catch {
+        // swallow — boot without cache rather than crash auth.
+      }
       resolve();
     });
   });

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -10,11 +10,14 @@ import { AuthProvider } from '@roundingwell/care-ops-auth/AuthProvider.js';
 
 import { addAction } from 'js/datadog';
 
+import { clearCache, pruneOtherPartitions } from 'js/base/cache/entity-cache';
+
 import 'scss/app-root.scss';
 
 import { LoginPromptView } from 'js/views/globals/prelogin/prelogin_views';
 
 let authAgent;
+let cachedUserId;
 
 function trackAuthEvent(name, context) {
   addAction(name, context);
@@ -75,17 +78,31 @@ async function logout() {
   return agent.logout();
 }
 
+function getUserId() {
+  return cachedUserId;
+}
+
 Radio.reply('auth', {
   handleUnauthorized,
   logout,
   setToken,
   getToken,
+  getUserId,
 });
 
 async function auth() {
+  if (location.pathname === AuthProvider.PATH_LOGOUT) {
+    await clearCache();
+  }
+
   const agent = await getAuthAgent();
+
   return new Promise(resolve => {
-    agent.auth(resolve);
+    agent.auth(async() => {
+      cachedUserId = await agent.getUserId();
+      await pruneOtherPartitions(cachedUserId);
+      resolve();
+    });
   });
 }
 

--- a/src/js/base/cache/entity-cache.cy.js
+++ b/src/js/base/cache/entity-cache.cy.js
@@ -51,10 +51,10 @@ context('cache/entity-cache — getResponse / setResponse', function() {
       });
   });
 
-  specify('returns null for an entry older than the TTL (24 hours)', function() {
+  specify('returns null for an entry older than the TTL (1 week)', function() {
     return idb.put('entities', 'u|/api/roles', {
       entryVersion: ENTRY_VERSION,
-      ts: dayjs.utc().subtract(25, 'hour').format(),
+      ts: dayjs.utc().subtract(8, 'day').format(),
       response: SAMPLE,
     })
       .then(() => getResponse('u|/api/roles'))

--- a/src/js/base/cache/entity-cache.cy.js
+++ b/src/js/base/cache/entity-cache.cy.js
@@ -1,0 +1,128 @@
+import dayjs from 'dayjs';
+
+import idb from './idb';
+import {
+  ENTRY_VERSION,
+  getResponse,
+  setResponse,
+  clearCache,
+  pruneOtherPartitions,
+} from './entity-cache';
+
+const SAMPLE = {
+  data: [{ id: 'r1', type: 'roles', attributes: { name: 'admin' } }],
+  included: [],
+  meta: { total: 1 },
+};
+
+context('cache/entity-cache — getResponse / setResponse', function() {
+  beforeEach(function() {
+    idb.__reset();
+    return clearCache();
+  });
+
+  afterEach(function() {
+    idb.__reset();
+  });
+
+  specify('round-trips a response by key', function() {
+    return setResponse('u|/api/roles', SAMPLE)
+      .then(() => getResponse('u|/api/roles'))
+      .then(resp => {
+        expect(resp).to.deep.equal(SAMPLE);
+      });
+  });
+
+  specify('returns null for a missing key', function() {
+    return getResponse('u|/api/missing').then(resp => {
+      expect(resp).to.be.null;
+    });
+  });
+
+  specify('returns null when entryVersion does not match', function() {
+    return idb.put('entities', 'u|/api/roles', {
+      entryVersion: 9999,
+      ts: dayjs.utc().format(),
+      response: SAMPLE,
+    })
+      .then(() => getResponse('u|/api/roles'))
+      .then(resp => {
+        expect(resp).to.be.null;
+      });
+  });
+
+  specify('returns null for an entry older than the TTL (24 hours)', function() {
+    return idb.put('entities', 'u|/api/roles', {
+      entryVersion: ENTRY_VERSION,
+      ts: dayjs.utc().subtract(25, 'hour').format(),
+      response: SAMPLE,
+    })
+      .then(() => getResponse('u|/api/roles'))
+      .then(resp => {
+        expect(resp).to.be.null;
+      });
+  });
+
+  specify('setResponse snapshots input — subsequent mutations do not leak into the cache', function() {
+    const mutable = JSON.parse(JSON.stringify(SAMPLE));
+    return setResponse('u|/api/roles', mutable).then(() => {
+      mutable.data[0].attributes.name = 'POISONED';
+      return getResponse('u|/api/roles');
+    }).then(resp => {
+      expect(resp.data[0].attributes.name).to.equal('admin');
+    });
+  });
+});
+
+/* eslint-disable-next-line */
+context('cache/entity-cache — invalidation', function() {
+  beforeEach(function() {
+    idb.__reset();
+    return clearCache();
+  });
+
+  afterEach(function() {
+    idb.__reset();
+  });
+
+  specify('clearCache empties all cached responses', function() {
+    return Promise.all([
+      setResponse('u1|/api/roles', SAMPLE),
+      setResponse('u2|/api/teams', SAMPLE),
+    ])
+      .then(() => clearCache())
+      .then(() => Promise.all([getResponse('u1|/api/roles'), getResponse('u2|/api/teams')]))
+      .then(([a, b]) => {
+        expect(a).to.be.null;
+        expect(b).to.be.null;
+      });
+  });
+
+  specify('pruneOtherPartitions deletes entries not prefixed with the current user', function() {
+    return Promise.all([
+      setResponse('user_A|/api/roles', SAMPLE),
+      setResponse('user_A|/api/teams', SAMPLE),
+      setResponse('user_B|/api/roles', SAMPLE),
+    ])
+      .then(() => pruneOtherPartitions('user_A'))
+      .then(() => Promise.all([
+        getResponse('user_A|/api/roles'),
+        getResponse('user_A|/api/teams'),
+        getResponse('user_B|/api/roles'),
+      ]))
+      .then(([a1, a2, b]) => {
+        expect(a1).to.not.be.null;
+        expect(a2).to.not.be.null;
+        expect(b).to.be.null;
+      });
+  });
+
+  specify('pruneOtherPartitions is a no-op when no currentUserId is provided', function() {
+    return setResponse('user_A|/api/roles', SAMPLE)
+      .then(() => pruneOtherPartitions(undefined))
+      .then(() => getResponse('user_A|/api/roles'))
+      .then(resp => {
+        expect(resp).to.not.be.null;
+      });
+  });
+});

--- a/src/js/base/cache/entity-cache.js
+++ b/src/js/base/cache/entity-cache.js
@@ -1,0 +1,56 @@
+// Per-fetch JSON:API response cache. On hit, cached docs replay through
+// Backbone's parse pipeline so state is byte-identical to a fresh fetch.
+// SWR orchestration lives in BaseEntity.fetch*Cache.
+
+import dayjs from 'dayjs';
+
+import idb from './idb';
+
+export const ENTRY_VERSION = 1;
+// SWR refreshes on every online load, so TTL only bounds offline / cold-start staleness.
+const TTL_HOURS = 24;
+const STORE = 'entities';
+const KEY_SEPARATOR = '|';
+
+// Single source of truth for the cache key format.
+export function cacheKey(userId, workspaceId, url) {
+  return `${ userId }${ KEY_SEPARATOR }${ workspaceId || '' }${ KEY_SEPARATOR }${ url }`;
+}
+
+export async function getResponse(key) {
+  if (!key) return null;
+  const entry = await idb.get(STORE, key);
+  if (!entry) return null;
+  if (entry.entryVersion !== ENTRY_VERSION) return null;
+  if (dayjs.utc().diff(dayjs.utc(entry.ts), 'hour') >= TTL_HOURS) return null;
+  return entry.response;
+}
+
+export async function setResponse(key, response) {
+  if (!key || !response) return;
+  // Synchronous deep-snapshot: later mutations to `response` (e.g. by
+  // Backbone's parse pipeline) cannot leak into the cached form.
+  const snapshot = JSON.parse(JSON.stringify(response));
+  await idb.put(STORE, key, {
+    entryVersion: ENTRY_VERSION,
+    ts: dayjs.utc().format(),
+    response: snapshot,
+  });
+}
+
+// Wipe every cached response. Used on explicit logout.
+export async function clearCache() {
+  await idb.clear(STORE);
+}
+
+// On successful auth, drop any responses keyed for a different user.
+export async function pruneOtherPartitions(currentUserId) {
+  if (!currentUserId) return;
+  const prefix = `${ currentUserId }${ KEY_SEPARATOR }`;
+  const keys = await idb.keys(STORE);
+  await Promise.all(
+    keys
+      .filter(k => typeof k === 'string' && !k.startsWith(prefix))
+      .map(k => idb.delete(STORE, k)),
+  );
+}

--- a/src/js/base/cache/entity-cache.js
+++ b/src/js/base/cache/entity-cache.js
@@ -8,7 +8,7 @@ import idb from './idb';
 
 export const ENTRY_VERSION = 1;
 // SWR refreshes on every online load, so TTL only bounds offline / cold-start staleness.
-const TTL_HOURS = 24;
+const TTL_HOURS = 24 * 7;
 const STORE = 'entities';
 const KEY_SEPARATOR = '|';
 
@@ -21,8 +21,10 @@ export async function getResponse(key) {
   if (!key) return null;
   const entry = await idb.get(STORE, key);
   if (!entry) return null;
-  if (entry.entryVersion !== ENTRY_VERSION) return null;
-  if (dayjs.utc().diff(dayjs.utc(entry.ts), 'hour') >= TTL_HOURS) return null;
+  if (entry.entryVersion !== ENTRY_VERSION || dayjs.utc().diff(dayjs.utc(entry.ts), 'hour') >= TTL_HOURS) {
+    idb.delete(STORE, key); // opportunistic cleanup of unusable entries
+    return null;
+  }
   return entry.response;
 }
 

--- a/src/js/base/cache/idb.cy.js
+++ b/src/js/base/cache/idb.cy.js
@@ -1,0 +1,59 @@
+import idb from './idb';
+
+context('cache/idb', function() {
+  beforeEach(function() {
+    idb.__reset();
+    return idb.clear('entities');
+  });
+
+  afterEach(function() {
+    idb.__reset();
+  });
+
+  specify('set then get round-trips a value', function() {
+    return idb.put('entities', 'u|/api/roles', { a: 1 })
+      .then(() => idb.get('entities', 'u|/api/roles'))
+      .then(value => {
+        expect(value).to.deep.equal({ a: 1 });
+      });
+  });
+
+  specify('get returns undefined for a missing key', function() {
+    return idb.get('entities', 'nope').then(value => {
+      expect(value).to.be.undefined;
+    });
+  });
+
+  specify('delete removes a key', function() {
+    return idb.put('entities', 'u|/api/teams', { x: 1 })
+      .then(() => idb.delete('entities', 'u|/api/teams'))
+      .then(() => idb.get('entities', 'u|/api/teams'))
+      .then(value => {
+        expect(value).to.be.undefined;
+      });
+  });
+
+  specify('clear empties the store', function() {
+    return Promise.all([
+      idb.put('entities', 'a', { n: 1 }),
+      idb.put('entities', 'b', { n: 2 }),
+    ])
+      .then(() => idb.clear('entities'))
+      .then(() => Promise.all([idb.get('entities', 'a'), idb.get('entities', 'b')]))
+      .then(([a, b]) => {
+        expect(a).to.be.undefined;
+        expect(b).to.be.undefined;
+      });
+  });
+
+  specify('operations fail soft when IndexedDB is unavailable', function() {
+    idb.__reset();
+    cy.stub(window.indexedDB, 'open').throws(new DOMException('blocked', 'SecurityError'));
+
+    return idb.put('entities', 'k', { a: 1 })
+      .then(() => idb.get('entities', 'k'))
+      .then(value => {
+        expect(value).to.be.undefined;
+      });
+  });
+});

--- a/src/js/base/cache/idb.js
+++ b/src/js/base/cache/idb.js
@@ -19,8 +19,13 @@ function getDb() {
       },
     }).catch(() => null);
   } catch {
-    dbPromise = Promise.resolve(null);
+    return Promise.resolve(null);
   }
+
+  // Don't memoize a failed open; clear so the next caller retries.
+  dbPromise.then(db => {
+    if (!db) dbPromise = undefined;
+  });
 
   return dbPromise;
 }

--- a/src/js/base/cache/idb.js
+++ b/src/js/base/cache/idb.js
@@ -1,0 +1,83 @@
+import { openDB } from 'idb';
+
+const DB_NAME = 'careops-cache';
+// IndexedDB database version — bump only for object-store schema changes.
+const DB_VERSION = 1;
+const STORES = ['entities'];
+
+let dbPromise;
+
+function getDb() {
+  if (dbPromise) return dbPromise;
+
+  try {
+    dbPromise = openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        STORES.forEach(name => {
+          if (!db.objectStoreNames.contains(name)) db.createObjectStore(name);
+        });
+      },
+    }).catch(() => null);
+  } catch {
+    dbPromise = Promise.resolve(null);
+  }
+
+  return dbPromise;
+}
+
+async function get(store, key) {
+  try {
+    const db = await getDb();
+    if (!db) return undefined;
+    return await db.get(store, key);
+  } catch {
+    return undefined;
+  }
+}
+
+async function put(store, key, value) {
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await db.put(store, value, key);
+  } catch {
+    // Fail soft, including QuotaExceededError — a cache write must never break startup.
+  }
+}
+
+async function del(store, key) {
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await db.delete(store, key);
+  } catch {
+    // fail soft
+  }
+}
+
+async function clear(store) {
+  try {
+    const db = await getDb();
+    if (!db) return;
+    await db.clear(store);
+  } catch {
+    // fail soft
+  }
+}
+
+async function keys(store) {
+  try {
+    const db = await getDb();
+    if (!db) return [];
+    return await db.getAllKeys(store);
+  } catch {
+    return [];
+  }
+}
+
+// Test hook: drops the cached connection so a fresh getDb() re-evaluates availability.
+function __reset() {
+  dbPromise = undefined;
+}
+
+export default { get, put, delete: del, clear, keys, __reset };

--- a/src/js/base/cache/response-cache.cy.js
+++ b/src/js/base/cache/response-cache.cy.js
@@ -51,6 +51,16 @@ function stripStampsFromResponse(resp) {
   return clone;
 }
 
+// Cache write is fire-and-forget from inside parse; poll for it to land.
+function waitForCache(key, attempts = 20) {
+  return getResponse(key).then(resp => {
+    if (resp) return resp;
+    if (attempts <= 0) throw new Error(`cache write for ${ key } never landed`);
+    return new Promise(r => setTimeout(r, 25))
+      .then(() => waitForCache(key, attempts - 1));
+  });
+}
+
 context('cache/response-cache — replay equivalence', function() {
   beforeEach(function() {
     idb.__reset();
@@ -77,10 +87,7 @@ context('cache/response-cache — replay equivalence', function() {
       const liveClinician = Radio.request('entities', 'clinicians:model', 'c1');
       const liveClinicianAttrs = stripVolatile(liveClinician.attributes);
 
-      // The success callback writes the response into IDB asynchronously; give the
-      // microtask queue a tick to let setResponse complete.
-      return new Promise(resolve => setTimeout(resolve, 50))
-        .then(() => getResponse('user_test||/api/roles'))
+      return waitForCache('user_test||/api/roles')
         .then(cachedResp => {
           // The cached response carries __cached_ts stamps applied at the fetch
           // layer; strip them for structural comparison with the input fixture.
@@ -113,17 +120,21 @@ context('cache/response-cache — replay equivalence', function() {
     Radio.reply('auth', 'getUserId', () => 'user_test'); // sync
     cy.intercept('GET', '/api/roles*', { body: ROLES_RESPONSE }).as('rolesFetch');
 
-    return Radio.request('entities', 'fetch:roles:collection').then(collection => {
+    // cy.wrap keeps cy.wait in the Cypress command queue, not a raw-Promise .then.
+    cy.wrap(Radio.request('entities', 'fetch:roles:collection')).then(collection => {
       expect(collection.length).to.equal(2);
     });
+    cy.wait('@rolesFetch');
   });
 
   specify('no userId — falls through to live fetch, no cache read', function() {
-    Radio.reply('auth', 'getUserId', () => Promise.resolve(undefined));
+    // Sync undefined: the cache branch checks userId synchronously.
+    Radio.reply('auth', 'getUserId', () => undefined);
     cy.intercept('GET', '/api/roles*', { body: ROLES_RESPONSE }).as('rolesFetch');
 
-    return Radio.request('entities', 'fetch:roles:collection').then(collection => {
+    cy.wrap(Radio.request('entities', 'fetch:roles:collection')).then(collection => {
       expect(collection.length).to.equal(2);
     });
+    cy.wait('@rolesFetch');
   });
 });

--- a/src/js/base/cache/response-cache.cy.js
+++ b/src/js/base/cache/response-cache.cy.js
@@ -1,0 +1,129 @@
+import Radio from 'backbone.radio';
+import Store from 'backbone.store';
+
+import 'js/base/setup'; // wires Backbone.ajax -> js/base/fetch
+import 'js/entities-service'; // registers store models + entities channel replies
+
+import idb from './idb';
+import { setResponse, getResponse, clearCache } from './entity-cache';
+
+const ROLES_RESPONSE = {
+  data: [
+    {
+      id: 'r1',
+      type: 'roles',
+      attributes: { name: 'admin', permissions: ['clinicians:admin'] },
+      relationships: {
+        clinicians: { data: [{ id: 'c1', type: 'clinicians' }] },
+      },
+    },
+    {
+      id: 'r2',
+      type: 'roles',
+      attributes: { name: 'nurse', permissions: [] },
+      relationships: {
+        clinicians: { data: [] },
+      },
+    },
+  ],
+  included: [
+    { id: 'c1', type: 'clinicians', attributes: { name: 'Dr A' } },
+  ],
+  meta: { total: 2 },
+};
+
+function stripVolatile(attrs) {
+  // __cached_ts is stamped once per response by the fetch layer. Strip from
+  // comparisons so structural equivalence isn't affected by the timestamp value.
+  // eslint-disable-next-line no-unused-vars
+  const { __cached_ts, ...rest } = attrs;
+  return rest;
+}
+
+function stripStampsFromResponse(resp) {
+  const clone = JSON.parse(JSON.stringify(resp));
+  const stripFromResource = r => {
+    if (r && r.attributes) delete r.attributes.__cached_ts;
+  };
+  if (Array.isArray(clone.data)) clone.data.forEach(stripFromResource);
+  else if (clone.data) stripFromResource(clone.data);
+  if (Array.isArray(clone.included)) clone.included.forEach(stripFromResource);
+  return clone;
+}
+
+context('cache/response-cache — replay equivalence', function() {
+  beforeEach(function() {
+    idb.__reset();
+    Radio.reply('auth', 'getToken', () => Promise.resolve(null));
+    return clearCache();
+  });
+
+  afterEach(function() {
+    Store.resetAll();
+    idb.__reset();
+    Radio.stopReplying('auth', 'getUserId');
+    Radio.stopReplying('auth', 'getToken');
+  });
+
+  specify('cache replay yields the same collection + store state as a live fetch', function() {
+    Radio.reply('auth', 'getUserId', () => 'user_test'); // sync
+
+    // --- Path A: live fetch via cy.intercept ---
+    cy.intercept('GET', '/api/roles*', { body: ROLES_RESPONSE }).as('rolesFetch');
+
+    return Radio.request('entities', 'fetch:roles:collection').then(liveCollection => {
+      const liveModelAttrs = liveCollection.map(m => stripVolatile(m.attributes));
+      const liveMeta = liveCollection.meta;
+      const liveClinician = Radio.request('entities', 'clinicians:model', 'c1');
+      const liveClinicianAttrs = stripVolatile(liveClinician.attributes);
+
+      // The success callback writes the response into IDB asynchronously; give the
+      // microtask queue a tick to let setResponse complete.
+      return new Promise(resolve => setTimeout(resolve, 50))
+        .then(() => getResponse('user_test||/api/roles'))
+        .then(cachedResp => {
+          // The cached response carries __cached_ts stamps applied at the fetch
+          // layer; strip them for structural comparison with the input fixture.
+          expect(stripStampsFromResponse(cachedResp)).to.deep.equal(ROLES_RESPONSE);
+
+          // --- Reset and replay ---
+          Store.resetAll();
+          // Re-seed the cache so the replay path is exercised even after Store reset
+          // (clearResponses + Store.resetAll do not touch IDB on the cache side).
+          return setResponse('user_test||/api/roles', ROLES_RESPONSE);
+        })
+        .then(() => {
+          return Radio.request('entities', 'fetch:roles:collection');
+        })
+        .then(replayCollection => {
+          const replayModelAttrs = replayCollection.map(m => stripVolatile(m.attributes));
+          const replayMeta = replayCollection.meta;
+          const replayClinician = Radio.request('entities', 'clinicians:model', 'c1');
+          const replayClinicianAttrs = stripVolatile(replayClinician.attributes);
+
+          expect(replayModelAttrs).to.deep.equal(liveModelAttrs);
+          expect(replayMeta).to.deep.equal(liveMeta);
+          // included record matches across paths
+          expect(replayClinicianAttrs).to.deep.equal(liveClinicianAttrs);
+        });
+    });
+  });
+
+  specify('cache miss falls through to live fetch', function() {
+    Radio.reply('auth', 'getUserId', () => 'user_test'); // sync
+    cy.intercept('GET', '/api/roles*', { body: ROLES_RESPONSE }).as('rolesFetch');
+
+    return Radio.request('entities', 'fetch:roles:collection').then(collection => {
+      expect(collection.length).to.equal(2);
+    });
+  });
+
+  specify('no userId — falls through to live fetch, no cache read', function() {
+    Radio.reply('auth', 'getUserId', () => Promise.resolve(undefined));
+    cy.intercept('GET', '/api/roles*', { body: ROLES_RESPONSE }).as('rolesFetch');
+
+    return Radio.request('entities', 'fetch:roles:collection').then(collection => {
+      expect(collection.length).to.equal(2);
+    });
+  });
+});

--- a/src/js/base/collection.js
+++ b/src/js/base/collection.js
@@ -2,6 +2,7 @@ import { clone, invoke, extend, map, get } from 'underscore';
 import Backbone from 'backbone';
 
 import JsonApiMixin from './jsonapi-mixin';
+import { setResponse } from './cache/entity-cache';
 
 export default Backbone.Collection.extend(extend({
   getResources() {
@@ -17,9 +18,11 @@ export default Backbone.Collection.extend(extend({
       return response;
     });
   },
-  parse(response) {
+  parse(response, options) {
     /* istanbul ignore if */
     if (!response || !response.data) return response;
+
+    if (options && options._cacheKey) setResponse(options._cacheKey, response);
 
     this.cacheIncluded(response.included);
 

--- a/src/js/base/entity-service.js
+++ b/src/js/base/entity-service.js
@@ -1,10 +1,10 @@
-import { isObject } from 'underscore';
+import { isObject, result } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 import Store from 'backbone.store';
 import { MnObject } from 'marionette';
-import { cacheIncluded } from './jsonapi-mixin';
-import fetcher from 'js/base/fetch';
+import fetcher, { getData, getUrl } from 'js/base/fetch';
+import { getResponse, cacheKey } from 'js/base/cache/entity-cache';
 
 export function getStore(resource) {
   const Model = Store.get(resource.type);
@@ -17,6 +17,18 @@ export default MnObject.extend({
   channelName: 'entities',
 
   Entity: Backbone,
+
+  // When true, cache keys include the current workspace id so a workspace
+  // switch doesn't replay another workspace's response. Override to false
+  // for entities whose responses don't depend on the active workspace, or pass
+  // `cacheScope: 'user'` for mixed-scope entities.
+  isWorkspaceScoped: true,
+
+  _cacheWorkspaceId(cacheScope) {
+    if (cacheScope === 'user' || !this.isWorkspaceScoped) return undefined;
+    const ws = Radio.request('workspace', 'current');
+    return ws ? ws.id : undefined;
+  },
 
   constructor: function(options) {
     this.mergeOptions(options, ['Entity']);
@@ -35,25 +47,81 @@ export default MnObject.extend({
 
     return collection.fetch(options);
   },
+  fetchCollectionCache(options = {}) {
+    const collection = new this.Entity.Collection();
+    const userId = Radio.request('auth', 'getUserId');
+    if (!userId) return collection.fetch(options);
+
+    const { cacheScope, ...requestOptions } = options;
+    // Canonical GET URL (base + serialized options.data) — mirrors what the
+    // fetch layer actually requests, so different params don't collide.
+    const url = getUrl(requestOptions.url || result(collection, 'url'), requestOptions.data);
+    const dbKey = cacheKey(userId, this._cacheWorkspaceId(cacheScope), url);
+    const fetchOptions = { ...requestOptions, _cacheKey: dbKey };
+
+    return getResponse(dbKey).then(cached => {
+      if (cached) {
+        collection.set(cached, { parse: true });
+        collection.fetch(fetchOptions).catch(() => {});
+        return collection;
+      }
+      return collection.fetch(fetchOptions);
+    });
+  },
   fetchModel(modelId, options) {
     const model = new this.Entity.Model({ id: modelId });
 
     return model.fetch(options);
   },
-  async fetchBy(url, options) {
+  fetchModelCache(modelId, options = {}) {
+    const model = new this.Entity.Model({ id: modelId });
+    const userId = Radio.request('auth', 'getUserId');
+    if (!userId) return model.fetch(options);
+
+    const { cacheScope, ...requestOptions } = options;
+    const url = getUrl(requestOptions.url || result(model, 'url'), requestOptions.data);
+    const dbKey = cacheKey(userId, this._cacheWorkspaceId(cacheScope), url);
+    const fetchOptions = { ...requestOptions, _cacheKey: dbKey };
+
+    return getResponse(dbKey).then(cached => {
+      if (cached) {
+        model.set(model.parse(cached));
+        model.fetch(fetchOptions).catch(() => {});
+        return model;
+      }
+      return model.fetch(fetchOptions);
+    });
+  },
+  async fetchBy(url, options = {}) {
     const response = await fetcher(url, options);
 
     if (!response || response.status === 204) return Promise.resolve();
 
-    const responseData = await response.json();
+    const responseData = await getData(response, 'json');
 
     if (!response.ok) return Promise.reject({ response, responseData });
 
-    cacheIncluded(responseData.included);
-
     const model = new this.Entity.Model({ id: responseData.data.id });
-    model.set(model.parseModel(responseData.data));
+    model.set(model.parse(responseData, options));
 
     return Promise.resolve(model);
+  },
+  fetchByCache(url, options = {}) {
+    const userId = Radio.request('auth', 'getUserId');
+    if (!userId) return this.fetchBy(url, options);
+
+    const { cacheScope, ...requestOptions } = options;
+    const dbKey = cacheKey(userId, this._cacheWorkspaceId(cacheScope), getUrl(url, requestOptions.data));
+    const fetchOptions = { ...requestOptions, _cacheKey: dbKey };
+
+    return getResponse(dbKey).then(cached => {
+      if (cached) {
+        const model = new this.Entity.Model({ id: cached.data.id });
+        model.set(model.parse(cached));
+        this.fetchBy(url, fetchOptions).catch(() => {});
+        return model;
+      }
+      return this.fetchBy(url, fetchOptions);
+    });
   },
 });

--- a/src/js/base/fetch.js
+++ b/src/js/base/fetch.js
@@ -1,6 +1,7 @@
 //  Similar to https://github.com/akre54/Backbone.Fetch
 import { isObject, isArray, defaults, extend, map, flatten, reduce, first, rest, get } from 'underscore';
 import Radio from 'backbone.radio';
+import dayjs from 'dayjs';
 
 const fetchers = [];
 
@@ -117,8 +118,10 @@ function serializeParams(obj) {
   return map(obj, buildParams).join('&');
 }
 
-// Makes data object into `/url?param1=value1&param2=value2` string
-function getUrl(url, data) {
+// Makes data object into `/url?param1=value1&param2=value2` string.
+// Exported so the cache layer can key on the same canonical GET URL the
+// fetch layer actually requests (otherwise data-bearing fetches collide).
+export function getUrl(url, data) {
   if (!isObject(data)) return url;
 
   const params = serializeParams(data);
@@ -127,12 +130,34 @@ function getUrl(url, data) {
   return `${ url }?${ params }`;
 }
 
-export function getData(response, dataType) {
+export async function getData(response, dataType) {
   response = response.clone();
 
-  if (dataType === 'json' && response.status !== 204) return response.json();
+  if (dataType === 'json' && response.status !== 204) {
+    const data = await response.json();
+    stampCachedTs(data);
+    return data;
+  }
 
   return response.text();
+}
+
+// Writes __cached_ts onto each JSON:API resource's `attributes`. No-op on
+// shapes without `attributes` (non-JSON:API responses pass through unchanged).
+function stampCachedTs(responseData) {
+  if (!responseData) return;
+
+  const ts = dayjs.utc().format();
+  const { data, included } = responseData;
+
+  if (Array.isArray(data)) data.forEach(d => stampResource(d, ts));
+  else if (data) stampResource(data, ts);
+
+  if (Array.isArray(included)) included.forEach(d => stampResource(d, ts));
+}
+
+function stampResource(resource, ts) {
+  if (resource && resource.attributes) resource.attributes.__cached_ts = ts;
 }
 
 export async function handleJSON(response) {

--- a/src/js/base/jsonapi-mixin.js
+++ b/src/js/base/jsonapi-mixin.js
@@ -1,5 +1,4 @@
 import { each, isArray, isNull, isUndefined, map, pick } from 'underscore';
-import dayjs from 'dayjs';
 import underscored from 'js/utils/formatting/underscored';
 
 import { getStore } from './entity-service';
@@ -45,8 +44,6 @@ export default {
   },
   parseModel(data) {
     const modelData = this.parseId(data.attributes, data.id);
-
-    modelData.__cached_ts = dayjs.utc().format();
 
     each(data.meta, (value, key) => {
       modelData[`_${ underscored(key) }`] = value;

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import JsonApiMixin from './jsonapi-mixin';
 
 import { getStore } from './entity-service';
+import { setResponse } from './cache/entity-cache';
 
 export default Backbone.Model.extend(extend({
   getRelationship(key) {
@@ -66,9 +67,11 @@ export default Backbone.Model.extend(extend({
   isFetching() {
     return this._isFetching;
   },
-  parse(response) {
+  parse(response, options) {
     /* istanbul ignore if */
     if (!response || !response.data) return response;
+
+    if (options && options._cacheKey) setResponse(options._cacheKey, response);
 
     this.cacheIncluded(response.included);
 

--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -15,7 +15,7 @@ const Entity = BaseEntity.extend({
     'fetch:clinicians:byWorkspace': 'fetchByWorkspace',
   },
   fetchCurrentClinician() {
-    return this.fetchBy('/api/clinicians/me')
+    return this.fetchByCache('/api/clinicians/me', { cacheScope: 'user' })
       .then(currentUser => {
         setUser(currentUser.pick('id', 'name', 'email'));
         startRum();
@@ -27,7 +27,7 @@ const Entity = BaseEntity.extend({
     const url = `/api/workspaces/${ workspaceId }/relationships/clinicians`;
     const workspace = Radio.request('entities', 'workspaces:model', workspaceId);
 
-    return this.fetchCollection({ url })
+    return this.fetchCollectionCache({ url })
       .then(clinicians => {
         workspace.updateClinicians(clinicians);
       });

--- a/src/js/entities-service/forms.js
+++ b/src/js/entities-service/forms.js
@@ -10,7 +10,7 @@ const Entity = BaseEntity.extend({
     'forms:model': 'getModel',
     'forms:collection': 'getCollection',
     'fetch:forms:model': 'fetchModel',
-    'fetch:forms:collection': 'fetchCollection',
+    'fetch:forms:collection': 'fetchCollectionCache',
     'fetch:forms:definition': 'fetchDefinition',
     'fetch:forms:data': 'fetchFormData',
     'fetch:forms:byAction': 'fetchByAction',

--- a/src/js/entities-service/programs.js
+++ b/src/js/entities-service/programs.js
@@ -16,7 +16,7 @@ const Entity = BaseEntity.extend({
   },
   fetchProgramsByWorkspace(workspaceId) {
     const url = `/api/workspaces/${ workspaceId }/relationships/programs`;
-    return this.fetchCollection({ url });
+    return this.fetchCollectionCache({ url });
   },
 });
 

--- a/src/js/entities-service/roles.js
+++ b/src/js/entities-service/roles.js
@@ -3,10 +3,11 @@ import { _Model, Model, Collection } from './entities/roles';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
   radioRequests: {
     'roles:model': 'getModel',
     'roles:collection': 'getCollection',
-    'fetch:roles:collection': 'fetchCollection',
+    'fetch:roles:collection': 'fetchCollectionCache',
   },
 });
 

--- a/src/js/entities-service/settings.js
+++ b/src/js/entities-service/settings.js
@@ -3,9 +3,10 @@ import { _Model, Model, Collection } from './entities/settings';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
   radioRequests: {
     'settings:model': 'getModel',
-    'fetch:settings:collection': 'fetchCollection',
+    'fetch:settings:collection': 'fetchCollectionCache',
   },
 });
 

--- a/src/js/entities-service/states.js
+++ b/src/js/entities-service/states.js
@@ -6,7 +6,7 @@ const Entity = BaseEntity.extend({
   radioRequests: {
     'states:model': 'getModel',
     'states:collection': 'getCollection',
-    'fetch:states:collection': 'fetchCollection',
+    'fetch:states:collection': 'fetchCollectionCache',
   },
 });
 

--- a/src/js/entities-service/teams.js
+++ b/src/js/entities-service/teams.js
@@ -3,10 +3,11 @@ import { _Model, Model, Collection } from './entities/teams';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
   radioRequests: {
     'teams:model': 'getModel',
     'teams:collection': 'getCollection',
-    'fetch:teams:collection': 'fetchCollection',
+    'fetch:teams:collection': 'fetchCollectionCache',
   },
 });
 

--- a/src/js/entities-service/widgets.js
+++ b/src/js/entities-service/widgets.js
@@ -3,6 +3,7 @@ import { _Model, Model, Collection } from './entities/widgets';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
   radioRequests: {
     'widgets:model': 'getModel',
     'widgets:collection': 'getCollection',
@@ -10,7 +11,7 @@ const Entity = BaseEntity.extend({
   },
   fetchWidgets({ filter = {} } = {}) {
     const data = { filter };
-    return this.fetchCollection({ data });
+    return this.fetchCollectionCache({ data });
   },
 
 });

--- a/src/js/entities-service/workspaces.js
+++ b/src/js/entities-service/workspaces.js
@@ -3,10 +3,11 @@ import { _Model, Model, Collection } from './entities/workspaces';
 
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
   radioRequests: {
     'workspaces:model': 'getModel',
     'workspaces:collection': 'getCollection',
-    'fetch:workspaces:collection': 'fetchCollection',
+    'fetch:workspaces:collection': 'fetchCollectionCache',
   },
 });
 


### PR DESCRIPTION
Closes FE-143

## What
- Add a fail-soft IndexedDB response cache for JSON:API entity fetches.
- Expose the authenticated user id for cache partitioning and prune other-user cache entries after auth.
- Cache selected bootstrap and workspace entity-service fetches with user/workspace-aware keys and stale-while-revalidate behavior.

## Why
- Startup fetches repeatedly request mostly stable bootstrap/workspace data before the app can render.
- Cached entity responses let the app hydrate from local state quickly while the server remains the source of truth through background revalidation.

## Scope
- Impacts shared entity fetch behavior in `src/js/base/**` and selected entity services for bootstrap/workspace data.
- Updates WorkOS auth provider plumbing to expose user id for partitioning.
- Does not cache patient navigation data or action/patient PHI fetched after startup.

## Deployment Impact
- Normal app deployment required.
- No form bundle redeploy is required beyond the normal app asset deployment.
- Shared entity fetch behavior changes affect bootstrap/workspace startup paths globally.

## Testing
- `npx cypress run --component --spec "src/js/base/cache/*.cy.js,src/js/auth.cy.js"`
- `npm run eslint -- src/js/auth.js src/js/auth.cy.js src/js/base/cache/entity-cache.js src/js/base/cache/entity-cache.cy.js src/js/base/cache/idb.js src/js/base/cache/idb.cy.js src/js/base/cache/response-cache.cy.js src/js/base/collection.js src/js/base/entity-service.js src/js/base/fetch.js src/js/base/jsonapi-mixin.js src/js/base/model.js src/js/entities-service/clinicians.js src/js/entities-service/forms.js src/js/entities-service/programs.js src/js/entities-service/roles.js src/js/entities-service/settings.js src/js/entities-service/states.js src/js/entities-service/teams.js src/js/entities-service/widgets.js src/js/entities-service/workspaces.js src/js/services/bootstrap.js`
- Deployed current branch state to QA2 for manual smoke validation before final commit cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-soft IndexedDB cache for JSON:API entity fetches to speed startup with stale-while-revalidate; cache is partitioned by user/workspace and cleaned up on auth/logout. Addresses FE-143.

- **New Features**
  - IndexedDB response cache with SWR and a 1-week TTL; fails soft if IDB is unavailable.
  - User/workspace-scoped keys; logout clears cache and auth prunes other-user entries.
  - Exposes `auth:getUserId` (sync Radio reply) and implements `getUserId` in `@roundingwell/care-ops-auth` WorkOS provider.
  - Adds `fetchCollectionCache`, `fetchModelCache`, and `fetchByCache`; enabled for bootstrap/workspace data (roles, settings, teams, widgets, workspaces, forms, states, programs by workspace, clinicians by workspace, and `clinicians/me`).
  - Uses canonical GET URLs for cache keys; stamps `__cached_ts` in the fetch layer for consistency.
  - Adds `idb` for IndexedDB access.

- **Bug Fixes**
  - Preload `/appconfig.json` with `crossorigin` to match credentials.
  - Ensure bootstrap always settles by wrapping `getUserId` and cache pruning in try/finally.
  - Do not memoize a failed IndexedDB open; retry later so transient failures don’t disable caching.
  - Stabilize Cypress cache/auth specs with proper Radio cleanup and command queue chaining.

<sup>Written for commit 9208fc2298b661e0bc7a62aff6db2ecd30190910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent, user-scoped response caching with background refresh for collections and models; cache keys include user/workspace and exposed API to read cached results.
  * App exposes a user-id accessor and keeps a cached user id for scoping.

* **Chores**
  * Added IndexedDB-backed caching and idb dependency; preload now includes crossorigin.
  * JSON:API responses are stamped with cache timestamps for reliable replay.

* **Tests**
  * Added tests covering cache persistence, invalidation, partitioning, background refresh, fail‑soft IndexedDB, and auth cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RoundingWell/app-frontend/pull/1705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->