### PR TITLE
ci(nightly): notify frontend on Cypress failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   aws-cli: circleci/aws-cli@4.0
   cypress:   cypress-io/cypress@4
   coveralls: coveralls/coveralls@2
+  slack:     circleci/slack@6.1.3
 
 aliases:
   .node-image: &node-image cimg/node:24.15
@@ -119,6 +120,9 @@ jobs:
       upload_coverage:
         type: boolean
         default: true
+      notify_on_fail:
+        type: boolean
+        default: false
     executor: cypress-all-browsers
     parallelism: << parameters.parallelism >>
     steps:
@@ -180,6 +184,29 @@ jobs:
             - coveralls/upload:
                 fail_on_error: false
                 parallel: true
+
+      # Notify #frontend on failure (nightly only)
+      - when:
+          condition: << parameters.notify_on_fail >>
+          steps:
+            - slack/notify:
+                event: fail
+                # #frontend channel ID. Set here explicitly so nightly alerts
+                # do not inherit the deploy default channel.
+                channel: 'C02U318AW'
+                custom: |
+                  {
+                    "text": "Nightly Cypress failed: ${CIRCLE_JOB}",
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "🌙 Nightly Cypress failed: *${CIRCLE_JOB}* on `develop`\n<${CIRCLE_BUILD_URL}|View job>"
+                        }
+                      }
+                    ]
+                  }
 
   coveralls-finish:
     docker:
@@ -387,8 +414,11 @@ workflows:
     jobs:
       - run-cypress:
           name: Chrome nightly
+          context:
+            - slack-secrets
           parallelism: 1
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run
             --browser chrome
@@ -396,9 +426,12 @@ workflows:
 
       - run-cypress:
           name: Chrome nightly Component
+          context:
+            - slack-secrets
           parallelism: 1
           should_build: false
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run --component
             --browser chrome
@@ -406,8 +439,11 @@ workflows:
 
       - run-cypress:
           name: Firefox nightly
+          context:
+            - slack-secrets
           parallelism: 1
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run
             --browser firefox
@@ -415,9 +451,12 @@ workflows:
 
       - run-cypress:
           name: Firefox nightly Component
+          context:
+            - slack-secrets
           parallelism: 1
           should_build: false
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run --component
             --browser firefox
@@ -425,8 +464,11 @@ workflows:
 
       - run-cypress:
           name: Edge nightly
+          context:
+            - slack-secrets
           parallelism: 1
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run
             --browser edge
@@ -434,9 +476,12 @@ workflows:
 
       - run-cypress:
           name: Edge nightly Component
+          context:
+            - slack-secrets
           parallelism: 1
           should_build: false
           upload_coverage: false
+          notify_on_fail: true
           cypress_command: >
             npx cypress run --component
             --browser edge


### PR DESCRIPTION
Closes FE-170

## What
- Add the CircleCI Slack orb to the main config.
- Add a `notify_on_fail` option to the shared `run-cypress` job.
- Enable failure notifications for the six scheduled nightly Cypress jobs.

## Why
Nightly browser coverage can fail without surfacing to the frontend team unless someone checks CircleCI manually.

## Scope
- Impacts only `.circleci/config.yml` and the scheduled `test-nightly` workflow.
- Regular PR/develop Cypress jobs are unchanged because `notify_on_fail` defaults to `false`.
- No app runtime, shared package, or form behavior changes.

## Deployment Impact
No form redeploy or app deployment impact. This changes CI notification behavior only.

## Testing
- `git show origin/ci/nightly-slack-notify:.circleci/config.yml | circleci config validate -`
- Inspected `circleci config process -` output to confirm the Slack orb gates posting to failed jobs.
- Did not run a live scheduled workflow or send a Slack test message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Slack alerts to #frontend when nightly Cypress jobs fail, making failures visible without checking CircleCI. Targets only the six nightly jobs; PR/develop runs stay quiet (FE-170).

- **New Features**
  - Added `circleci/slack@6.1.3` orb and a `notify_on_fail` param to the shared `run-cypress` job (default false).
  - Enabled `notify_on_fail: true` for the six nightly Cypress jobs; uses `slack-secrets` context and posts to channel ID `C02U318AW`.
  - No app/runtime changes; CI notifications only.

<sup>Written for commit f6c0ea4e05bb67648ee6f137419ee6bb115a7643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

