### PR TITLE
refactor(router): move shell coordination to app frame

### DIFF
--- a/src/js/apps/globals/app-frame_app.cy.js
+++ b/src/js/apps/globals/app-frame_app.cy.js
@@ -62,4 +62,34 @@ context('AppFrameApp', function() {
       workspaceSlug: 'test-ws',
     });
   });
+
+  specify('wires form app start and stop to nav visibility', function() {
+    const formsApp = Object.assign({}, Backbone.Events);
+    const RouterApp = function() {
+      return formsApp;
+    };
+
+    app.workspaceSlug = 'test-ws';
+    app.getRegion = cy.stub().withArgs('content').returns('content-region');
+    app.toggleNav = cy.stub();
+
+    app.initFormsApp({ default: RouterApp });
+
+    formsApp.trigger('start');
+    formsApp.trigger('stop');
+
+    expect(app.toggleNav).to.have.been.calledWith(false);
+    expect(app.toggleNav).to.have.been.calledWith(true);
+  });
+
+  specify('toggles the nav when running', function() {
+    const toggleNav = cy.stub();
+
+    app.isRunning = cy.stub().returns(true);
+    app.getView = cy.stub().returns({ toggleNav });
+
+    app.toggleNav(true);
+
+    expect(toggleNav).to.have.been.calledWith(true);
+  });
 });

--- a/src/js/apps/globals/app-frame_app.cy.js
+++ b/src/js/apps/globals/app-frame_app.cy.js
@@ -7,16 +7,16 @@ context('AppFrameApp', function() {
   let app;
   let navSelect;
   let sidebarStop;
-  let applyRoute;
+  let setLatestList;
 
   beforeEach(function() {
     navSelect = cy.stub();
     sidebarStop = cy.stub();
-    applyRoute = cy.stub();
+    setLatestList = cy.stub();
 
     Radio.reply('nav', 'select', navSelect);
     Radio.reply('sidebar', 'stop', sidebarStop);
-    Radio.reply('history', 'apply:route', applyRoute);
+    Radio.reply('history', 'set:latestList', setLatestList);
 
     app = new AppFrameApp();
   });
@@ -39,7 +39,7 @@ context('AppFrameApp', function() {
 
     expect(navSelect).to.have.been.calledWith('PatientsApp', 'worklist', ['owned-by']);
     expect(sidebarStop).to.have.been.calledOnce;
-    expect(applyRoute).to.have.been.calledWith(routeContext);
+    expect(setLatestList).to.have.been.calledWith(routeContext);
   });
 
   specify('passes the current workspace slug to area routers', function() {

--- a/src/js/apps/globals/app-frame_app.cy.js
+++ b/src/js/apps/globals/app-frame_app.cy.js
@@ -1,0 +1,65 @@
+import Backbone from 'backbone';
+import Radio from 'backbone.radio';
+
+import AppFrameApp from './app-frame_app';
+
+context('AppFrameApp', function() {
+  let app;
+  let navSelect;
+  let sidebarStop;
+  let applyRoute;
+
+  beforeEach(function() {
+    navSelect = cy.stub();
+    sidebarStop = cy.stub();
+    applyRoute = cy.stub();
+
+    Radio.reply('nav', 'select', navSelect);
+    Radio.reply('sidebar', 'stop', sidebarStop);
+    Radio.reply('history', 'apply:route', applyRoute);
+
+    app = new AppFrameApp();
+  });
+
+  afterEach(function() {
+    app.destroy();
+    Radio.reset();
+  });
+
+  specify('coordinates global shell behavior before an area route', function() {
+    const routeContext = {
+      event: 'worklist',
+      eventArgs: ['owned-by'],
+      definition: {
+        meta: { isList: true },
+      },
+    };
+
+    app.onBeforeAppRoute({ routerAppName: 'PatientsApp' }, routeContext);
+
+    expect(navSelect).to.have.been.calledWith('PatientsApp', 'worklist', ['owned-by']);
+    expect(sidebarStop).to.have.been.calledOnce;
+    expect(applyRoute).to.have.been.calledWith(routeContext);
+  });
+
+  specify('passes the current workspace slug to area routers', function() {
+    let routerOptions;
+    const RouterApp = function(options) {
+      routerOptions = options;
+    };
+
+    Object.assign(RouterApp.prototype, Backbone.Events, {
+      destroy() {},
+    });
+
+    app.workspaceSlug = 'test-ws';
+    app.getRegion = cy.stub().withArgs('content').returns('content-region');
+
+    app.initRouter({ default: RouterApp });
+
+    expect(routerOptions).to.deep.equal({
+      region: 'content-region',
+      workspaceSlug: 'test-ws',
+    });
+  });
+});

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -81,7 +81,7 @@ export default App.extend({
 
     Radio.request('nav', 'select', router.routerAppName, event, eventArgs);
     Radio.request('sidebar', 'stop');
-    Radio.request('history', 'apply:route', routeContext);
+    Radio.request('history', 'set:latestList', routeContext);
   },
   initFormsApp(FormsApp) {
     const formsApp = this.initRouter(FormsApp);

--- a/src/js/apps/globals/app-frame_app.js
+++ b/src/js/apps/globals/app-frame_app.js
@@ -38,6 +38,8 @@ export default App.extend({
     ];
   },
   onStart(options, currentWorkspace, PatientsMainApp, DashboardsMainApp, CliniciansMainApp, ProgramsMainApp, FormsApp) {
+    this.workspaceSlug = currentWorkspace.get('slug');
+
     this.initRouter(PatientsMainApp);
     this.initRouter(DashboardsMainApp);
     this.initRouter(CliniciansMainApp);
@@ -64,9 +66,22 @@ export default App.extend({
 
     const RouterApp = RouterAppImport.default;
 
-    const router = new RouterApp({ region: this.getRegion('content') });
+    const router = new RouterApp({
+      region: this.getRegion('content'),
+      workspaceSlug: this.workspaceSlug,
+    });
+
+    this.listenTo(router, 'before:appRoute', this.onBeforeAppRoute);
+
     this.routers.push(router);
     return router;
+  },
+  onBeforeAppRoute(router, routeContext) {
+    const { event, eventArgs } = routeContext;
+
+    Radio.request('nav', 'select', router.routerAppName, event, eventArgs);
+    Radio.request('sidebar', 'stop');
+    Radio.request('history', 'apply:route', routeContext);
   },
   initFormsApp(FormsApp) {
     const formsApp = this.initRouter(FormsApp);

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -62,7 +62,7 @@ export default RouterApp.extend({
     },
   },
 
-  onBeforeAppRoute({ event, eventArgs: [patientId] }) {
+  onBeforeAppRoute(router, { event, eventArgs: [patientId] }) {
     // if routing to flow route, currentPatientId is set by flow_app's onStart()
     if (event.startsWith('flow')) return;
 

--- a/src/js/base/routerapp.cy.js
+++ b/src/js/base/routerapp.cy.js
@@ -84,6 +84,23 @@ context('RouterApp', function() {
     specify('requires a workspace slug for non-root routes', function() {
       expect(() => new Router()).to.throw('RouterApp requires workspaceSlug for non-root routes');
     });
+
+    specify('does not require a workspace slug for root routes', function() {
+      const RootRouter = RouterApp.extend({
+        eventRoutes: {
+          root: {
+            action: 'showRoot',
+            route: '',
+            root: true,
+          },
+        },
+        showRoot() {},
+      });
+
+      app = new RootRouter();
+
+      expect(app.router.getDefaultRoute('root')).to.equal('');
+    });
   });
 
   describe('route context', function() {

--- a/src/js/base/routerapp.cy.js
+++ b/src/js/base/routerapp.cy.js
@@ -1,5 +1,3 @@
-import Radio from 'backbone.radio';
-
 import RouterApp from './routerapp';
 import SubRouterApp from './subrouterapp';
 
@@ -51,30 +49,15 @@ function trigger(app, event, ...args) {
 
 context('RouterApp', function() {
   let app;
-  let navSelect;
-  let sidebarStop;
-  let setLatestList;
-
-  beforeEach(function() {
-    navSelect = cy.stub();
-    sidebarStop = cy.stub();
-    setLatestList = cy.stub();
-
-    Radio.reply('workspace', 'current', () => ({ get: () => 'test-ws' }));
-    Radio.reply('nav', 'select', navSelect);
-    Radio.reply('sidebar', 'stop', sidebarStop);
-    Radio.reply('history', 'set:latestList', setLatestList);
-  });
 
   afterEach(function() {
     if (app) app.destroy();
     app = null;
-    Radio.reset();
   });
 
   describe('route triggers and aliases', function() {
     specify('prefixes the workspace slug onto non-root routes', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/dashboard/:id');
     });
 
@@ -89,7 +72,7 @@ context('RouterApp', function() {
           };
         },
       });
-      app = new AliasRouter();
+      app = new AliasRouter({ workspaceSlug: 'test-ws' });
 
       expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/:id/workflow');
       expect(app.translateEvent('patient:dashboard', 'p1')).to.equal('test-ws/patient/p1/workflow');
@@ -97,20 +80,26 @@ context('RouterApp', function() {
       trigger(app, 'patient:dashboard', 'p1');
       expect(app.getCurrentRoute().definition.route).to.equal('patient/:id/workflow');
     });
+
+    specify('requires a workspace slug for non-root routes', function() {
+      expect(() => new Router()).to.throw('RouterApp requires workspaceSlug for non-root routes');
+    });
   });
 
   describe('route context', function() {
     specify('sets the current route before before:appRoute and exposes the full context', function() {
       const CapturingRouter = Router.extend({
-        onBeforeAppRoute(routeContext) {
+        onBeforeAppRoute(router, routeContext) {
+          this.capturedRouter = router;
           this.captured = routeContext;
           this.currentDuringHook = this.getCurrentRoute();
         },
       });
-      app = new CapturingRouter();
+      app = new CapturingRouter({ workspaceSlug: 'test-ws' });
 
       trigger(app, 'patient:dashboard', 'p1');
 
+      expect(app.capturedRouter).to.equal(app);
       expect(app.captured.event).to.equal('patient:dashboard');
       expect(app.captured.eventArgs).to.deep.equal(['p1']);
       expect(app.captured.definition.action).to.equal('showPatient');
@@ -118,36 +107,32 @@ context('RouterApp', function() {
       expect(app.currentDuringHook).to.equal(app.captured);
     });
 
+    specify('passes the router before route context to appRoute events', function() {
+      app = new Router({ workspaceSlug: 'test-ws' });
+      const beforeAppRoute = cy.stub();
+      const appRoute = cy.stub();
+
+      app.on('before:appRoute', beforeAppRoute);
+      app.on('appRoute', appRoute);
+
+      trigger(app, 'patient:dashboard', 'p1');
+
+      const routeContext = app.getCurrentRoute();
+
+      expect(beforeAppRoute).to.have.been.calledWith(app, routeContext);
+      expect(appRoute).to.have.been.calledWith(app, routeContext);
+    });
+
     specify('getCurrentRouteMeta returns the definition meta', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       trigger(app, 'worklist', 'w1');
       expect(app.getCurrentRouteMeta()).to.deep.equal({ isList: true });
     });
   });
 
-  describe('latest-list meta', function() {
-    specify('records the latest list for meta.isList routes', function() {
-      app = new Router();
-      trigger(app, 'worklist', 'w1');
-      expect(setLatestList).to.have.been.calledWith('worklist', ['w1']);
-    });
-
-    specify('clears the latest list for meta.clearLatestList routes', function() {
-      app = new Router();
-      trigger(app, 'schedule');
-      expect(setLatestList).to.have.been.calledWith(false);
-    });
-
-    specify('leaves the latest list alone for plain routes', function() {
-      app = new Router();
-      trigger(app, 'patient:dashboard', 'p1');
-      expect(setLatestList).not.to.have.been.called;
-    });
-  });
-
   describe('scope identity', function() {
     specify('reuses the child and forwards the route for an equal scope', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       trigger(app, 'patient:dashboard', 'p1');
       const child = app.getCurrent();
 
@@ -159,7 +144,7 @@ context('RouterApp', function() {
     });
 
     specify('restarts the child for a different scope', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       trigger(app, 'patient:dashboard', 'p1');
       const child = app.getCurrent();
 
@@ -169,7 +154,7 @@ context('RouterApp', function() {
     });
 
     specify('startCurrent is unconditional even for an equal scope', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       app.startCurrent('patient', { patientId: 'p1' });
       const child = app.getCurrent();
       app.startCurrent('patient', { patientId: 'p1' });
@@ -180,7 +165,7 @@ context('RouterApp', function() {
 
   describe('child stop cleanup', function() {
     specify('clears current references when the child stops itself', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       trigger(app, 'patient:dashboard', 'p1');
       const child = app.getCurrent();
 
@@ -191,7 +176,7 @@ context('RouterApp', function() {
     });
 
     specify('keeps the current child when it restarts itself', function() {
-      app = new Router();
+      app = new Router({ workspaceSlug: 'test-ws' });
       trigger(app, 'patient:dashboard', 'p1');
       const child = app.getCurrent();
 

--- a/src/js/base/routerapp.js
+++ b/src/js/base/routerapp.js
@@ -1,6 +1,5 @@
 import { isArray, isEqual, isFunction, map, partial, reduce, rest, result } from 'underscore';
 import Backbone from 'backbone';
-import Radio from 'backbone.radio';
 import EventRouter from 'backbone.eventrouter';
 import App from './app';
 
@@ -8,7 +7,9 @@ export default App.extend({
   // Set in router apps for nav selection
   routerAppName: '',
 
-  constructor: function() {
+  constructor: function(options = {}) {
+    this.workspaceSlug = options.workspaceSlug;
+
     this.initRouter();
 
     // if the app does not handle a given route, stop
@@ -51,10 +52,11 @@ export default App.extend({
   _prefixRoute(route, root) {
     if (root) return route;
 
-    const currentWorkspace = Radio.request('workspace', 'current');
-    const workspace = currentWorkspace.get('slug');
+    if (!this.workspaceSlug) {
+      throw new Error('RouterApp requires workspaceSlug for non-root routes');
+    }
 
-    return route ? `${ workspace }/${ route }` : workspace;
+    return route ? `${ this.workspaceSlug }/${ route }` : this.workspaceSlug;
   },
 
   getEventActions(eventRoutes, routeAction) {
@@ -96,12 +98,7 @@ export default App.extend({
       },
     };
 
-    this.triggerMethod('before:appRoute', this._currentRoute);
-
-    Radio.request('nav', 'select', this.routerAppName, event, args);
-    Radio.request('sidebar', 'stop');
-
-    this.setLatestList(this._currentRoute);
+    this.triggerMethod('before:appRoute', this, this._currentRoute);
 
     if (!isFunction(action)) {
       action = this[action];
@@ -109,20 +106,7 @@ export default App.extend({
 
     action.apply(this, args);
 
-    this.triggerMethod('appRoute', this._currentRoute);
-  },
-
-  setLatestList(routeContext) {
-    const { meta } = routeContext.definition;
-
-    if (meta.isList) {
-      Radio.request('history', 'set:latestList', routeContext.event, routeContext.eventArgs);
-      return;
-    }
-
-    if (!meta.clearLatestList) return;
-
-    Radio.request('history', 'set:latestList', false);
+    this.triggerMethod('appRoute', this, this._currentRoute);
   },
 
   // handler that ensures one running app

--- a/src/js/base/routing.md
+++ b/src/js/base/routing.md
@@ -9,8 +9,13 @@ definitions.
 - **RouterApp** (`src/js/base/routerapp.js`) — owns URL ↔ event mapping for a
   top-level area (Patients, Programs, Clinicians, Dashboards, Forms, Nav, Error).
   It registers routes with `backbone.eventrouter`, builds a normalized route
-  context on each match, selects the nav item, manages the single current child
-  app, and fires the `before:appRoute` / `appRoute` lifecycle hooks.
+  context on each match, manages the single current child app, and fires the
+  `before:appRoute` / `appRoute` lifecycle hooks.
+- **AppFrameApp** (`src/js/apps/globals/app-frame_app.js`) — owns the global app
+  shell and the area RouterApps it instantiates. It responds to area route
+  transitions by selecting the nav item, closing the transient sidebar, and
+  forwarding route metadata to the latest-list service. It also passes the
+  current workspace slug into area RouterApps when they are created.
 - **SubRouterApp** (`src/js/base/subrouterapp.js`) — a child app that dispatches a
   route to a local handler without owning any URLs. It carries declarative scope
   identity, retains the latest route while loading, and re-dispatches after its
@@ -35,7 +40,8 @@ eventRoutes: {
 Structural fields: `action`, `route`, `root`. Behavioral flags go under `meta`
 (`isList`, `clearLatestList`). `action` is a method name (resolved on the RouterApp)
 or a function; `route` is a string or a non-empty array of alias strings; non-root
-routes are prefixed with the workspace slug, so they must not begin with `/`.
+routes are prefixed with the `workspaceSlug` supplied by AppFrame, so they must not
+begin with `/`.
 
 ### Aliases
 
@@ -56,16 +62,23 @@ Each match is normalized before any hook runs:
 ```
 
 - `getCurrentRoute()` returns this object; `getCurrentRouteMeta()` returns its `meta`.
-- `before:appRoute` and `appRoute` receive the context object (not positional args).
+- `before:appRoute` and `appRoute` receive the RouterApp followed by the context
+  object: `(router, routeContext)`.
 - Action handlers still receive **positional** arguments (`showPatient(patientId)`).
 
-Side-effect order inside `routeAction` (deliberate — the current route is set first
-so it is observable in `before:appRoute`):
+Side-effect order during an area route transition (deliberate — the current route
+is set first so it is observable in `before:appRoute`):
 
 ```text
-set current route → before:appRoute → nav select → sidebar stop
-  → latest-list update → action handler → appRoute
+set current route → before:appRoute
+  → AppFrame selects nav, stops sidebar, applies latest-list metadata
+  → action handler → appRoute
 ```
+
+Router-specific `onBeforeAppRoute` / `onAppRoute` hooks use the same
+`(router, routeContext)` signature. Root/workspace routing in `NavApp` and global
+error routing are not coordinated by AppFrame because they are not area routers
+instantiated through `AppFrameApp.initRouter()`.
 
 ## Scope identity (which child is "the same")
 
@@ -158,6 +171,8 @@ Route dispatch stays synchronous — do not add another async layer.
   double slash).
 - Leaving `isList` / `clearLatestList` at the top level of a definition instead of
   under `meta` (silently stops updating the latest-list history).
+- Adding global shell effects directly to RouterApp. AppFrame owns nav selection,
+  transient-sidebar cleanup, and latest-list metadata handling for area routes.
 
 ## AI checklist for adding or changing a route
 

--- a/src/js/services/latest-list.cy.js
+++ b/src/js/services/latest-list.cy.js
@@ -55,4 +55,16 @@ context('LatestListService', function() {
     expect(service._latestList).to.equal('worklist');
     expect(service._latestListArgs).to.deep.equal(['owned-by']);
   });
+
+  specify('routes back to the latest list', function() {
+    const eventRouter = Radio.channel('event-router');
+    const worklist = cy.stub();
+
+    service.listenTo(eventRouter, 'worklist', worklist);
+    service.setLatestList('worklist', ['owned-by']);
+
+    Radio.request('history', 'go:latestList');
+
+    expect(worklist).to.have.been.calledWith('owned-by');
+  });
 });

--- a/src/js/services/latest-list.cy.js
+++ b/src/js/services/latest-list.cy.js
@@ -1,0 +1,58 @@
+import Radio from 'backbone.radio';
+
+import LatestListService from './latest-list';
+
+context('LatestListService', function() {
+  let service;
+
+  beforeEach(function() {
+    service = new LatestListService();
+  });
+
+  afterEach(function() {
+    service.destroy();
+    Radio.reset();
+  });
+
+  specify('records list routes from route metadata', function() {
+    Radio.request('history', 'apply:route', {
+      event: 'worklist',
+      eventArgs: ['owned-by'],
+      definition: {
+        meta: { isList: true },
+      },
+    });
+
+    expect(service._latestList).to.equal('worklist');
+    expect(service._latestListArgs).to.deep.equal(['owned-by']);
+  });
+
+  specify('clears the latest list when requested by route metadata', function() {
+    service.setLatestList('worklist', ['owned-by']);
+
+    Radio.request('history', 'apply:route', {
+      event: 'schedule',
+      eventArgs: [],
+      definition: {
+        meta: { clearLatestList: true },
+      },
+    });
+
+    expect(service.hasLatestList()).to.equal(false);
+  });
+
+  specify('leaves the latest list unchanged for plain routes', function() {
+    service.setLatestList('worklist', ['owned-by']);
+
+    Radio.request('history', 'apply:route', {
+      event: 'patient:dashboard',
+      eventArgs: ['patient-id'],
+      definition: {
+        meta: {},
+      },
+    });
+
+    expect(service._latestList).to.equal('worklist');
+    expect(service._latestListArgs).to.deep.equal(['owned-by']);
+  });
+});

--- a/src/js/services/latest-list.cy.js
+++ b/src/js/services/latest-list.cy.js
@@ -15,7 +15,7 @@ context('LatestListService', function() {
   });
 
   specify('records list routes from route metadata', function() {
-    Radio.request('history', 'apply:route', {
+    Radio.request('history', 'set:latestList', {
       event: 'worklist',
       eventArgs: ['owned-by'],
       definition: {
@@ -28,9 +28,9 @@ context('LatestListService', function() {
   });
 
   specify('clears the latest list when requested by route metadata', function() {
-    service.setLatestList('worklist', ['owned-by']);
+    service._setLatestList('worklist', ['owned-by']);
 
-    Radio.request('history', 'apply:route', {
+    Radio.request('history', 'set:latestList', {
       event: 'schedule',
       eventArgs: [],
       definition: {
@@ -42,9 +42,9 @@ context('LatestListService', function() {
   });
 
   specify('leaves the latest list unchanged for plain routes', function() {
-    service.setLatestList('worklist', ['owned-by']);
+    service._setLatestList('worklist', ['owned-by']);
 
-    Radio.request('history', 'apply:route', {
+    Radio.request('history', 'set:latestList', {
       event: 'patient:dashboard',
       eventArgs: ['patient-id'],
       definition: {
@@ -61,7 +61,7 @@ context('LatestListService', function() {
     const worklist = cy.stub();
 
     service.listenTo(eventRouter, 'worklist', worklist);
-    service.setLatestList('worklist', ['owned-by']);
+    service._setLatestList('worklist', ['owned-by']);
 
     Radio.request('history', 'go:latestList');
 

--- a/src/js/services/latest-list.js
+++ b/src/js/services/latest-list.js
@@ -6,24 +6,23 @@ export default App.extend({
   channelName: 'history',
 
   radioRequests: {
-    'apply:route': 'applyRoute',
     'set:latestList': 'setLatestList',
     'has:latestList': 'hasLatestList',
     'go:latestList': 'goLatestList',
   },
 
-  applyRoute(routeContext) {
+  setLatestList(routeContext) {
     const { event, eventArgs, definition: { meta } } = routeContext;
 
     if (meta.isList) {
-      this.setLatestList(event, eventArgs);
+      this._setLatestList(event, eventArgs);
       return;
     }
 
-    if (meta.clearLatestList) this.setLatestList(false);
+    if (meta.clearLatestList) this._setLatestList(false);
   },
 
-  setLatestList(event,
+  _setLatestList(event,
     /* istanbul ignore next */
     eventArgs = []) {
     this._latestList = event;

--- a/src/js/services/latest-list.js
+++ b/src/js/services/latest-list.js
@@ -6,9 +6,21 @@ export default App.extend({
   channelName: 'history',
 
   radioRequests: {
+    'apply:route': 'applyRoute',
     'set:latestList': 'setLatestList',
     'has:latestList': 'hasLatestList',
     'go:latestList': 'goLatestList',
+  },
+
+  applyRoute(routeContext) {
+    const { event, eventArgs, definition: { meta } } = routeContext;
+
+    if (meta.isList) {
+      this.setLatestList(event, eventArgs);
+      return;
+    }
+
+    if (meta.clearLatestList) this.setLatestList(false);
   },
 
   setLatestList(event,


### PR DESCRIPTION
Closes FE-165

## What
- Move nav selection, transient sidebar cleanup, and latest-list route metadata handling out of `RouterApp` and into `AppFrameApp` / `LatestListService`.
- Change `before:appRoute` and `appRoute` lifecycle events to pass `(router, routeContext)`.
- Pass `workspaceSlug` from `AppFrameApp` into area routers so `RouterApp` no longer reads workspace state directly for route prefixing.

## Why
`RouterApp` was mixing generic route mechanics with global app-shell behavior. Keeping shell coordination in `AppFrameApp` makes the router base class easier to reuse and reason about before the patient workspace refactor.

## Scope
Impacted areas:
- Routing infrastructure: `src/js/base/routerapp.js`, `src/js/base/routing.md`
- Global app shell: `src/js/apps/globals/app-frame_app.js`
- Latest-list service behavior: `src/js/services/latest-list.js`
- Patient router hook signature: `src/js/apps/patients/patients-main_app.js`

Intentionally not changed:
- No patient workspace URL changes.
- No card/action/form page refactor work.
- No root/workspace routing changes in `NavApp`.

## Deployment Impact
No forms redeploy beyond the normal app deployment is needed. This affects app routing/shared shell behavior in the main frontend bundle; it does not modify standalone form definitions or form bundles.

## Testing
- `npx cypress run --component --spec 'src/js/base/routerapp.cy.js,src/js/apps/globals/app-frame_app.cy.js,src/js/services/latest-list.cy.js'`
- `npm run lint`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves global shell coordination from `RouterApp` to `AppFrameApp` and `LatestListService`, updates route hook signatures to include the router, and requires explicit `workspaceSlug` injection. Simplifies routing internals, centralizes latest-list handling, and aligns with FE-165.

- **Refactors**
  - `AppFrameApp` selects nav, stops the transient sidebar, and forwards route metadata to `LatestListService` via `history` `set:latestList`.
  - `RouterApp` triggers `before:appRoute`/`appRoute` as `(router, routeContext)` and no longer touches nav/sidebar/latest-list.
  - Area routers receive `workspaceSlug` from `AppFrameApp.initRouter`; non-root routes now require it (root routes can omit it).
  - `LatestListService` reads route metadata from the full `routeContext` and reuses a single setter to set/clear the latest list.
  - Docs and tests updated for the new flow.

- **Migration**
  - Update any `onBeforeAppRoute`/`onAppRoute` handlers to `(router, routeContext)`.
  - Instantiate area routers through `AppFrameApp.initRouter` (or pass `workspaceSlug`) to avoid constructor errors on non-root routes.
  - Do not update latest-list directly; if you must, `history` `set:latestList` now expects the full `routeContext` instead of `(event, args)`.

<sup>Written for commit 9093c881df7d39a0a4d230c59db0c7544e2bff2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Cypress coverage for router navigation selection, sidebar stop behavior, form-app start/stop wiring, and latest-list state updates.
* **Documentation**
  * Refined routing documentation, including `before:appRoute`/`appRoute` context shape and where global shell side effects should be handled.
* **Refactor**
  * Improved routing coordination by centralizing global shell effects and enforcing consistent workspace-slug handling for route dispatch and aliases.
  * Updated latest-list updates to be driven by route context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->