### PR TITLE
fix(deploy): fail CloudFront invalidation errors

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -91,7 +91,7 @@ This discovers the deploy target in CloudFormation by tags:
 And then:
 1. Generates `dist/appconfig.json` from Secrets Manager secret `customer/<stage>/<organization-id>`
 2. Uploads `dist/` to the organization's WebsiteBucket
-3. Invalidates CloudFront if the secret contains `DistroId` or `DistroID`
+3. Resolves the stack's `CloudFrontDistribution` resource and invalidates CloudFront
 
 ## Local Deploy: All Organizations In A Stage
 
@@ -211,6 +211,7 @@ The AWS account must expose the deploy target to run successfully:
 - Secrets Manager must have a secret named `customer/<stage>/<organization>`
 - CloudFormation stack must have `stage` and `organization` tags
 - CloudFormation stack must have a `WebsiteBucket` output
+- Non-dev CloudFormation stacks must include a `CloudFrontDistribution` resource
 
 ## Troubleshooting
 
@@ -223,4 +224,5 @@ The AWS account must expose the deploy target to run successfully:
   - CircleCI deploy: verify the job assumed the expected `CircleCIRole` via `aws-cli/setup`.
 
 - `No CloudFront distribution found, skipping invalidation`
-  - Verify that `DistroId` (or `DistroID`) is defined in the organization secret.
+  - Dev deploys skip invalidation when the stack has no `CloudFrontDistribution` resource.
+  - Non-dev deploys fail when CloudFront lookup or invalidation fails.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -223,6 +223,6 @@ The AWS account must expose the deploy target to run successfully:
   - Local deploy: verify SSO login and `AWS_PROFILE`.
   - CircleCI deploy: verify the job assumed the expected `CircleCIRole` via `aws-cli/setup`.
 
-- `No CloudFront distribution found, skipping invalidation`
+- `No CloudFront distribution found for <stack>, skipping invalidation`
   - Dev deploys skip invalidation when the stack has no `CloudFrontDistribution` resource.
   - Non-dev deploys fail when CloudFront lookup or invalidation fails.

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -2,14 +2,14 @@
 
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
-import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { DescribeStackResourceCommand, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { parseArgs } from 'node:util';
 import fsSync from 'node:fs';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { writeAppConfig } from './generate-appconfig.js';
-import { createAwsClients, fetchOrganizationSecret } from './lib/aws.js';
+import { createAwsClients } from './lib/aws.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -20,6 +20,7 @@ const DEPLOYABLE_STATUSES = new Set([
 ]);
 const SHARED_RUNTIME_CACHE_CONTROL = 'no-cache';
 const PROD_WILDCARD_EXCLUDED_ORGANIZATIONS = new Set(['demonstration']);
+const CLOUDFRONT_DISTRIBUTION_LOGICAL_ID = 'CloudFrontDistribution';
 
 function isMainModule() {
   if (!process.argv[1]) {
@@ -70,7 +71,7 @@ export function shouldIncludeDeployTarget(stage, filterOrganization, organizatio
  * @param {CloudFormationClient} cfClient - CloudFormation client instance
  * @param {string} stage - Deployment stage (dev, qa, prod, sandbox)
  * @param {string} filterOrganization - Optional specific organization identifier to filter
- * @returns {Promise<Map>} Map of organization identifiers to bucket names
+ * @returns {Promise<Map>} Map of organization identifiers to deploy targets
  */
 async function listStageOrganizations(cfClient, stage, filterOrganization) {
   const organizationBuckets = new Map();
@@ -92,7 +93,7 @@ async function listStageOrganizations(cfClient, stage, filterOrganization) {
 
 /**
  * Resolve and add WebsiteBucket for organizations in a DescribeStacks page.
- * @param {Map<string, string>} organizationBuckets - Target map
+ * @param {Map<string, Object>} organizationBuckets - Target map
  * @param {Object} response - DescribeStacks response page
  * @param {string} stage - Deployment stage
  * @param {string} filterOrganization - Optional specific organization identifier to filter
@@ -119,7 +120,10 @@ export function addOrganizationsFromPage(organizationBuckets, response, stage, f
       );
     }
 
-    organizationBuckets.set(organizationIdentifier, bucketName);
+    organizationBuckets.set(organizationIdentifier, {
+      bucketName,
+      stackName: deploymentTarget.StackName,
+    });
   }
 }
 
@@ -267,32 +271,71 @@ async function invalidateCloudFront(cloudFrontClient, organization, distroId) {
   process.stdout.write(`CloudFront invalidation created for distribution ${ distroId } of ${ organization }\n`);
 }
 
+function isCloudFrontDistributionResourceMissing(error) {
+  return error?.name === 'ValidationError'
+    && String(error.message || '').includes(`Resource ${ CLOUDFRONT_DISTRIBUTION_LOGICAL_ID } does not exist for stack`);
+}
+
+/**
+ * Resolve the deploy target's CloudFront distribution from CloudFormation.
+ * @param {CloudFormationClient} cloudFormationClient - CloudFormation client instance
+ * @param {Object} options - Resolution options
+ * @param {string} options.stage - Deployment stage
+ * @param {string} options.stackName - CloudFormation stack name
+ * @returns {Promise<string|null>} CloudFront distribution id, or null for dev stacks without one
+ */
+export async function resolveInvalidationDistribution(cloudFormationClient, { stage, stackName }) {
+  let response;
+
+  try {
+    response = await cloudFormationClient.send(new DescribeStackResourceCommand({
+      StackName: stackName,
+      LogicalResourceId: CLOUDFRONT_DISTRIBUTION_LOGICAL_ID,
+    }));
+  } catch(error) {
+    if (stage === 'dev' && isCloudFrontDistributionResourceMissing(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  const distributionId = response.StackResourceDetail?.PhysicalResourceId;
+
+  if (!distributionId) {
+    throw new Error(`CloudFormation stack ${ stackName } resource ${ CLOUDFRONT_DISTRIBUTION_LOGICAL_ID } did not include a PhysicalResourceId`);
+  }
+
+  return distributionId;
+}
+
 /**
  * Deploy to a single organization.
  * @param {Object} clients - AWS clients
  * @param {string} stage - Deployment stage
  * @param {string} organization - Organization identifier
- * @param {string} bucketName - S3 bucket name
+ * @param {Object} deployTarget - Deploy target
+ * @param {string} deployTarget.bucketName - S3 bucket name
+ * @param {string} deployTarget.stackName - CloudFormation stack name
  * @param {string} distDir - Path to dist directory
  */
-async function deployToOrganization(clients, stage, organization, bucketName, distDir) {
+async function deployToOrganization(clients, stage, organization, deployTarget, distDir) {
   process.stdout.write(`\nDeploying ${ organization } (${ stage })\n`);
 
   await generateAppConfig(stage, organization);
 
-  process.stdout.write(`Uploading dist directory to ${ bucketName }...\n`);
-  await uploadDirectory(clients.s3, bucketName, distDir);
+  process.stdout.write(`Uploading dist directory to ${ deployTarget.bucketName }...\n`);
+  await uploadDirectory(clients.s3, deployTarget.bucketName, distDir);
 
-  try {
-    const secrets = await fetchOrganizationSecret(clients.secretsManager, stage, organization);
-    const distroId = secrets.DistroId || secrets.DistroID;
-    if (distroId) {
-      await invalidateCloudFront(clients.cloudFront, organization, distroId);
-    } else {
-      process.stdout.write('No CloudFront distribution found, skipping invalidation\n');
-    }
-  } catch(error) {
-    process.stderr.write(`Warning: Could not invalidate CloudFront: ${ error.message }\n`);
+  const distroId = await resolveInvalidationDistribution(clients.cloudFormation, {
+    stage,
+    stackName: deployTarget.stackName,
+  });
+
+  if (distroId) {
+    await invalidateCloudFront(clients.cloudFront, organization, distroId);
+  } else {
+    process.stdout.write(`No CloudFront distribution found for ${ deployTarget.stackName }, skipping invalidation\n`);
   }
 
   process.stdout.write(`Deployed ${ organization } (${ stage })\n`);
@@ -309,7 +352,7 @@ export function resolveDeployInputs(values) {
 
   if (!stage) {
     process.stderr.write('Error: --stage is required (or set DEPLOY_STAGE)\n');
-    process.stderr.write('Usage: npm run deploy -- --stage=prod [--organization=salvation]\n');
+    process.stderr.write('Usage: npm run deploy -- --stage=prod [--organization=<organization-id>]\n');
     process.stderr.write('   or: npm run deploy:dev (uses .env)\n');
     process.exit(1);
   }
@@ -358,7 +401,7 @@ export function readDeployMarkerStatus(statusFile) {
 
   try {
     payload = JSON.parse(fsSync.readFileSync(statusFile, 'utf8'));
-  } catch (error) {
+  } catch(error) {
     throw new Error(`Deploy marker status file is not valid JSON: ${ statusFile }. Delete it and retry. ${ error.message }`);
   }
 
@@ -372,23 +415,26 @@ export function readDeployMarkerStatus(statusFile) {
   };
 }
 
-export function readResolvedDeployTargets(targetsFile) {
-  if (!targetsFile) {
-    throw new Error('Resolved deploy targets file path is required.');
-  }
+function isResolvedDeployTargetEntry(entry) {
+  if (!Array.isArray(entry) || entry.length !== 2) return false;
 
-  if (!fsSync.existsSync(targetsFile)) {
-    throw new Error(`Resolved deploy targets file not found: ${ targetsFile }`);
-  }
+  const deployTarget = entry[1];
+  return Boolean(deployTarget)
+    && typeof deployTarget === 'object'
+    && !Array.isArray(deployTarget)
+    && typeof deployTarget.bucketName === 'string'
+    && typeof deployTarget.stackName === 'string';
+}
 
-  let payload;
-
+function readResolvedDeployTargetsPayload(targetsFile) {
   try {
-    payload = JSON.parse(fsSync.readFileSync(targetsFile, 'utf8'));
+    return JSON.parse(fsSync.readFileSync(targetsFile, 'utf8'));
   } catch {
     throw new Error(`Resolved deploy targets file is not valid JSON: ${ targetsFile }`);
   }
+}
 
+function getResolvedDeployTargetEntries(payload, targetsFile) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     throw new Error(`Resolved deploy targets payload must be a JSON object: ${ targetsFile }`);
   }
@@ -399,12 +445,24 @@ export function readResolvedDeployTargets(targetsFile) {
     throw new Error(`Resolved deploy targets payload must include an organizationBuckets array: ${ targetsFile }`);
   }
 
-  const hasInvalidEntry = organizationBuckets.some(entry => !Array.isArray(entry) || entry.length !== 2);
-
-  if (hasInvalidEntry) {
-    throw new Error(`Resolved deploy targets organizationBuckets must be an array of [key, value] entries: ${ targetsFile }`);
+  if (organizationBuckets.some(entry => !isResolvedDeployTargetEntry(entry))) {
+    throw new Error(`Resolved deploy targets organizationBuckets must be an array of [organization, { bucketName, stackName }] entries: ${ targetsFile }. Regenerate deploy targets with the current deploy script.`);
   }
 
+  return organizationBuckets;
+}
+
+export function readResolvedDeployTargets(targetsFile) {
+  if (!targetsFile) {
+    throw new Error('Resolved deploy targets file path is required.');
+  }
+
+  if (!fsSync.existsSync(targetsFile)) {
+    throw new Error(`Resolved deploy targets file not found: ${ targetsFile }`);
+  }
+
+  const payload = readResolvedDeployTargetsPayload(targetsFile);
+  const organizationBuckets = getResolvedDeployTargetEntries(payload, targetsFile);
   return new Map(organizationBuckets);
 }
 
@@ -417,6 +475,30 @@ export function writeResolvedDeployTargets(targetsFile, organizationBuckets) {
 
 export function formatFailedDeploymentsError(failedEnvironments) {
   return `Deployment failed for environments: ${ failedEnvironments.join(', ') }`;
+}
+
+export async function deployOrganizations({
+  clients,
+  stage,
+  organizationTargets,
+  distDir,
+  markerStatus,
+  statusFile,
+  deployOrganization = deployToOrganization,
+}) {
+  for (const [organization, deployTarget] of organizationTargets) {
+    const environment = `${ stage }:${ organization }`;
+
+    try {
+      await deployOrganization(clients, stage, organization, deployTarget, distDir);
+      markerStatus.successfulEnvironments.push(environment);
+      writeDeployMarkerStatus(statusFile, markerStatus);
+    } catch(error) {
+      markerStatus.failedEnvironments.push(environment);
+      writeDeployMarkerStatus(statusFile, markerStatus);
+      process.stderr.write(`Deployment failed for ${ environment }: ${ error.message }\n`);
+    }
+  }
 }
 
 /**
@@ -468,25 +550,20 @@ async function main() {
   writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
 
   process.stdout.write(`Found ${ organizationBuckets.size } organizations to deploy:\n`);
-  organizationBuckets.forEach((bucketName, organization) => {
-    process.stdout.write(`  - ${ organization } -> ${ bucketName }\n`);
+  organizationBuckets.forEach((deployTarget, organization) => {
+    process.stdout.write(`  - ${ organization } -> ${ deployTarget.bucketName } (${ deployTarget.stackName })\n`);
   });
 
   const distDir = path.join(__dirname, '../dist');
 
-  for (const [organization, bucketName] of organizationBuckets) {
-    const environment = `${ stage }:${ organization }`;
-
-    try {
-      await deployToOrganization(clients, stage, organization, bucketName, distDir);
-      markerStatus.successfulEnvironments.push(environment);
-      writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
-    } catch (error) {
-      markerStatus.failedEnvironments.push(environment);
-      writeDeployMarkerStatus(values['marker-status-file'], markerStatus);
-      process.stderr.write(`Deployment failed for ${ environment }: ${ error.message }\n`);
-    }
-  }
+  await deployOrganizations({
+    clients,
+    stage,
+    organizationTargets: organizationBuckets,
+    distDir,
+    markerStatus,
+    statusFile: values['marker-status-file'],
+  });
 
   if (markerStatus.failedEnvironments.length) {
     throw new Error(formatFailedDeploymentsError(markerStatus.failedEnvironments));

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -417,6 +417,7 @@ export function readDeployMarkerStatus(statusFile) {
 
 function isResolvedDeployTargetEntry(entry) {
   if (!Array.isArray(entry) || entry.length !== 2) return false;
+  if (typeof entry[0] !== 'string' || !entry[0]) return false;
 
   const deployTarget = entry[1];
   return Boolean(deployTarget)
@@ -429,8 +430,8 @@ function isResolvedDeployTargetEntry(entry) {
 function readResolvedDeployTargetsPayload(targetsFile) {
   try {
     return JSON.parse(fsSync.readFileSync(targetsFile, 'utf8'));
-  } catch {
-    throw new Error(`Resolved deploy targets file is not valid JSON: ${ targetsFile }`);
+  } catch(error) {
+    throw new Error(`Resolved deploy targets file is not valid JSON: ${ targetsFile }. ${ error.message }`);
   }
 }
 

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -279,6 +279,15 @@ test('readResolvedDeployTargets rejects malformed snapshot payloads', () => {
     /Regenerate deploy targets/,
   );
 
+  fs.writeFileSync(targetsFile, JSON.stringify({
+    organizationBuckets: [[42, { bucketName: 'bucket-a', stackName: 'stack-a' }]],
+  }));
+
+  assert.throws(
+    () => readResolvedDeployTargets(targetsFile),
+    /Regenerate deploy targets/,
+  );
+
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -6,9 +6,11 @@ import test from 'node:test';
 import {
   addOrganizationsFromPage,
   buildDeployMarkerEnvironments,
+  deployOrganizations,
   formatFailedDeploymentsError,
   readDeployMarkerStatus,
   readResolvedDeployTargets,
+  resolveInvalidationDistribution,
   shouldIncludeDeployTarget,
   writeDeployMarkerStatus,
   writeResolvedDeployTargets,
@@ -32,34 +34,46 @@ function stack(name, organization, { stage = 'sandbox', websiteBucket } = {}) {
 
 test('addOrganizationsFromPage maps a website stack to its WebsiteBucket', () => {
   const organizationBuckets = new Map();
-  const response = { Stacks: [stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' })] };
+  const response = { Stacks: [stack('careops-sandbox-alpha', 'alpha', { websiteBucket: 'alpha-bucket' })] };
 
   addOrganizationsFromPage(organizationBuckets, response, 'sandbox', '');
 
-  assert.deepEqual([...organizationBuckets], [['vumc', 'vumc-bucket']]);
+  assert.deepEqual([...organizationBuckets], [[
+    'alpha',
+    {
+      bucketName: 'alpha-bucket',
+      stackName: 'careops-sandbox-alpha',
+    },
+  ]]);
 });
 
 test('addOrganizationsFromPage skips a sibling stack that shares the tags but has no WebsiteBucket output', () => {
   const organizationBuckets = new Map();
   const response = {
     Stacks: [
-      stack('adit-sandbox-vumc', 'vumc'),
-      stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' }),
+      stack('adit-sandbox-alpha', 'alpha'),
+      stack('careops-sandbox-alpha', 'alpha', { websiteBucket: 'alpha-bucket' }),
     ],
   };
 
-  // adit-sandbox-vumc matched stage=sandbox/organization=vumc but is not a website stack.
+  // adit-sandbox-alpha matched stage=sandbox/organization=alpha but is not a website stack.
   addOrganizationsFromPage(organizationBuckets, response, 'sandbox', '');
 
-  assert.deepEqual([...organizationBuckets], [['vumc', 'vumc-bucket']]);
+  assert.deepEqual([...organizationBuckets], [[
+    'alpha',
+    {
+      bucketName: 'alpha-bucket',
+      stackName: 'careops-sandbox-alpha',
+    },
+  ]]);
 });
 
 test('addOrganizationsFromPage throws when two website stacks claim the same organization', () => {
   const organizationBuckets = new Map();
   const response = {
     Stacks: [
-      stack('careops-sandbox-vumc', 'vumc', { websiteBucket: 'vumc-bucket' }),
-      stack('careops-sandbox-vumc-dupe', 'vumc', { websiteBucket: 'other-bucket' }),
+      stack('careops-sandbox-alpha', 'alpha', { websiteBucket: 'alpha-bucket' }),
+      stack('careops-sandbox-alpha-dupe', 'alpha', { websiteBucket: 'other-bucket' }),
     ],
   };
 
@@ -209,8 +223,8 @@ test('writeResolvedDeployTargets persists the resolved deploy target snapshot', 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-targets-'));
   const targetsFile = path.join(tempDir, 'targets.json');
   const organizationBuckets = new Map([
-    ['qa2', 'bucket-a'],
-    ['quality-assurance', 'bucket-b'],
+    ['qa2', { bucketName: 'bucket-a', stackName: 'stack-a' }],
+    ['quality-assurance', { bucketName: 'bucket-b', stackName: 'stack-b' }],
   ]);
 
   writeResolvedDeployTargets(targetsFile, organizationBuckets);
@@ -246,8 +260,153 @@ test('readResolvedDeployTargets rejects malformed snapshot payloads', () => {
 
   assert.throws(
     () => readResolvedDeployTargets(targetsFile),
-    /organizationBuckets must be an array of \[key, value\] entries/,
+    /organizationBuckets must be an array of \[organization, \{ bucketName, stackName \}\] entries/,
   );
+
+  fs.writeFileSync(targetsFile, JSON.stringify({ organizationBuckets: [['qa2', 'bucket-a']] }));
+
+  assert.throws(
+    () => readResolvedDeployTargets(targetsFile),
+    /Regenerate deploy targets/,
+  );
+
+  fs.writeFileSync(targetsFile, JSON.stringify({
+    organizationBuckets: [['qa2', { bucketName: 'bucket-a' }]],
+  }));
+
+  assert.throws(
+    () => readResolvedDeployTargets(targetsFile),
+    /Regenerate deploy targets/,
+  );
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function cloudFormationClient(responseOrError) {
+  return {
+    async send(command) {
+      assert.equal(command.input.StackName, 'careops-sandbox-alpha');
+      assert.equal(command.input.LogicalResourceId, 'CloudFrontDistribution');
+
+      if (responseOrError instanceof Error) {
+        throw responseOrError;
+      }
+
+      return responseOrError;
+    },
+  };
+}
+
+function validationError(message) {
+  const error = new Error(message);
+  error.name = 'ValidationError';
+  return error;
+}
+
+test('resolveInvalidationDistribution returns the CloudFront physical resource id', async() => {
+  const distributionId = await resolveInvalidationDistribution(
+    cloudFormationClient({
+      StackResourceDetail: {
+        PhysicalResourceId: 'E123456789',
+      },
+    }),
+    { stage: 'sandbox', stackName: 'careops-sandbox-alpha' },
+  );
+
+  assert.equal(distributionId, 'E123456789');
+});
+
+test('resolveInvalidationDistribution skips missing CloudFront resources only for dev', async() => {
+  const error = validationError('Resource CloudFrontDistribution does not exist for stack careops-sandbox-alpha');
+  const distributionId = await resolveInvalidationDistribution(
+    cloudFormationClient(error),
+    { stage: 'dev', stackName: 'careops-sandbox-alpha' },
+  );
+
+  assert.equal(distributionId, null);
+});
+
+test('resolveInvalidationDistribution throws for dev stack-not-found errors', async() => {
+  const error = validationError('Stack with id careops-sandbox-alpha does not exist');
+
+  await assert.rejects(
+    () => resolveInvalidationDistribution(
+      cloudFormationClient(error),
+      { stage: 'dev', stackName: 'careops-sandbox-alpha' },
+    ),
+    /Stack with id careops-sandbox-alpha does not exist/,
+  );
+});
+
+test('resolveInvalidationDistribution throws for dev permission errors', async() => {
+  const error = new Error('User is not authorized to perform: cloudformation:DescribeStackResource');
+  error.name = 'AccessDenied';
+
+  await assert.rejects(
+    () => resolveInvalidationDistribution(
+      cloudFormationClient(error),
+      { stage: 'dev', stackName: 'careops-sandbox-alpha' },
+    ),
+    /not authorized/,
+  );
+});
+
+test('resolveInvalidationDistribution throws for missing CloudFront resources outside dev', async() => {
+  const error = validationError('Resource CloudFrontDistribution does not exist for stack careops-sandbox-alpha');
+
+  await assert.rejects(
+    () => resolveInvalidationDistribution(
+      cloudFormationClient(error),
+      { stage: 'sandbox', stackName: 'careops-sandbox-alpha' },
+    ),
+    /Resource CloudFrontDistribution does not exist/,
+  );
+});
+
+test('resolveInvalidationDistribution throws when CloudFormation omits the physical resource id', async() => {
+  await assert.rejects(
+    () => resolveInvalidationDistribution(
+      cloudFormationClient({ StackResourceDetail: {} }),
+      { stage: 'sandbox', stackName: 'careops-sandbox-alpha' },
+    ),
+    /did not include a PhysicalResourceId/,
+  );
+});
+
+test('deployOrganizations records failed environments and continues deploying remaining targets', async() => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-organizations-'));
+  const statusFile = path.join(tempDir, 'status.json');
+  const markerStatus = {
+    failedEnvironments: [],
+    successfulEnvironments: [],
+  };
+  const deployedOrganizations = [];
+
+  await deployOrganizations({
+    clients: {},
+    stage: 'sandbox',
+    organizationTargets: new Map([
+      ['alpha', { bucketName: 'bucket-a', stackName: 'stack-a' }],
+      ['beta', { bucketName: 'bucket-b', stackName: 'stack-b' }],
+    ]),
+    distDir: '/tmp/dist',
+    markerStatus,
+    statusFile,
+    async deployOrganization(clients, stage, organization) {
+      deployedOrganizations.push(organization);
+
+      if (organization === 'alpha') {
+        throw new Error('Invalidation failed');
+      }
+    },
+  });
+
+  assert.deepEqual(deployedOrganizations, ['alpha', 'beta']);
+  assert.deepEqual(markerStatus, {
+    failedEnvironments: ['sandbox:alpha'],
+    successfulEnvironments: ['sandbox:beta'],
+  });
+  assert.deepEqual(JSON.parse(fs.readFileSync(statusFile, 'utf8')), markerStatus);
 
   fs.rmSync(tempDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
Closes FE-168

## What
- Resolves CloudFront distribution IDs from the deploy stack's `CloudFrontDistribution` resource instead of organization secrets.
- Fails non-dev deployments when distribution lookup or invalidation fails, while preserving per-environment progress tracking.
- Updates resolved target snapshot validation, deploy tests, and deploy documentation.

## Why
Deploys could upload new app assets, fail to invalidate CloudFront, and still report success. That left stale cached assets in place without a failed deploy signal.

## Scope
Deployment behavior in `scripts/deploy.js`, deploy unit coverage in `scripts/deploy.test.js`, and deploy documentation in `docs/deploy.md`.

## Deployment Impact
No form redeploy is needed. This affects future app deploy behavior for environments deployed through the frontend deploy script.

Before merging, verify the live CircleCI deploy roles can call `cloudformation:DescribeStackResource` and confirm each non-dev deploy stack includes `CloudFrontDistribution`.

## Testing
- `node --test scripts/deploy.test.js`
- `node --test scripts/deploy-markers.test.js`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail deployments when CloudFront invalidation fails and resolve the distribution from the deploy stack instead of org secrets, preventing silent success with stale assets. Aligns with FE-168.

- **Bug Fixes**
  - Resolve `CloudFrontDistribution` via CloudFormation (`DescribeStackResource`) instead of Secrets Manager.
  - Fail non-dev deploys on distribution lookup or invalidation errors; dev skips only when the resource is absent.
  - Keep per-environment progress via deploy markers; continue deploying remaining orgs.
  - Resolved deploy targets now include `bucketName` and `stackName` with stricter validation and clearer errors.

- **Migration**
  - Ensure deploy roles can call `cloudformation:DescribeStackResource`.
  - Confirm non-dev stacks include a `CloudFrontDistribution` logical resource.
  - If you store resolved targets, regenerate them with the current deploy script (format now includes `stackName`).

<sup>Written for commit 13b3d682ef7faa0ac0f0aa5d646f5aa70f069c85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deployment runbook to clarify how CloudFront invalidation works based on stack configuration, and explicitly defined requirements for non-dev deployment stacks.

* **Refactor**
  * Refactored deployment infrastructure resolution to use cloud stack resources instead of previous configuration methods, improving deployment orchestration.

* **Tests**
  * Expanded test coverage for deployment orchestration and cloud resource resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->