### PR TITLE
fix(forms): send sparse fields for form list

### DIFF
--- a/src/js/entities-service/forms.js
+++ b/src/js/entities-service/forms.js
@@ -4,17 +4,28 @@ import { _Model, Model, Collection } from './entities/forms';
 
 import BaseModel from 'js/base/model';
 
+const FORM_COLLECTION_FIELDS = ['name', 'details', 'created_at', 'updated_at'];
+
 const Entity = BaseEntity.extend({
   Entity: { _Model, Model, Collection },
   radioRequests: {
     'forms:model': 'getModel',
     'forms:collection': 'getCollection',
     'fetch:forms:model': 'fetchModel',
-    'fetch:forms:collection': 'fetchCollectionCache',
+    'fetch:forms:collection': 'fetchFormsCollection',
     'fetch:forms:definition': 'fetchDefinition',
     'fetch:forms:data': 'fetchFormData',
     'fetch:forms:byAction': 'fetchByAction',
     'fetch:forms:definition:byAction': 'fetchDefinitionByAction',
+  },
+  fetchFormsCollection() {
+    const data = {
+      fields: {
+        forms: FORM_COLLECTION_FIELDS,
+      },
+    };
+
+    return this.fetchCollectionCache({ data });
   },
   fetchDefinition(formId) {
     return fetcher(`/api/forms/${ formId }/definition`).then(handleJSON);

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -25,11 +25,16 @@ export function getForms() {
 
 Cypress.Commands.add('routeForms', (mutator = _.identity) => {
   cy
-    .intercept('GET', '/api/forms', {
-      body: mutator({
-        data: getForms(),
-        included: [],
-      }),
+    .intercept({ method: 'GET', pathname: '/api/forms' }, req => {
+      const params = new URL(req.url).searchParams;
+      expect(params.get('fields[forms]')).to.equal('name,details,created_at,updated_at');
+
+      req.reply({
+        body: mutator({
+          data: getForms(),
+          included: [],
+        }),
+      });
     })
     .as('routeForms');
 });


### PR DESCRIPTION
Closes FE-135

## What
- Add a dedicated `fetchFormsCollection` request path for `/api/forms` collection fetches.
- Send `fields[forms]=name,details,created_at,updated_at` explicitly for form list loading.
- Assert the sparse fieldset in the shared Cypress `routeForms()` bootstrap helper.

## Why
The backend OpenAPI default for `GET /forms` already limits the form list response to those fields. FE-135 makes that frontend request contract explicit during workspace bootstrap instead of relying on the backend default.

## Scope
Impacted areas: app-frontend forms entity-service collection fetches and Cypress form list request assertions.

`fetch:forms:model` is intentionally unchanged so `/forms/{formId}` detail fetches can continue requesting the full form payload.

## Deployment Impact
Normal app deployment only. No separate form bundle or customer form redeploy is required.

## Testing
- `npx eslint src/js/entities-service/forms.js test/support/api/forms.js --max-warnings=0`
- `npm run build -- --mode test`
- `npx cypress run --spec test/integration/globals/app-nav.js`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send explicit sparse fields for `/api/forms` list fetch to make the frontend request contract clear and aligned with backend defaults.

Implements FE-135 by routing `fetch:forms:collection` to a new `fetchFormsCollection` that requests `fields[forms]=name,details,created_at,updated_at`; updates Cypress `routeForms` to assert the query param; `fetch:forms:model` remains unchanged.

<sup>Written for commit 5cdba889696b8f7214fecc898ac774b8c1932358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved forms data retrieval handling with explicit field specification.

* **Tests**
  * Enhanced API test support for forms collection requests with field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->