### PR TITLE
feat(forms): replace draft prompt with persistent draft status indicator

### DIFF
--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -17,7 +17,7 @@ import {
   StatusView,
   ReadOnlyView,
   SaveView,
-  LastUpdatedView,
+  DraftStatusView,
 } from 'js/views/forms/form/form_views';
 
 export default App.extend({
@@ -116,11 +116,12 @@ export default App.extend({
     this.showFormSave();
   },
   onFormServiceUpdateSubmission(updated) {
-    this.showLastUpdated(updated);
+    this.setState({ updated });
   },
   stateEvents: {
     'change': 'onChangeState',
     'change:isExpanded': 'showSidebar',
+    'change:updated': 'onChangeDraftStatus',
   },
   onChangeState(state) {
     localStore.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
@@ -141,7 +142,16 @@ export default App.extend({
     this.toggleState('isExpanded');
   },
   showContent() {
+    if (!this.isReadOnly) this.loadDraftStatus();
     this.showForm();
+  },
+  async loadDraftStatus() {
+    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+
+    /* istanbul ignore if: difficult to force stale async render */
+    if (this.isDestroyed()) return;
+
+    this.setState({ updated });
   },
   showForm(responseId) {
     this.showChildView('form', new IframeView({
@@ -171,10 +181,26 @@ export default App.extend({
   showReadOnly() {
     this.showChildView('formAction', new ReadOnlyView());
   },
-  showLastUpdated(updated) {
-    const lastUpdatedView = new LastUpdatedView({ updated });
+  onChangeDraftStatus() {
+    const updated = this.getState('updated');
 
-    this.showChildView('formUpdated', lastUpdatedView);
+    if (!updated) {
+      this.getRegion('draftStatus').empty();
+      return;
+    }
+
+    if (this.getRegion('draftStatus').hasView()) return;
+
+    const draftStatusView = new DraftStatusView({ model: this.getState() });
+    this.showChildView('draftStatus', draftStatusView);
+
+    this.listenTo(draftStatusView, {
+      async 'discard:submission'() {
+        await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
+        this.showForm();
+        this.showFormActions();
+      },
+    });
   },
   showFormSaveDisabled() {
     if (this.isSubmitHidden) return;

--- a/src/js/apps/forms/form/form-patient_app.js
+++ b/src/js/apps/forms/form/form-patient_app.js
@@ -13,7 +13,6 @@ import WidgetsHeaderApp from 'js/apps/forms/widgets/widgets_header_app';
 import {
   LayoutView,
   IframeView,
-  StoredSubmissionView,
   FormStateActionsView,
   StatusView,
   ReadOnlyView,
@@ -141,40 +140,7 @@ export default App.extend({
   onClickExpandButton() {
     this.toggleState('isExpanded');
   },
-  canShowStoredSubmission() {
-    return !this.isReadOnly;
-  },
-  async showContent() {
-    const showContentRequestId = (this._showContentRequestId || 0) + 1;
-    this._showContentRequestId = showContentRequestId;
-
-    if (!this.canShowStoredSubmission()) {
-      this.showForm();
-      return;
-    }
-
-    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
-
-    /* istanbul ignore if: difficult to force stale async render */
-    if (this.isDestroyed() || this._showContentRequestId !== showContentRequestId || !this.canShowStoredSubmission()) return;
-
-    if (updated) {
-      const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
-
-      this.listenTo(storedSubmissionView, {
-        'submit'() {
-          this.showForm();
-        },
-        async 'discard:submission'() {
-          await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
-          this.showForm();
-          this.showFormActions();
-        },
-      });
-
-      return;
-    }
-
+  showContent() {
     this.showForm();
   },
   showForm(responseId) {

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -23,7 +23,7 @@ import {
   SaveView,
   UpdateView,
   HistoryView,
-  LastUpdatedView,
+  DraftStatusView,
 } from 'js/views/forms/form/form_views';
 
 export default App.extend({
@@ -159,7 +159,7 @@ export default App.extend({
     this.showFormSave();
   },
   onFormServiceUpdateSubmission(updated) {
-    this.showLastUpdated(updated);
+    this.setState({ updated });
   },
   onFormServiceRefresh() {
     this.restart();
@@ -170,6 +170,7 @@ export default App.extend({
     'change:isActionSidebar': 'showSidebar',
     'change:shouldShowHistory': 'showFormActions',
     'change:responseId': 'onChangeResponseId',
+    'change:updated': 'onChangeDraftStatus',
   },
   onChangeState(state) {
     localStore.set(`form-state_${ this.currentUser.id }`, state.pick('isExpanded', 'saveButtonType'));
@@ -208,7 +209,16 @@ export default App.extend({
     this.setState({ responseId: get(this.responses.getFirstSubmission(), 'id'), shouldShowHistory: !this.getState('shouldShowHistory') });
   },
   showContent() {
+    if (!this.isReadOnly && !this.isLocked && !this.getState('responseId')) this.loadDraftStatus();
     this.showForm();
+  },
+  async loadDraftStatus() {
+    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
+
+    /* istanbul ignore if: difficult to force stale async render */
+    if (this.isDestroyed()) return;
+
+    this.setState({ updated });
   },
   showForm() {
     this.showChildView('form', new IframeView({
@@ -307,10 +317,26 @@ export default App.extend({
       this.setState({ responseId: null });
     });
   },
-  showLastUpdated(updated) {
-    const lastUpdatedView = new LastUpdatedView({ updated });
+  onChangeDraftStatus() {
+    const updated = this.getState('updated');
 
-    this.showChildView('formUpdated', lastUpdatedView);
+    if (!updated) {
+      this.getRegion('draftStatus').empty();
+      return;
+    }
+
+    if (this.getRegion('draftStatus').hasView()) return;
+
+    const draftStatusView = new DraftStatusView({ model: this.getState() });
+    this.showChildView('draftStatus', draftStatusView);
+
+    this.listenTo(draftStatusView, {
+      async 'discard:submission'() {
+        await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
+        this.showForm();
+        this.showFormActions();
+      },
+    });
   },
   showFormSaveDisabled() {
     if (this.isSubmitHidden) {

--- a/src/js/apps/forms/form/form_app.js
+++ b/src/js/apps/forms/form/form_app.js
@@ -16,7 +16,6 @@ import FormsService from 'js/services/forms';
 import {
   LayoutView,
   IframeView,
-  StoredSubmissionView,
   FormStateActionsView,
   StatusView,
   ReadOnlyView,
@@ -208,41 +207,7 @@ export default App.extend({
   onClickHistoryButton() {
     this.setState({ responseId: get(this.responses.getFirstSubmission(), 'id'), shouldShowHistory: !this.getState('shouldShowHistory') });
   },
-  canShowStoredSubmission() {
-    const responseId = this.getState('responseId');
-    return !this.isReadOnly && !this.isLocked && !responseId;
-  },
-  async showContent() {
-    const showContentRequestId = (this._showContentRequestId || 0) + 1;
-    this._showContentRequestId = showContentRequestId;
-
-    if (!this.canShowStoredSubmission()) {
-      this.showForm();
-      return;
-    }
-
-    const { updated } = await Radio.request(`form${ this.form.id }`, 'get:storedSubmission');
-
-    /* istanbul ignore if: difficult to force stale async render */
-    if (this.isDestroyed() || this._showContentRequestId !== showContentRequestId || !this.canShowStoredSubmission()) return;
-
-    if (updated) {
-      const storedSubmissionView = this.showChildView('form', new StoredSubmissionView({ updated }));
-
-      this.listenTo(storedSubmissionView, {
-        'submit'() {
-          this.showForm();
-        },
-        async 'discard:submission'() {
-          await Radio.request(`form${ this.form.id }`, 'clear:storedSubmission');
-          this.showForm();
-          this.showFormActions();
-        },
-      });
-
-      return;
-    }
-
+  showContent() {
     this.showForm();
   },
   showForm() {

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -133,15 +133,6 @@ careOptsFrontend:
             droplistItemText: Submit Form + Go Back
         statusView:
           label: Last submitted { date }
-        storedSubmissionView:
-          cancelButton: Discard My Work...
-          discardModal:
-            bodyText: Discarding your unsubmitted work on this form will load the latest data for this patient, but you'll lose your unsubmitted work.
-            headingText: Are you sure?
-            submitText: Discard My Work
-          submitButton: Load Form with My Work
-          title: You have unsubmitted work on this form. Would you like to load your work?
-          updated: Last edit was { updated }
         updateView:
           buttonText: Update
   globals:

--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -116,9 +116,14 @@ careOptsFrontend:
           nameText: '• By { name }'
         historyView:
           currentVersionButton: Back to Current Version
-        lastUpdatedView:
-          storedWork: Your work is stored automatically.
-          updatedAt: Last edit was { updated }
+        draftStatusView:
+          discardDraft: Discard draft...
+          discardModal:
+            bodyText: Discarding your unsubmitted work on this form will load the latest data for this patient, but you'll lose your unsubmitted work.
+            headingText: Are you sure?
+            submitText: Discard My Work
+          storedWork: Your draft is saved automatically.
+          updatedAt: Last saved { updated }
         readOnlyView:
           buttonText: Read Only
         lockedSubmitView:

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -76,26 +76,6 @@
   }
 }
 
-.form__prompt {
-  margin: 60px auto 20px;
-  padding: 20px;
-  text-align: center;
-}
-
-.form__prompt-title {
-  font-size: 24px;
-  margin-bottom: 32px;
-}
-
-.form__prompt-dialog {
-  display: flex;
-  justify-content: center;
-}
-
-.form__discard-button {
-  color: color(red);
-  margin-left: 48px;
-}
 
 .form__context-trail {
   color: #{$black-20};

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -8,7 +8,6 @@
   }
 }
 
-
 .form__frame {
   background: #{$black-95};
   display: flex;
@@ -76,7 +75,6 @@
   }
 }
 
-
 .form__context-trail {
   color: #{$black-20};
   position: relative;
@@ -127,6 +125,7 @@
   }
 
   &:hover,
+  &.is-active,
   &.is-selected {
     .icon {
       color: color(blue);
@@ -167,18 +166,45 @@
   }
 }
 
-.form__submit-status-text {
-  font-size: 12px;
-}
-
 .form__submit-status-locked-text {
   font-size: 12px;
   max-width: 160px;
 }
 
+.form__draft-menu {
+  background: #{$white};
+  border: 1px solid #{$black-90};
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  font-size: 12px;
+  padding: 12px 16px;
+  white-space: nowrap;
+}
+
+.form__draft-menu-info {
+  color: #{$black-40};
+}
+
+.form__draft-menu-saved {
+  font-size: 14px;
+  margin-top: 8px;
+}
+
+.form__draft-menu-discard-button {
+  color: color(red);
+  cursor: pointer;
+  display: block;
+  font-size: 14px;
+  margin-top: 8px;
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    color: color(red, light);
+  }
+}
+
 .form__form-action {
-  border-left: 1px solid #{$black-80};
   display: flex;
-  margin-left: 20px;
-  padding-left: 20px;
+  margin-left: 16px;
 }

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -197,45 +197,6 @@ const IframeView = View.extend({
   },
 });
 
-const StoredSubmissionView = View.extend({
-  className: 'form__content',
-  template: hbs`
-    <div class="form__prompt">
-      <h2 class="form__prompt-title">{{ @intl.forms.form.formViews.storedSubmissionView.title }}</h2>
-      <div class="form__prompt-dialog">
-        <div class="flex-shrink">
-          <button class="button--blue button--large js-submit">{{ @intl.forms.form.formViews.storedSubmissionView.submitButton }}</button>
-          <div class="u-margin--t-16">{{formatHTMLMessage (intlGet "forms.form.formViews.storedSubmissionView.updated") updated=(formatDateTime updated "TIME_OR_DAY")}}</div>
-        </div>
-        <div class="flex-shrink">
-          <button class="button-secondary button--large form__discard-button js-discard" style="color:red">{{ @intl.forms.form.formViews.storedSubmissionView.cancelButton }}</button>
-        </div>
-      </div>
-    </div>
-  `,
-  templateContext() {
-    return {
-      updated: this.getOption('updated'),
-    };
-  },
-  triggers: {
-    'click .js-submit': 'submit',
-    'click .js-discard': 'discard',
-  },
-  onDiscard() {
-    const modal = Radio.request('modal', 'show:small', {
-      bodyText: i18n.storedSubmissionView.discardModal.bodyText,
-      headingText: i18n.storedSubmissionView.discardModal.headingText,
-      submitText: i18n.storedSubmissionView.discardModal.submitText,
-      buttonClass: 'button--red',
-      onSubmit: () => {
-        modal.destroy();
-        this.triggerMethod('discard:submission');
-      },
-    });
-  },
-});
-
 const StatusView = View.extend({
   className: 'u-text-align--right',
   template: hbs`{{formatHTMLMessage (intlGet "forms.form.formViews.statusView.label") date=(formatDateTime updated_at "AT_TIME")}}`,
@@ -442,7 +403,6 @@ const HistoryView = View.extend({
 export {
   LayoutView,
   IframeView,
-  StoredSubmissionView,
   FormStateActionsView,
   StatusView,
   ReadOnlyView,

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -144,7 +144,7 @@ const LayoutView = View.extend({
           <div data-status-region>&nbsp;</div>
           <div class="form__controls">
             <div data-state-actions-region></div>
-            <div data-form-updated-region></div>
+            <div data-draft-status-region></div>
             <div data-form-action-region></div>
           </div>
         </div>
@@ -158,7 +158,7 @@ const LayoutView = View.extend({
   regions: {
     contextTrail: '[data-context-trail-region]',
     form: '[data-form-region]',
-    formUpdated: '[data-form-updated-region]',
+    draftStatus: '[data-draft-status-region]',
     formAction: {
       el: '[data-form-action-region]',
       replaceElement: true,
@@ -251,35 +251,64 @@ const SaveButtonTypeDroplist = Droplist.extend({
   },
 });
 
-const LastUpdatedView = View.extend({
-  className: 'form__submit-status',
+const DraftMenuView = View.extend({
+  className: 'form__draft-menu',
   template: hbs`
-    <div class="form__submit-status-icon">
-      {{far "shield-check"}}
-    </div>
-    <div class="form__submit-status-text">
-      <div class="u-text--overflow">{{ @intl.forms.form.formViews.lastUpdatedView.storedWork }}</div>
-      {{#if updated}}
-        <div class="u-text--overflow">{{formatHTMLMessage (intlGet "forms.form.formViews.lastUpdatedView.updatedAt") updated=(formatDateTime updated "AGO_OR_TODAY")}}</div>
-      {{/if}}
-    </div>
+    <div class="form__draft-menu-info">{{ @intl.forms.form.formViews.draftStatusView.storedWork }}</div>
+    <div class="form__draft-menu-saved">{{formatHTMLMessage (intlGet "forms.form.formViews.draftStatusView.updatedAt") updated=(formatDateTime updated "AGO_OR_TODAY")}}</div>
+    <button class="form__draft-menu-discard-button js-discard">{{ @intl.forms.form.formViews.draftStatusView.discardDraft }}</button>
   `,
-  templateContext() {
-    return {
-      updated: this.updated,
-    };
+  modelEvents: {
+    'change:updated': 'render',
   },
-  initialize({ updated }) {
-    this.updated = updated;
-
-    if (this.updated) {
-      this.renderInterval = setInterval(() => {
-        this.render();
-      }, 45000);
-    }
+  templateContext() {
+    return { updated: this.model.get('updated') };
+  },
+  triggers: {
+    'click .js-discard': 'click:discard',
+  },
+  initialize() {
+    this.renderInterval = setInterval(() => {
+      this.render();
+    }, 45000);
   },
   onBeforeDestroy() {
     clearInterval(this.renderInterval);
+  },
+});
+
+const DraftStatusView = Droplist.extend({
+  align: 'right',
+  viewOptions: {
+    className: 'form__actions-icon u-margin--l-16 u-margin--r-0',
+    template: hbs`{{far "shield-check"}}`,
+  },
+  initialize({ model }) {
+    this.model = model;
+  },
+  showPicklist() {
+    const menuView = new DraftMenuView({ model: this.model });
+
+    this.popRegion.show(menuView, this.popRegionOptions());
+    this.bindEvents(menuView, this._picklistEvents);
+  },
+  _picklistEvents: {
+    'click:discard': 'onClickDiscard',
+    'destroy': 'onPicklistDestroy',
+  },
+  onClickDiscard() {
+    this.popRegion.empty();
+
+    const modal = Radio.request('modal', 'show:small', {
+      bodyText: i18n.draftStatusView.discardModal.bodyText,
+      headingText: i18n.draftStatusView.discardModal.headingText,
+      submitText: i18n.draftStatusView.discardModal.submitText,
+      buttonClass: 'button--red',
+      onSubmit: () => {
+        modal.destroy();
+        this.triggerMethod('discard:submission');
+      },
+    });
   },
 });
 
@@ -410,5 +439,5 @@ export {
   SaveView,
   UpdateView,
   HistoryView,
-  LastUpdatedView,
+  DraftStatusView,
 };

--- a/src/scss/core/_space.scss
+++ b/src/scss/core/_space.scss
@@ -2,12 +2,14 @@
 // -----------------------------------------------------------
 
 // Aligns with small button text
+.u-margin--t-0 { margin-top: 0 !important; }
 .u-margin--t-4 { margin-top: 4px !important; }
 .u-margin--t-8 { margin-top: 8px !important; }
 .u-margin--t-16 { margin-top: 16px !important; }
 .u-margin--t-24 { margin-top: 24px !important; }
 .u-margin--t-32 { margin-top: 32px !important; }
 
+.u-margin--r-0 { margin-right: 0 !important; }
 .u-margin--r-4 { margin-right: 4px !important; }
 .u-margin--r-8 { margin-right: 8px !important; }
 .u-margin--r-16 { margin-right: 16px !important; }
@@ -15,12 +17,14 @@
 .u-margin--r-32 { margin-right: 32px !important; }
 .u-margin--r-auto { margin-right: auto !important; }
 
+.u-margin--b-0 { margin-bottom: 0 !important; }
 .u-margin--b-4 { margin-bottom: 4px !important; }
 .u-margin--b-8 { margin-bottom: 8px !important; }
 .u-margin--b-16 { margin-bottom: 16px !important; }
 .u-margin--b-24 { margin-bottom: 24px !important; }
 .u-margin--b-32 { margin-bottom: 32px !important; }
 
+.u-margin--l-0 { margin-left: 0 !important; }
 .u-margin--l-4 { margin-left: 4px !important; }
 .u-margin--l-8 { margin-left: 8px !important; }
 .u-margin--l-16 { margin-left: 16px !important; }

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -267,22 +267,14 @@ context('Patient Action Form', function() {
       })
       .visitOnClock(`/patient-action/${ testAction.id }/form/${ testForm.id }`, { now: testTs() })
       .wait('@routeAction')
-      .wait('@routePatientByAction');
+      .wait('@routePatientByAction')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
 
     cy
       .get('.form__controls')
       .find('.form__submit-status')
       .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormByAction')
-      .wait('@routeFormDefinition');
 
     cy
       .get('iframe')
@@ -342,7 +334,9 @@ context('Patient Action Form', function() {
       })
       .visitOnClock(`/patient-action/${ testAction.id }/form/${ testForm.id }`, { now: testTs() })
       .wait('@routeAction')
-      .wait('@routePatientByAction');
+      .wait('@routePatientByAction')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
 
     cy
       .intercept('PATCH', `/api/form-responses/${ formResponse.id }`, {
@@ -355,16 +349,6 @@ context('Patient Action Form', function() {
       .get('.form__controls')
       .find('.form__submit-status')
       .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormByAction')
-      .wait('@routeFormDefinition');
 
     cy
       .get('iframe')
@@ -394,136 +378,6 @@ context('Patient Action Form', function() {
         expect(data.id).to.equal(formResponse.id);
         expect(data.attributes.status).to.equal(FORM_RESPONSE_STATUS.DRAFT);
         expect(data.attributes.response.data.fields.foo).to.equal('baz');
-      });
-  });
-
-  specify('discarding stored submission', function() {
-    const formResponse = getFormResponse({
-      attributes: {
-        status: FORM_RESPONSE_STATUS.DRAFT,
-        updated_at: testTsSubtract(1),
-        response: {
-          data: { fields: { foo: 'bazinga' } },
-        },
-      },
-    });
-
-    const testPatient = getPatient();
-
-    const testAction = getAction({
-      relationships: {
-        'form': getRelationship(testForm),
-        'form-responses': getRelationship([formResponse]),
-      },
-    });
-
-    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`;
-
-    cy.setFormDraft(draftKey, {
-      updated: testTs(),
-      submission: {
-        fields: { foo: 'foo' },
-      },
-    });
-
-    cy
-      .routeAction(fx => {
-        fx.data = testAction;
-
-        return fx;
-      })
-      .routeFormActionFields(fx => {
-        fx.data = getFormFields({
-          attributes: {
-            fields: { foo: 'bar' },
-          },
-        });
-
-        return fx;
-      })
-      .routeFormByAction(fx => {
-        fx.data = testForm;
-
-        return fx;
-      })
-      .routeLatestFormResponse(() => {
-        return {
-          data: formResponse,
-        };
-      })
-      .routeFormDefinition()
-      .routeActionActivity()
-      .routePatientByAction(fx => {
-        fx.data = testPatient;
-
-        return fx;
-      })
-      .visitOnClock(`/patient-action/${ testAction.id }/form/${ testForm.id }`, { now: testTs() })
-      .wait('@routeAction')
-      .wait('@routePatientByAction')
-      .wait('@routeLatestFormResponse');
-
-    cy
-      .intercept('POST', '/api/form-responses', {
-        statusCode: 201,
-        body: { data: getFormResponse() },
-      })
-      .as('routePostResponse');
-
-    cy
-      .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Your work is stored automatically.')
-      .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-discard')
-      .click();
-
-    cy
-      .get('.modal--small')
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormByAction')
-      .wait('@routeFormDefinition')
-      .wait('@routeFormActionFields');
-
-    cy
-      .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Your work is stored automatically.')
-      .should('not.contain', 'Last edit was');
-
-    cy
-      .waitForFormDraft(draftKey, { exists: false })
-      .should(draft => {
-        expect(draft).to.be.null;
-      });
-
-    cy
-      .iframeStub()
-      .then(iframeStub => {
-        iframeStub.send('update:storedSubmission', { fields: { foo: 'baz' } });
-      });
-
-    cy
-      .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .tick(15000);
-
-    cy
-      .wait('@routePostResponse')
-      .its('request.body')
-      .should(({ data }) => {
-        expect(data.id).to.not.equal(formResponse.id);
-        expect(data.attributes.status).to.equal(FORM_RESPONSE_STATUS.DRAFT);
       });
   });
 
@@ -2813,14 +2667,7 @@ context('Patient Action Form', function() {
     cy
       .tick(1800000)
       .wait('@routeLatestFormResponse')
-      .wait('@routePatientByAction');
-
-    cy
-      .get('.form__content')
-      .find('.js-submit')
-      .click();
-
-    cy
+      .wait('@routePatientByAction')
       .wait('@routeFormByAction')
       .wait('@routeFormDefinition');
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -120,7 +120,7 @@ context('Patient Action Form', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .get('[data-form-updated-region]')
+      .get('[data-draft-status-region]')
       .should('be.empty');
 
     cy
@@ -194,8 +194,12 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .tick(15000);
@@ -211,9 +215,23 @@ context('Patient Action Form', function() {
       .tick(45000);
 
     cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a minute ago');
+
+    cy
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('update:storedSubmission', { fields: { foo: 'baz' } });
+      });
+
+    cy
       .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a minute ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
   });
 
   specify('restoring stored submission', function() {
@@ -273,8 +291,12 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .get('iframe')
@@ -347,8 +369,12 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .get('iframe')
@@ -378,6 +404,141 @@ context('Patient Action Form', function() {
         expect(data.id).to.equal(formResponse.id);
         expect(data.attributes.status).to.equal(FORM_RESPONSE_STATUS.DRAFT);
         expect(data.attributes.response.data.fields.foo).to.equal('baz');
+      });
+  });
+
+  specify('discarding stored submission', function() {
+    const formResponse = getFormResponse({
+      attributes: {
+        status: FORM_RESPONSE_STATUS.DRAFT,
+        updated_at: testTsSubtract(1),
+        response: {
+          data: { fields: { foo: 'bazinga' } },
+        },
+      },
+    });
+
+    const testPatient = getPatient();
+
+    const testAction = getAction({
+      relationships: {
+        'form': getRelationship(testForm),
+        'form-responses': getRelationship([formResponse]),
+      },
+    });
+
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }-${ testAction.id }`;
+
+    cy.setFormDraft(draftKey, {
+      updated: testTs(),
+      submission: {
+        fields: { foo: 'foo' },
+      },
+    });
+
+    cy
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      })
+      .routeFormActionFields(fx => {
+        fx.data = getFormFields({
+          attributes: {
+            fields: { foo: 'bar' },
+          },
+        });
+
+        return fx;
+      })
+      .routeFormByAction(fx => {
+        fx.data = testForm;
+
+        return fx;
+      })
+      .routeLatestFormResponse(() => {
+        return {
+          data: formResponse,
+        };
+      })
+      .routeFormDefinition()
+      .routeActionActivity()
+      .routePatientByAction(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .visitOnClock(`/patient-action/${ testAction.id }/form/${ testForm.id }`, { now: testTs() })
+      .wait('@routeAction')
+      .wait('@routePatientByAction')
+      .wait('@routeLatestFormResponse');
+
+    cy
+      .intercept('POST', '/api/form-responses', {
+        statusCode: 201,
+        body: { data: getFormResponse() },
+      })
+      .as('routePostResponse');
+
+    cy
+      .get('.form__controls')
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('.form__draft-menu')
+      .find('.js-discard')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click();
+
+    cy
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormActionFields');
+
+    cy
+      .get('.form__controls')
+      .find('[data-draft-status-region]')
+      .should('be.empty');
+
+    cy
+      .waitForFormDraft(draftKey, { exists: false })
+      .should(draft => {
+        expect(draft).to.be.null;
+      });
+
+    cy
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('update:storedSubmission', { fields: { foo: 'baz' } });
+      });
+
+    cy
+      .get('.form__controls')
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .tick(15000);
+
+    cy
+      .wait('@routePostResponse')
+      .its('request.body')
+      .should(({ data }) => {
+        expect(data.id).to.not.equal(formResponse.id);
+        expect(data.attributes.status).to.equal(FORM_RESPONSE_STATUS.DRAFT);
       });
   });
 
@@ -1184,7 +1345,7 @@ context('Patient Action Form', function() {
       .wait('@routeFormDefinition');
 
     cy
-      .get('[data-form-updated-region]')
+      .get('[data-draft-status-region]')
       .should('be.empty');
 
     cy
@@ -1257,7 +1418,7 @@ context('Patient Action Form', function() {
       .wait('@routeFormActionFields');
 
     cy
-      .get('[data-form-updated-region]')
+      .get('[data-draft-status-region]')
       .should('be.empty');
 
     cy
@@ -1992,8 +2153,12 @@ context('Patient Action Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .tick(15000);

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -211,8 +211,12 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .tick(15000);
@@ -228,9 +232,27 @@ context('Patient Form', function() {
       .tick(45000);
 
     cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a minute ago');
+
+    cy
+      .get('body')
+      .type('{esc}');
+
+    cy
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('update:storedSubmission', { fields: { foo: 'baz' } });
+      });
+
+    cy
       .get('.form__controls')
-      .find('.form__submit-status-text')
-      .should('contain', 'Last edit was a minute ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
   });
 
   specify('restoring draft', function() {
@@ -275,8 +297,12 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .get('iframe')
@@ -330,8 +356,12 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Last edit was a few seconds ago');
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
 
     cy
       .get('iframe')
@@ -340,6 +370,88 @@ context('Patient Form', function() {
         const response = receivedMessages.findLast(m => m.message === 'fetch:form:data');
 
         expect(response.args.value.storedSubmission.fields.foo).to.equal('foo');
+      });
+  });
+
+  specify('discarding stored submission', function() {
+    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`;
+
+    cy.setFormDraft(draftKey, {
+      updated: testTs(),
+      submission: {
+        fields: { foo: 'foo' },
+      },
+    });
+
+    cy
+      .routeForm(fx => {
+        fx.data = testForm;
+
+        return fx;
+      })
+      .routeFormDefinition()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFormFields(fx => {
+        fx.data = getFormFields({
+          attributes: {
+            fields: {
+              foo: 'bar',
+            },
+          },
+        });
+
+        return fx;
+      })
+      .routeLatestFormResponse()
+      .visitOnClock(`/patient/${ testPatient.id }/form/${ testForm.id }`, { now: testTs() })
+      .wait('@routeForm')
+      .wait('@routePatient');
+
+    cy
+      .get('.form__controls')
+      .find('.form__actions-icon:has(.fa-shield-check)')
+      .click();
+
+    cy
+      .get('.form__draft-menu-saved')
+      .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('.form__draft-menu')
+      .find('.js-discard')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click();
+
+    cy
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
+
+    cy
+      .get('.form__controls')
+      .find('[data-draft-status-region]')
+      .should('be.empty');
+
+    cy
+      .waitForFormDraft(draftKey, { exists: false })
+      .should(draft => {
+        expect(draft).to.be.null;
+      });
+
+    cy
+      .get('iframe')
+      .should(([iframe]) => {
+        const { receivedMessages } = iframe.contentWindow.iframeStub;
+        const response = receivedMessages.findLast(m => m.message === 'fetch:form:data');
+
+        expect(response.args.value.formData.fields.foo).to.equal('bar');
       });
   });
 
@@ -382,7 +494,7 @@ context('Patient Form', function() {
       .wait('@routeFormFields');
 
     cy
-      .get('[data-form-updated-region]')
+      .get('[data-draft-status-region]')
       .should('be.empty');
 
     cy

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -270,21 +270,13 @@ context('Patient Form', function() {
       })
       .visitOnClock(`/patient/${ testPatient.id }/form/${ testForm.id }`, { now: testTs() })
       .wait('@routeForm')
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .wait('@routeFormDefinition');
 
     cy
       .get('.form__controls')
       .find('.form__submit-status')
       .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormDefinition');
 
     cy
       .get('iframe')
@@ -333,21 +325,13 @@ context('Patient Form', function() {
       })
       .visitOnClock(`/patient/${ testPatient.id }/form/${ testForm.id }`, { now: testTs() })
       .wait('@routeForm')
-      .wait('@routePatient');
+      .wait('@routePatient')
+      .wait('@routeFormDefinition');
 
     cy
       .get('.form__controls')
       .find('.form__submit-status')
       .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormDefinition');
 
     cy
       .get('iframe')
@@ -356,87 +340,6 @@ context('Patient Form', function() {
         const response = receivedMessages.findLast(m => m.message === 'fetch:form:data');
 
         expect(response.args.value.storedSubmission.fields.foo).to.equal('foo');
-      });
-  });
-
-  specify('discarding stored submission', function() {
-    const draftKey = `form-subm-${ currentClinician.id }-${ testPatient.id }-${ testForm.id }`;
-
-    cy.setFormDraft(draftKey, {
-      updated: testTs(),
-      submission: {
-        fields: { foo: 'foo' },
-      },
-    });
-
-    cy
-      .routeForm(fx => {
-        fx.data = testForm;
-
-        return fx;
-      })
-      .routeFormDefinition()
-      .routePatient(fx => {
-        fx.data = testPatient;
-
-        return fx;
-      })
-      .routeFormFields(fx => {
-        fx.data = getFormFields({
-          attributes: {
-            fields: {
-              foo: 'bar',
-            },
-          },
-        });
-
-        return fx;
-      })
-      .routeLatestFormResponse()
-      .visitOnClock(`/patient/${ testPatient.id }/form/${ testForm.id }`, { now: testTs() })
-      .wait('@routeForm')
-      .wait('@routePatient');
-
-    cy
-      .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Your work is stored automatically.')
-      .should('contain', 'Last edit was a few seconds ago');
-
-    cy
-      .get('.form__content')
-      .should('contain', `Last edit was ${ formatDate(testTs(), 'TIME_OR_DAY') }`)
-      .find('.js-discard')
-      .click();
-
-    cy
-      .get('.modal--small')
-      .find('.js-submit')
-      .click();
-
-    cy
-      .wait('@routeFormDefinition')
-      .wait('@routeFormFields');
-
-    cy
-      .get('.form__controls')
-      .find('.form__submit-status')
-      .should('contain', 'Your work is stored automatically.')
-      .should('not.contain', 'Last edit was');
-
-    cy
-      .waitForFormDraft(draftKey, { exists: false })
-      .should(draft => {
-        expect(draft).to.be.null;
-      });
-
-    cy
-      .get('iframe')
-      .should(([iframe]) => {
-        const { receivedMessages } = iframe.contentWindow.iframeStub;
-        const response = receivedMessages.findLast(m => m.message === 'fetch:form:data');
-
-        expect(response.args.value.formData.fields.foo).to.equal('bar');
       });
   });
 


### PR DESCRIPTION
Closes FE-150

Summary of changes:

- Always load the user's draft when opening a form
- Replace the `StoredSubmissionView` interstitial prompt (full-page "you have unsubmitted work" screen with Load/Discard buttons, [screenshot](https://github.com/user-attachments/assets/b94bac9d-c618-46cd-ac8a-bb8995bb46f4)) with a persistent shield icon button in the form controls bar
- Draft status is now always visible while editing — clicking the shield opens a dropdown showing when the draft was last saved and a "Discard draft..." option
- Discarding from the dropdown shows a confirmation modal before clearing the draft (same as before)

<img width="264" height="79" alt="Screenshot 2026-06-09 at 2 20 22 PM" src="https://github.com/user-attachments/assets/4ff6ea95-c068-4932-b3b6-b91a2c5ebc12" />

<img width="384" height="167" alt="Screenshot 2026-06-09 at 2 20 28 PM" src="https://github.com/user-attachments/assets/65c7b032-c6f7-415e-a397-2f763c3a3b48" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the full-screen draft prompt with a non-blocking shield button that shows live draft status and a discard option. Drafts now auto-load so users can start editing right away (FE-150).

- **New Features**
  - Draft status button (shield) shows “Last saved …” and auto-refreshes every 45s.
  - Click opens a dropdown with “Discard draft...” and a confirm modal.
  - Drafts auto-load; removed the interstitial load/discard screen.
  - Only shows when a draft exists and the form is editable (not read-only/locked, no response selected).

- **Refactors**
  - Removed `StoredSubmissionView` and `LastUpdatedView`; added `DraftStatusView` and `DraftMenuView` with new `data-draft-status-region`.
  - Updated i18n copy/keys (“Your draft is saved automatically.” / “Last saved ...”); removed obsolete keys.
  - CSS cleanup: removed prompt styles; added draft menu styles and new zero-margin utilities.
  - Updated integration tests for auto-load and the new dropdown flow.

<sup>Written for commit 68fc7799488d4d8ab661e8928f3d0c4e65e36d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added draft status menu with "Last saved" timestamp display that auto-refreshes every 45 seconds
  * Added draft discard functionality with confirmation modal

* **Style**
  * Updated styling for draft status menu and related form controls
  * Added zero-value margin utility classes

* **Tests**
  * Updated integration tests to verify draft status UI interactions and timestamp updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
