### PR TITLE
refactor(forms): persist drafts with indexedDB

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -141,13 +141,22 @@ export default App.extend({
   onClickExpandButton() {
     this.toggleState('isExpanded');
   },
-  showContent() {
-    if (this.isReadOnly) {
+  canShowStoredSubmission() {
+    return !this.isReadOnly;
+  },
+  async showContent() {
+    const showContentRequestId = (this._showContentRequestId || 0) + 1;
+    this._showContentRequestId = showContentRequestId;
+
+    if (!this.canShowStoredSubmission()) {
       this.showForm();
       return;
     }
 
-    const { updated } = Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+
+    /* istanbul ignore if: difficult to force stale async render */
+    if (this.isDestroyed() || this._showContentRequestId !== showContentRequestId || !this.canShowStoredSubmission()) return;
 
     if (updated) {
       const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
@@ -156,8 +165,8 @@ export default App.extend({
         'submit'() {
           this.showForm();
         },
-        'discard:submission'() {
-          Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
+        async 'discard:submission'() {
+          await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
           this.showForm();
           this.showFormActions();
         },

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -208,15 +208,23 @@ export default App.extend({
   onClickHistoryButton() {
     this.setState({ responseId: get(this.responses.getFirstSubmission(), 'id'), shouldShowHistory: !this.getState('shouldShowHistory') });
   },
-  showContent() {
+  canShowStoredSubmission() {
     const responseId = this.getState('responseId');
+    return !this.isReadOnly && !this.isLocked && !responseId;
+  },
+  async showContent() {
+    const showContentRequestId = (this._showContentRequestId || 0) + 1;
+    this._showContentRequestId = showContentRequestId;
 
-    if (this.isReadOnly || this.isLocked || responseId) {
+    if (!this.canShowStoredSubmission()) {
       this.showForm();
       return;
     }
 
-    const { updated } = Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+
+    /* istanbul ignore if: difficult to force stale async render */
+    if (this.isDestroyed() || this._showContentRequestId !== showContentRequestId || !this.canShowStoredSubmission()) return;
 
     if (updated) {
       const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
@@ -225,8 +233,8 @@ export default App.extend({
         'submit'() {
           this.showForm();
         },
-        'discard:submission'() {
-          Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
+        async 'discard:submission'() {
+          await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
           this.showForm();
           this.showFormActions();
         },

--- a/src/js/auth.cy.js
+++ b/src/js/auth.cy.js
@@ -1,14 +1,64 @@
 import Radio from 'backbone.radio';
 
-import 'js/auth'; // registers the 'auth' channel replies
+import { AuthProvider } from '@roundingwell/care-ops-auth/AuthProvider.js';
 
-context('auth:getUserId', function() {
-  afterEach(function() {
-    Radio.stopReplying('auth', 'getUserId');
+import { auth } from 'js/auth'; // registers the 'auth' channel replies
+import { getDraft, setDraft, clearDrafts } from 'js/services/form-drafts';
+
+context('auth', function() {
+  context('getUserId', function() {
+    afterEach(function() {
+      Radio.stopReplying('auth', 'getUserId');
+    });
+
+    specify('exposes a synchronous getUserId reply that consumers can override', function() {
+      Radio.reply('auth', 'getUserId', () => 'user_test');
+      expect(Radio.request('auth', 'getUserId')).to.equal('user_test');
+    });
   });
 
-  specify('exposes a synchronous getUserId reply that consumers can override', function() {
-    Radio.reply('auth', 'getUserId', () => 'user_test');
-    expect(Radio.request('auth', 'getUserId')).to.equal('user_test');
+  context('draft cleanup', function() {
+    beforeEach(function() {
+      return clearDrafts();
+    });
+
+    afterEach(function() {
+      window.history.pushState({}, '', '/');
+      return clearDrafts();
+    });
+
+    specify('clears form drafts on explicit logout', function() {
+      cy.stub(AuthProvider.prototype, 'auth').callsFake(success => success());
+      cy.stub(AuthProvider.prototype, 'getUserId').resolves('user_A');
+
+      return setDraft('form-subm-user_A-patient-form', { updated: 'a' })
+        .then(() => {
+          window.history.pushState({}, '', AuthProvider.PATH_LOGOUT);
+          return auth();
+        })
+        .then(() => getDraft('form-subm-user_A-patient-form'))
+        .then(draft => {
+          expect(draft).to.be.null;
+        });
+    });
+
+    specify('keeps current-user drafts and prunes other-user drafts on auth', function() {
+      cy.stub(AuthProvider.prototype, 'auth').callsFake(success => success());
+      cy.stub(AuthProvider.prototype, 'getUserId').resolves('user_A');
+
+      return Promise.all([
+        setDraft('form-subm-user_A-patient-form', { updated: 'a' }),
+        setDraft('form-subm-user_B-patient-form', { updated: 'b' }),
+      ])
+        .then(() => auth())
+        .then(() => Promise.all([
+          getDraft('form-subm-user_A-patient-form'),
+          getDraft('form-subm-user_B-patient-form'),
+        ]))
+        .then(([currentUserDraft, otherUserDraft]) => {
+          expect(currentUserDraft).to.not.be.null;
+          expect(otherUserDraft).to.be.null;
+        });
+    });
   });
 });

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -11,6 +11,7 @@ import { AuthProvider } from '@roundingwell/care-ops-auth/AuthProvider.js';
 import { addAction } from 'js/datadog';
 
 import { clearCache, pruneOtherPartitions } from 'js/base/cache/entity-cache';
+import { clearDrafts, pruneOtherDrafts } from 'js/services/form-drafts';
 
 import 'scss/app-root.scss';
 
@@ -92,7 +93,7 @@ Radio.reply('auth', {
 
 async function auth() {
   if (location.pathname === AuthProvider.PATH_LOGOUT) {
-    await clearCache();
+    await Promise.all([clearCache(), clearDrafts()]);
   }
 
   const agent = await getAuthAgent();
@@ -101,7 +102,10 @@ async function auth() {
     agent.auth(async() => {
       try {
         cachedUserId = await agent.getUserId();
-        await pruneOtherPartitions(cachedUserId);
+        await Promise.all([
+          pruneOtherPartitions(cachedUserId),
+          pruneOtherDrafts(cachedUserId),
+        ]);
       } catch {
         // swallow — boot without cache rather than crash auth.
       }

--- a/src/js/base/cache/idb.js
+++ b/src/js/base/cache/idb.js
@@ -2,8 +2,8 @@ import { openDB } from 'idb';
 
 const DB_NAME = 'careops-cache';
 // IndexedDB database version — bump only for object-store schema changes.
-const DB_VERSION = 1;
-const STORES = ['entities'];
+const DB_VERSION = 2;
+const STORES = ['entities', 'formDrafts'];
 
 let dbPromise;
 

--- a/src/js/services/form-drafts.cy.js
+++ b/src/js/services/form-drafts.cy.js
@@ -1,0 +1,154 @@
+import idb from 'js/base/cache/idb';
+import {
+  draftKeyPrefix,
+  getDraft,
+  setDraft,
+  removeDraft,
+  clearDrafts,
+  pruneOtherDrafts,
+} from './form-drafts';
+
+context('cache/form-drafts', function() {
+  beforeEach(function() {
+    idb.__reset();
+    return clearDrafts();
+  });
+
+  afterEach(function() {
+    idb.__reset();
+  });
+
+  specify('round-trips a draft by key', function() {
+    const draft = { updated: '2026-06-05T00:00:00Z', submission: { fields: { foo: 'bar' } } };
+
+    return setDraft('form-subm-user_A-patient-form', draft)
+      .then(() => getDraft('form-subm-user_A-patient-form'))
+      .then(value => {
+        expect(value).to.deep.equal(draft);
+      });
+  });
+
+  specify('returns null for a missing key', function() {
+    return getDraft('form-subm-user_A-missing').then(value => {
+      expect(value).to.be.null;
+    });
+  });
+
+  specify('ignores empty inputs', function() {
+    expect(draftKeyPrefix()).to.be.undefined;
+
+    return Promise.all([
+      getDraft(),
+      setDraft(),
+      setDraft('form-subm-user_A-patient-form'),
+      removeDraft(),
+    ]).then(([draft]) => {
+      expect(draft).to.be.null;
+    });
+  });
+
+  specify('removeDraft deletes a draft', function() {
+    return setDraft('form-subm-user_A-patient-form', { updated: 'now' })
+      .then(() => removeDraft('form-subm-user_A-patient-form'))
+      .then(() => getDraft('form-subm-user_A-patient-form'))
+      .then(value => {
+        expect(value).to.be.null;
+      });
+  });
+
+  specify('clearDrafts empties all drafts', function() {
+    return Promise.all([
+      setDraft('form-subm-user_A-patient-form', { updated: 'a' }),
+      setDraft('form-subm-user_B-patient-form', { updated: 'b' }),
+    ])
+      .then(() => clearDrafts())
+      .then(() => Promise.all([
+        getDraft('form-subm-user_A-patient-form'),
+        getDraft('form-subm-user_B-patient-form'),
+      ]))
+      .then(([a, b]) => {
+        expect(a).to.be.null;
+        expect(b).to.be.null;
+      });
+  });
+
+  specify('pruneOtherDrafts keeps only drafts prefixed for the current user', function() {
+    return Promise.all([
+      setDraft('form-subm-1-patient-form', { updated: 'current' }),
+      setDraft('form-subm-12-patient-form', { updated: 'collision' }),
+      setDraft('form-subm-user_B-patient-form', { updated: 'other' }),
+    ])
+      .then(() => pruneOtherDrafts('1'))
+      .then(() => Promise.all([
+        getDraft('form-subm-1-patient-form'),
+        getDraft('form-subm-12-patient-form'),
+        getDraft('form-subm-user_B-patient-form'),
+      ]))
+      .then(([current, collision, other]) => {
+        expect(current).to.not.be.null;
+        expect(collision).to.be.null;
+        expect(other).to.be.null;
+      });
+  });
+
+  specify('pruneOtherDrafts is a no-op when no currentUserId is provided', function() {
+    return setDraft('form-subm-user_A-patient-form', { updated: 'a' })
+      .then(() => pruneOtherDrafts(undefined))
+      .then(() => getDraft('form-subm-user_A-patient-form'))
+      .then(value => {
+        expect(value).to.not.be.null;
+      });
+  });
+
+  specify('operations fail soft when IndexedDB is unavailable', function() {
+    idb.__reset();
+    cy.stub(window.indexedDB, 'open').throws(new DOMException('blocked', 'SecurityError'));
+
+    return setDraft('form-subm-user_A-patient-form', { updated: 'a' })
+      .then(() => getDraft('form-subm-user_A-patient-form'))
+      .then(value => {
+        expect(value).to.be.null;
+      });
+  });
+
+  specify('write failures no-op without rejecting', function() {
+    cy.stub(idb, 'put').rejects(new DOMException('quota', 'QuotaExceededError'));
+
+    return setDraft('form-subm-user_A-patient-form', { updated: 'a' })
+      .then(() => {
+        expect(idb.put).to.have.been.calledOnce;
+      });
+  });
+
+  specify('read failures return null', function() {
+    cy.stub(idb, 'get').rejects(new DOMException('blocked', 'SecurityError'));
+
+    return getDraft('form-subm-user_A-patient-form').then(value => {
+      expect(value).to.be.null;
+    });
+  });
+
+  specify('remove failures no-op without rejecting', function() {
+    cy.stub(idb, 'delete').rejects(new DOMException('blocked', 'SecurityError'));
+
+    return removeDraft('form-subm-user_A-patient-form').then(() => {
+      expect(idb.delete).to.have.been.calledOnce;
+    });
+  });
+
+  specify('clear failures no-op without rejecting', function() {
+    cy.stub(idb, 'clear').rejects(new DOMException('blocked', 'SecurityError'));
+
+    return clearDrafts().then(() => {
+      expect(idb.clear).to.have.been.calledOnce;
+    });
+  });
+
+  specify('prune failures no-op without rejecting', function() {
+    cy.stub(idb, 'keys').rejects(new DOMException('blocked', 'SecurityError'));
+
+    return pruneOtherDrafts('user_A').then(() => {
+      expect(idb.keys).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/js/services/form-drafts.cy.js
+++ b/src/js/services/form-drafts.cy.js
@@ -110,45 +110,4 @@ context('cache/form-drafts', function() {
         expect(value).to.be.null;
       });
   });
-
-  specify('write failures no-op without rejecting', function() {
-    cy.stub(idb, 'put').rejects(new DOMException('quota', 'QuotaExceededError'));
-
-    return setDraft('form-subm-user_A-patient-form', { updated: 'a' })
-      .then(() => {
-        expect(idb.put).to.have.been.calledOnce;
-      });
-  });
-
-  specify('read failures return null', function() {
-    cy.stub(idb, 'get').rejects(new DOMException('blocked', 'SecurityError'));
-
-    return getDraft('form-subm-user_A-patient-form').then(value => {
-      expect(value).to.be.null;
-    });
-  });
-
-  specify('remove failures no-op without rejecting', function() {
-    cy.stub(idb, 'delete').rejects(new DOMException('blocked', 'SecurityError'));
-
-    return removeDraft('form-subm-user_A-patient-form').then(() => {
-      expect(idb.delete).to.have.been.calledOnce;
-    });
-  });
-
-  specify('clear failures no-op without rejecting', function() {
-    cy.stub(idb, 'clear').rejects(new DOMException('blocked', 'SecurityError'));
-
-    return clearDrafts().then(() => {
-      expect(idb.clear).to.have.been.calledOnce;
-    });
-  });
-
-  specify('prune failures no-op without rejecting', function() {
-    cy.stub(idb, 'keys').rejects(new DOMException('blocked', 'SecurityError'));
-
-    return pruneOtherDrafts('user_A').then(() => {
-      expect(idb.keys).to.have.been.calledOnce;
-    });
-  });
 });

--- a/src/js/services/form-drafts.js
+++ b/src/js/services/form-drafts.js
@@ -9,53 +9,33 @@ export function draftKeyPrefix(currentUserId) {
 }
 
 export async function getDraft(key) {
-  try {
-    if (!key) return null;
-    const draft = await idb.get(STORE, key);
-    return draft || null;
-  } catch {
-    return null;
-  }
+  if (!key) return null;
+  const draft = await idb.get(STORE, key);
+  return draft || null;
 }
 
 export async function setDraft(key, draft) {
-  try {
-    if (!key || !draft) return;
-    await idb.put(STORE, key, draft);
-  } catch {
-    // Draft writes must never interrupt form editing.
-  }
+  if (!key || !draft) return;
+  await idb.put(STORE, key, draft);
 }
 
 export async function removeDraft(key) {
-  try {
-    if (!key) return;
-    await idb.delete(STORE, key);
-  } catch {
-    // fail soft
-  }
+  if (!key) return;
+  await idb.delete(STORE, key);
 }
 
 export async function clearDrafts() {
-  try {
-    await idb.clear(STORE);
-  } catch {
-    // fail soft
-  }
+  await idb.clear(STORE);
 }
 
 export async function pruneOtherDrafts(currentUserId) {
-  try {
-    const prefix = draftKeyPrefix(currentUserId);
-    if (!prefix) return;
+  const prefix = draftKeyPrefix(currentUserId);
+  if (!prefix) return;
 
-    const keys = await idb.keys(STORE);
-    await Promise.all(
-      keys
-        .filter(key => typeof key === 'string' && !key.startsWith(prefix))
-        .map(key => removeDraft(key)),
-    );
-  } catch {
-    // fail soft
-  }
+  const keys = await idb.keys(STORE);
+  await Promise.all(
+    keys
+      .filter(key => typeof key === 'string' && !key.startsWith(prefix))
+      .map(key => removeDraft(key)),
+  );
 }

--- a/src/js/services/form-drafts.js
+++ b/src/js/services/form-drafts.js
@@ -1,0 +1,61 @@
+import idb from 'js/base/cache/idb';
+
+const STORE = 'formDrafts';
+const KEY_PREFIX = 'form-subm-';
+
+export function draftKeyPrefix(currentUserId) {
+  if (!currentUserId) return;
+  return `${ KEY_PREFIX }${ currentUserId }-`;
+}
+
+export async function getDraft(key) {
+  try {
+    if (!key) return null;
+    const draft = await idb.get(STORE, key);
+    return draft || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setDraft(key, draft) {
+  try {
+    if (!key || !draft) return;
+    await idb.put(STORE, key, draft);
+  } catch {
+    // Draft writes must never interrupt form editing.
+  }
+}
+
+export async function removeDraft(key) {
+  try {
+    if (!key) return;
+    await idb.delete(STORE, key);
+  } catch {
+    // fail soft
+  }
+}
+
+export async function clearDrafts() {
+  try {
+    await idb.clear(STORE);
+  } catch {
+    // fail soft
+  }
+}
+
+export async function pruneOtherDrafts(currentUserId) {
+  try {
+    const prefix = draftKeyPrefix(currentUserId);
+    if (!prefix) return;
+
+    const keys = await idb.keys(STORE);
+    await Promise.all(
+      keys
+        .filter(key => typeof key === 'string' && !key.startsWith(prefix))
+        .map(key => removeDraft(key)),
+    );
+  } catch {
+    // fail soft
+  }
+}

--- a/src/js/services/forms.js
+++ b/src/js/services/forms.js
@@ -2,9 +2,8 @@ import { map, get, debounce } from 'underscore';
 import dayjs from 'dayjs';
 import Radio from 'backbone.radio';
 
-import localStore from 'js/utils/local-store';
-
 import App from 'js/base/app';
+import { getDraft, setDraft, removeDraft } from 'js/services/form-drafts';
 
 import { FORM_RESPONSE_STATUS } from 'js/static';
 
@@ -92,11 +91,11 @@ export default App.extend({
 
     return (this.latestResponse && this.latestResponse.getDraft()) || {};
   },
-  getStoredSubmission() {
+  async getStoredSubmission() {
     if (this.isReadOnly()) return {};
 
     const draft = this.getLatestDraft();
-    const localDraft = localStore.get(this.getStoreId()) || {};
+    const localDraft = await getDraft(this.getStoreId()) || {};
 
     if (draft.updated && (!localDraft.updated || dayjs(draft.updated).isAfter(localDraft.updated))) {
       this.trigger('update:submission', draft.updated);
@@ -115,22 +114,15 @@ export default App.extend({
     // Cache the draft for debounced updateDraft
     this._draft = submission;
 
-    try {
-      localStore.set(this.getStoreId(), { submission, updated });
-      this.trigger('update:submission', updated);
-    } catch /* istanbul ignore next: Tested locally, test runner borks on CI */ {
-      localStore.each((value, key) => {
-        if (String(key).startsWith('form-subm-')) localStore.remove(key);
-      });
-      localStore.set(this.getStoreId(), { submission, updated });
-    }
+    setDraft(this.getStoreId(), { submission, updated });
+    this.trigger('update:submission', updated);
 
     this.updateDraft();
     this.refreshForm();
   },
-  clearStoredSubmission() {
+  async clearStoredSubmission() {
     this.latestResponse = null;
-    localStore.remove(this.getStoreId());
+    await removeDraft(this.getStoreId());
     this.trigger('update:submission');
   },
   fetchField({ fieldName }, requestId) {
@@ -245,9 +237,9 @@ export default App.extend({
 
     return Radio.request('entities', 'fetch:formResponses:model', get(firstResponse, 'id'));
   },
-  fetchFormData(args, requestId) {
+  async fetchFormData(args, requestId) {
     const message = 'fetch:form:data';
-    const storedSubmission = this.getStoredSubmission();
+    const storedSubmission = await this.getStoredSubmission();
 
     if (storedSubmission.updated) {
       this.send(message, { value: {
@@ -257,25 +249,25 @@ export default App.extend({
       return;
     }
 
-    Promise.all([
-      Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
-      this.fetchLatestFormResponse(),
-    ])
-      .then(([data, response]) => {
-        this.send(message, { value: {
-          isReadOnly: this.isReadOnly(),
-          formData: data.attributes,
-          responseData: response.getFormData(),
-          formSubmission: response.getResponse(),
-          options: this.form.get('options'),
-        } }, requestId);
-      })
-      .catch(
-        /* istanbul ignore next: Don't test BE errors */
-        ({ responseData }) => {
-          this.send(message, { error: responseData }, requestId);
-        },
-      );
+    try {
+      const [data, response] = await Promise.all([
+        Radio.request('entities', 'fetch:forms:data', get(this.action, 'id'), this.patient.id, this.form.id),
+        this.fetchLatestFormResponse(),
+      ]);
+
+      this.send(message, { value: {
+        isReadOnly: this.isReadOnly(),
+        formData: data.attributes,
+        responseData: response.getFormData(),
+        formSubmission: response.getResponse(),
+        options: this.form.get('options'),
+      } }, requestId);
+    } catch(
+      { responseData }
+    ) {
+      /* istanbul ignore next: Don't test BE errors */
+      this.send(message, { error: responseData }, requestId);
+    }
   },
   fetchFormResponse({ responseId }, requestId) {
     const message = 'fetch:form:response';
@@ -340,11 +332,11 @@ export default App.extend({
     const formResponse = Radio.request('entities', 'formResponses:model', data);
 
     return formResponse.saveAll()
-      .then(() => {
+      .then(async() => {
         // Cancel any draft updates or stale form refreshes that may have been queued while the form was submitting
         this.updateDraft.cancel();
         this.refreshForm.cancel();
-        this.clearStoredSubmission();
+        await this.clearStoredSubmission();
         this.trigger('success', formResponse);
       }).catch(({ responseData }) => {
         /* istanbul ignore next: Don't handle non-API errors */

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -24,6 +24,7 @@ import { FORM_RESPONSE_STATUS } from 'js/static';
 context('Patient Action Form', function() {
   beforeEach(function() {
     cy
+      .clearFormDrafts()
       .routeWorkspacePatient()
       .routesForDefault();
   });
@@ -144,6 +145,8 @@ context('Patient Action Form', function() {
       },
     });
 
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`;
+
     cy
       .routeAction(fx => {
         fx.data = testAction;
@@ -183,12 +186,10 @@ context('Patient Action Form', function() {
       });
 
     cy
-      .window()
-      .should(win => {
-        const storage = win.localStorage.getItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`);
-
-        expect(storage, 'draft storage').to.exist;
-        expect(JSON.parse(storage).submission.fields.foo).to.equal('bar');
+      .waitForFormDraft(draftKey, { exists: true })
+      .should(draft => {
+        expect(draft, 'draft storage').to.exist;
+        expect(draft.submission.fields.foo).to.equal('bar');
       });
 
     cy
@@ -224,12 +225,12 @@ context('Patient Action Form', function() {
       },
     });
 
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`, JSON.stringify({
+    cy.setFormDraft(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`, {
       updated: testTs(),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeAction(fx => {
@@ -313,12 +314,12 @@ context('Patient Action Form', function() {
       },
     });
 
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`, JSON.stringify({
+    cy.setFormDraft(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`, {
       updated: testTsSubtract(1),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeAction(fx => {
@@ -416,12 +417,14 @@ context('Patient Action Form', function() {
       },
     });
 
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`, JSON.stringify({
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`;
+
+    cy.setFormDraft(draftKey, {
       updated: testTs(),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeAction(fx => {
@@ -494,6 +497,12 @@ context('Patient Action Form', function() {
       .find('.form__submit-status')
       .should('contain', 'Your work is stored automatically.')
       .should('not.contain', 'Last edit was');
+
+    cy
+      .waitForFormDraft(draftKey, { exists: false })
+      .should(draft => {
+        expect(draft).to.be.null;
+      });
 
     cy
       .iframeStub()

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -28,6 +28,7 @@ const testReadOnlyForm = getForm({
 context('Patient Form', function() {
   beforeEach(function() {
     cy
+      .clearFormDrafts()
       .routeWorkspacePatient();
   });
 
@@ -166,6 +167,8 @@ context('Patient Form', function() {
   });
 
   specify('storing stored submission', function() {
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`;
+
     cy
       .routeForm(fx => {
         fx.data = testForm;
@@ -200,13 +203,10 @@ context('Patient Form', function() {
       });
 
     cy
-      .window()
-      .should(win => {
-        const storage = win.localStorage.getItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`);
-
-        expect(storage, 'draft storage').to.exist;
-
-        expect(JSON.parse(storage).submission.fields.foo).to.equal('bar');
+      .waitForFormDraft(draftKey, { exists: true })
+      .should(draft => {
+        expect(draft, 'draft storage').to.exist;
+        expect(draft.submission.fields.foo).to.equal('bar');
       });
 
     cy
@@ -234,12 +234,12 @@ context('Patient Form', function() {
   });
 
   specify('restoring draft', function() {
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`, JSON.stringify({
+    cy.setFormDraft(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`, {
       updated: testTsSubtract(1),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeForm(fx => {
@@ -297,12 +297,12 @@ context('Patient Form', function() {
   });
 
   specify('restoring stored submission', function() {
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`, JSON.stringify({
+    cy.setFormDraft(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`, {
       updated: testTs(),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeForm(fx => {
@@ -360,12 +360,14 @@ context('Patient Form', function() {
   });
 
   specify('discarding stored submission', function() {
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`, JSON.stringify({
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`;
+
+    cy.setFormDraft(draftKey, {
       updated: testTs(),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routeForm(fx => {
@@ -423,6 +425,12 @@ context('Patient Form', function() {
       .should('not.contain', 'Last edit was');
 
     cy
+      .waitForFormDraft(draftKey, { exists: false })
+      .should(draft => {
+        expect(draft).to.be.null;
+      });
+
+    cy
       .get('iframe')
       .should(([iframe]) => {
         const { receivedMessages } = iframe.contentWindow.iframeStub;
@@ -433,12 +441,12 @@ context('Patient Form', function() {
   });
 
   specify('read only form', function() {
-    localStorage.setItem(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testReadOnlyForm.id }`, JSON.stringify({
+    cy.setFormDraft(`form-subm-${ currentClinician.id }-${ testPatient.id }-${ testReadOnlyForm.id }`, {
       updated: testTs(),
       submission: {
         fields: { foo: 'foo' },
       },
-    }));
+    });
 
     cy
       .routePatient(fx => {

--- a/test/support/e2e.js
+++ b/test/support/e2e.js
@@ -16,6 +16,7 @@ import 'js/base/dayjs';
 
 import './defaults';
 import './commands';
+import './form-drafts';
 import '@cypress/code-coverage/support';
 import './websockets';
 

--- a/test/support/form-drafts.js
+++ b/test/support/form-drafts.js
@@ -1,0 +1,28 @@
+import {
+  getDraft,
+  setDraft,
+  clearDrafts,
+} from 'js/services/form-drafts';
+
+Cypress.Commands.add('setFormDraft', (key, draft) => {
+  return cy.then(() => setDraft(key, draft));
+});
+
+Cypress.Commands.add('getFormDraft', key => {
+  return cy.then(() => getDraft(key));
+});
+
+function waitForFormDraft(key, { exists, attempts = 20 } = {}) {
+  return getDraft(key).then(draft => {
+    if (exists === undefined || Boolean(draft) === exists || attempts <= 0) return draft;
+    return Cypress.Promise.delay(25).then(() => waitForFormDraft(key, { exists, attempts: attempts - 1 }));
+  });
+}
+
+Cypress.Commands.add('waitForFormDraft', (key, options) => {
+  return cy.then(() => waitForFormDraft(key, options));
+});
+
+Cypress.Commands.add('clearFormDrafts', () => {
+  return cy.then(() => clearDrafts());
+});


### PR DESCRIPTION
Closes FE-152

## What

- Add a formDrafts IndexedDB store and draft service for saved form submissions.
- Persist patient/action form drafts through IndexedDB instead of localStorage.
- Clear drafts on logout, prune other users drafts during auth, and update draft test helpers/assertions.

## Why

Draft payloads are better suited to IndexedDB than localStorage, and draft cleanup should follow the authenticated user/session lifecycle.

## Scope

Impacts patient/action form draft persistence, auth logout cleanup, and form draft test helpers. This does not change submitted form response APIs or form bundle definitions.

## Deployment Impact

Normal frontend app deployment is needed. No backend changes or separate form bundle redeploys are required. This was deployed to dev:paul at commit 80259f13.

## Testing

- npm run lint -- src/js/base/cache/idb.js src/js/services/form-drafts.js src/js/services/form-drafts.cy.js src/js/auth.js src/js/auth.cy.js src/js/services/forms.js src/js/apps/forms/form/form_app.js src/js/apps/forms/form/form-patient_app.js test/support/form-drafts.js test/integration/forms/action.js test/integration/forms/patient.js
- npx cypress run --component --spec "src/js/services/form-drafts.cy.js,src/js/auth.cy.js"
- npm run build -- --mode test
- npx cypress run --spec "test/integration/forms/action.js,test/integration/forms/patient.js"
- Manual dev deploy smoke: https://paul.roundingwell.dev/appconfig.json reported version=80259f13; homepage and generated draft chunks returned HTTP 200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist form drafts in IndexedDB via a new `formDrafts` store, replacing localStorage. Implements FE-152; clears drafts on logout, prunes by user on auth, and makes draft reads/writes async with guards to avoid stale renders.

- **Refactors**
  - Added `formDrafts` IndexedDB store (DB v2) and async draft service: `getDraft`, `setDraft`, `removeDraft`, `clearDrafts`, `pruneOtherDrafts`.
  - Switched form apps/services to async stored-submission flow: `getStoredSubmission`/`fetchFormData`/`clearStoredSubmission` now async; `showContent` awaits `get:storedSubmission` and uses `canShowStoredSubmission` to skip read-only/locked views; discard awaits `clear:storedSubmission`.
  - Added Cypress helpers `setFormDraft`, `getFormDraft`, `waitForFormDraft`, `clearFormDrafts`; new component tests and updated integrations.

- **Bug Fixes**
  - Clear all drafts on explicit logout and prune non-current-user drafts during auth via `@roundingwell/care-ops-auth`.
  - Prevent stale UI by guarding async `showContent` with request ids; await draft cleanup on submit and discard.
  - Fail-soft when IndexedDB is unavailable to avoid interrupting edits.

<sup>Written for commit 60c9161386de6cc3d566aba75428f042166ca87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user form draft persistence using an IndexedDB-backed drafts store and draft management utilities.
* **Bug Fixes**
  * More reliable async handling for showing, discarding and clearing stored submissions; prevents stale renders and ensures drafts are cleared on logout or account change.
* **Tests**
  * New and updated end-to-end tests and helpers for creating, verifying, pruning and clearing drafts.
* **Chores**
  * Cache storage schema version bumped to support drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->