### PR TITLE
feat(forms): add draft status/discard UI to the patient form modal

### DIFF
--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -1,4 +1,6 @@
+import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import hbs from 'handlebars-inline-precompile';
 import App from 'js/base/app';
 
 import intl from 'js/i18n';
@@ -6,6 +8,7 @@ import intl from 'js/i18n';
 import FormsService from 'js/services/forms';
 
 import { ModalView, SidebarModalView, SmallModalView, IframeFormView } from 'js/views/globals/modal/modal_views';
+import { DraftStatusView } from 'js/views/forms/form/form_views';
 
 export default App.extend({
   channelName: 'modal',
@@ -58,6 +61,8 @@ export default App.extend({
       return;
     }
 
+    const draftModel = new Backbone.Model();
+
     const modal = this.showModal({
       className: 'modal--large',
       headingText: formName,
@@ -74,7 +79,42 @@ export default App.extend({
 
     modal.disableSubmit();
 
+    this.listenTo(draftModel, 'change:updated', (model, updated) => {
+      if (!updated) {
+        modal.getRegion('draftStatus').empty();
+        return;
+      }
+
+      if (modal.getRegion('draftStatus').hasView()) return;
+
+      const draftStatusView = new DraftStatusView({
+        model: draftModel,
+        viewOptions: {
+          className: 'button--icon flex flex-align-center u-margin--r-16',
+          template: hbs`{{far "shield-check"}}`,
+        },
+        position() {
+          const bounds = this.getView().getBounds();
+          return { ...bounds, outerHeight: bounds.outerHeight + 4 };
+        },
+      });
+
+      modal.showChildView('draftStatus', draftStatusView);
+
+      this.listenTo(draftStatusView, {
+        async 'discard:submission'() {
+          await Radio.request(`form${ form.id }`, 'clear:storedSubmission');
+
+          modal.getChildView('body').render();
+          modal.disableSubmit();
+        },
+      });
+    });
+
     this.listenTo(formService, {
+      'update:submission'(updated) {
+        draftModel.set('updated', updated);
+      },
       'success'() {
         modal.destroy();
       },
@@ -84,6 +124,13 @@ export default App.extend({
       'error'() {
         modal.disableSubmit(false);
       },
+    });
+
+    Radio.request(`form${ form.id }`, 'get:storedSubmission').then(({ updated }) => {
+      /* istanbul ignore if: difficult to force stale async render */
+      if (modal.isDestroyed()) return;
+
+      draftModel.set('updated', updated);
     });
 
     return modal;

--- a/src/js/views/globals/modal/modal.hbs
+++ b/src/js/views/globals/modal/modal.hbs
@@ -1,6 +1,7 @@
 <div class="modal__header {{ headerClass }}" data-header-region>
   {{#if headerIcon}}<span class="modal__header-icon">{{fa headerIconType headerIcon}}</span>{{/if}}
   <div class="flex-grow">{{ headingText }}</div>
+  <div data-draft-status-region></div>
   <button class="button--icon flex flex-align-center js-close">{{far "xmark"}}</button>
 </div>
 

--- a/src/js/views/globals/modal/modal_views.js
+++ b/src/js/views/globals/modal/modal_views.js
@@ -62,6 +62,7 @@ const ModalView = View.extend({
   regionClass: ReplaceElRegion,
   regions: {
     header: '[data-header-region]',
+    draftStatus: '[data-draft-status-region]',
     body: {
       el: '[data-body-region]',
       regionClass: PreloadRegion.extend({ timeout: 0 }),

--- a/src/scss/modules/buttons.scss
+++ b/src/scss/modules/buttons.scss
@@ -265,7 +265,8 @@
   transition: color 0.15s linear;
 
   &:hover,
-  &:focus {
+  &:focus,
+  &.is-active {
     color: #{$black-20};
   }
 }

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import formatDate from 'helpers/format-date';
 import { testDate, testDateSubtract } from 'helpers/test-date';
 import { getResource, getRelationship, getErrors } from 'helpers/json-api';
+import { testTs } from 'helpers/test-timestamp';
 
 import { workspaceOne, getWorkspace } from 'support/api/workspaces';
 import { getWorkspacePatient } from 'support/api/workspace-patients';
@@ -88,7 +89,6 @@ context('patient sidebar', function() {
           'formWidget',
           'formModalWidget',
           'readOnlyFormModalWidget',
-          'reportFormModalWidget',
           'formModalWidgetSmall',
           'formModalWidgetLarge',
           'patientMRNIdentifier',
@@ -237,7 +237,7 @@ context('patient sidebar', function() {
       });
 
     cy
-      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
       .wait('@routeWorkspacePatient')
       .wait('@routePrograms')
@@ -412,6 +412,72 @@ context('patient sidebar', function() {
     cy
       .get('.modal--large')
       .should('not.exist');
+
+    cy
+      .get('@patientSidebar')
+      .find('.widgets__form-widget')
+      .contains('Test Modal Form')
+      .click()
+      .wait('@routeFormApp')
+      .wait('@routeFormDefinition');
+
+    cy
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('update:storedSubmission', {
+          familyHistory: 'New typing',
+        });
+      });
+
+    cy
+      .get('.modal--large')
+      .find('.fa-shield-check')
+      .click();
+
+    cy.tick(60000);
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a minute ago');
+
+    cy
+      .iframeStub()
+      .then(iframeStub => {
+        iframeStub.send('update:storedSubmission', {
+          familyHistory: 'More new typing',
+        });
+      });
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('.form__draft-menu')
+      .find('.js-discard')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click()
+      .wait('@routeFormApp');
+
+    cy
+      .get('.modal--large')
+      .find('.fa-shield-check')
+      .should('not.exist');
+
+    cy
+      .get('.modal--large')
+      .find('.js-submit')
+      .should('be.disabled');
+
+    cy
+      .get('.modal--large')
+      .find('.js-close')
+      .first()
+      .click();
 
     cy
       .get('.patient-sidebar')


### PR DESCRIPTION
Closes FE-160

To match the same implementation made for the form app in https://github.com/RoundingWell/app-frontend/pull/1715.

<img width="540" height="165" alt="Screenshot 2026-06-11 at 11 57 26 AM" src="https://github.com/user-attachments/assets/a201a540-67cf-4887-a45e-28b9fecf22ef" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds draft status and discard UI to the patient form modal so users can see when a draft exists and clear it. Addresses FE-160 and matches the form app behavior.

- **New Features**
  - Shows a shield icon in the modal header when a stored submission exists.
  - Initializes draft status on open and listens for live updates; shows last-saved time.
  - Discard from the draft menu asks for confirmation, clears the stored submission, reloads the form, removes the icon, and disables submit.
  - Adds a header region for draft status and supports `.button--icon.is-active` styling.

<sup>Written for commit ea19e244fae6b95ebacb98d87bdd41695d08682b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal forms display a live draft-submission status, initialized when the modal opens
  * Users can discard a draft to reset the form and disable submit until a fresh submission exists

* **Style**
  * Icon buttons show an active-state styling in addition to hover/focus

* **Tests**
  * Integration test added/updated to exercise draft flow (open modal, update draft, verify timestamps, discard, and submit)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->