### PR TITLE
feat(forms): UI updates to draft status button & droplist

### DIFF
--- a/src/js/i18n/en-US.yml
+++ b/src/js/i18n/en-US.yml
@@ -118,6 +118,7 @@ careOptsFrontend:
           currentVersionButton: Back to Current Version
         draftStatusView:
           discardDraft: Discard draft...
+          tooltip: See draft status
           discardModal:
             bodyText: Discarding your unsubmitted work on this form will load the latest data for this patient, but you'll lose your unsubmitted work.
             headingText: Are you sure?

--- a/src/js/views/forms/form/form.scss
+++ b/src/js/views/forms/form/form.scss
@@ -177,17 +177,19 @@
   border-radius: 4px;
   box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
   font-size: 12px;
-  padding: 12px 16px;
+  padding: 12px 0;
   white-space: nowrap;
 }
 
 .form__draft-menu-info {
   color: #{$black-40};
+  padding: 0 16px;
 }
 
 .form__draft-menu-saved {
   font-size: 14px;
   margin-top: 8px;
+  padding: 0 16px;
 }
 
 .form__draft-menu-discard-button {
@@ -196,11 +198,13 @@
   display: block;
   font-size: 14px;
   margin-top: 8px;
+  padding: 4px 16px;
   text-align: left;
   width: 100%;
 
   &:hover {
-    color: color(red, light);
+    background-color: color(blue);
+    color: #{$white};
   }
 }
 

--- a/src/js/views/forms/form/form_views.js
+++ b/src/js/views/forms/form/form_views.js
@@ -286,6 +286,31 @@ const DraftStatusView = Droplist.extend({
   initialize({ model }) {
     this.model = model;
   },
+  onShow() {
+    this._showTooltip();
+
+    this.listenTo(this.getState(), 'change:isActive', (state, isActive) => {
+      if (isActive) {
+        this._tooltip.destroy();
+        this.getView().$el.off('.tooltip');
+        return;
+      }
+
+      this._showTooltip();
+    });
+  },
+  _showTooltip() {
+    const view = this.getView();
+
+    view.$el.off('.tooltip');
+    this._tooltip = new Tooltip({
+      message: i18n.draftStatusView.tooltip,
+      uiView: view,
+      ui: view.$el,
+      orientation: 'vertical',
+      shouldDelay: true,
+    });
+  },
   showPicklist() {
     const menuView = new DraftMenuView({ model: this.model });
 

--- a/test/integration/forms/action.js
+++ b/test/integration/forms/action.js
@@ -195,11 +195,38 @@ context('Patient Action Form', function() {
     cy
       .get('.form__controls')
       .find('.form__actions-icon:has(.fa-shield-check)')
+      .as('draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('contain', 'See draft status');
+
+    cy
+      .get('@draftStatusButton')
       .click();
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
 
     cy
       .get('.form__draft-menu')
       .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('@draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
 
     cy
       .tick(15000);
@@ -225,8 +252,7 @@ context('Patient Action Form', function() {
       });
 
     cy
-      .get('.form__controls')
-      .find('.form__actions-icon:has(.fa-shield-check)')
+      .get('@draftStatusButton')
       .click();
 
     cy

--- a/test/integration/forms/patient.js
+++ b/test/integration/forms/patient.js
@@ -212,11 +212,38 @@ context('Patient Form', function() {
     cy
       .get('.form__controls')
       .find('.form__actions-icon:has(.fa-shield-check)')
+      .as('draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('contain', 'See draft status');
+
+    cy
+      .get('@draftStatusButton')
       .click();
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
 
     cy
       .get('.form__draft-menu')
       .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('@draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
 
     cy
       .tick(15000);
@@ -246,8 +273,7 @@ context('Patient Form', function() {
       });
 
     cy
-      .get('.form__controls')
-      .find('.form__actions-icon:has(.fa-shield-check)')
+      .get('@draftStatusButton')
       .click();
 
     cy

--- a/test/integration/patients/patient/sidebar.js
+++ b/test/integration/patients/patient/sidebar.js
@@ -431,8 +431,39 @@ context('patient sidebar', function() {
 
     cy
       .get('.modal--large')
-      .find('.fa-shield-check')
+      .find('button:has(.fa-shield-check)')
+      .as('draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('contain', 'See draft status');
+
+    cy
+      .get('@draftStatusButton')
       .click();
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
+
+    cy
+      .get('.form__draft-menu')
+      .should('contain', 'Last saved a few seconds ago');
+
+    cy
+      .get('@draftStatusButton')
+      .trigger('pointerover');
+
+    // visitOnClock installs fake timers — tick past the tooltip's setTimeout(0) delay
+    cy.tick(1);
+
+    cy
+      .get('.tooltip')
+      .should('not.exist');
 
     cy.tick(60000);
 
@@ -464,8 +495,7 @@ context('patient sidebar', function() {
       .wait('@routeFormApp');
 
     cy
-      .get('.modal--large')
-      .find('.fa-shield-check')
+      .get('@draftStatusButton')
       .should('not.exist');
 
     cy


### PR DESCRIPTION
FE-160

Follow up work to https://github.com/RoundingWell/app-frontend/pull/1718.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “See draft status” tooltip to the draft status button and refines the draft droplist spacing and discard hover state for clarity. Addresses FE-160 by making draft status easier to find and aligning menu styles.

- **New Features**
  - Tooltip: shows “See draft status” on hover with a slight delay; auto-hides while the droplist is open. Added i18n key at `draftStatusView.tooltip`.
  - Draft menu UI: adjusted vertical and side padding for info/saved text; discard button hover now uses a blue background with white text.

<sup>Written for commit 33f80a6968e49c895a91a80980b2dca347ab5ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “See draft status” tooltip for the draft status control, including delayed display and proper dismissal behavior.

* **Style**
  * Refined draft menu spacing with updated padding for menu info and saved-state areas.
  * Updated discard button hover styling to use a blue background with white text.

* **Tests**
  * Improved integration coverage to validate the tooltip timing, text, dismissal, and draft menu content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->