### PR TITLE
chore(clinicians): update GET workspace clinicians API path

### DIFF
--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -24,7 +24,7 @@ const Entity = BaseEntity.extend({
       });
   },
   fetchByWorkspace(workspaceId) {
-    const url = `/api/workspaces/${ workspaceId }/relationships/clinicians`;
+    const url = `/api/workspaces/${ workspaceId }/clinicians`;
     const workspace = Radio.request('entities', 'workspaces:model', workspaceId);
 
     return this.fetchCollectionCache({ url })

--- a/test/integration/globals/error.js
+++ b/test/integration/globals/error.js
@@ -125,7 +125,7 @@ context('Global Error Page', function() {
     });
 
     cy
-      .intercept('GET', '/api/workspaces/**/relationships/clinicians*', {
+      .intercept('GET', '/api/workspaces/**/clinicians*', {
         statusCode: 500,
         body: {},
       })

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -103,7 +103,7 @@ Cypress.Commands.add('routeWorkspaceClinicians', (mutator = _.identity) => {
   const data = [{ id: fxCurrentClinician.id, type: TYPE }, ...getClinicians()];
 
   cy
-    .intercept('GET', '/api/workspaces/**/relationships/clinicians*', {
+    .intercept('GET', '/api/workspaces/**/clinicians*', {
       body: mutator({ data, included: [] }),
     })
     .as('routeWorkspaceClinicians');


### PR DESCRIPTION
Closes FE-134

Replaces the deprecated `GET /workspaces/{id}/relationships/clinicians` with `GET /workspaces/{id}/clinicians`.

BE change made in https://github.com/RoundingWell/app-backend/pull/11081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched workspace clinicians requests to the canonical GET /api/workspaces/{id}/clinicians endpoint, replacing the deprecated /relationships/clinicians path. Updated Cypress intercepts to match; no user-facing changes.

<sup>Written for commit 08ad51f95afbb7839d3146a8ea79e79b511764e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal API endpoint structure for clinician data retrieval to improve consistency.

* **Tests**
  * Updated integration and test stubs to align with the refined API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->