### PR TITLE
WIP - Action page example

### DIFF
--- a/src/js/apps/patients/patient/action/action_app.js
+++ b/src/js/apps/patients/patient/action/action_app.js
@@ -1,0 +1,340 @@
+import { get } from 'underscore';
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+import dayjs from 'dayjs';
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'marionette';
+
+import App from 'js/base/app';
+import handleErrors from 'js/utils/handle-errors';
+
+import intl from 'js/i18n';
+
+import { SidebarView, MenuView, HeadingView, FooterView } from 'js/views/patients/sidebar/action/action-sidebar_views';
+import { ActionView, ReadOnlyActionView } from 'js/views/patients/sidebar/action/action-sidebar-action_views';
+import { DialerView } from 'js/views/patients/sidebar/action/action-sidebar-dialer_views';
+import { FormLayoutView } from 'js/views/patients/sidebar/action/action-sidebar-forms_views';
+import { CommentFormView } from 'js/views/patients/shared/comments_views';
+import { ActivitiesView, TimestampsView } from 'js/views/patients/sidebar/action/action-sidebar-activity-views';
+import { AttachmentsView } from 'js/views/patients/sidebar/action/action-sidebar-attachments-views';
+
+const LayoutView = View.extend({
+  className: 'patient-action flex-region',
+  template: hbs`
+    <div class="patient-action__header">
+      <div data-heading-region></div>
+      <div data-menu-region></div>
+    </div>
+    <div class="patient-action__content" data-content-region></div>
+    <div class="patient-action__footer" data-footer-region></div>
+  `,
+  regions: {
+    heading: '[data-heading-region]',
+    menu: '[data-menu-region]',
+    content: '[data-content-region]',
+    footer: '[data-footer-region]',
+  },
+});
+
+export default App.extend({
+  setAccess() {
+    const canEdit = !this.action.isFlowDone() && this.action.canEdit();
+    const canDelete = this.action.canDelete();
+
+    this.setState({ canEdit, canDelete });
+  },
+  stateEvents: {
+    'change:canEdit': 'onStateChangeCanEdit',
+    'change:canDelete': 'onStateChangeCanDelete',
+  },
+  onStateChangeCanEdit() {
+    this.showAction();
+    this.showDialer();
+  },
+  onStateChangeCanDelete() {
+    this.showMenu();
+  },
+  onBeforeStart() {
+    this.getRegion().startPreloader();
+  },
+  beforeStart({ actionId, flowId }) {
+    return [
+      Radio.request('entities', 'fetch:actions:model', actionId),
+      flowId && Radio.request('entities', 'fetch:flows:model', flowId),
+      Radio.request('entities', 'fetch:actionEvents:collection', actionId),
+      Radio.request('entities', 'fetch:comments:collection:byAction', actionId),
+      Radio.request('entities', 'fetch:files:collection:byAction', actionId),
+    ];
+  },
+  /* istanbul ignore next: page-level action error handling */
+  onFail(options, error) {
+    if (get(error, ['response', 'status']) === 410) {
+      Radio.request('alert', 'show:error', intl.patients.patient.patientViews.actionNotFound);
+      this.stop();
+      return;
+    }
+
+    handleErrors(error);
+  },
+  onStart(options, action, flow, activity, comments, attachments) {
+    this.patient = options.patient;
+    this.flow = flow || null;
+    this.action = action;
+    this.activityCollection = new Backbone.Collection([...activity.models, ...comments.models]);
+    this.comments = comments;
+    this.attachments = attachments;
+
+    this.setAccess();
+    const currentFlow = this.flow || this.action.getFlow();
+    if (currentFlow) this.listenTo(currentFlow, 'change:_state', this.setAccess);
+
+    this.listenTo(action, {
+      'change:_owner': this.onChangeOwner,
+      'ws:add:comment': this.onWsAddComment,
+      'ws:add:attachment': this.onWsAddAttachment,
+    });
+
+    this.showView(new LayoutView());
+
+    this.showChildView('heading', new HeadingView({ model: this.action }));
+    this.showContent();
+    this.showChildView('footer', new FooterView());
+    this.showMenu();
+    this.showActivity();
+    this.showNewCommentForm();
+    this.showAttachments();
+
+    this.triggerMethod('context:change', {
+      page: 'action',
+      actionId: this.action.id,
+      actionName: this.action.get('name'),
+      flowId: this.flow && this.flow.id,
+      flowName: this.getFlowName(),
+    });
+
+    this.subscribe();
+  },
+  onBeforeStop() {
+    if (!this.action) return;
+
+    this.unsubscribe();
+  },
+  onChangeOwner() {
+    this.setAccess();
+    if (this.isRunning()) this.showAttachments();
+  },
+  onWsAddComment(model) {
+    this.activityCollection.add(model);
+    this.comments.add(model);
+
+    Radio.request('ws', 'add', model);
+  },
+  onWsAddAttachment(model) {
+    this.attachments.add(model);
+
+    Radio.request('ws', 'add', model);
+
+    if (this.attachments.length === 1) this.showAttachments();
+  },
+  showContent() {
+    const actionView = new SidebarView({ model: this.action });
+
+    this.showChildView('content', actionView);
+    this.showAction();
+    this.showForm();
+    this.showDialer();
+  },
+  showAction() {
+    if (!this.getState('canEdit')) {
+      this.showContentView('action', new ReadOnlyActionView({ model: this.action }));
+      return;
+    }
+
+    const actionView = new ActionView({ model: this.action });
+
+    this.listenTo(actionView, {
+      'save': this.onSave,
+    });
+
+    this.showContentView('action', actionView);
+  },
+  onSave({ model }) {
+    this.action.save({ details: model.get('details') });
+  },
+  showMenu() {
+    if (!this.getState('canDelete')) {
+      this.getRegion('menu').empty();
+      return;
+    }
+
+    const menuView = new MenuView({ model: this.action });
+
+    this.listenTo(menuView, 'delete', this.onDelete);
+
+    this.showChildView('menu', menuView);
+  },
+  onDelete() {
+    this.action.destroy({ wait: true })
+      .then(() => {
+        this.navigateAfterDelete();
+      })
+      .catch(({ responseData }) => {
+        Radio.request('alert', 'show:apiError', responseData);
+      });
+  },
+  navigateAfterDelete() {
+    if (this.flow) {
+      Radio.trigger('event-router', 'patient:flow', this.patient.id, this.flow.id);
+      return;
+    }
+
+    Radio.trigger('event-router', 'patient:workflow', this.patient.id);
+  },
+  getFlowName() {
+    return this.flow && this.flow.get('name');
+  },
+  showForm() {
+    if (!this.action.getForm() && !this.action.hasSharing()) return;
+
+    const formView = this.showContentView('form', new FormLayoutView({
+      model: this.action,
+      isShowingForm: this.getOption('isShowingForm'),
+    }));
+
+    this.listenTo(formView, {
+      'click:form': this.onClickForm,
+    });
+  },
+  onClickForm(form) {
+    Radio.trigger('event-router', 'patient:form:action', this.patient.id, form.id, this.action.id);
+  },
+  showDialer() {
+    if (!Radio.request('settings', 'get', 'dialer')) return;
+
+    this.showContentView('dialer', new DialerView({
+      model: this.action,
+      canEdit: this.getState('canEdit'),
+    }));
+  },
+  showActivity() {
+    const activitiesView = new ActivitiesView({
+      collection: this.activityCollection,
+      model: this.action,
+    });
+    const createdEvent = this.activityCollection.find({ event_type: 'ActionCreated' });
+
+    this.listenTo(activitiesView, {
+      'remove:comment': this.onRemoveComment,
+    });
+
+    this.showContentView('activity', activitiesView);
+    this.showFooterView('timestamps', new TimestampsView({ model: this.action, createdEvent }));
+  },
+  showNewCommentForm() {
+    const clinician = Radio.request('bootstrap', 'currentUser');
+
+    const newCommentFormView = this.showFooterView('comment', new CommentFormView({
+      model: Radio.request('entities', 'comments:model', {
+        _action: this.action.getResource(),
+        _clinician: clinician.getResource(),
+      }),
+    }));
+
+    this.listenTo(newCommentFormView, {
+      'post:comment': this.onPostNewComment,
+      'cancel:comment': this.onCancelNewComment,
+    });
+  },
+  onPostNewComment({ model }) {
+    model.set({ created_at: dayjs.utc().format() });
+
+    model.save().then(() => {
+      this.action.addComment(model);
+      Radio.request('ws', 'add', model);
+    });
+
+    this.activityCollection.add(model);
+    this.comments.add(model);
+
+    this.showNewCommentForm();
+  },
+  onCancelNewComment() {
+    this.showNewCommentForm();
+  },
+  onRemoveComment(model) {
+    this.action.removeComment(model);
+
+    Radio.request('ws', 'unsubscribe', model);
+  },
+  showAttachments() {
+    const canUploadAttachments = !!Radio.request('settings', 'get', 'upload_attachments') && this.action.hasAllowedUploads();
+
+    if (!canUploadAttachments && !this.attachments.length) return;
+
+    const attachmentsView = new AttachmentsView({
+      collection: this.attachments,
+      canUploadAttachments,
+      canRemoveAttachments: this.action.canEdit(),
+    });
+
+    this.listenTo(attachmentsView, {
+      'add:attachment': this.onAddAttachment,
+      'remove:attachment': this.onRemoveAttachment,
+    });
+
+    this.showContentView('attachments', attachmentsView);
+  },
+  onAddAttachment(file) {
+    const attachment = this.attachments.add({
+      _actions: [this.action.getResource()],
+      _patient: this.action.getPatient().getResource(),
+      created_at: dayjs.utc().format(),
+    });
+    attachment.upload(file);
+
+    this.listenTo(attachment, {
+      'upload:success': uploadedAttachment => {
+        this.action.addFile(uploadedAttachment);
+        Radio.request('ws', 'add', uploadedAttachment);
+      },
+      'upload:failed': () => {
+        Radio.request('alert', 'show:error', intl.patients.sidebar.actionSidebarApp.uploadError);
+      },
+    });
+  },
+  onRemoveAttachment(model) {
+    model.destroy();
+
+    this.action.removeFile(model);
+
+    Radio.request('ws', 'unsubscribe', model);
+  },
+  getSubscriptionResources() {
+    return [
+      this.action,
+      this.flow,
+      ...this.comments.models,
+      ...this.attachments.models,
+    ].filter(Boolean);
+  },
+  subscribe() {
+    Radio.request('ws', 'subscribe', this.getSubscriptionResources());
+  },
+  unsubscribe() {
+    if (!this.comments || !this.attachments) return;
+
+    Radio.request('ws', 'unsubscribe', this.getSubscriptionResources());
+  },
+  showContentView(name, view, options) {
+    const contentView = this.getView().getChildView('content');
+    const region = contentView.getRegion(name);
+    region.show(view, options);
+    return view;
+  },
+  showFooterView(name, view, options) {
+    const footerView = this.getView().getChildView('footer');
+    const region = footerView.getRegion(name);
+    region.show(view, options);
+    return view;
+  },
+});

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -1,48 +1,49 @@
-import { partial, get, noop } from 'underscore';
+import { get, partial } from 'underscore';
+import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
 import handleErrors from 'js/utils/handle-errors';
 
 import SubRouterApp from 'js/base/subrouterapp';
 
-import DashboardApp from 'js/apps/patients/patient/dashboard/dashboard_app';
-import ArchiveApp from 'js/apps/patients/patient/archive/archive_app';
+// These existing apps stand in for page-oriented replacements during the
+// migration. The PatientApp contract below is the intended workspace shape.
+import WorkflowPageApp from 'js/apps/patients/patient/dashboard/dashboard_app';
+import FlowPageApp from 'js/apps/patients/patient/flow/flow_app';
+import ActionApp from 'js/apps/patients/patient/action/action_app';
+import FormPageApp from 'js/apps/forms/form/form-patient_app';
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
-import ActionSiderbarApp from 'js/apps/patients/sidebar/action-sidebar_app';
 
-import { LayoutView, intl } from 'js/views/patients/patient/patient_views';
+import { LayoutView } from 'js/views/patients/patient/patient_views';
 
 export default SubRouterApp.extend({
   routeScope: ['patientId'],
 
   routeActions() {
     return {
-      'patient:dashboard': partial(this.startList, 'dashboard'),
-      'patient:archive': partial(this.startList, 'archive'),
-      'patient:action': partial(this.startPatientAction, 'dashboard'),
-      'patient:action:archive': partial(this.startPatientAction, 'archive'),
+      'patient:workflow': partial(this.showWorkflow, 'active'),
+      'patient:workflow:closed': partial(this.showWorkflow, 'closed'),
+      'patient:action': this.showPatientAction,
+      'patient:flow': this.showFlow,
+      'patient:flow:action': this.showFlowAction,
+      'patient:form': this.showPatientForm,
+      'patient:form:action': this.showActionForm,
     };
   },
 
   childApps: {
-    dashboard: DashboardApp,
-    archive: ArchiveApp,
-    actionSidebar: ActionSiderbarApp,
-    patient: PatientSidebarApp,
+    workflow: WorkflowPageApp,
+    flow: FlowPageApp,
+    action: ActionApp,
+    form: FormPageApp,
+    patientSidebar: PatientSidebarApp,
   },
 
   currentAppOptions() {
     return {
       region: this.getRegion('content'),
-      patient: this.getOption('patient'),
+      patient: this.patient,
     };
-  },
-
-  onBeforeStartRoute() {
-    if (this.action) {
-      this.action.trigger('editing', false);
-      delete this.action;
-    }
   },
 
   onBeforeStart() {
@@ -50,21 +51,13 @@ export default SubRouterApp.extend({
   },
 
   beforeStart() {
-    const [patientId, actionId] = this.getCurrentRoute().eventArgs;
+    const [patientId] = this.getCurrentRoute().eventArgs;
 
-    return [
-      Radio.request('entities', 'fetch:patients:model', patientId),
-      // the action is a non-aborting prefetch: it warms the cache for the initial
-      // route but its failure must never reject startup or override a newer route —
-      // dispatch (startPatientAction) is the source of truth and handles errors
-      actionId && Radio.request('entities', 'fetch:actions:model', actionId).catch(noop),
-    ];
+    return Radio.request('entities', 'fetch:patients:model', patientId);
   },
 
   /* istanbul ignore next: beforeStart error handling */
   onFail(options, error) {
-    // the action prefetch is non-aborting, so a startup failure is the patient's;
-    // a 410 means the patient is gone
     if (get(error, ['response', 'status']) === 410) {
       Radio.trigger('event-router', 'notFound');
       this.stop();
@@ -74,101 +67,81 @@ export default SubRouterApp.extend({
     handleErrors(error);
   },
 
-  // status-aware action failure handling for the on-demand dispatch fetch
-  failAction(error, patientId) {
-    /* istanbul ignore else: only the 410 path is exercised; others are generic */
-    if (get(error, ['response', 'status']) === 410) {
-      this.showActionNotFound();
-      this.stop();
-      Radio.trigger('event-router', 'patient:dashboard', patientId);
-      return;
-    }
-
-    /* istanbul ignore next: generic error handling */
-    handleErrors(error);
-  },
-
   onStart(options, patient) {
     this.patient = patient;
+    this.contextTrail = new Backbone.Model();
 
-    this.setView(new LayoutView({ model: patient }));
+    this.setView(new LayoutView({
+      model: patient,
+      contextTrail: this.contextTrail,
+    }));
 
-    this.showSidebar();
-
+    this.showPatientSidebar();
     this.startCurrentRoute();
-
     this.showView();
   },
 
-  onStop() {
-    delete this._list;
-    delete this.action;
-  },
-
-  showActionNotFound() {
-    Radio.request('alert', 'show:error', intl.actionNotFound);
-  },
-
-  startList(list) {
-    if (this._list === list) return;
-
-    this._list = list;
-
-    this.startCurrent(list);
-
-    if (this.action) {
-      this.listenToOnce(this.getChildApp(list), 'start', () => {
-        this.action.trigger('editing', true);
-      });
-    }
-  },
-
-  startPatientAction(list, patientId, actionId) {
-    const action = Radio.request('entities', 'actions:model', actionId);
-    this.action = action;
-
-    this.startList(list);
-
-    this.getChildApp('actionSidebar').stop();
-
-    if (action.isCached()) {
-      this.showActionSidebar(action, list, patientId);
-      return;
-    }
-
-    // not cached when its route coalesced into a still-loading PatientApp, the
-    // prefetch failed, or the action is absent from the list: fetch it on demand
-    // rather than reporting it missing
-    Radio.request('entities', 'fetch:actions:model', actionId)
-      .then(() => this.showActionSidebar(action, list, patientId))
-      .catch(error => {
-        // suppress when a newer action route superseded this one (or the app stopped)
-        if (this.action !== action) return;
-
-        this.failAction(error, patientId);
-      });
-  },
-
-  showActionSidebar(action, list, patientId) {
-    // a newer action route may have superseded this one while it loaded
-    if (this.action !== action) return;
-
-    /* istanbul ignore next: defensive — app stopped mid-fetch */
-    if (!this.isRunning()) return;
-
-    const sidebarApp = this.getChildApp('actionSidebar');
-
-    Radio.request('sidebar', 'start', sidebarApp, { action });
-
-    // re-dispatched routes must not accumulate close handlers on the singleton
-    this.stopListening(sidebarApp, 'close');
-    this.listenTo(sidebarApp, 'close', () => {
-      Radio.trigger('event-router', `patient:${ list }`, patientId);
+  showWorkflow(mode) {
+    this.showPage('workflow', { mode }, {
+      page: 'workflow',
+      mode,
     });
   },
 
-  showSidebar() {
-    this.startChildApp('patient', {
+  showPatientAction(patientId, actionId) {
+    this.showPage('action', { actionId }, {
+      page: 'action',
+      actionId,
+    });
+  },
+
+  showFlow(patientId, flowId) {
+    this.showPage('flow', { flowId }, {
+      page: 'flow',
+      flowId,
+    });
+  },
+
+  showFlowAction(patientId, flowId, actionId) {
+    this.showPage('action', { actionId, flowId }, {
+      page: 'action',
+      flowId,
+      actionId,
+    });
+  },
+
+  showPatientForm(patientId, formId) {
+    this.showPage('form', { formId }, {
+      page: 'form',
+      formId,
+    });
+  },
+
+  showActionForm(patientId, formId, actionId) {
+    this.showPage('form', { formId, actionId }, {
+      page: 'form',
+      formId,
+      actionId,
+    });
+  },
+
+  showPage(appName, options, context) {
+    this.contextTrail.set(context);
+
+    const pageApp = this.getChildApp(appName);
+
+    this.stopListening(pageApp, 'context:change');
+    this.listenTo(pageApp, 'context:change', this.updateContextTrail);
+
+    this.startCurrent(appName, options);
+  },
+
+  updateContextTrail(context) {
+    this.contextTrail.set(context);
+  },
+
+  showPatientSidebar() {
+    this.startChildApp('patientSidebar', {
       region: this.getRegion('sidebar'),
       patient: this.patient,
     });

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -1,8 +1,10 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
+
+import handleErrors from 'js/utils/handle-errors';
 
 import RouterApp from 'js/base/routerapp';
 
-import FlowApp from 'js/apps/patients/patient/flow/flow_app';
 import PatientApp from 'js/apps/patients/patient/patient_app';
 import WorklistApp from 'js/apps/patients/worklist/worklist_app';
 import ScheduleApp from 'js/apps/patients/schedule/schedule_app';
@@ -11,7 +13,6 @@ export default RouterApp.extend({
   routerAppName: 'PatientsApp',
 
   childApps: {
-    flow: FlowApp,
     patient: PatientApp,
     ownedBy: WorklistApp,
     forTeam: WorklistApp,
@@ -27,59 +28,82 @@ export default RouterApp.extend({
       route: 'worklist/:id',
       meta: { isList: true },
     },
-    'patient:dashboard': {
-      action: 'showPatient',
-      route: 'patient/dashboard/:id',
-    },
-    'patient:archive': {
-      action: 'showPatient',
-      route: 'patient/archive/:id',
-    },
-    'patient:action': {
-      action: 'showPatient',
-      route: 'patient/:id/action/:id',
-    },
-    'patient:action:archive': {
-      action: 'showPatient',
-      route: 'patient/archive/:id/action/:id',
-    },
-    'flow': {
-      action: 'showFlow',
-      route: 'flow/:id',
-    },
-    'flow:details': {
-      action: 'showFlow',
-      route: 'flow/:id/details',
-    },
-    'flow:action': {
-      action: 'showFlow',
-      route: 'flow/:id/action/:id',
-    },
     'schedule': {
       action: 'showSchedule',
       route: 'schedule',
       meta: { isList: true },
     },
-  },
 
-  onBeforeAppRoute({ event, eventArgs: [patientId] }) {
-    // if routing to flow route, currentPatientId is set by flow_app's onStart()
-    if (event.startsWith('flow')) return;
+    // Canonical patient-workspace routes. Every route starts the same PatientApp;
+    // PatientApp dispatches the page while its patient shell remains mounted.
+    'patient:workflow': {
+      action: 'showPatient',
+      route: [
+        'patient/:id/workflow',
+        'patient/dashboard/:id',
+      ],
+    },
+    'patient:workflow:closed': {
+      action: 'showPatient',
+      route: [
+        'patient/:id/workflow/closed',
+        'patient/archive/:id',
+      ],
+    },
+    'patient:action': {
+      action: 'showPatient',
+      route: [
+        'patient/:id/action/:id',
+        'patient/archive/:id/action/:id',
+      ],
+    },
+    'patient:flow': {
+      action: 'showPatient',
+      route: 'patient/:id/flow/:id',
+    },
+    'patient:flow:action': {
+      action: 'showPatient',
+      route: 'patient/:id/flow/:id/action/:id',
+    },
+    'patient:form': {
+      action: 'showPatient',
+      route: 'patient/:id/form/:id',
+    },
+    'patient:form:action': {
+      action: 'showPatient',
+      route: 'patient/:id/form/:id/action/:id',
+    },
 
-    // determines if dialer patient buttons are shown or hidden
-    const isPatientRoute = event.startsWith('patient');
-    Radio.trigger('dialer', 'change:currentPatientId', isPatientRoute ? patientId : null);
+    // Legacy routes without a patient ID cannot be aliases. Their handlers
+    // resolve the patient and replace the URL with its canonical equivalent.
+    'flow': {
+      action: 'redirectLegacyFlow',
+      route: [
+        'flow/:id',
+        'flow/:id/details',
+      ],
+    },
+    'flow:action': {
+      action: 'redirectLegacyFlowAction',
+      route: 'flow/:id/action/:id',
+    },
+    'form:patientAction': {
+      action: 'redirectLegacyActionForm',
+      route: 'patient-action/:id/form/:id',
+    },
   },
 
   onStop() {
+    this.clearCurrentPatient();
+  },
+
+  clearCurrentPatient() {
     Radio.trigger('dialer', 'change:currentPatientId', null);
   },
 
-  showPatient(patientId) {
-    this.startRoute('patient', { patientId });
-  },
-
   showPatientsWorklist(worklistId, clinicianId) {
+    this.clearCurrentPatient();
+
     const worklistsById = {
       'owned-by': 'ownedBy',
       'shared-by': 'forTeam',
@@ -96,11 +120,66 @@ export default RouterApp.extend({
     this.startCurrent(worklistsById[worklistId], { worklistId, clinicianId });
   },
 
-  showFlow(flowId) {
-    this.startRoute('flow', { flowId });
+  showSchedule() {
+    this.clearCurrentPatient();
+    this.startCurrent('schedule');
   },
 
-  showSchedule() {
-    this.startCurrent('schedule');
+  showPatient(patientId) {
+    Radio.trigger('dialer', 'change:currentPatientId', patientId);
+    this.startRoute('patient', { patientId });
+  },
+
+  redirectLegacyFlow(flowId) {
+    this.resolveLegacyFlow('patient:flow', flowId);
+  },
+
+  redirectLegacyFlowAction(flowId, actionId) {
+    this.resolveLegacyFlow('patient:flow:action', flowId, actionId);
+  },
+
+  redirectLegacyActionForm(actionId, formId) {
+    const sourceRoute = this.getCurrentRoute();
+
+    Radio.request('entities', 'fetch:actions:model', actionId)
+      .then(action => {
+        const patientId = action.getPatient().id;
+        this.redirectRoute(sourceRoute, 'patient:form:action', patientId, formId, actionId);
+      })
+      .catch(error => this.failLegacyRoute(sourceRoute, error));
+  },
+
+  resolveLegacyFlow(event, flowId, actionId) {
+    const sourceRoute = this.getCurrentRoute();
+
+    Radio.request('entities', 'fetch:flows:model', flowId)
+      .then(flow => {
+        const patientId = flow.getPatient().id;
+        const routeArgs = actionId ?
+          [patientId, flowId, actionId] :
+          [patientId, flowId];
+
+        this.redirectRoute(sourceRoute, event, ...routeArgs);
+      })
+      .catch(error => this.failLegacyRoute(sourceRoute, error));
+  },
+
+  redirectRoute(sourceRoute, event, ...eventArgs) {
+    // Ignore a resolver that completed after the user navigated elsewhere.
+    if (this.getCurrentRoute() !== sourceRoute) return;
+
+    this.replaceRoute(event, ...eventArgs);
+    Radio.trigger('event-router', event, ...eventArgs);
+  },
+
+  failLegacyRoute(sourceRoute, error) {
+    if (this.getCurrentRoute() !== sourceRoute) return;
+
+    if (get(error, ['response', 'status']) === 410) {
+      Radio.trigger('event-router', 'notFound');
+      return;
+    }
+
+    handleErrors(error);
   },
 });


### PR DESCRIPTION
Not looking to merge this, but showing the refactor shape of moving action to a full page and what that changes in the routing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the Action view to a full page in the Patient workspace and centralizes patient routing under the PatientApp, with legacy routes redirected to canonical patient URLs. This sets the pattern for page-based patient views (workflow, flow, action, form) while keeping the patient shell mounted.

- **New Features**
  - Added Action page app with header/menu/content/footer layout.
  - Read-only vs edit mode, delete gating, and dialer support.
  - Activity stream merges events and comments; new comment form with real-time add.
  - Attachments upload/remove with live updates; WebSocket subscribe/unsubscribe.
  - Context updates via `context:change` for breadcrumbs and navigation.
  - Action delete navigates back to the flow or the patient workflow; handles 410 with user feedback.

- **Routing**
  - Patient routes consolidated: workflow (active/closed), flow, action, and form all run inside PatientApp.
  - Legacy routes (`/flow/:id`, flow action, and action form) resolve the patient and redirect to canonical patient routes.
  - PatientApp manages a lightweight context model and the patient sidebar; removed action sidebar usage.
  - Dialer patient context is now set/cleared based on active patient routes.

<sup>Written for commit a883268cb03db489a7a73527c0d550e8be425141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

