### PR TITLE
fix(actions): create patient actions via root endpoint

### DIFF
--- a/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
@@ -43,7 +43,7 @@ context('patient dashboard page', function() {
     });
 
     cy
-      .intercept('POST', `/api/patients/${ testPatient.id }/relationships/actions*`, {
+      .intercept('POST', '/api/actions', {
         statusCode: 201,
         body: {
           data: actionData,
@@ -1034,6 +1034,8 @@ context('patient dashboard page', function() {
         expect(data.relationships.state.data.id).to.equal(stateTodo.id);
         expect(data.relationships.owner.data.id).to.equal(teamCoordinator.id);
         expect(data.relationships.owner.data.type).to.equal(teamCoordinator.type);
+        expect(data.relationships.patient.data.id).to.equal(testPatient.id);
+        expect(data.relationships['program-action'].data.id).to.equal(testProgramActions[0].id);
       });
 
     cy
@@ -1090,6 +1092,8 @@ context('patient dashboard page', function() {
         expect(data.relationships.state.data.id).to.equal(stateTodo.id);
         expect(data.relationships.owner.data.id).to.be.equal(currentClinican.id);
         expect(data.relationships.owner.data.type).to.be.equal(currentClinican.type);
+        expect(data.relationships.patient.data.id).to.equal(testPatient.id);
+        expect(data.relationships['program-action'].data.id).to.equal(testProgramActions[1].id);
       });
 
     cy
@@ -1129,6 +1133,8 @@ context('patient dashboard page', function() {
       .should(({ data }) => {
         expect(data.attributes.name).to.equal('Two of Two');
         expect(data.attributes.due_date).to.be.undefined;
+        expect(data.relationships.patient.data.id).to.equal(testPatient.id);
+        expect(data.relationships['program-action'].data.id).to.equal(testProgramActions[2].id);
       });
 
     cy

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -1039,7 +1039,7 @@ context('patient flow page', function() {
     });
 
     cy
-      .intercept('POST', '/api/flows/**/relationships/actions', {
+      .intercept('POST', '/api/actions', {
         statusCode: 201,
         body: {
           data: conditionalAction,
@@ -1078,6 +1078,8 @@ context('patient flow page', function() {
       .its('request.body')
       .should(({ data }) => {
         expect(data.attributes.name).to.equal('Conditional');
+        expect(data.relationships.patient.data.id).to.equal(testFlow.relationships.patient.data.id);
+        expect(data.relationships.flow.data.id).to.equal(testFlow.id);
         expect(data.relationships['program-action'].data.id).to.equal(testProgramAction.id);
       });
 

--- a/src/js/entities-service/entities/actions.js
+++ b/src/js/entities-service/entities/actions.js
@@ -64,17 +64,7 @@ const _Model = BaseModel.extend({
       this.destroy({ isDeleted: true });
     },
   },
-  urlRoot() {
-    if (this.isNew()) {
-      const flow = this.getFlow();
-      const patient = this.getPatient();
-      return flow ?
-        `/api/flows/${ flow.id }/relationships/actions` :
-        `/api/patients/${ patient.id }/relationships/actions`;
-    }
-
-    return '/api/actions';
-  },
+  urlRoot: '/api/actions',
   type: TYPE,
   getForm() {
     return this.getRelationship('_form');
@@ -247,6 +237,7 @@ const _Model = BaseModel.extend({
     if (this.isNew()) attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
+      'patient': this.toRelation(attrs._patient),
       'flow': this.toRelation(attrs._flow),
       'form': this.toRelation(attrs._form),
       'owner': this.toRelation(attrs._owner),

--- a/src/js/entities-service/entities/program-actions.js
+++ b/src/js/entities-service/entities/program-actions.js
@@ -42,6 +42,7 @@ const _Model = BaseModel.extend({
     const states = currentWorkspace.getStates();
 
     const defaultInitialState = first(states.filter({ status: STATE_STATUS.QUEUED }));
+    const actionPatient = patient || flow.getPatient();
 
     const attrs = {
       name: this.get('name'),
@@ -51,8 +52,8 @@ const _Model = BaseModel.extend({
         type: 'clinicians',
       },
       _program_action: this.getResource(),
+      _patient: actionPatient.getResource(),
     };
-    if (patient) attrs._patient = patient.getResource();
     if (flow) attrs._flow = flow.getResource();
     attrs._program = this.getProgram().getResource();
 


### PR DESCRIPTION
Resolves FE-167

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create patient actions via the root `POST /api/actions` endpoint. Always include `patient`, `program`, `program-action`, and `flow` (when present); owner updates still `PATCH` existing actions. Aligns with FE-167.

- **Refactors**
  - Program actions derive `patient` from the explicit patient or the flow and include `program` on create.
  - Tests updated to intercept `POST /api/actions` and assert `patient`, `program-action`, and `flow` relationships.

<sup>Written for commit 9078d92bfec499530afa3867bafab7af6cce07a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New actions now always send the correct patient and flow details when created, preventing missing or incorrect associations.
  * Action creation now uses a single endpoint, improving consistency for patient and flow actions.
* **Tests**
  * Updated end-to-end coverage to verify action requests include the expected patient, flow, and program-action relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->