### PR TITLE
chore(comments): update GET action comments API path

### DIFF
--- a/src/js/entities-service/comments.js
+++ b/src/js/entities-service/comments.js
@@ -9,7 +9,7 @@ const Entity = BaseEntity.extend({
     'fetch:comments:collection:byAction': 'fetchCommentsByAction',
   },
   fetchCommentsByAction(actionId) {
-    const url = `/api/actions/${ actionId }/relationships/comments`;
+    const url = `/api/actions/${ actionId }/comments`;
 
     return this.fetchCollection({ url });
   },

--- a/test/support/api/comments.js
+++ b/test/support/api/comments.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('routeActionComments', (mutator = _.identity) => {
   const data = getComments();
 
   cy
-    .intercept('GET', '/api/actions/**/relationships/comments', {
+    .intercept('GET', '/api/actions/**/comments', {
       body: mutator({ data, included: [] }),
     })
     .as('routeActionComments');


### PR DESCRIPTION
Closes FE-133

Replaces the deprecated `GET /actions/{id}/relationships/comments` with `GET /actions/{id}/comments`.

BE change made in https://github.com/RoundingWell/app-backend/pull/11082.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the action comments API path to use the canonical GET /api/actions/{id}/comments, replacing the deprecated .../relationships/comments per FE-133. Updates the comments service and Cypress intercept to match the backend change and avoid 404s.

<sup>Written for commit bcee3db93d54279aa3554f4bae6a82efdc7b4706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

