### PR TITLE
fix(cache): keep blocked IndexedDB upgrades from hanging startup

### DIFF
--- a/src/js/base/cache/idb.cy.js
+++ b/src/js/base/cache/idb.cy.js
@@ -1,5 +1,68 @@
 import idb from './idb';
 
+// A stand-in for an IDBOpenDBRequest whose open never settles — what a blocked
+// version upgrade (another tab holding an older version open) looks like to idb.
+function neverSettlingRequest() {
+  const request = {
+    then() {
+      return request;
+    },
+    catch() {
+      return request;
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  return request;
+}
+
+// Like the above, but the open can be completed later via resolveWith(db).
+// Backed by a real promise so every subscriber (idb internals, the orphan
+// guard, Promise.race) resolves correctly regardless of when it subscribed.
+function pendingRequest() {
+  let resolveOpen;
+  const opened = new Promise(resolve => {
+    resolveOpen = resolve;
+  });
+  return {
+    then(onFulfilled, onRejected) {
+      return opened.then(onFulfilled, onRejected);
+    },
+    catch(onRejected) {
+      return opened.catch(onRejected);
+    },
+    addEventListener() {},
+    removeEventListener() {},
+    resolveWith(db) {
+      resolveOpen(db);
+    },
+  };
+}
+
+// A stand-in for the live IDBDatabase the idb library hands back after a
+// successful open. It records the versionchange/close listeners idb wires up so
+// a test can fire them and exercise the blocking()/terminated() handlers.
+function openedDatabase() {
+  const handlers = {};
+  const close = cy.stub();
+  const db = {
+    close,
+    get() {
+      return Promise.resolve(undefined);
+    },
+    addEventListener(type, handler) {
+      (handlers[type] || (handlers[type] = [])).push(handler);
+    },
+  };
+  return {
+    db,
+    close,
+    fire(type) {
+      (handlers[type] || []).forEach(fn => fn({}));
+    },
+  };
+}
+
 context('cache/idb', function() {
   beforeEach(function() {
     idb.__reset();
@@ -48,12 +111,130 @@ context('cache/idb', function() {
 
   specify('operations fail soft when IndexedDB is unavailable', function() {
     idb.__reset();
-    cy.stub(window.indexedDB, 'open').throws(new DOMException('blocked', 'SecurityError'));
+    const open = cy.stub(window.indexedDB, 'open').throws(new DOMException('blocked', 'SecurityError'));
 
     return idb.put('entities', 'k', { a: 1 })
       .then(() => idb.get('entities', 'k'))
       .then(value => {
         expect(value).to.be.undefined;
+        // The failed open is memoized as unavailable — later ops don't retry it.
+        expect(open).to.be.calledOnce;
       });
+  });
+
+  specify('operations fail soft when the open is blocked and never settles', function() {
+    idb.__reset();
+    cy.stub(window.indexedDB, 'open').returns(neverSettlingRequest());
+
+    cy.clock();
+    const result = {};
+    cy.then(() => {
+      result.op = idb.get('entities', 'k');
+    });
+    cy.tick(5000);
+    cy.then(() => result.op).then(value => {
+      expect(value).to.be.undefined;
+    });
+  });
+
+  specify('stays unavailable after a blocked open times out, without re-waiting', function() {
+    idb.__reset();
+    cy.stub(window.indexedDB, 'open').returns(neverSettlingRequest());
+
+    cy.clock();
+    const result = {};
+    cy.then(() => {
+      result.first = idb.get('entities', 'k');
+    });
+    cy.tick(5000);
+    cy.then(() => result.first).then(value => {
+      expect(value).to.be.undefined;
+      // A second read must resolve WITHOUT advancing the clock again — the
+      // timed-out open is memoized as unavailable, so callers fail fast rather
+      // than each paying another timeout.
+      result.second = idb.get('entities', 'k');
+    });
+    cy.then(() => result.second).then(value => {
+      expect(value).to.be.undefined;
+    });
+  });
+
+  specify('closes a connection that finishes opening after the timeout', function() {
+    idb.__reset();
+    const request = pendingRequest();
+    const lateClose = cy.stub();
+    cy.stub(window.indexedDB, 'open').returns(request);
+
+    cy.clock();
+    const result = {};
+    cy.then(() => {
+      result.op = idb.get('entities', 'k');
+    });
+    cy.tick(5000);
+    cy.then(() => result.op).then(value => {
+      expect(value).to.be.undefined;
+    });
+    cy.then(() => {
+      // The open completes only after we gave up: the orphaned connection must
+      // be closed so it cannot linger or block a later upgrade.
+      request.resolveWith({ close: lateClose, addEventListener() {} });
+      // Let the open's late resolution (and the orphan-close handler) settle.
+      return request.then(() => null).then(() => null);
+    });
+    cy.then(() => {
+      expect(lateClose).to.be.calledOnce;
+    });
+  });
+
+  specify('blocking() closes the connection and reopens on the next read', function() {
+    idb.__reset();
+    const request = pendingRequest();
+    const open = cy.stub(window.indexedDB, 'open').returns(request);
+
+    cy.clock();
+    const ctx = {};
+    cy.then(() => {
+      ctx.conn = openedDatabase();
+      ctx.first = idb.get('entities', 'k');
+    });
+    // Resolve after a command boundary so the open's race adoption is wired up.
+    cy.then(() => {
+      request.resolveWith(ctx.conn.db);
+    });
+    cy.then(() => ctx.first).then(() => {
+      expect(open).to.be.calledOnce;
+      // Another tab starts a newer-version upgrade: versionchange fires
+      // blocking(), which must close our connection so the upgrade proceeds...
+      ctx.conn.fire('versionchange');
+      expect(ctx.conn.close).to.be.calledOnce;
+      // ...and drop the memo so the next read reopens instead of reusing it.
+      ctx.second = idb.get('entities', 'k');
+      expect(open).to.be.calledTwice;
+    });
+  });
+
+  specify('terminated() drops the memo so the next read reopens', function() {
+    idb.__reset();
+    const request = pendingRequest();
+    const open = cy.stub(window.indexedDB, 'open').returns(request);
+
+    cy.clock();
+    const ctx = {};
+    cy.then(() => {
+      ctx.conn = openedDatabase();
+      ctx.first = idb.get('entities', 'k');
+    });
+    // Resolve after a command boundary so the open's race adoption is wired up.
+    cy.then(() => {
+      request.resolveWith(ctx.conn.db);
+    });
+    cy.then(() => ctx.first).then(() => {
+      expect(open).to.be.calledOnce;
+      // The connection closes underneath us: terminated() drops the memo so a
+      // later read reopens rather than handing back a dead connection.
+      ctx.conn.fire('close');
+      ctx.second = idb.get('entities', 'k');
+      expect(open).to.be.calledTwice;
+    });
   });
 });

--- a/src/js/base/cache/idb.js
+++ b/src/js/base/cache/idb.js
@@ -4,28 +4,77 @@ const DB_NAME = 'careops-cache';
 // IndexedDB database version — bump only for object-store schema changes.
 const DB_VERSION = 2;
 const STORES = ['entities', 'formDrafts'];
+// A blocked version upgrade (e.g. another tab holding an older version open)
+// leaves the open pending forever. Cap the wait so a cache open can never gate
+// startup — callers fall back to running without the cache.
+const OPEN_TIMEOUT_MS = 3000;
 
 let dbPromise;
+
+function openDatabase() {
+  let db;
+
+  return openDB(DB_NAME, DB_VERSION, {
+    upgrade(database) {
+      STORES.forEach(name => {
+        if (!database.objectStoreNames.contains(name)) database.createObjectStore(name);
+      });
+    },
+    blocking() {
+      // A newer version is trying to open in another tab and we are blocking
+      // it. Close so that upgrade proceeds instead of deadlocking both tabs,
+      // and drop the memo so the next caller opens afresh.
+      dbPromise = undefined;
+      if (db) db.close();
+    },
+    terminated() {
+      dbPromise = undefined;
+    },
+  }).then(opened => {
+    db = opened;
+    return opened;
+  });
+}
 
 function getDb() {
   if (dbPromise) return dbPromise;
 
+  let opening;
   try {
-    dbPromise = openDB(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        STORES.forEach(name => {
-          if (!db.objectStoreNames.contains(name)) db.createObjectStore(name);
-        });
-      },
-    }).catch(() => null);
+    opening = openDatabase();
   } catch {
-    return Promise.resolve(null);
+    // Synchronous open failure (IndexedDB unavailable): memoize no-cache so
+    // later callers fail fast like the timeout/async-failure cases.
+    dbPromise = Promise.resolve(null);
+    return dbPromise;
   }
 
-  // Don't memoize a failed open; clear so the next caller retries.
-  dbPromise.then(db => {
-    if (!db) dbPromise = undefined;
+  // A blocked upgrade (another tab holding an older version open) leaves the
+  // open pending forever. Bound the wait once, inside the memoized promise, so
+  // a blocked or failed open resolves to null and every later caller fails fast
+  // instead of paying the timeout again. blocking()/terminated() or __reset()
+  // clear the memo to allow a fresh open.
+  let timedOut = false;
+  let timer;
+  const timeout = new Promise(resolve => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve(null);
+    }, OPEN_TIMEOUT_MS);
   });
+
+  // If the open only finishes after we have already given up, close the
+  // orphaned connection so it cannot linger or block a later upgrade.
+  opening.then(db => {
+    if (timedOut && db) db.close();
+  }).catch(() => {});
+
+  dbPromise = Promise.race([opening, timeout])
+    .catch(() => null)
+    .then(db => {
+      clearTimeout(timer);
+      return db;
+    });
 
   return dbPromise;
 }


### PR DESCRIPTION
Closes FE-166

## What
- Adds a timeout around the memoized IndexedDB open path so blocked cache opens resolve to no-cache mode.
- Closes an existing IDB connection when it blocks a newer version upgrade.
- Adds component coverage for unavailable IndexedDB, blocked opens, and fail-fast behavior after timeout.

## Why
One environment could hang during startup when `idb.openDB()` never settled during a blocked version upgrade.

## Scope
Impacts the shared `src/js/base/cache/idb.js` wrapper used by entity response caching and form draft storage. No unrelated cache key, entity-service, or draft behavior was changed.

## Deployment Impact
Normal app frontend deployment only. No form redeploy or separate bundle redeploy is required.

## Testing
- `npx cypress run --component --spec src/js/base/cache/idb.cy.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents startup and logout hangs from a blocked `idb.openDB()` upgrade by capping the open at 3s and falling back to no-cache. Fixes FE-166.

- **Bug Fixes**
  - Memoizes a single open with a 3s timeout; blocked/failed or sync-unavailable opens resolve to null, and later calls fail fast without re-waiting.
  - Adds `blocking()` to close the current connection and clear the memo; `terminated()` drops the memo so the next read reopens.
  - Closes any connection that completes after the timeout so it can’t linger or block upgrades; expands tests for unavailable IndexedDB, blocked opens, fail-fast, late-open close, and `versionchange`/`close` using `cy.clock()`/`cy.tick()`.

<sup>Written for commit 017b5472b948c3c6dc8ce831100693233f64abe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved IndexedDB cache initialization with a bounded wait, preventing startup deadlocks when a version upgrade is blocked in another tab.
  * Enhanced cache connection lifecycle handling: timed-out or “orphaned” connections are closed, and later reads automatically recover by reopening as needed.

* **Tests**
  * Added Cypress coverage for blocked IndexedDB opens, timeout-based fail-fast memoization, orphaned connection cleanup after late completion, and versionchange blocking/termination behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->