### PR TITLE
fix(test): fix flakey `programs-all` test

### DIFF
--- a/test/support/api/programs.js
+++ b/test/support/api/programs.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { v4 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxPrograms from 'fixtures/collections/programs';
@@ -27,7 +28,7 @@ function getProgramResource(id, defaultRelationships) {
 
   if (testWorkspace) return mergeJsonApi(testWorkspace, { relationships: defaultRelationships });
 
-  return getResource(_.sample(fxSamplePrograms), TYPE, defaultRelationships);
+  return getResource({ ..._.sample(fxSamplePrograms), id: uuid() }, TYPE, defaultRelationships);
 }
 
 export function getProgram(data, { depth = 0, id } = {}) {


### PR DESCRIPTION
Closes FE-148

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `programs-all` test by ensuring `getProgram()` generates a unique id when none is provided. This removes random duplicate ids from sampled fixtures and stabilizes counts. Addresses FE-148.

- **Bug Fixes**
  - Use `uuid` v4 to assign a new id to sampled program fixtures when `id` is not passed.
  - Prevents collection dedup that led to "Found 2, expected 3" failures.

<sup>Written for commit 15a573f353d3607bcc77640e3d2233b65cc14a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resource generation to ensure unique identifiers across test runs, enhancing test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->