### PR TITLE
feat(ws): use connect tokens for websocket auth

### DIFF
--- a/src/js/services/ws.cy.js
+++ b/src/js/services/ws.cy.js
@@ -8,6 +8,26 @@ import WSService from './ws';
 let service;
 const clientKey = 'clientKey';
 const workspace = 'workspaceId';
+const endpoint = 'ws://cypress-websocket/ws';
+
+function getWsResponse(token, options = {}) {
+  return {
+    statusCode: 200,
+    body: {
+      data: {
+        is_enabled: true,
+        endpoint,
+        authentication: {
+          type: 'connect-token',
+          token,
+          query_parameter: 'connect_token',
+          expires_in: 60,
+        },
+        ...options,
+      },
+    },
+  };
+}
 
 Cypress.Commands.add('startService', () => {
   const startStub = cy.stub().as('startService');
@@ -27,20 +47,16 @@ context('WS Service', function() {
     Radio.reply('workspace', 'current', { id: workspace });
     Radio.reply('auth', 'getToken', () => 'Bearer token');
 
+    let tokenId = 0;
+
     cy
-      .intercept('GET', '/api/websockets', {
-        statusCode: 200,
-        body: {
-          data: {
-            is_enabled: true,
-            endpoint: 'ws://cypress-websocket/ws',
-          },
-        },
+      .intercept('GET', '/api/websockets', req => {
+        tokenId += 1;
+        req.reply(getWsResponse(`connect-token-${ tokenId }`));
       })
       .as('websocketsApi');
 
-    const url = 'ws://cypress-websocket/ws';
-    cy.mockWs(url);
+    cy.mockWs(endpoint);
     service = new WSService();
   });
 
@@ -579,12 +595,58 @@ context('WS Service', function() {
       });
   });
 
-  specify('auth token added to websocket URL', function() {
+  specify('websocket config request includes normal auth', function() {
+    cy.startService();
+
+    cy
+      .wait('@websocketsApi')
+      .then(({ request }) => {
+        expect(request.headers.authorization).to.equal('Bearer token');
+        expect(request.headers.workspace).to.equal(workspace);
+        expect(request.headers['client-key']).to.equal(clientKey);
+      });
+  });
+
+  specify('connect token added to websocket URL', function() {
     cy
       .startService()
       .then(() => {
-        expect(service.url).to.be.instanceOf(URL);
-        expect(service.url.searchParams.get('auth')).to.equal('Bearer token');
+        const url = new URL(service.ws.url);
+
+        expect(url.searchParams.get('connect_token')).to.equal('connect-token-1');
+        expect(url.toString()).to.not.include('Bearer');
+      });
+  });
+
+  specify('reconnecting fetches a fresh connect token', function() {
+    const channel = Radio.channel('ws');
+
+    cy
+      .startService()
+      .then(() => {
+        channel.request('subscribe', { id: 'foo', type: 'bar' });
+        service.ws.close();
+      });
+
+    cy
+      .get('@startService')
+      .should('be.calledTwice')
+      .then(() => {
+        const url = new URL(service.ws.url);
+
+        expect(url.searchParams.get('connect_token')).to.equal('connect-token-2');
+      });
+
+    cy
+      .get('@websocketsApi.all')
+      .should('have.length', 2);
+  });
+
+  specify('websocket auth does not use Sec-WebSocket-Protocol', function() {
+    cy
+      .startService()
+      .then(() => {
+        expect(service.ws.protocol).to.equal('');
       });
   });
 });
@@ -602,7 +664,7 @@ context('WS Service - Disabled', function() {
         body: {
           data: {
             is_enabled: false,
-            endpoint: 'ws://cypress-websocket/ws',
+            endpoint,
           },
         },
       })

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -41,29 +41,26 @@ export default App.extend({
   },
 
   getUrl() {
-    if (this.url) return this.url;
-
     return fetcher('/api/websockets')
       .then(handleJSON)
       .then(({ data }) => {
         if (!data.is_enabled) return;
-        this.url = new URL(data.endpoint);
-        return this.url;
+        const { token, query_parameter: queryParameter } = data.authentication;
+
+        const url = new URL(data.endpoint);
+        url.searchParams.set(queryParameter, token);
+        return url;
       });
   },
 
   beforeStart() {
-    return [
-      Radio.request('auth', 'getToken'),
-      this.getUrl(),
-    ];
+    return this.getUrl();
   },
 
-  onStart({ data }, token) {
+  onStart({ data }, url) {
     /* istanbul ignore next: Essentially avoid offline */
-    if (!token || !this.url) return;
-    this.url.searchParams.set('auth', token);
-    this.ws = new WebSocket(this.url.toString());
+    if (!url) return;
+    this.ws = new WebSocket(url.toString());
     this.ws.addEventListener('open', this.onOpen.bind(this, data));
     this.ws.addEventListener('close', this.onClose.bind(this));
     this.ws.addEventListener('message', this.onMessage.bind(this));

--- a/test/support/defaults.js
+++ b/test/support/defaults.js
@@ -40,6 +40,12 @@ beforeEach(function() {
         data: {
           is_enabled: true,
           endpoint: 'ws://cypress-websocket/ws',
+          authentication: {
+            type: 'connect-token',
+            token: 'connect-token',
+            query_parameter: 'connect_token',
+            expires_in: 60,
+          },
         },
       },
     });


### PR DESCRIPTION
Closes FE-153

## What
- Fetch authenticated websocket configuration through the shared API fetcher.
- Build each websocket connection URL from the returned single-use token and query-parameter metadata.
- Fetch fresh websocket configuration before reconnecting while preserving current subscriptions and reconnect backoff.

## Why
BE-172 replaces frontend use of the application auth token in websocket URLs with short-lived, single-use connect tokens. Each connection attempt must fetch a new token because the backend consumes tokens once.

## Scope
- Impacts the shared frontend websocket service and websocket test defaults.
- Keeps the Subscribe payload, subscription version, filter handling, and reconnect behavior unchanged.
- Does not add a frontend fallback to the legacy `auth` query parameter; migration compatibility remains backend-only for older deployed clients.

## Deployment Impact
- Requires a normal app deployment.
- Requires the BE-172 backend contract to be deployed in the target environment before this frontend version.
- No forms or form bundles need redeployment.

## Testing
- `npx eslint src/js/services/ws.js src/js/services/ws.cy.js test/support/defaults.js --max-warnings=0`
- `npx cypress run --component --spec src/js/services/ws.cy.js --reporter spec` (20 passing)

Covered cases include authenticated config headers, initial connect-token use, fresh token fetch on reconnect, disabled websocket config, and absence of application-token websocket auth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches WebSocket auth to single-use connect tokens and builds the URL from server-provided config. Implements FE-153 by replacing the old application-token query param.

- New Features
  - Fetch WebSocket config via the shared API fetcher using normal auth headers.
  - Build the connection URL with the provided connect token and query parameter; remove legacy URL auth and do not use Sec-WebSocket-Protocol.
  - On reconnect, fetch a fresh token and keep current subscriptions and backoff.

- Migration
  - Requires the BE-172 connect-token backend contract to be deployed before this frontend.
  - No fallback to the legacy `auth` query parameter; older clients rely on backend compatibility.

<sup>Written for commit 130bbe36564a0eafba75a0ae88c9b7d54ddb46d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

