### PR TITLE
fix(ws): harden reconnect subscriptions

### DIFF
--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -203,6 +203,35 @@ context('WS Service', function() {
       .sendWs({ name: 'pong' });
   });
 
+  specify('Clearing timers on stop', function() {
+    const channel = Radio.channel('ws');
+    const resource = { id: 'foo', type: 'bar' };
+
+    cy
+      .startService()
+      .then(() => {
+        service.HEART_BEAT_INTERVAL = 10;
+        cy.spy(service, 'sendData').as('sendData');
+      });
+
+    cy.clock();
+    cy
+      .then(() => {
+        channel.request('subscribe', resource);
+      })
+      .get('@sendData')
+      .should('be.calledOnce')
+      .then(() => {
+        service.stop();
+        service.sendData.resetHistory();
+      });
+
+    cy
+      .tick(10)
+      .get('@sendData')
+      .should('not.be.called');
+  });
+
   specify('Subscribing', function() {
     const notifications = [
       { id: 'foo', type: 'bar' },
@@ -299,34 +328,161 @@ context('WS Service', function() {
       category: 'Flow',
       status: ['active'],
     };
+    let subscriptionVersion;
 
     cy
       .startService()
       .then(() => {
+        service.RECONNECT_BASE_DELAY = 1000;
+        cy.stub(Math, 'random').returns(0);
         channel.request('subscribe', [], { filters });
-        const subscriptionVersion = service.subscriptionVersion;
-
-        service.ws.close();
-
-        return cy.get('@startService').should('be.calledTwice').then(spy => {
-          const secondCall = spy.getCall(1);
-
-          expect(secondCall.args[0]).to.deep.equal({
-            state: {},
-            data: {
-              name: 'Subscribe',
-              data: {
-                clientKey,
-                workspace,
-                resources: [],
-                subscriptionVersion: service.subscriptionVersion,
-                filters,
-              },
-            },
-          });
-          expect(service.subscriptionVersion).to.not.equal(subscriptionVersion);
-        });
+      })
+      .get('@wsHandleMessage')
+      .should('be.calledWith', {
+        name: 'Subscribe',
+        data: {
+          clientKey,
+          workspace,
+          resources: [],
+          subscriptionVersion: Cypress.sinon.match.string,
+          filters,
+        },
+      })
+      .then(() => {
+        subscriptionVersion = service.subscriptionVersion;
       });
+
+    cy.clock();
+    cy.then(() => {
+      service.ws.readyState = WebSocket.CLOSED;
+      service.onClose();
+    });
+
+    cy
+      .get('@startService')
+      .should('be.calledOnce')
+      .tick(999)
+      .get('@startService')
+      .should('be.calledOnce')
+      .tick(1);
+
+    cy
+      .get('@startService')
+      .should('be.calledTwice')
+      .then(spy => {
+        const secondCall = spy.getCall(1);
+
+        expect(secondCall.args[0]).to.deep.equal({
+          state: {},
+          data: {
+            name: 'Subscribe',
+            data: {
+              clientKey,
+              workspace,
+              resources: [],
+              subscriptionVersion: service.subscriptionVersion,
+              filters,
+            },
+          },
+        });
+        expect(service.subscriptionVersion).to.not.equal(subscriptionVersion);
+      });
+  });
+
+  specify('Skipping reconnect without active subscriptions', function() {
+    const channel = Radio.channel('ws');
+
+    cy
+      .startService()
+      .then(() => {
+        service.RECONNECT_BASE_DELAY = 1000;
+        channel.request('subscribe', []);
+      });
+
+    cy.clock();
+    cy
+      .then(() => {
+        service.ws.readyState = WebSocket.CLOSED;
+        service.onClose();
+        // No subscription, so no reconnect was scheduled.
+        expect(service.reconnect).to.be.undefined;
+      })
+      .tick(1000)
+      .get('@startService')
+      .should('be.calledOnce');
+  });
+
+  specify('Skipping scheduled resubscribe after subscriptions clear', function() {
+    cy
+      .startService()
+      .then(() => {
+        service.RECONNECT_BASE_DELAY = 1000;
+        cy.stub(Math, 'random').returns(0);
+        cy.spy(service, '_subscribe').as('_subscribe');
+      });
+
+    cy.clock();
+    cy.then(() => {
+      // Schedule a reconnect with no resources, so the timer is a no-op.
+      service.startReconnect();
+    });
+
+    cy
+      .tick(1000)
+      .get('@_subscribe')
+      .should('not.be.called')
+      .then(() => {
+        expect(service.reconnect).to.be.null;
+      });
+  });
+
+  specify('Applying reconnect backoff and jitter', function() {
+    service.RECONNECT_BASE_DELAY = 1000;
+    service.RECONNECT_MAX_DELAY = 3000;
+
+    // Jitter spans [0, RECONNECT_BASE_DELAY); 0.5 => +500.
+    cy
+      .stub(Math, 'random')
+      .returns(0.5);
+
+    service.reconnectAttempts = 0;
+    expect(service._getReconnectDelay()).to.equal(1500);
+
+    service.reconnectAttempts = 1;
+    expect(service._getReconnectDelay()).to.equal(2500);
+
+    // Backoff is capped at RECONNECT_MAX_DELAY.
+    service.reconnectAttempts = 2;
+    expect(service._getReconnectDelay()).to.equal(3500);
+
+    service.reconnectAttempts = 8;
+    expect(service._getReconnectDelay()).to.equal(3500);
+  });
+
+  specify('Resetting backoff and clearing a pending reconnect when the socket opens', function() {
+    cy
+      .startService()
+      .then(() => {
+        service.RECONNECT_BASE_DELAY = 1000;
+        service.reconnectAttempts = 3;
+        cy.spy(service, '_subscribe').as('_subscribe');
+      });
+
+    cy.clock();
+    cy.then(() => {
+      service.startReconnect();
+      expect(service.reconnect).to.not.be.null;
+
+      // A successful (re)open resets backoff and cancels the pending reconnect.
+      service.onOpen();
+      expect(service.reconnectAttempts).to.equal(0);
+      expect(service.reconnect).to.be.null;
+    });
+
+    cy
+      .tick(1000)
+      .get('@_subscribe')
+      .should('not.be.called');
   });
 
   specify('Ignoring empty filters without subscribed resources', function() {

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -4,6 +4,7 @@ import Radio from 'backbone.radio';
 import { v4 as uuid } from 'uuid';
 
 import App from 'js/base/app';
+import fetcher, { handleJSON } from 'js/base/fetch';
 
 const AdderApp = App.extend({
   restartWithParent: false,
@@ -19,6 +20,8 @@ const AdderApp = App.extend({
 
 export default App.extend({
   HEART_BEAT_INTERVAL: 50000,
+  RECONNECT_BASE_DELAY: 1000,
+  RECONNECT_MAX_DELAY: 30000,
   channelName: 'ws',
 
   radioRequests: {
@@ -34,13 +37,14 @@ export default App.extend({
     this.resources = new Backbone.Collection();
     this.persistent = {};
     this.ws = {};
+    this.reconnectAttempts = 0;
   },
 
   getUrl() {
     if (this.url) return this.url;
 
-    return fetch('/api/websockets')
-      .then(response => response.json())
+    return fetcher('/api/websockets')
+      .then(handleJSON)
       .then(({ data }) => {
         if (!data.is_enabled) return;
         this.url = new URL(data.endpoint);
@@ -118,6 +122,8 @@ export default App.extend({
   },
 
   onOpen(data) {
+    this.stopReconnect();
+    this.reconnectAttempts = 0;
     if (data) this.sendData(data);
     this.startHeartbeat();
   },
@@ -137,10 +143,40 @@ export default App.extend({
     this.heartBeat = null;
   },
 
+  _getReconnectDelay() {
+    const backoff = Math.min(this.RECONNECT_MAX_DELAY, this.RECONNECT_BASE_DELAY * (2 ** this.reconnectAttempts));
+
+    return backoff + Math.floor(Math.random() * this.RECONNECT_BASE_DELAY);
+  },
+
+  startReconnect() {
+    this.stopReconnect();
+
+    this.reconnect = setTimeout(() => {
+      this.reconnect = null;
+      if (!this.isRunning() || !this._hasSubscription()) return;
+      this._subscribe();
+    }, this._getReconnectDelay());
+
+    this.reconnectAttempts += 1;
+  },
+
+  stopReconnect() {
+    if (!this.reconnect) return;
+
+    clearTimeout(this.reconnect);
+    this.reconnect = null;
+  },
+
   onClose() {
     this.stopHeartbeat();
-    if (!this.isRunning()) return;
-    if (this._hasSubscription()) this._subscribe();
+    if (!this.isRunning() || !this._hasSubscription()) return;
+    this.startReconnect();
+  },
+
+  onBeforeStop() {
+    this.stopHeartbeat();
+    this.stopReconnect();
   },
 
   triggerMessage(data, model) {


### PR DESCRIPTION
Closes FE-149

## What
- Adds capped exponential reconnect backoff with jitter before resubscribing after a websocket close, replacing the previous immediate resubscribe.
- Resets backoff and clears any pending reconnect timer when the socket (re)opens; clears all timers on stop.
- Authenticates the `/api/websockets` config fetch via `fetcher`/`handleJSON` instead of a raw `fetch`.

## Why
- A forced disconnect or backend blip previously caused every client to resubscribe immediately, risking a resubscribe storm. Backoff + jitter spreads reconnect attempts out.

## Scope
- Impacts global frontend websocket reconnect behavior in `src/js/services/ws.js` only.
- Reconnect uses the same `start*/stop*` timer idiom as the existing heartbeat; the per-view subscribe/add/unsubscribe paths are unchanged.
- Does **not** include: client-side subscription TTL refresh, same-tick subscribe coalescing, model message-queue changes, reconnect reconciliation (list-refetch / since-cursor), or any backend requirement. These were intentionally split out — see Follow-ups.

## Deployment Impact
- No form redeploy is required.
- No backend deployment is required.
- Normal app deployment updates the shared frontend websocket reconnect behavior for all app users.

## Follow-ups (not in this PR)
- **Subscription TTL (backend):** server subscriptions expire at ~115 min and `ping`/`pong` does not refresh `ExpiresAt`, so an idle-but-connected client goes silently stale. The correct fix is to slide the TTL on `ping` server-side rather than a client re-subscribe timer.
- **Reconnect reconciliation:** backoff makes reconnect gentler but nothing refetches what changed while disconnected; active views still hold stale models after a blip. Needs a refetch-on-reconnect or since-cursor design.

## Testing
- `npx cypress run --component --spec src/js/services/ws.cy.js` -> 17 passing, 0 failing.
- `npx eslint src/js/services/ws.js src/js/services/ws.cy.js` -> passed with no output.
- Covers: reconnect backoff/jitter and cap, backoff reset on open, clearing a pending reconnect on reopen, skipping reconnect with no active subscriptions, filter-only reconnect after close, timer cleanup on stop, and the existing subscribe/unsubscribe/message-handling behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reconnection with exponential backoff and jitter to prevent overwhelming the server during connection failures.
  * Fixed timer cleanup to prevent stale operations after disconnection.
  * Enhanced subscription handling when socket reconnects, ensuring proper message flow.

* **Tests**
  * Added comprehensive test coverage for reconnection scenarios, subscription cleanup, and timer management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
