### PR TITLE
test(local-store): make storage stubs work in Firefox

### DIFF
--- a/src/js/utils/local-store.cy.js
+++ b/src/js/utils/local-store.cy.js
@@ -1,5 +1,26 @@
 import localStore from './local-store';
 
+// Firefox exposes `localStorage` as an exotic Storage object whose built-in
+// methods cannot be replaced on the instance, so `cy.stub(localStorage, 'setItem')`
+// is silently inert there. Swap the whole object instead so the stubs apply in
+// every browser.
+function useFakeStorage(overrides) {
+  const real = window.localStorage;
+  const fake = {
+    getItem: key => real.getItem(key),
+    setItem: (key, value) => real.setItem(key, value),
+    removeItem: key => real.removeItem(key),
+    key: index => real.key(index),
+    clear: () => real.clear(),
+    get length() {
+      return real.length;
+    },
+    ...overrides,
+  };
+
+  cy.stub(window, 'localStorage').value(fake);
+}
+
 context('localStore', function() {
   beforeEach(function() {
     localStorage.clear();
@@ -31,17 +52,17 @@ context('localStore', function() {
   });
 
   specify('set does not throw when storage is unavailable', function() {
-    cy.stub(localStorage, 'setItem').throws(new DOMException('blocked', 'SecurityError'));
+    useFakeStorage({ setItem: cy.stub().throws(new DOMException('blocked', 'SecurityError')) });
     expect(() => localStore.set('key', 'val')).not.to.throw();
   });
 
   specify('set rethrows QuotaExceededError', function() {
-    cy.stub(localStorage, 'setItem').throws(new DOMException('quota', 'QuotaExceededError'));
+    useFakeStorage({ setItem: cy.stub().throws(new DOMException('quota', 'QuotaExceededError')) });
     expect(() => localStore.set('key', 'val')).to.throw('quota');
   });
 
   specify('set rethrows unexpected errors', function() {
-    cy.stub(localStorage, 'setItem').throws(new Error('unexpected'));
+    useFakeStorage({ setItem: cy.stub().throws(new Error('unexpected')) });
     expect(() => localStore.set('key', 'val')).to.throw('unexpected');
   });
 
@@ -52,7 +73,7 @@ context('localStore', function() {
   });
 
   specify('remove does not throw when storage is unavailable', function() {
-    cy.stub(localStorage, 'removeItem').throws(new DOMException('blocked', 'SecurityError'));
+    useFakeStorage({ removeItem: cy.stub().throws(new DOMException('blocked', 'SecurityError')) });
     expect(() => localStore.remove('key')).not.to.throw();
   });
 
@@ -83,7 +104,11 @@ context('localStore', function() {
   });
 
   specify('each does not throw when storage is unavailable', function() {
-    cy.stub(localStorage, 'key').throws(new DOMException('blocked', 'SecurityError'));
+    localStorage.setItem('seed', JSON.stringify('value'));
+    const keyStub = cy.stub().throws(new DOMException('blocked', 'SecurityError'));
+
+    useFakeStorage({ key: keyStub });
     expect(() => localStore.each(() => {})).not.to.throw();
+    expect(keyStub.called).to.be.true;
   });
 });


### PR DESCRIPTION
Closes FE-169

## What
- Updates `src/js/utils/local-store.cy.js` to replace direct native `localStorage` method stubs with a fake `window.localStorage` object.
- Keeps the fake storage backed by the real browser storage for unstubbed methods.

## Why
Firefox exposes `localStorage` as a native Storage object whose methods are not reliably replaceable by Cypress instance stubs. This caused the Firefox daily component run to miss the intended storage error paths.

## Scope
- Impacts only the `local-store` Cypress component spec.
- No production runtime behavior is changed.

## Deployment Impact
No form or app redeploy beyond normal CI validation is needed. This is test-only coverage maintenance.

## Testing
- `npx cypress run --component --spec src/js/utils/local-store.cy.js --browser firefox`
- Covered unavailable storage, quota exceeded, unexpected errors, removal, and iteration behavior in Firefox.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cypress tests for `localStore` on Firefox by swapping in a fake `window.localStorage` so stubs run consistently and error paths are exercised. Closes FE-169.

- **Bug Fixes**
  - Added `useFakeStorage` to replace `window.localStorage` with a stub-friendly fake backed by the real storage.
  - Updated `src/js/utils/local-store.cy.js` to use `useFakeStorage` for quota, security, unexpected error, removal, and iteration tests; added an assertion that the `key` stub is called to avoid vacuous passes on Firefox.

<sup>Written for commit c043ae7937b2c0e979d67c0d23e216b4853861f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for local storage functionality in Firefox by enhancing how local storage failures are simulated.
  * Refactored coverage for `set`, `remove`, and `each` to preserve existing expectations around which errors are handled versus surfaced.
  * Added assertions to confirm storage key access occurs as expected during iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->