### PR TITLE
docs(ai): strengthen repo guidance and entities docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Load a scoped overlay only when your change touches `scripts/**` or `packages/ca
 - Follow Marionette patterns: define `ui`, prefer `triggers` and `triggerMethod`, and keep DOM mutation scoped to the view.
 - Route data access through `src/js/entities-service/**`.
 - Import SCSS from the module that renders the view. Use BEM naming and do not style `.js-*` hooks.
-- Prefer this import order: third-party libraries, SCSS or CSS modules, shared utilities and base classes, entities and service modules, apps and controllers, views and components, then templates and final local style overrides.
+- Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
 - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
 - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
 - Component specs live in `src/**/*.cy.js`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Load a scoped overlay only when your change touches `scripts/**` or `packages/ca
 - Follow Marionette patterns: define `ui`, prefer `triggers` and `triggerMethod`, and keep DOM mutation scoped to the view.
 - Route data access through `src/js/entities-service/**`.
 - Import SCSS from the module that renders the view. Use BEM naming and do not style `.js-*` hooks.
-- Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
+- Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors, regions, and components, views, then templates and view-local SCSS last.
 - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
 - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
 - Component specs live in `src/**/*.cy.js`.
@@ -28,6 +28,7 @@ Load a scoped overlay only when your change touches `scripts/**` or `packages/ca
 ## Reviews
 
 - Put findings first.
+- Do not flag intentional choices: the Backbone/Marionette stack, synchronous string-based Radio requests, underscore over native, and JavaScript over TypeScript (see the Intentional Choices section in `/AGENTS.md`).
 - Prioritize repo-specific risks first: `scripts/**`, `packages/care-ops-five9/sdk/**`, `src/js/entities-service/**`, Marionette view patterns, and template or SCSS coupling.
 - Keep review output concise and operational.
 - Avoid low-signal comments on tiny mechanical or pure copy-only diffs unless a repo-specific risk is involved.

--- a/.github/copilot.yaml
+++ b/.github/copilot.yaml
@@ -9,7 +9,7 @@ pull_request_review:
         - Follow Marionette patterns: define `ui`, prefer `triggers` and `triggerMethod`, and keep DOM mutation scoped to the view.
         - Route data access through `src/js/entities-service/**`.
         - Import SCSS from the module that renders the view. Use BEM naming and do not style `.js-*` hooks.
-        - Prefer this import order: third-party libraries, SCSS or CSS modules, shared utilities and base classes, entities and service modules, apps and controllers, views and components, then templates and final local style overrides.
+        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
         - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
         - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
         - Component specs live in `src/**/*.cy.js`.
@@ -32,7 +32,7 @@ code_generation:
         - Use Marionette patterns: define `ui`, prefer `triggers`, and use `triggerMethod`.
         - Put data fetching in `src/js/entities-service/**`.
         - Import SCSS from the rendering module and use BEM naming without styling `.js-*` hooks.
-        - Prefer this import order: third-party libraries, SCSS or CSS modules, shared utilities and base classes, entities and service modules, apps and controllers, views and components, then templates and final local style overrides.
+        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
         - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
         - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
         - Component specs live in `src/**/*.cy.js`.

--- a/.github/copilot.yaml
+++ b/.github/copilot.yaml
@@ -9,7 +9,7 @@ pull_request_review:
         - Follow Marionette patterns: define `ui`, prefer `triggers` and `triggerMethod`, and keep DOM mutation scoped to the view.
         - Route data access through `src/js/entities-service/**`.
         - Import SCSS from the module that renders the view. Use BEM naming and do not style `.js-*` hooks.
-        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
+        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors, regions, and components, views, then templates and view-local SCSS last.
         - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
         - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
         - Component specs live in `src/**/*.cy.js`.
@@ -20,6 +20,7 @@ pull_request_review:
         - Prioritize repo-specific risks first: `scripts/**`, `packages/care-ops-five9/sdk/**`, `src/js/entities-service/**`, Marionette view patterns, and template or SCSS coupling.
         - Keep review comments short, direct, and evidence-based. Explain only when needed.
         - Avoid low-signal comments on tiny mechanical or pure copy-only diffs unless a repo-specific risk is involved.
+        - Do not flag intentional choices: the Backbone/Marionette stack, synchronous string-based Radio requests, underscore over native, and JavaScript over TypeScript (see the Intentional Choices section in `/AGENTS.md`).
 
 # Local development assistance
 code_generation:
@@ -32,7 +33,7 @@ code_generation:
         - Use Marionette patterns: define `ui`, prefer `triggers`, and use `triggerMethod`.
         - Put data fetching in `src/js/entities-service/**`.
         - Import SCSS from the rendering module and use BEM naming without styling `.js-*` hooks.
-        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors and regions and components, views, then templates and view-local SCSS last.
+        - Prefer this import order: third-party libraries, shared SCSS modules, shared utilities and i18n, base classes, entities and service modules, apps and controllers, behaviors, regions, and components, views, then templates and view-local SCSS last.
         - Keep Handlebars spacing tight: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
         - Keep template attribute order predictable: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
         - Component specs live in `src/**/*.cy.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Load a scoped overlay only when the task touches:
 - `scripts/**` -> `scripts/AGENTS.md`
 - `packages/care-ops-five9/**` -> `packages/care-ops-five9/AGENTS.md`
 - routing infrastructure (`src/js/base/routerapp.js`, `src/js/base/subrouterapp.js`) or application route definitions -> `src/js/base/routing.md`
+- data access, entities, or `src/js/entities-service/**` -> `src/js/entities-service/README.md`
 
 ## Instruction Priority
 
@@ -37,6 +38,25 @@ Load a scoped overlay only when the task touches:
 - Keep feature flags easy to remove. Prefer guard-clause style branching.
 - Reuse existing utilities and workspace packages before adding dependencies.
 - Use i18n keys that match the repo's existing formatjs-style naming.
+
+## Intentional Choices — Do Not Propose Changing or Flag in Review
+
+These are deliberate, settled decisions. Do not suggest "modernizing" them in
+generated code, and do not flag them as issues, tech debt, or risks in review.
+
+- The Backbone + Marionette stack is the permanent direction. The team
+  maintains `backbone.marionette` and `backbone.radio` upstream. Never propose
+  a framework migration or describe the stack as legacy.
+- `backbone.radio` stays synchronous. Do not propose Promise normalization,
+  async middleware, or typed wrappers around Radio.
+- String-based Radio request names (e.g. `'fetch:actions:model'`) are
+  intentional: they keep test stubbing and console debugging trivial. Do not
+  propose typed or constant-based replacements.
+- Underscore is the default data-manipulation API, including where native
+  equivalents exist (see `src/js/README.md`). Do not flag underscore usage as
+  outdated or suggest native one-for-one rewrites.
+- JavaScript, not TypeScript, per the guardrails above. Do not flag missing
+  type annotations.
 
 ## Communication
 
@@ -82,6 +102,14 @@ Load a scoped overlay only when the task touches:
 - Review is most useful for non-trivial diffs, risky refactors, shared package changes, release or deploy changes, and behavior changes that may not be caught by lint.
 - Review is less useful for tiny mechanical edits, pure copy changes, or changes where tests and lint already provide the meaningful signal.
 
+## Commits and Pull Requests
+
+- Use conventional-commit subjects, `type(scope): summary` with the scope
+  optional — e.g. `feat`, `fix`, `chore`, `refactor`, `perf`, `docs`, `test`,
+  `build`, `ci`, `revert`.
+- Keep PR descriptions short and operational, consistent with the
+  Communication rules above.
+
 ## Validation
 
 - Use `npm run lint` for code changes that affect files covered by the repo lint setup.
@@ -112,3 +140,4 @@ Load a scoped overlay only when the task touches:
 - Copilot prompt surfaces intentionally inline a small subset of rules that they must see locally, such as import order and review-output constraints.
 - Prefer deleting stale AI docs over maintaining low-signal indexes or checklists.
 - This repo intentionally does not maintain a dedicated AI-doc audit script. Keep AI docs accurate through same-patch updates, targeted repo inspection, AI review when warranted, and human review.
+- When an AI review comment is noise or an agent makes a repo-specific mistake these docs should have prevented, patch the doc that failed in the next related change rather than letting the failure repeat.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,14 +47,16 @@ Load a scoped overlay only when the task touches:
 
 ## Template, Style, and Import Conventions
 
-- Prefer this import order when adding or reorganizing imports:
+- Prefer this import order when adding or reorganizing imports (canonical list; the worked example is in `src/js/README.md`):
   1. polyfills and third-party libraries
-  2. SCSS or CSS modules
-  3. shared utilities and base classes
-  4. entities and service modules
-  5. apps and controllers
-  6. views and components
-  7. templates and final local style overrides
+  2. shared SCSS modules
+  3. shared utilities and i18n
+  4. base classes
+  5. entities and service modules
+  6. apps and controllers
+  7. behaviors, regions, and components
+  8. views
+  9. templates, then view-local SCSS last
 - Handlebars spacing should stay tight and consistent: `{{ value }}` and `{{#if}}{{else}}{{/if}}`.
 - Use `{{{ }}}` only for trusted HTML.
 - Keep attribute order predictable in templates: class, id or name, src or for or type or href or value, title or alt, role or aria-*, then boolean attributes.
@@ -83,21 +85,25 @@ Load a scoped overlay only when the task touches:
 ## Validation
 
 - Use `npm run lint` for code changes that affect files covered by the repo lint setup.
-- Run targeted Cypress coverage commands when UI behavior changes:
-  - `npm run coverage:component`
-  - `npm run coverage:e2e`
-  - `npm run coverage`
+- Iterate with single specs; they are much faster than the full suites:
+  - Component: `npx cypress run --component --spec src/js/base/routerapp.cy.js`
+  - E2E: build and serve the test app once (`npm run build -- --mode test`, then `npx vite preview -m test` in the background to serve on port 8090), then `npx cypress run --spec test/integration/<area>/<spec>.js`
+  - Do not pass `--spec` through `npm run coverage:e2e`; npm appends it after the script's `exit`, so the full suite still runs unfiltered and the script then exits 1 (`exit: too many arguments`).
+- Before claiming UI behavior is validated, run the full suite relevant to the change:
+  - `npm run coverage:component` for component behavior
+  - `npm run coverage:e2e` for app flows
+  - `npm run coverage` runs both; do not stack it with the individual commands.
 - Never claim validation passed unless you actually ran the command.
 
 ## Common Commands
 
-- `npm run dev`
-- `npm run test`
+- `npm run dev` — blocking dev server; not a validation step.
+- `npm run test` — opens the interactive Cypress runner; never run it non-interactively (it hangs). Agents validate with the headless commands below instead.
 - `npm run lint`
-- `npm run coverage:component`
-- `npm run coverage:e2e`
-- `npm run coverage`
-- `npm run stop`
+- `npm run coverage:component` — headless, agent-safe.
+- `npm run coverage:e2e` — headless, agent-safe; builds and serves the test app itself.
+- `npm run coverage` — full suite, slow; headless.
+- `npm run stop` — kills vite and clears its cache.
 
 ## AI Docs Maintenance
 

--- a/packages/care-ops-five9/CLAUDE.md
+++ b/packages/care-ops-five9/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -3,6 +3,7 @@
 ## Import Order
 
 When importing dependencies we loosely follow some general rules and strictly follow others.
+The canonical ordering list lives in [`/AGENTS.md`](../../AGENTS.md); this is the worked example.
 ```js
 // 3rd party dependencies generally in order or "lowest-level" dependency
 import { extend } from 'underscore'; // underscore is a dependency of marionette so it goes first.
@@ -19,6 +20,9 @@ import intl from 'js/i18n';
 
 // Base classes
 import App from 'js/base/app';
+
+// Entities and service modules
+import { FooEntity } from 'js/entities-service/entities/foo';
 
 // Apps (typically alphabetically)
 import ChildApp from 'js/apps/foo/child_app';

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -22,7 +22,7 @@ import intl from 'js/i18n';
 import App from 'js/base/app';
 
 // Entities and service modules
-import { FooEntity } from 'js/entities-service/entities/foo';
+import { Model as PatientModel } from 'js/entities-service/entities/patients';
 
 // Apps (typically alphabetically)
 import ChildApp from 'js/apps/foo/child_app';

--- a/src/js/entities-service/README.md
+++ b/src/js/entities-service/README.md
@@ -1,7 +1,104 @@
-# Entities & Entities Services
+# Entities & Entity Services
 
-An entity is a generic term for Models and/or Collections.
-All interfacing with the server should be done through the entities or the entity services.
+All interfacing with the server goes through this layer. Consumers never fetch
+directly — they make requests on the `entities` Radio channel and receive
+Backbone models and collections.
 
-The entity services are a service class specifically for gathering a particular entity to some set specifications.
-Once the entity has been requested interface with the entity directly for fetching or posting data.
+## Architecture
+
+Two layers per entity type:
+
+- **`entities/<type>.js`** — the data definitions. Exports `_Model` (domain
+  logic: getters, save helpers, validation), `Model` (`Store(_Model, TYPE)` —
+  deduplicated by `type` + `id`, so two fetches of the same resource share one
+  instance), and `Collection`.
+- **`<type>.js`** (this directory) — the service. Extends
+  `js/base/entity-service`, binds the entity definitions via `Entity`, maps
+  Radio requests to fetch methods, and is instantiated once as a singleton.
+  `index.js` imports every service (alphabetically) to register them.
+
+## Radio requests
+
+Channel: `entities`. Naming convention:
+
+- `'<type>:model'` / `'<type>:collection'` — instantiate without fetching
+  (`getModel` accepts an id or an attrs object).
+- `'fetch:<type>:model'` / `'fetch:<type>:collection'` — fetch by id / fetch a list.
+- `'fetch:<type>:collection:by<Parent>'` — custom endpoint variants defined on
+  the service (e.g. `'fetch:actions:collection:byFlow'` in `actions.js`).
+
+Base verbs available on every service (`js/base/entity-service.js`):
+`getModel`, `getCollection`, `fetchModel`, `fetchCollection`, `fetchBy(url)`,
+plus the cached variants `fetchModelCache`, `fetchCollectionCache`, and
+`fetchByCache`. All `fetch*` methods return promises.
+
+Typical consumption from an app:
+
+```js
+beforeStart() {
+  const [patientId] = this.getCurrentRoute().eventArgs;
+  return [
+    Radio.request('entities', 'fetch:patients:model', patientId),
+    Radio.request('entities', 'fetch:actions:collection:byPatient', { patientId }),
+  ];
+}
+```
+
+## JSON:API parsing
+
+`js/base/jsonapi-mixin.js` flattens JSON:API resources onto model attributes:
+
+- `data.attributes` plus `data.id` become plain attributes.
+- `data.meta.*` and `data.relationships.*` become `_underscored_key` attributes
+  (relationship `patient` → `_patient`). Has-many relationships parse to arrays
+  of `{ id, type }` refs; has-one keeps the raw `{ id, type }` data.
+- Dereference a has-one ref with `model.getRelationship('_patient')`, which
+  returns the shared instance from the Store.
+- `included` resources are written into the Store on parse, so fetching an
+  action with `include=flow` also populates the flow model.
+- Saving relationships is explicit: `model.save(attrs, { relationships })` with
+  values built by `toRelation(entity)`. Plain `save(attrs)` sends attributes only.
+
+## Caching (opt-in, stale-while-revalidate)
+
+Only the `fetch*Cache` methods cache; the default `fetch*` methods are always
+fresh. The cached variants resolve immediately with the IndexedDB copy when one
+exists, then refetch in the background (background failures are swallowed) so
+fresh data streams into the shared Store instances. Cache keys combine user id,
+workspace id, and the canonical request URL (`js/base/cache/entity-cache.js`);
+entries expire after 7 days and per-user partitions are pruned on auth changes.
+
+- `isWorkspaceScoped: true` is the service default — set it to `false` for
+  entities whose responses don't vary by workspace, or pass
+  `cacheScope: 'user'` per request for mixed-scope entities.
+- A model parsed from cache reports `model.isCached()`.
+
+## Checklist: adding an entity
+
+1. `entities/<type>.js` — define and export `_Model`,
+   `Model = Store(_Model, TYPE)`, and `Collection`.
+2. `<type>.js` — service extending `js/base/entity-service` with `Entity` and
+   `radioRequests` following the naming convention above.
+3. Register the service with an import in `index.js` (alphabetical).
+4. Test support — add `test/support/api/<type>.js` with `get<Type>` /
+   `route<Type>` helpers composed from `helpers/json-api`, and import it in
+   `test/support/e2e.js`.
+
+## Common mistakes
+
+- Fetching outside this layer. Raw `fetch()` or ad hoc XHR misses auth and
+  workspace headers, request dedup, and error handling — Backbone sync is
+  globally routed through `js/base/fetch` (`js/base/backbone-fetch.js`), so
+  always go through Backbone entities. For new endpoints, add a service method
+  and Radio request rather than calling `.fetch()` from apps or views, so the
+  endpoint stays discoverable and can adopt caching.
+- Mutating Store-shared instances casually. Models are deduplicated by
+  `type` + `id` — a `set()` is visible to every consumer of that resource.
+- Assuming `fetch*Cache` data is fresh. It resolves with up-to-7-day-old data
+  and refreshes silently in the background; refresh failures don't surface.
+- Forgetting `{ relationships }` on save and expecting relationship changes to
+  persist.
+- Reading relationship attrs without the underscore prefix
+  (`get('_patient')`, not `get('patient')`).
+- Adding a service file but not importing it in `index.js` — the Radio
+  requests never register.

--- a/test/README.md
+++ b/test/README.md
@@ -95,7 +95,7 @@ Fixtures should be json files loaded in `test/fixtures/`.
 
 ## Composing APIs
 
-In Cypress, API routes are setup in `test/support/api/`. Each added file must be listed in `test/support/index.js`.
+In Cypress, API routes are setup in `test/support/api/`. Each added file must be imported in `test/support/e2e.js`.
 API's are organized by model and collection requests. Multiple versions of the same route might be added to support different scenarios. For instance both a check-in and a clinician response share the same API, but return different data depending on what is requested from the `id`. Each route follows the same format so that in practice the data can be mutated for a particular test scenario.
 
 ```js


### PR DESCRIPTION
Closes FE-164

## What
- Clarify safe AI execution: interactive versus headless commands, targeted Cypress iteration, full-suite validation, and the `coverage:e2e` argument limitation.
- Record canonical import and commit conventions plus settled architectural choices for Backbone/Marionette, Radio, Underscore, and JavaScript across the root and Copilot guidance.
- Add a verified entities-service reference covering Radio requests, JSON:API parsing, Store identity, caching, entity creation, common mistakes, and Cypress API support registration.
- Add scoped `CLAUDE.md` symlinks for `scripts/**` and `packages/care-ops-five9/**`.

## Why
The AI documentation had command guidance that could cause blocking or unnecessarily broad validation, duplicated import guidance that had drifted, and too little detail around the entities-service boundary. Review tools also repeatedly suggested changes to intentional repository architecture because those decisions were not recorded explicitly.

## Scope
Impacted documentation and agent surfaces:
- `AGENTS.md`
- `.github/copilot-instructions.md`
- `.github/copilot.yaml`
- `src/js/README.md`
- `src/js/entities-service/README.md`
- `test/README.md`
- scoped Claude overlays under `scripts/` and `packages/care-ops-five9/`

No application runtime, form bundle, shared package API, Cypress configuration, npm script behavior, or global production behavior changes.

## Deployment Impact
No forms or bundles need redeploy. No deployment beyond the normal documentation-only application merge is required.

## Testing
- Ran `git diff --check origin/develop...HEAD`.
- Reviewed the complete branch diff against `origin/develop`.
- Verified Cypress spec patterns and preview port against `cypress.config.mjs` and `vite.config.js`.
- Verified the shell behavior when `--spec` is appended to `npm run coverage:e2e`.
- Verified entities-service documentation against the service, JSON:API, model, collection, fetch, cache, registration, and Cypress support implementations.
- Verified both scoped `CLAUDE.md` files are committed symlinks to their local `AGENTS.md` overlays.
- Cypress suites were not run because the changes are documentation and symlink updates only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guides for import ordering, entity service architecture, and Cypress testing procedures.
  * Added intentional design pattern documentation for the framework stack.

* **Chores**
  * Updated AI assistant configuration and guidance files.
  * Standardized documentation references across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->