### PR TITLE
chore(ci): update CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -36,9 +36,9 @@ jobs:
               - packages/care-ops-five9/**
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes FE-162

## What
- Updates `.github/workflows/codeql.yml` to use `github/codeql-action` v4 for `init`, `autobuild`, and `analyze`.

## Why
- GitHub now emits a deprecation warning for CodeQL Action v3. Moving to v4 keeps the CodeQL workflow on the current action runtime.

## Scope
- Impacts only the CodeQL GitHub Actions workflow.
- Does not change app code, workflow triggers, runner selection, or token permissions.
- Intentionally does not add `metadata: read` because it is not a documented GitHub Actions `GITHUB_TOKEN` permission key.

## Deployment Impact
- No app or form redeploy required.
- This affects CI behavior only when CodeQL runs on `develop`, PRs targeting `develop`, or the scheduled scan.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/codeql.yml`
- Confirmed no remaining `github/codeql-action/*@v3` or `metadata: read` references in `.github/workflows/codeql.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade CodeQL CI to `github/codeql-action` v4 to remove v3 deprecation warnings and keep security scans current. Addresses FE-162 and touches only the CodeQL workflow.

- **Dependencies**
  - Bump `github/codeql-action/{init,autobuild,analyze}` from v3 to v4 in `.github/workflows/codeql.yml`.
  - No changes to triggers, runners, or token permissions; do not add `metadata: read`.

<sup>Written for commit 7606bc1d47474f99038ccbc79123f767ade0ce08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

