### PR TITLE
refactor(routing): scope RouterApp route reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Load a scoped overlay only when the task touches:
 
 - `scripts/**` -> `scripts/AGENTS.md`
 - `packages/care-ops-five9/**` -> `packages/care-ops-five9/AGENTS.md`
+- routing infrastructure (`src/js/base/routerapp.js`, `src/js/base/subrouterapp.js`) or application route definitions -> `src/js/base/routing.md`
 
 ## Instruction Priority
 

--- a/src/js/apps/clinicians/clinicians-all_app.js
+++ b/src/js/apps/clinicians/clinicians-all_app.js
@@ -11,7 +11,8 @@ import { getClinicianModal } from 'js/views/clinicians/clinician-modal/clinician
 
 export default SubRouterApp.extend({
   routerAppName: 'CliniciansApp',
-  eventRoutes: {
+  routeScope: [],
+  routeActions: {
     'clinician': 'showClinicianSidebar',
     'clinicians:all': 'hideCliniciansSidebar',
   },
@@ -38,7 +39,7 @@ export default SubRouterApp.extend({
   beforeStart() {
     return Radio.request('entities', 'fetch:clinicians:collection');
   },
-  onStart({ currentRoute }, clinicians) {
+  onStart(options, clinicians) {
     this.clinicians = clinicians;
 
     this.showChildView('list', new ListView({
@@ -46,7 +47,7 @@ export default SubRouterApp.extend({
       state: this.getState(),
     }));
 
-    this.startRoute(currentRoute);
+    this.startCurrentRoute();
   },
   showSearchView() {
     const searchComponent = this.showChildView('search', new SearchComponent({
@@ -75,6 +76,7 @@ export default SubRouterApp.extend({
 
     Radio.request('sidebar', 'start', sidebarApp, { clinician });
 
+    this.stopListening(sidebarApp, 'close');
     this.listenTo(sidebarApp, 'close', () => {
       Radio.trigger('event-router', 'clinicians:all');
     });

--- a/src/js/apps/clinicians/clinicians-main_app.js
+++ b/src/js/apps/clinicians/clinicians-main_app.js
@@ -13,7 +13,7 @@ export default RouterApp.extend({
     'clinicians:all': {
       action: 'showCliniciansAll',
       route: 'clinicians',
-      isList: true,
+      meta: { isList: true },
     },
     'clinician': {
       action: 'showCliniciansAll',

--- a/src/js/apps/dashboards/dashboards-main_app.js
+++ b/src/js/apps/dashboards/dashboards-main_app.js
@@ -15,7 +15,7 @@ export default RouterApp.extend({
     'dashboards:all': {
       action: 'showDashboardsAll',
       route: 'dashboards',
-      isList: true,
+      meta: { isList: true },
     },
     'dashboard': {
       action: 'showDashboard',

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -29,7 +29,8 @@ export default SubRouterApp.extend({
     bulkEditActions: BulkEditActionsApp,
     flowSidebar: FlowSiderbarApp,
   },
-  eventRoutes: {
+  routeScope: ['flowId'],
+  routeActions: {
     'flow': 'hideSidebar',
     'flow:action': 'showActionSidebar',
     'flow:details': 'showFlowDetails',
@@ -62,10 +63,9 @@ export default SubRouterApp.extend({
 
     handleErrors(error);
   },
-  onStart({ currentRoute }, flow, actions, patient) {
+  onStart(options, flow, actions, patient) {
     this.flow = flow;
     this.actions = actions;
-    this.currentRoute = currentRoute;
     this.editableCollection = actions.clone();
     this.patient = patient;
 
@@ -98,7 +98,7 @@ export default SubRouterApp.extend({
       'change:_owner': this.onFlowChangeOwner,
     });
 
-    this.startRoute(currentRoute);
+    this.startCurrentRoute();
   },
   hideSidebar() {
     this.stopChildApp('flowSidebar');
@@ -219,7 +219,7 @@ export default SubRouterApp.extend({
           .catch(() => {
             Radio.request('alert', 'show:error', i18n.bulkEditFailure);
             this.getState().clearSelected();
-            this.restart({ flowId: this.flow.id, currentRoute: this.currentRoute });
+            this.restart({ flowId: this.flow.id });
           });
       },
     });
@@ -307,6 +307,7 @@ export default SubRouterApp.extend({
 
     Radio.request('sidebar', 'start', sidebarApp, { action });
 
+    this.stopListening(sidebarApp, 'close');
     this.listenTo(sidebarApp, 'close', () => {
       Radio.trigger('event-router', 'flow', flowId);
     });
@@ -321,6 +322,7 @@ export default SubRouterApp.extend({
 
     Radio.request('sidebar', 'start', sidebarApp, { flow: this.flow });
 
+    this.stopListening(sidebarApp, 'close');
     this.listenTo(sidebarApp, 'close', () => {
       Radio.trigger('event-router', 'flow', this.flow.id);
     });

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -1,4 +1,4 @@
-import { partial, some, get } from 'underscore';
+import { partial, get, noop } from 'underscore';
 import Radio from 'backbone.radio';
 
 import handleErrors from 'js/utils/handle-errors';
@@ -13,7 +13,9 @@ import ActionSiderbarApp from 'js/apps/patients/sidebar/action-sidebar_app';
 import { LayoutView, intl } from 'js/views/patients/patient/patient_views';
 
 export default SubRouterApp.extend({
-  eventRoutes() {
+  routeScope: ['patientId'],
+
+  routeActions() {
     return {
       'patient:dashboard': partial(this.startList, 'dashboard'),
       'patient:archive': partial(this.startList, 'archive'),
@@ -47,41 +49,53 @@ export default SubRouterApp.extend({
     this.getRegion().startPreloader();
   },
 
-  beforeStart({ currentRoute: { eventArgs: [patientId, actionId] } }) {
+  beforeStart() {
+    const [patientId, actionId] = this.getCurrentRoute().eventArgs;
+
     return [
       Radio.request('entities', 'fetch:patients:model', patientId),
-      actionId && Radio.request('entities', 'fetch:actions:model', actionId),
+      // the action is a non-aborting prefetch: it warms the cache for the initial
+      // route but its failure must never reject startup or override a newer route —
+      // dispatch (startPatientAction) is the source of truth and handles errors
+      actionId && Radio.request('entities', 'fetch:actions:model', actionId).catch(noop),
     ];
   },
 
-  /* istanbul ignore next: error handling */
-  onFail({ currentRoute: { eventArgs: [patientId] } }, error) {
+  /* istanbul ignore next: beforeStart error handling */
+  onFail(options, error) {
+    // the action prefetch is non-aborting, so a startup failure is the patient's;
+    // a 410 means the patient is gone
     if (get(error, ['response', 'status']) === 410) {
-      if (!some(error.responseData.errors, err => {
-        return get(err, ['source', 'parameter']) === 'actionId';
-      })) {
-        Radio.trigger('event-router', 'notFound');
-        this.stop();
-        return;
-      }
-
-      this.showActionNotFound();
+      Radio.trigger('event-router', 'notFound');
       this.stop();
-      Radio.trigger('event-router', 'patient:dashboard', patientId);
       return;
     }
 
     handleErrors(error);
   },
 
-  onStart({ currentRoute }, patient) {
+  // status-aware action failure handling for the on-demand dispatch fetch
+  failAction(error, patientId) {
+    /* istanbul ignore else: only the 410 path is exercised; others are generic */
+    if (get(error, ['response', 'status']) === 410) {
+      this.showActionNotFound();
+      this.stop();
+      Radio.trigger('event-router', 'patient:dashboard', patientId);
+      return;
+    }
+
+    /* istanbul ignore next: generic error handling */
+    handleErrors(error);
+  },
+
+  onStart(options, patient) {
     this.patient = patient;
 
     this.setView(new LayoutView({ model: patient }));
 
     this.showSidebar();
 
-    this.startRoute(currentRoute);
+    this.startCurrentRoute();
 
     this.showView();
   },
@@ -110,21 +124,44 @@ export default SubRouterApp.extend({
   },
 
   startPatientAction(list, patientId, actionId) {
-    this.action = Radio.request('entities', 'actions:model', actionId);
+    const action = Radio.request('entities', 'actions:model', actionId);
+    this.action = action;
 
     this.startList(list);
 
-    const sidebarApp = this.getChildApp('actionSidebar');
+    this.getChildApp('actionSidebar').stop();
 
-    sidebarApp.stop();
-
-    if (!this.action.isCached()) {
-      this.showActionNotFound();
+    if (action.isCached()) {
+      this.showActionSidebar(action, list, patientId);
       return;
     }
 
-    Radio.request('sidebar', 'start', sidebarApp, { action: this.action });
+    // not cached when its route coalesced into a still-loading PatientApp, the
+    // prefetch failed, or the action is absent from the list: fetch it on demand
+    // rather than reporting it missing
+    Radio.request('entities', 'fetch:actions:model', actionId)
+      .then(() => this.showActionSidebar(action, list, patientId))
+      .catch(error => {
+        // suppress when a newer action route superseded this one (or the app stopped)
+        if (this.action !== action) return;
 
+        this.failAction(error, patientId);
+      });
+  },
+
+  showActionSidebar(action, list, patientId) {
+    // a newer action route may have superseded this one while it loaded
+    if (this.action !== action) return;
+
+    /* istanbul ignore next: defensive — app stopped mid-fetch */
+    if (!this.isRunning()) return;
+
+    const sidebarApp = this.getChildApp('actionSidebar');
+
+    Radio.request('sidebar', 'start', sidebarApp, { action });
+
+    // re-dispatched routes must not accumulate close handlers on the singleton
+    this.stopListening(sidebarApp, 'close');
     this.listenTo(sidebarApp, 'close', () => {
       Radio.trigger('event-router', `patient:${ list }`, patientId);
     });

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -25,7 +25,7 @@ export default RouterApp.extend({
     'worklist': {
       action: 'showPatientsWorklist',
       route: 'worklist/:id',
-      isList: true,
+      meta: { isList: true },
     },
     'patient:dashboard': {
       action: 'showPatient',
@@ -58,11 +58,11 @@ export default RouterApp.extend({
     'schedule': {
       action: 'showSchedule',
       route: 'schedule',
-      isList: true,
+      meta: { isList: true },
     },
   },
 
-  onBeforeAppRoute(event, patientId) {
+  onBeforeAppRoute({ event, eventArgs: [patientId] }) {
     // if routing to flow route, currentPatientId is set by flow_app's onStart()
     if (event.startsWith('flow')) return;
 

--- a/src/js/apps/programs/program/flow/flow_app.js
+++ b/src/js/apps/programs/program/flow/flow_app.js
@@ -17,7 +17,8 @@ export default SubRouterApp.extend({
     programSidebar: ProgramSidebarApp,
     flowSidebar: FlowSidebarApp,
   },
-  eventRoutes: {
+  routeScope: ['flowId'],
+  routeActions: {
     'programFlow:action': 'showActionSidebar',
     'programFlow:action:new': 'showActionSidebar',
   },
@@ -35,7 +36,7 @@ export default SubRouterApp.extend({
     Radio.trigger('event-router', 'notFound');
     this.stop();
   },
-  onStart({ currentRoute }, program, flow, actions) {
+  onStart(options, program, flow, actions) {
     this.program = program;
     this.flow = flow;
     this.actions = actions;
@@ -52,7 +53,7 @@ export default SubRouterApp.extend({
     this.showActionList();
     this.showProgramSidebar();
 
-    this.startRoute(currentRoute);
+    this.startCurrentRoute();
   },
 
   maintainFlowActions() {

--- a/src/js/apps/programs/program/program_app.js
+++ b/src/js/apps/programs/program/program_app.js
@@ -14,7 +14,9 @@ import { LayoutView } from 'js/views/programs/program/program_views';
 import { SidebarView } from 'js/views/programs/program/sidebar/sidebar-views';
 
 export default SubRouterApp.extend({
-  eventRoutes() {
+  routeScope: ['programId'],
+
+  routeActions() {
     return {
       'program:details': partial(this.startCurrent, 'workflows'),
       'program:action': this.startProgramAction,
@@ -45,14 +47,14 @@ export default SubRouterApp.extend({
     return Radio.request('entities', 'fetch:programs:model', programId);
   },
 
-  onStart({ currentRoute }, program) {
+  onStart(options, program) {
     this.program = program;
 
     this.setView(new LayoutView({ model: program }));
 
     this.showSidebar();
 
-    this.startRoute(currentRoute);
+    this.startCurrentRoute();
 
     this.showView();
   },

--- a/src/js/apps/programs/programs-main_app.js
+++ b/src/js/apps/programs/programs-main_app.js
@@ -17,7 +17,7 @@ export default RouterApp.extend({
     'programs:all': {
       action: 'showProgramsAll',
       route: 'programs',
-      isList: true,
+      meta: { isList: true },
     },
     'program:details': {
       action: 'showProgram',

--- a/src/js/base/README.md
+++ b/src/js/base/README.md
@@ -4,3 +4,9 @@ This directory houses the base libraries that the rest of the application uses a
 We extend some libraries with custom functionality specifically for our unique application uses.
 Additionally there are some modules here that are fairly generic and could be extracted as a 3rd party lib.
 The files here are the building blocks and configuration for building a complex app and should be more than a utility.
+
+## Routing
+
+`RouterApp` and `SubRouterApp` drive URL routing and app lifecycle. See
+[routing.md](./routing.md) before changing routing infrastructure or application
+route definitions.

--- a/src/js/base/routerapp.cy.js
+++ b/src/js/base/routerapp.cy.js
@@ -1,0 +1,205 @@
+import Radio from 'backbone.radio';
+
+import RouterApp from './routerapp';
+import SubRouterApp from './subrouterapp';
+
+const PatientStub = SubRouterApp.extend({
+  routeScope: ['patientId'],
+  routeActions() {
+    return {
+      'patient:dashboard': 'show',
+      'patient:action': 'show',
+    };
+  },
+  initialize() {
+    this.startCount = 0;
+    this.routes = [];
+  },
+  onStart() {
+    this.startCount++;
+    this.startCurrentRoute();
+  },
+  onStartRoute(routeContext) {
+    this.routes.push(routeContext.event);
+  },
+  show() {},
+});
+
+const Router = RouterApp.extend({
+  routerAppName: 'patients',
+  childApps: {
+    patient: PatientStub,
+  },
+  eventRoutes() {
+    return {
+      'patient:dashboard': { action: 'showPatient', route: 'patient/dashboard/:id' },
+      'patient:action': { action: 'showPatient', route: 'patient/:id/action/:aid' },
+      'worklist': { action: 'showWorklist', route: 'worklist/:id', meta: { isList: true } },
+      'schedule': { action: 'showSchedule', route: 'schedule', meta: { clearLatestList: true } },
+    };
+  },
+  showPatient(patientId) {
+    this.startRoute('patient', { patientId });
+  },
+  showWorklist() {},
+  showSchedule() {},
+});
+
+function trigger(app, event, ...args) {
+  app.router.getChannel().trigger(event, ...args);
+}
+
+context('RouterApp', function() {
+  let app;
+  let navSelect;
+  let sidebarStop;
+  let setLatestList;
+
+  beforeEach(function() {
+    navSelect = cy.stub();
+    sidebarStop = cy.stub();
+    setLatestList = cy.stub();
+
+    Radio.reply('workspace', 'current', () => ({ get: () => 'test-ws' }));
+    Radio.reply('nav', 'select', navSelect);
+    Radio.reply('sidebar', 'stop', sidebarStop);
+    Radio.reply('history', 'set:latestList', setLatestList);
+  });
+
+  afterEach(function() {
+    if (app) app.destroy();
+    app = null;
+    Radio.reset();
+  });
+
+  describe('route triggers and aliases', function() {
+    specify('prefixes the workspace slug onto non-root routes', function() {
+      app = new Router();
+      expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/dashboard/:id');
+    });
+
+    specify('registers every alias and treats the first as canonical', function() {
+      const AliasRouter = Router.extend({
+        eventRoutes() {
+          return {
+            'patient:dashboard': {
+              action: 'showPatient',
+              route: ['patient/:id/workflow', 'patient/dashboard/:id'],
+            },
+          };
+        },
+      });
+      app = new AliasRouter();
+
+      expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/:id/workflow');
+      expect(app.translateEvent('patient:dashboard', 'p1')).to.equal('test-ws/patient/p1/workflow');
+
+      trigger(app, 'patient:dashboard', 'p1');
+      expect(app.getCurrentRoute().definition.route).to.equal('patient/:id/workflow');
+    });
+  });
+
+  describe('route context', function() {
+    specify('sets the current route before before:appRoute and exposes the full context', function() {
+      const CapturingRouter = Router.extend({
+        onBeforeAppRoute(routeContext) {
+          this.captured = routeContext;
+          this.currentDuringHook = this.getCurrentRoute();
+        },
+      });
+      app = new CapturingRouter();
+
+      trigger(app, 'patient:dashboard', 'p1');
+
+      expect(app.captured.event).to.equal('patient:dashboard');
+      expect(app.captured.eventArgs).to.deep.equal(['p1']);
+      expect(app.captured.definition.action).to.equal('showPatient');
+      expect(app.captured.definition.route).to.equal('patient/dashboard/:id');
+      expect(app.currentDuringHook).to.equal(app.captured);
+    });
+
+    specify('getCurrentRouteMeta returns the definition meta', function() {
+      app = new Router();
+      trigger(app, 'worklist', 'w1');
+      expect(app.getCurrentRouteMeta()).to.deep.equal({ isList: true });
+    });
+  });
+
+  describe('latest-list meta', function() {
+    specify('records the latest list for meta.isList routes', function() {
+      app = new Router();
+      trigger(app, 'worklist', 'w1');
+      expect(setLatestList).to.have.been.calledWith('worklist', ['w1']);
+    });
+
+    specify('clears the latest list for meta.clearLatestList routes', function() {
+      app = new Router();
+      trigger(app, 'schedule');
+      expect(setLatestList).to.have.been.calledWith(false);
+    });
+
+    specify('leaves the latest list alone for plain routes', function() {
+      app = new Router();
+      trigger(app, 'patient:dashboard', 'p1');
+      expect(setLatestList).not.to.have.been.called;
+    });
+  });
+
+  describe('scope identity', function() {
+    specify('reuses the child and forwards the route for an equal scope', function() {
+      app = new Router();
+      trigger(app, 'patient:dashboard', 'p1');
+      const child = app.getCurrent();
+
+      trigger(app, 'patient:action', 'p1', 'a1');
+
+      expect(app.getCurrent()).to.equal(child);
+      expect(child.startCount).to.equal(1);
+      expect(child.routes).to.deep.equal(['patient:dashboard', 'patient:action']);
+    });
+
+    specify('restarts the child for a different scope', function() {
+      app = new Router();
+      trigger(app, 'patient:dashboard', 'p1');
+      const child = app.getCurrent();
+
+      trigger(app, 'patient:dashboard', 'p2');
+
+      expect(child.startCount).to.equal(2);
+    });
+
+    specify('startCurrent is unconditional even for an equal scope', function() {
+      app = new Router();
+      app.startCurrent('patient', { patientId: 'p1' });
+      const child = app.getCurrent();
+      app.startCurrent('patient', { patientId: 'p1' });
+
+      expect(child.startCount).to.equal(2);
+    });
+  });
+
+  describe('child stop cleanup', function() {
+    specify('clears current references when the child stops itself', function() {
+      app = new Router();
+      trigger(app, 'patient:dashboard', 'p1');
+      const child = app.getCurrent();
+
+      child.stop();
+
+      expect(app.getCurrent()).to.equal(null);
+      expect(app.isCurrent('patient', { patientId: 'p1' })).to.equal(false);
+    });
+
+    specify('keeps the current child when it restarts itself', function() {
+      app = new Router();
+      trigger(app, 'patient:dashboard', 'p1');
+      const child = app.getCurrent();
+
+      // a Toolkit restart() emits stop+start; the child remains current
+      child.restart();
+
+      expect(app.getCurrent()).to.equal(child);
+      expect(app.isCurrent('patient', { patientId: 'p1' })).to.equal(true);
+    });
+  });
+});

--- a/src/js/base/routerapp.js
+++ b/src/js/base/routerapp.js
@@ -1,4 +1,4 @@
-import { extend, isEqual, isFunction, partial, reduce, rest, result } from 'underscore';
+import { isArray, isEqual, isFunction, map, partial, reduce, rest, result } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 import EventRouter from 'backbone.eventrouter';
@@ -36,20 +36,25 @@ export default App.extend({
     this._currentRoute = null;
   },
 
-  // For each route in the hash creates a routeTriggers hash
+  // For each route in the hash creates a routeTriggers hash,
+  // prefixing every (non-root) route or alias with the workspace slug
   getRouteTriggers() {
-    return reduce(this._routes, function(routeTriggers, { route, root }, eventName) {
-      if (root) {
-        routeTriggers[eventName] = route;
-        return routeTriggers;
-      }
-
-      const currentWorkspace = Radio.request('workspace', 'current');
-      const workspace = currentWorkspace.get('slug');
-      routeTriggers[eventName] = route ? `${ workspace }/${ route }` : workspace;
+    return reduce(this._routes, (routeTriggers, { route, root }, eventName) => {
+      routeTriggers[eventName] = isArray(route) ?
+        map(route, pattern => this._prefixRoute(pattern, root)) :
+        this._prefixRoute(route, root);
 
       return routeTriggers;
     }, {});
+  },
+
+  _prefixRoute(route, root) {
+    if (root) return route;
+
+    const currentWorkspace = Radio.request('workspace', 'current');
+    const workspace = currentWorkspace.get('slug');
+
+    return route ? `${ workspace }/${ route }` : workspace;
   },
 
   getEventActions(eventRoutes, routeAction) {
@@ -78,17 +83,25 @@ export default App.extend({
       this.start();
     }
 
-    this.triggerMethod('before:appRoute', event, ...args);
-
-    Radio.request('nav', 'select', this.routerAppName, event, args);
-    Radio.request('sidebar', 'stop');
-
-    this.setLatestList(event, args);
+    const definition = this._routes[event];
 
     this._currentRoute = {
       event,
       eventArgs: args,
+      definition: {
+        action: definition.action,
+        route: isArray(definition.route) ? definition.route[0] : definition.route,
+        root: definition.root,
+        meta: definition.meta || {},
+      },
     };
+
+    this.triggerMethod('before:appRoute', this._currentRoute);
+
+    Radio.request('nav', 'select', this.routerAppName, event, args);
+    Radio.request('sidebar', 'stop');
+
+    this.setLatestList(this._currentRoute);
 
     if (!isFunction(action)) {
       action = this[action];
@@ -96,16 +109,18 @@ export default App.extend({
 
     action.apply(this, args);
 
-    this.triggerMethod('appRoute', event, ...args);
+    this.triggerMethod('appRoute', this._currentRoute);
   },
 
-  setLatestList(event, eventArgs) {
-    if (this._routes[event].isList) {
-      Radio.request('history', 'set:latestList', event, eventArgs);
+  setLatestList(routeContext) {
+    const { meta } = routeContext.definition;
+
+    if (meta.isList) {
+      Radio.request('history', 'set:latestList', routeContext.event, routeContext.eventArgs);
       return;
     }
 
-    if (!this._routes[event].clearLatestList) return;
+    if (!meta.clearLatestList) return;
 
     Radio.request('history', 'set:latestList', false);
   },
@@ -114,24 +129,40 @@ export default App.extend({
   startCurrent(appName, options) {
     this.stopCurrent();
 
+    const child = this.getChildApp(appName);
+
+    // only SubRouterApp children participate in route dispatch and scope identity;
+    // plain list/leaf children (worklist, schedule, programs-all) do neither
+    if (isFunction(child.setCurrentRoute)) {
+      child.setCurrentRoute(this.getCurrentRoute());
+    }
+
     this._currentAppName = appName;
-    this._currentAppOptions = options;
+    this._currentAppScope = this.getChildScope(child, options);
+    this._current = child;
 
-    options = extend({
-      currentRoute: this._currentRoute,
-    }, options);
+    // child apps are singletons; ensure exactly one stop listener
+    this.stopListening(child, 'stop');
+    this.listenTo(child, 'stop', this._handleChildStop);
 
-    const app = this.startChildApp(appName, options);
+    this.startChildApp(appName, options);
 
-    this._current = app;
+    return child;
+  },
 
-    return app;
+  getChildScope(child, options) {
+    return isFunction(child.getRouteScope) ? child.getRouteScope(options) : undefined;
   },
 
   startRoute(appName, options) {
-    if (this.isCurrent(appName, options) && this.getCurrent().isRunning()) {
-      return this.getCurrent().startRoute(this.getCurrentRoute());
+    const child = this.getChildApp(appName);
+    const scope = this.getChildScope(child, options);
+    const current = this.getCurrent();
+
+    if (current && this.isCurrent(appName, scope) && (current.isRunning() || current.isLoading())) {
+      return current.startRoute(this.getCurrentRoute());
     }
+
     return this.startCurrent(appName, options);
   },
 
@@ -139,22 +170,41 @@ export default App.extend({
     return this._current;
   },
 
-  isCurrent(appName, options) {
+  isCurrent(appName, scope) {
     return (appName === this._currentAppName)
-      && (isEqual(options, this._currentAppOptions));
+      && (isEqual(scope, this._currentAppScope));
   },
 
   getCurrentRoute() {
     return this._currentRoute;
   },
 
+  getCurrentRouteMeta() {
+    return this._currentRoute && this._currentRoute.definition.meta;
+  },
+
+  _handleChildStop() {
+    // Preserve the current child through Toolkit restart().
+    if (this._current && this._current.isRestarting()) return;
+
+    this._clearCurrent();
+  },
+
   stopCurrent() {
     if (!this._current) return;
 
-    this._current.stop();
+    const current = this._current;
+
+    this.stopListening(current, 'stop');
+    this._clearCurrent();
+
+    current.stop();
+  },
+
+  _clearCurrent() {
     this._current = null;
     this._currentAppName = null;
-    this._currentAppOptions = null;
+    this._currentAppScope = null;
   },
 
   // takes an event and translates data into the applicable url fragment

--- a/src/js/base/routing.md
+++ b/src/js/base/routing.md
@@ -1,0 +1,173 @@
+# Routing: RouterApp and SubRouterApp
+
+How URL routing maps to running apps in this codebase. Read this before changing
+`src/js/base/routerapp.js`, `src/js/base/subrouterapp.js`, or any application route
+definitions.
+
+## Responsibilities
+
+- **RouterApp** (`src/js/base/routerapp.js`) — owns URL ↔ event mapping for a
+  top-level area (Patients, Programs, Clinicians, Dashboards, Forms, Nav, Error).
+  It registers routes with `backbone.eventrouter`, builds a normalized route
+  context on each match, selects the nav item, manages the single current child
+  app, and fires the `before:appRoute` / `appRoute` lifecycle hooks.
+- **SubRouterApp** (`src/js/base/subrouterapp.js`) — a child app that dispatches a
+  route to a local handler without owning any URLs. It carries declarative scope
+  identity, retains the latest route while loading, and re-dispatches after its
+  async startup completes.
+- **page App** — a plain `js/base/app` (e.g. worklist, schedule, dashboard, form).
+  It renders a view and has no route dispatch or scope. RouterApp starts these via
+  `startCurrent` and never asks them for a route or scope.
+
+## Route definitions (RouterApp `eventRoutes`)
+
+```js
+eventRoutes: {
+  'patient:dashboard': {
+    action: 'showPatient',          // method name or function (positional handler)
+    route: 'patient/dashboard/:id', // string, or array of aliases (first is canonical)
+    // root: true,                  // skip the workspace-slug prefix
+    meta: { isList: true },         // behavioral flags live under meta
+  },
+}
+```
+
+Structural fields: `action`, `route`, `root`. Behavioral flags go under `meta`
+(`isList`, `clearLatestList`). `action` is a method name (resolved on the RouterApp)
+or a function; `route` is a string or a non-empty array of alias strings; non-root
+routes are prefixed with the workspace slug, so they must not begin with `/`.
+
+### Aliases
+
+`route` may be an array. Every alias is registered (each prefixed with the workspace
+slug unless `root`), and the **first** alias is canonical for URL generation
+(`translateEvent` / `replaceRoute`). EventRouter supports this natively.
+
+## Route context
+
+Each match is normalized before any hook runs:
+
+```js
+{
+  event,            // 'patient:dashboard'
+  eventArgs,        // ['patient-id', ...] — positional, as the action receives them
+  definition: { action, route, root, meta },
+}
+```
+
+- `getCurrentRoute()` returns this object; `getCurrentRouteMeta()` returns its `meta`.
+- `before:appRoute` and `appRoute` receive the context object (not positional args).
+- Action handlers still receive **positional** arguments (`showPatient(patientId)`).
+
+Side-effect order inside `routeAction` (deliberate — the current route is set first
+so it is observable in `before:appRoute`):
+
+```text
+set current route → before:appRoute → nav select → sidebar stop
+  → latest-list update → action handler → appRoute
+```
+
+## Scope identity (which child is "the same")
+
+Every `SubRouterApp` reached through `RouterApp.startRoute()` declares a `routeScope`:
+
+```js
+routeScope: ['patientId']   // PatientApp
+routeScope: ['flowId']      // PatientFlowApp, ProgramFlowApp
+routeScope: ['programId']   // ProgramApp
+routeScope: []              // CliniciansAllApp — always "the same" instance
+```
+
+`getRouteScope(options = {})` returns `pick(options, routeScope)`. RouterApp compares
+scope objects with `isEqual` — **never** the full startup options:
+
+- **Same app + equal scope** → reuse the running (or loading) child; forward the
+  newest route to it.
+- **Different app or scope** → stop the current child and start the replacement.
+
+Scope identity is workspace/resource identity, **not** route-specific detail. Put the
+ID that determines "same workspace" in `routeScope` (the patient, the flow). Do not
+put action IDs or sub-route detail there — those change within a scope and must not
+force a restart.
+
+`startCurrent()` is the unconditional path (always stop + start); it does not consult
+scope. Plain page Apps are always started this way.
+
+## Loading and dispatch (SubRouterApp)
+
+A `SubRouterApp` separates "record the route" from "dispatch the route":
+
+- `setCurrentRoute(routeContext)` / `getCurrentRoute()` — RouterApp sets the route on
+  the child *before* `startChildApp`, so it is available in `beforeStart()`,
+  `onFail()`, and `onStart()`. Read route data via `getCurrentRoute().eventArgs`;
+  do **not** read `currentRoute` from startup options.
+- `startRoute(routeContext)` — records the newest route; dispatches immediately only
+  if already running. While loading or stopped it just stores (latest wins).
+- `startCurrentRoute()` — synchronously dispatches the current route to its
+  `routeActions` handler. **Subclasses call this from `onStart()` after building
+  their shell.**
+
+This is why same-scope navigation arriving during an in-flight load does not restart
+the app: the route is retained and dispatched once `onStart` runs.
+
+```js
+onStart(options, data) {
+  // build the shared shell / set views
+  this.startCurrentRoute();
+}
+```
+
+`routeActions` (not `eventRoutes`) maps a route event to a local dispatch handler:
+
+```js
+routeActions: {
+  'flow:action': 'showActionSidebar',
+  'flow:details': 'showFlowDetails',
+}
+```
+
+## Stop and restart
+
+- RouterApp keeps exactly one stop listener per current child. A child that stops
+  **itself** clears RouterApp's current-child references.
+- A Toolkit `restart()` emits `stop` then `start`. RouterApp ignores the restart-stop
+  (`child.isRestarting()`), so a child that restarts itself (e.g. a worklist applying
+  filter state) **stays current**. Treating a restart as a teardown would desync
+  tracking and leave two apps in one region.
+- A `SubRouterApp` clears its `_currentRoute` on a normal stop but preserves it across
+  `restart()` (also guarded by `isRestarting()`), so the route re-dispatches after
+  re-fetching. Rely on this instead of threading `currentRoute` through restart
+  options.
+
+## Async ownership
+
+Async loading belongs in `beforeStart()` (return a promise / array of promises). The
+base App lifecycle sets `isLoading()` true until it resolves, then runs `onStart`.
+Route dispatch stays synchronous — do not add another async layer.
+
+## Common mistakes
+
+- Putting route-specific IDs (action IDs, sub-route detail) in `routeScope`. Scope is
+  resource identity; extra keys force needless restarts or block legitimate ones.
+- Reading `currentRoute` from startup options. Use `getCurrentRoute()`.
+- Forgetting `startCurrentRoute()` in a `SubRouterApp`'s `onStart()` — the route never
+  dispatches.
+- Accessing the private `_routes` / `_currentRoute` instead of `getCurrentRoute()` /
+  `getCurrentRouteMeta()`.
+- A non-root `route` beginning with `/` (the workspace slug is prepended, producing a
+  double slash).
+- Leaving `isList` / `clearLatestList` at the top level of a definition instead of
+  under `meta` (silently stops updating the latest-list history).
+
+## AI checklist for adding or changing a route
+
+1. Add/extend the `RouterApp` `eventRoutes` entry: `action`, `route` (string or alias
+   array), and `meta` for any behavioral flag. Keep IDs out of `meta`.
+2. Implement the positional action handler; route to a child via `startRoute(appName,
+   options)` (scoped child) or `startCurrent(appName, options)` (plain page app).
+3. If the child is a `SubRouterApp`: declare `routeScope`, add the event to
+   `routeActions`, read route data via `getCurrentRoute()`, and call
+   `startCurrentRoute()` in `onStart()`.
+4. Do not change existing URLs unless that is the explicit task.
+5. Add/extend specs in `src/js/base/*.cy.js` for base-class behavior and run targeted
+   `npm run coverage:e2e` specs for the affected area, plus `npm run lint`.

--- a/src/js/base/subrouterapp.cy.js
+++ b/src/js/base/subrouterapp.cy.js
@@ -1,0 +1,163 @@
+import SubRouterApp from './subrouterapp';
+
+// Resolve queued microtasks (the base App loading chain) before asserting.
+function flush() {
+  return new Cypress.Promise(resolve => setTimeout(resolve, 0));
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Cypress.Promise(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const BaseApp = SubRouterApp.extend({
+  routeScope: ['patientId'],
+  routeActions() {
+    return {
+      'patient:dashboard': 'showDashboard',
+      'patient:action': 'showAction',
+    };
+  },
+  initialize() {
+    this.calls = [];
+    this.beforeRoutes = [];
+    this.startedRoutes = [];
+  },
+  onBeforeStartRoute(routeContext) {
+    this.beforeRoutes.push(routeContext.event);
+  },
+  onStartRoute(routeContext) {
+    this.startedRoutes.push(routeContext.event);
+  },
+  showDashboard(patientId) {
+    this.calls.push(['dashboard', patientId]);
+  },
+  showAction(patientId, actionId) {
+    this.calls.push(['action', patientId, actionId]);
+  },
+});
+
+const SyncApp = BaseApp.extend({
+  onStart() {
+    this.startCurrentRoute();
+  },
+});
+
+const LoadingApp = BaseApp.extend({
+  beforeStart() {
+    this.loaded = deferred();
+    return this.loaded.promise;
+  },
+  onStart() {
+    this.startCurrentRoute();
+  },
+});
+
+const dashboard = { event: 'patient:dashboard', eventArgs: ['p1'], definition: {} };
+const action = { event: 'patient:action', eventArgs: ['p1', 'a1'], definition: {} };
+
+context('SubRouterApp', function() {
+  let app;
+
+  afterEach(function() {
+    if (app) app.destroy();
+    app = null;
+  });
+
+  describe('getRouteScope', function() {
+    specify('returns only the configured scope keys', function() {
+      app = new BaseApp();
+      expect(app.getRouteScope({ patientId: 'p1', clinicianId: 'c9' })).to.deep.equal({ patientId: 'p1' });
+    });
+
+    specify('returns {} when options are omitted', function() {
+      app = new BaseApp();
+      expect(app.getRouteScope()).to.deep.equal({});
+    });
+
+    specify('returns {} for an empty scope', function() {
+      app = new (BaseApp.extend({ routeScope: [] }))();
+      expect(app.getRouteScope({ patientId: 'p1' })).to.deep.equal({});
+    });
+
+    specify('returns the full options when no scope is declared', function() {
+      app = new (BaseApp.extend({ routeScope: undefined }))();
+      expect(app.getRouteScope({ patientId: 'p1', clinicianId: 'c9' })).to.deep.equal({ patientId: 'p1', clinicianId: 'c9' });
+    });
+  });
+
+  describe('synchronous startup', function() {
+    specify('dispatches the current route from onStart with positional args', function() {
+      app = new SyncApp();
+      app.setCurrentRoute(action);
+      app.start();
+
+      expect(app.calls).to.deep.equal([['action', 'p1', 'a1']]);
+      expect(app.beforeRoutes).to.deep.equal(['patient:action']);
+      expect(app.startedRoutes).to.deep.equal(['patient:action']);
+    });
+
+    specify('dispatches immediately when a route arrives while running', function() {
+      app = new SyncApp();
+      app.start();
+      expect(app.calls).to.deep.equal([]);
+
+      app.startRoute(dashboard);
+      expect(app.calls).to.deep.equal([['dashboard', 'p1']]);
+    });
+  });
+
+  describe('loading startup', function() {
+    specify('retains only the newest route while loading and dispatches it once ready', function() {
+      app = new LoadingApp();
+      app.setCurrentRoute(dashboard);
+      app.start();
+
+      // still loading: nothing dispatched
+      app.startRoute(action);
+      expect(app.calls).to.deep.equal([]);
+
+      app.loaded.resolve();
+      return flush().then(() => {
+        expect(app.calls).to.deep.equal([['action', 'p1', 'a1']]);
+      });
+    });
+  });
+
+  describe('unmatched routes', function() {
+    specify('is a safe no-op and does not fire startRoute', function() {
+      app = new SyncApp();
+      app.setCurrentRoute({ event: 'patient:missing', eventArgs: [], definition: {} });
+      app.start();
+
+      expect(app.calls).to.deep.equal([]);
+      expect(app.beforeRoutes).to.deep.equal(['patient:missing']);
+      expect(app.startedRoutes).to.deep.equal([]);
+    });
+  });
+
+  describe('stop and restart', function() {
+    specify('clears the current route on a normal stop', function() {
+      app = new SyncApp();
+      app.setCurrentRoute(dashboard);
+      app.start();
+      app.stop();
+
+      expect(app.getCurrentRoute()).to.equal(null);
+    });
+
+    specify('preserves the current route across restart', function() {
+      app = new SyncApp();
+      app.setCurrentRoute(dashboard);
+      app.start();
+      app.restart();
+
+      expect(app.getCurrentRoute()).to.deep.equal(dashboard);
+      // re-dispatched on restart
+      expect(app.calls).to.deep.equal([['dashboard', 'p1'], ['dashboard', 'p1']]);
+    });
+  });
+});

--- a/src/js/base/subrouterapp.js
+++ b/src/js/base/subrouterapp.js
@@ -1,4 +1,4 @@
-import { extend, result } from 'underscore';
+import { extend, pick, result } from 'underscore';
 import { normalizeMethods } from 'marionette';
 
 import App from './app';
@@ -6,31 +6,72 @@ import App from './app';
 export default App.extend({
   constructor: function() {
     this._current = null;
+    this._currentRoute = null;
 
     this.initRouter();
 
     this.on('before:stop', this.stopCurrent);
+    this.on('before:stop', this.clearCurrentRoute);
 
     App.apply(this, arguments);
   },
 
+  // route actions dispatch a matched route to a local handler
+  // (distinct from RouterApp's `eventRoutes` URL definitions)
   initRouter() {
-    const eventRoutes = result(this, 'eventRoutes', {});
-    this._eventRoutes = normalizeMethods(this, eventRoutes);
+    const routeActions = result(this, 'routeActions', {});
+    this._routeActions = normalizeMethods(this, routeActions);
   },
 
-  // Start a route from a currentRoute passed from a routerapp
-  startRoute(currentRoute) {
+  // declarative scope identity used by a parent RouterApp to decide reuse;
+  // without a declared routeScope, fall back to full-option identity
+  getRouteScope(options = {}) {
+    const scope = result(this, 'routeScope');
+    return scope ? pick(options, scope) : options;
+  },
+
+  setCurrentRoute(routeContext) {
+    this._currentRoute = routeContext;
+  },
+
+  getCurrentRoute() {
+    return this._currentRoute;
+  },
+
+  // records the newest route, dispatching only when already running;
+  // while loading or stopped the route is retained for startCurrentRoute()
+  startRoute(routeContext) {
+    this.setCurrentRoute(routeContext);
+
+    if (this.isRunning()) {
+      this.startCurrentRoute();
+    }
+  },
+
+  // synchronously dispatches the current route to its action
+  startCurrentRoute() {
+    const currentRoute = this.getCurrentRoute();
+
+    if (!currentRoute) return;
+
     this.triggerMethod('before:startRoute', currentRoute);
 
     const { event, eventArgs } = currentRoute;
-    const action = this._eventRoutes[event];
+    const action = this._routeActions[event];
 
     if (!action) return;
 
     action.apply(this, eventArgs);
 
     this.triggerMethod('startRoute', currentRoute);
+  },
+
+  // clears the current route on a normal stop, but preserves it across a
+  // Toolkit restart() so the route can be re-dispatched after re-fetching
+  clearCurrentRoute() {
+    if (!this.isRestarting()) {
+      this._currentRoute = null;
+    }
   },
 
   mixinOptions(options) {

--- a/test/integration/globals/app-nav.js
+++ b/test/integration/globals/app-nav.js
@@ -1023,7 +1023,12 @@ context('App Nav', function() {
       .click();
 
     cy
-      .routePatient()
+      .routePatient(fx => {
+        fx.data.id = testNewPatientId;
+
+        return fx;
+      })
+      .routeWorkspacePatient()
       .routeForm(fx => {
         fx.data = testForm;
 
@@ -1053,5 +1058,13 @@ context('App Nav', function() {
     cy
       .url()
       .should('contain', `/patient/${ testNewPatientId }/form/${ testForm.id }`);
+
+    cy
+      .wait('@routePatient')
+      .wait('@routeWorkspacePatient')
+      .wait('@routeForm')
+      .wait('@routeLatestFormResponse')
+      .wait('@routeFormDefinition')
+      .wait('@routeFormFields');
   });
 });

--- a/test/integration/patients/sidebar/action-sidebar.js
+++ b/test/integration/patients/sidebar/action-sidebar.js
@@ -795,7 +795,25 @@ context('action sidebar', function() {
       .url()
       .should('not.contain', '/action/');
 
+    // the action is deleted, so the on-demand fetch on navigating back returns 410
+    cy
+      .intercept('GET', `/api/actions/${ testAction.id }*`, {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find action',
+            source: { parameter: 'actionId' },
+          }),
+        },
+      })
+      .as('routeDeletedAction');
+
     cy.go('back');
+
+    cy
+      .wait('@routeDeletedAction');
 
     cy
       .get('.alert-box')
@@ -2710,5 +2728,308 @@ context('action sidebar', function() {
       .get('[data-action-region]')
       .should('contain', 'Permissions')
       .and('contain', 'You are not able to change settings on this action.');
+  });
+
+  // A patient action route can coalesce into a still-loading PatientApp (scope is the
+  // patient, not the action). The action model is therefore not fetched by patient
+  // startup and is not in the dashboard list, so the dispatch must fetch it on demand
+  // rather than report it missing.
+  specify('loads an action navigated to while the patient is still loading', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const testAction = getAction({
+      attributes: {
+        name: 'Coalesced Action',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+      },
+    });
+
+    cy
+      .routesForPatientAction()
+      .routePatientActions(fx => {
+        // action is NOT in the dashboard list, so it is not cached that way
+        fx.data = [];
+
+        return fx;
+      })
+      .routePatientByAction(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      });
+
+    // delay the patient model so PatientApp stays in its loading state
+    cy.intercept('GET', '/api/patients/**?*', {
+      body: { data: testPatient, included: [] },
+      delay: 1000,
+    });
+
+    cy.visit(`/patient/dashboard/${ testPatient.id }`);
+
+    // while PatientApp is loading (preloader shown), navigate to the action
+    cy.get('.loader').should('exist');
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, testAction.id);
+    });
+
+    // the action is fetched on demand and the sidebar renders (rather than "not found")
+    cy
+      .wait('@routeAction')
+      .wait('@routeActionActivity');
+
+    cy
+      .get('.action-sidebar__name')
+      .should('contain', 'Coalesced Action');
+  });
+
+  specify('ignores stale on-demand action fetches after a newer action route', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const staleAction = getAction({
+      id: 'stale-action',
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+      },
+    });
+
+    const currentAction = getAction({
+      id: 'current-action',
+      attributes: {
+        name: 'Current Action',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+      },
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeActionActivity()
+      .routeActionComments()
+      .routeActionFiles()
+      .intercept('GET', `/api/actions/${ staleAction.id }*`, {
+        statusCode: 410,
+        delay: 500,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find action',
+            source: { parameter: 'actionId' },
+          }),
+        },
+      })
+      .as('routeStaleAction')
+      .intercept('GET', `/api/actions/${ currentAction.id }*`, {
+        body: { data: currentAction, included: [] },
+      })
+      .as('routeCurrentAction');
+
+    cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient');
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, staleAction.id);
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, currentAction.id);
+    });
+
+    cy
+      .wait('@routeCurrentAction')
+      .wait('@routeActionActivity')
+      .wait('@routeStaleAction');
+
+    cy
+      .get('.action-sidebar__name')
+      .should('contain', 'Current Action');
+
+    cy
+      .get('.alert-box__body')
+      .should('not.exist');
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/action/${ currentAction.id }`);
+  });
+
+  specify('ignores a stale on-demand action fetch that succeeds after a newer route', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const staleAction = getAction({
+      id: 'stale-action',
+      attributes: {
+        name: 'Stale Action',
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+      },
+    });
+
+    const currentAction = getAction({
+      id: 'current-action',
+      attributes: {
+        name: 'Current Action',
+        updated_at: testTs(),
+      },
+      relationships: {
+        state: getRelationship(stateTodo),
+        patient: getRelationship(testPatient),
+      },
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeActionActivity()
+      .routeActionComments()
+      .routeActionFiles()
+      // the stale fetch succeeds, but resolves after the newer route
+      .intercept('GET', `/api/actions/${ staleAction.id }*`, {
+        body: { data: staleAction, included: [] },
+        delay: 500,
+      })
+      .as('routeStaleAction')
+      .intercept('GET', `/api/actions/${ currentAction.id }*`, {
+        body: { data: currentAction, included: [] },
+      })
+      .as('routeCurrentAction');
+
+    cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient');
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, staleAction.id);
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, currentAction.id);
+    });
+
+    cy
+      .wait('@routeCurrentAction')
+      .wait('@routeStaleAction');
+
+    // the stale fetch resolved last, but its sidebar is suppressed
+    cy
+      .get('.action-sidebar__name')
+      .should('contain', 'Current Action');
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/action/${ currentAction.id }`);
+  });
+
+  // The on-demand fetch must honor the same status-aware handling as beforeStart:
+  // a 410 shows "not found" and redirects to the patient dashboard rather than
+  // leaving the URL on a dead action route.
+  specify('redirects to the patient dashboard when an on-demand action is gone', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .intercept('GET', '/api/actions/*', {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find action',
+            source: { parameter: 'actionId' },
+          }),
+        },
+      })
+      .as('routeGoneAction');
+
+    cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient');
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, '1');
+    });
+
+    cy
+      .wait('@routeGoneAction');
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Action you requested does not exist.');
+
+    cy
+      .url()
+      .should('contain', `/patient/dashboard/${ testPatient.id }`)
+      .should('not.contain', '/action/');
   });
 });


### PR DESCRIPTION
Closes FE-161

## What
- Refactors `RouterApp` and `SubRouterApp` around normalized route context, scoped child reuse, and latest-route dispatch while loading.
- Migrates current subrouter consumers to `routeScope`, `routeActions`, and `startCurrentRoute()`.
- Adds patient action on-demand loading for same-patient route coalescing and documents the routing contract in `src/js/base/routing.md`.

## Why
This sets up the patient workspace refactor so patient-scoped routes can move between dashboard, actions, flows, and future in-page forms without unnecessarily reloading the shared patient shell/sidebar.

## Scope
Impacted areas:
- Shared routing base classes: `RouterApp`, `SubRouterApp`
- Patients, Programs, Clinicians, Dashboards route consumers
- Patient action route loading and error handling
- Router documentation and base component specs

Intentionally not changed:
- Existing URL route shapes
- Pagination or patient card UI work
- Moving forms into patient page context

## Deployment Impact
No separate form bundle redeploy is required. This is normal app frontend deployment only. Shared routing behavior affects the main app bundle and migrated route consumers.

## Testing
- `npx cypress run --component --spec 'src/js/base/routerapp.cy.js,src/js/base/subrouterapp.cy.js'` passed: 21 tests.
- `npx cypress run --spec test/integration/patients/patient/dashboard.js` passed during review: 8 tests, including add action/flow behavior.
- Deployed to `dev:paul` and verified live `index.html`, `appconfig.json`, and `sw.js` responses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes route reuse by resource identity and normalizes route context so same-patient navigation reuses the running app and dispatches the latest route without reloads. Enables FE-161 by keeping the patient shell steady while moving between dashboard, actions, and flows.

- **Refactors**
  - RouterApp: sets a route context early and passes it to hooks (`before:appRoute`/`appRoute`), adds `getCurrentRouteMeta`, supports route alias arrays (first is canonical) with workspace-prefixed patterns, moves latest-list flags to `definition.meta`, and switches child identity to `routeScope`-based reuse (including while loading) with restart-safe cleanup.
  - SubRouterApp: adds `routeScope`/`getRouteScope`, `routeActions`, and `setCurrentRoute`/`startRoute`/`startCurrentRoute`; clears the current route on stop but preserves it across `restart()`.
  - Migrates Patients, Programs, Clinicians, and Dashboards to `routeScope`, `routeActions`, `startCurrentRoute()`, and `meta` flags; `onBeforeAppRoute` now receives the route context. Adds `src/js/base/routing.md` (linked from `README.md` and `AGENTS.md`) and component specs for `routerapp`/`subrouterapp`.

- **New Features**
  - Patient action on-demand fetch for same-patient routes; suppresses stale results; 410 shows not-found and redirects to the patient dashboard. Dedupes sidebar close handlers on reuse. Adds e2e tests for action navigation during patient load, stale superseded routes, 410 redirects, and custom form routing on add-patient.

<sup>Written for commit bae0609f170c07bad0f5f228eead59d64bf125b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added routing infrastructure documentation for development reference.

* **Tests**
  * Expanded routing and error-handling test coverage, including improved validation of route dispatch behavior and action-not-found scenarios.

* **Refactor**
  * Updated internal routing infrastructure to normalize route context handling and improve lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->