### PR TITLE
fix(dev): proxy `/icons` and `/forms` to dev API URL

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -228,6 +228,13 @@ export default defineConfig(({ mode }) => {
             rewrite: rewritePath => rewritePath.replace(/^\/api/, ''),
           }),
         },
+        ...(env.VITE_DEV_API_URL && {
+          '/icons': {
+            target: env.VITE_DEV_API_URL,
+            changeOrigin: true,
+            secure: true,
+          },
+        }),
       },
       watch: {
         ignored: ['**/.stylelintcache'],

--- a/vite.config.js
+++ b/vite.config.js
@@ -235,6 +235,13 @@ export default defineConfig(({ mode }) => {
             secure: true,
           },
         }),
+        ...(!isTest && env.VITE_DEV_API_URL && {
+          '/forms': {
+            target: env.VITE_DEV_API_URL,
+            changeOrigin: true,
+            secure: true,
+          },
+        }),
       },
       watch: {
         ignored: ['**/.stylelintcache'],


### PR DESCRIPTION
To fix some icons not showing up in local dev and local cypress runs. And a auth loop when trying to load a form iframe in local dev.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxy `/icons` and `/forms` to the dev API via `VITE_DEV_API_URL` to fix missing icons and stop the forms iframe auth loop in local dev. The `/icons` proxy also runs in Cypress.

- **Bug Fixes**
  - Adds Vite dev server proxy: when `VITE_DEV_API_URL` is set, forward `/icons` with `changeOrigin` and `secure` enabled in local dev and Cypress.
  - Proxies `/forms` with `changeOrigin` and `secure` enabled in local dev only to prevent the iframe auth loop.

<sup>Written for commit 7b8e17d8348c70c998b363910d52cf6b5ad96882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Development server now proxies icon requests to the API server when configured.
  * Development server also conditionally proxies form requests to the API server (disabled during tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->