### PR TITLE
fix(ws): preserve filter-only reconnect subscriptions

### DIFF
--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -329,6 +329,33 @@ context('WS Service', function() {
       });
   });
 
+  specify('Ignoring empty filters without subscribed resources', function() {
+    const channel = Radio.channel('ws');
+
+    cy
+      .startService()
+      .then(() => {
+        channel.request('subscribe', [], { filters: {} });
+      })
+      .get('@wsHandleMessage')
+      .should('be.calledWith', {
+        name: 'Subscribe',
+        data: {
+          clientKey,
+          workspace,
+          resources: [],
+          subscriptionVersion: Cypress.sinon.match.string,
+        },
+      })
+      .then(() => {
+        service.ws.close();
+      });
+
+    cy
+      .get('@startService')
+      .should('be.calledOnce');
+  });
+
   specify('Clearing filters before reconnecting resource subscriptions', function() {
     const channel = Radio.channel('ws');
     const resource = { id: 'foo', type: 'bar' };

--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -270,6 +270,132 @@ context('WS Service', function() {
       .should('be.calledWith', testData([notifications[0], notifications[1]]));
   });
 
+  specify('Subscribing with filters and no resources', function() {
+    const channel = Radio.channel('ws');
+    const filters = {
+      category: 'Action',
+      status: ['active'],
+    };
+
+    channel.request('subscribe', [], { filters });
+
+    cy
+      .get('@wsHandleMessage')
+      .should('be.calledWith', {
+        name: 'Subscribe',
+        data: {
+          clientKey,
+          workspace,
+          resources: [],
+          subscriptionVersion: Cypress.sinon.match.string,
+          filters,
+        },
+      });
+  });
+
+  specify('Resubscribing filter-only subscriptions after socket close', function() {
+    const channel = Radio.channel('ws');
+    const filters = {
+      category: 'Flow',
+      status: ['active'],
+    };
+
+    cy
+      .startService()
+      .then(() => {
+        channel.request('subscribe', [], { filters });
+        const subscriptionVersion = service.subscriptionVersion;
+
+        service.ws.close();
+
+        return cy.get('@startService').should('be.calledTwice').then(spy => {
+          const secondCall = spy.getCall(1);
+
+          expect(secondCall.args[0]).to.deep.equal({
+            state: {},
+            data: {
+              name: 'Subscribe',
+              data: {
+                clientKey,
+                workspace,
+                resources: [],
+                subscriptionVersion: service.subscriptionVersion,
+                filters,
+              },
+            },
+          });
+          expect(service.subscriptionVersion).to.not.equal(subscriptionVersion);
+        });
+      });
+  });
+
+  specify('Clearing filters before reconnecting resource subscriptions', function() {
+    const channel = Radio.channel('ws');
+    const resource = { id: 'foo', type: 'bar' };
+
+    cy
+      .startService()
+      .then(() => {
+        channel.request('subscribe', [], {
+          filters: {
+            category: 'Action',
+          },
+        });
+      })
+      .get('@wsHandleMessage')
+      .should('be.calledWith', {
+        name: 'Subscribe',
+        data: {
+          clientKey,
+          workspace,
+          resources: [],
+          subscriptionVersion: Cypress.sinon.match.string,
+          filters: {
+            category: 'Action',
+          },
+        },
+      })
+      .then(() => {
+        channel.request('subscribe', resource);
+      })
+      .get('@wsHandleMessage')
+      .should('have.been.calledTwice')
+      .then(spy => {
+        expect(spy.lastCall.args[0]).to.deep.equal({
+          name: 'Subscribe',
+          data: {
+            clientKey,
+            workspace,
+            resources: [resource],
+            subscriptionVersion: service.subscriptionVersion,
+          },
+        });
+      })
+      .then(() => {
+        service.ws.close();
+      });
+
+    cy
+      .get('@startService')
+      .should('be.calledTwice')
+      .then(spy => {
+        const call = spy.getCall(1);
+
+        expect(call.args[0]).to.deep.equal({
+          state: {},
+          data: {
+            name: 'Subscribe',
+            data: {
+              clientKey,
+              workspace,
+              resources: [resource],
+              subscriptionVersion: service.subscriptionVersion,
+            },
+          },
+        });
+      });
+  });
+
   specify('auth token added to websocket URL', function() {
     cy
       .startService()

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -109,6 +109,10 @@ export default App.extend({
     this.ws.send(JSON.stringify(data));
   },
 
+  _hasSubscription() {
+    return this.resources.length || this.filters;
+  },
+
   onOpen(data) {
     if (data) this.sendData(data);
     this.startHeartbeat();
@@ -131,8 +135,8 @@ export default App.extend({
 
   onClose() {
     this.stopHeartbeat();
-    /* istanbul ignore next: resubscribing in tests causes test leaking */
-    if (!_TEST_ && this.resources.length) this._subscribe();
+    if (!this.isRunning()) return;
+    if (this._hasSubscription()) this._subscribe();
   },
 
   triggerMessage(data, model) {

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -1,4 +1,4 @@
-import { each, map, values, isArray } from 'underscore';
+import { each, map, values, isArray, isEmpty } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 import { v4 as uuid } from 'uuid';
@@ -78,7 +78,7 @@ export default App.extend({
       subscriptionVersion: this.subscriptionVersion,
     };
 
-    if (this.filters) data.filters = this.filters;
+    if (this._hasFilters()) data.filters = this.filters;
 
     this.send({
       name: 'Subscribe',
@@ -109,8 +109,12 @@ export default App.extend({
     this.ws.send(JSON.stringify(data));
   },
 
+  _hasFilters() {
+    return !isEmpty(this.filters);
+  },
+
   _hasSubscription() {
-    return this.resources.length || this.filters;
+    return !!this.resources.length || this._hasFilters();
   },
 
   onOpen(data) {


### PR DESCRIPTION
Closes FE-147

## What
- Added websocket subscription-state detection so reconnect resubscribes when active filters exist even with `resources: []`.
- Preserved the existing `Subscribe` payload shape, including regenerated `subscriptionVersion` and filters only when active.
- Added focused websocket service Cypress coverage for filter-only subscribe, filter-only reconnect, and stale filter clearing.

## Why
Backend websocket subscriptions now keep filter-definition rows separately from in-view resource rows. A filtered list can have zero currently visible resources but still needs a filter subscription so future matching actions or flows notify the client after a forced disconnect or rollback flush.

## Scope
- Impacts `src/js/services/ws.js` websocket reconnect behavior.
- Impacts `src/js/services/ws.cy.js` component coverage for websocket subscription behavior.
- Does not change backend contracts, entities-service data access, or websocket payload field names.

## Deployment Impact
- No form redeploy is needed.
- This affects websocket reconnect behavior through the normal app frontend deployment.
- No shared package or deployment script changes.

## Testing
- Ran `npx cypress run --component --spec src/js/services/ws.cy.js`.
- Result: 11 passing, 0 failing.
- Covered filter-only subscriptions with `resources: []`, reconnect after filter-only close, and clearing stale filters before reconnecting resource subscriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes websocket reconnect to preserve filter-only subscriptions when `resources: []` and skip empty filters. Keeps clients receiving events for active filters after disconnects (FE-147).

- **Bug Fixes**
  - Detect active subscription state; resubscribe when only non-empty filters are set.
  - Preserve `Subscribe` payload; regenerate `subscriptionVersion`; send `filters` only when non-empty.
  - Add Cypress tests for filter-only subscribe/reconnect, ignoring empty filters, and clearing filters before resource resubscribe.

<sup>Written for commit 325bc1767f3d10a59245fb536736a7d45dbb8053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added comprehensive test coverage for WebSocket subscriptions with resource filters, including validation of reconnection behavior and filter management scenarios.

* **Refactor**
  - Improved WebSocket reconnection logic to better handle subscriptions with active filters and connection state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->