### PR TITLE
fix(deploy): discover website stacks by WebsiteBucket output

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -43,10 +43,6 @@ function getTagValue(deploymentTarget, key) {
   return deploymentTarget.Tags?.find(tag => tag.Key === key)?.Value || '';
 }
 
-function getTargetName(deploymentTarget) {
-  return deploymentTarget.StackName || '<unknown-stack>';
-}
-
 function isDeployableTarget(deploymentTarget) {
   return DEPLOYABLE_STATUSES.has(deploymentTarget.StackStatus);
 }
@@ -101,7 +97,7 @@ async function listStageOrganizations(cfClient, stage, filterOrganization) {
  * @param {string} stage - Deployment stage
  * @param {string} filterOrganization - Optional specific organization identifier to filter
  */
-function addOrganizationsFromPage(organizationBuckets, response, stage, filterOrganization) {
+export function addOrganizationsFromPage(organizationBuckets, response, stage, filterOrganization) {
   for (const deploymentTarget of response.Stacks || []) {
     if (!isDeployableTarget(deploymentTarget)) continue;
     if (!matchesOrganizationTarget(deploymentTarget, stage, filterOrganization)) continue;
@@ -111,11 +107,11 @@ function addOrganizationsFromPage(organizationBuckets, response, stage, filterOr
 
     if (!shouldIncludeDeployTarget(stage, filterOrganization, organizationIdentifier)) continue;
 
-    if (!bucketName) {
-      throw new Error(
-        `CloudFormation target ${ getTargetName(deploymentTarget) } matched stage=${ stage } and organization=${ organizationIdentifier } but has no WebsiteBucket output`,
-      );
-    }
+    // The stage/organization tags are shared across every stack for an org (website,
+    // adit, backend, ...), so they cannot identify the website stack on their own.
+    // The WebsiteBucket output is the only tag-independent signal of a deploy target,
+    // so a matched stack without it is a sibling stack we simply skip.
+    if (!bucketName) continue;
 
     if (organizationBuckets.has(organizationIdentifier)) {
       throw new Error(

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
+  addOrganizationsFromPage,
   buildDeployMarkerEnvironments,
   formatFailedDeploymentsError,
   readDeployMarkerStatus,
@@ -12,6 +13,61 @@ import {
   writeDeployMarkerStatus,
   writeResolvedDeployTargets,
 } from './deploy.js';
+
+function stack(name, organization, { stage = 'sandbox', websiteBucket } = {}) {
+  const outputs = websiteBucket ?
+    [{ OutputKey: 'WebsiteBucket', OutputValue: websiteBucket }] :
+    [{ OutputKey: 'HttpApiUrl', OutputValue: 'https://example.test' }];
+
+  return {
+    StackName: name,
+    StackStatus: 'CREATE_COMPLETE',
+    Tags: [
+      { Key: 'stage', Value: stage },
+      { Key: 'organization', Value: organization },
+    ],
+    Outputs: outputs,
+  };
+}
+
+test('addOrganizationsFromPage maps a website stack to its WebsiteBucket', () => {
+  const organizationBuckets = new Map();
+  const response = { Stacks: [stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' })] };
+
+  addOrganizationsFromPage(organizationBuckets, response, 'sandbox', '');
+
+  assert.deepEqual([...organizationBuckets], [['vumc', 'vumc-bucket']]);
+});
+
+test('addOrganizationsFromPage skips a sibling stack that shares the tags but has no WebsiteBucket output', () => {
+  const organizationBuckets = new Map();
+  const response = {
+    Stacks: [
+      stack('adit-sandbox-vumc', 'vumc'),
+      stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' }),
+    ],
+  };
+
+  // adit-sandbox-vumc matched stage=sandbox/organization=vumc but is not a website stack.
+  addOrganizationsFromPage(organizationBuckets, response, 'sandbox', '');
+
+  assert.deepEqual([...organizationBuckets], [['vumc', 'vumc-bucket']]);
+});
+
+test('addOrganizationsFromPage throws when two website stacks claim the same organization', () => {
+  const organizationBuckets = new Map();
+  const response = {
+    Stacks: [
+      stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' }),
+      stack('careops-sandbox-vumc-dupe', 'vumc', { websiteBucket: 'other-bucket' }),
+    ],
+  };
+
+  assert.throws(
+    () => addOrganizationsFromPage(organizationBuckets, response, 'sandbox', ''),
+    /Duplicate CloudFormation targets/,
+  );
+});
 
 test('buildDeployMarkerEnvironments retains wildcard and adds sorted concrete environments', () => {
   assert.deepEqual(


### PR DESCRIPTION
## Problem

Sandbox deploy failed at **Resolve deploy marker environments** ([job 40065](https://app.circleci.com/pipelines/github/RoundingWell/app-frontend/9017/workflows/3e88e87a-14d2-455e-9a9d-93b70f5ac560/jobs/40065)):

```
CloudFormation target adit-sandbox-vumc matched stage=sandbox and organization=vumc
but has no WebsiteBucket output
```

Environment discovery matched CloudFormation stacks by `stage`+`organization` tags alone, then threw on any match lacking a `WebsiteBucket` output. A sibling stack `adit-sandbox-vumc` carries the same tags as the real website stack, so a wildcard sandbox deploy hard-failed on it.

## Why not filter by a tag

Inspected the deploy account directly. The website stack and its sibling have **byte-identical tags**:

| | `careops-qa-quality-assurance` (website) | `adit-qa-quality-assurance` (sibling) |
|---|---|---|
| tags | `stage`, `organization`, `env` | `stage`, `organization`, `env` — identical |
| `WebsiteBucket` output | present | absent |

No tag can partition them. The only signals are the `WebsiteBucket` output (convention-free) or the `careops-`/`adit-` name prefix (a naming convention we want to avoid relying on).

## Fix

- Define a deploy target as a stack that publishes a `WebsiteBucket` output; **skip** tag-matched stacks that lack it instead of throwing.
- Keep the duplicate-organization guard (two website stacks for one org is still a real error).
- Export `addOrganizationsFromPage` and add tests: maps website stack, skips foreign sibling, throws on duplicate.

## Tradeoff

A genuinely misconfigured `careops-*` stack missing its output would now be silently skipped rather than hard-failing — by tag it's indistinguishable from a sibling stack. Planned-vs-deployed marker reconciliation is the right place to catch that.

## Validation

- `node --test scripts/deploy.test.js` → 17/17 pass
- `npm run lint` passes (scopes to `src/js`+`test`; `scripts/` is covered by editorconfig-checker, which passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes environment discovery so website stacks are identified by the `WebsiteBucket` CloudFormation output, not just `stage`/`organization` tags. Prevents wildcard sandbox deploys from failing on sibling stacks with identical tags.

- **Bug Fixes**
  - Treat a stack as deployable only if it has a `WebsiteBucket` output; skip tag-matched stacks without it.
  - Keep the duplicate-organization guard and throw when two website stacks claim the same org.
  - Export `addOrganizationsFromPage` and add tests for mapping, skipping siblings, and duplicate detection.

<sup>Written for commit 2a6083b6268ddd7fdf06bf1f58bf0d2b7ea3f299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

