### PR TITLE
fix(ci): install curl before nightly Slack notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,15 @@ commands:
           role_arn: ${AWS_ROLE_ARN}
           role_session_name: app-frontend-${CIRCLE_BUILD_NUM}
 
+  install-curl-if-missing:
+    steps:
+      - run:
+          name: Install curl (if missing)
+          command: |
+            if ! command -v curl >/dev/null; then
+              apt-get update -y && apt-get install --no-install-recommends -y curl
+            fi
+
 # ------------------------------------------------------------
 # EXECUTOR  –  Node 24 LTS image with Chrome 147, FF 150, Edge 147
 # ------------------------------------------------------------
@@ -129,6 +138,13 @@ jobs:
       # Checkout
       - checkout
 
+      # Install curl up front so the on-fail Slack notify can run even when
+      # an earlier setup, build, or Cypress step fails.
+      - when:
+          condition: << parameters.notify_on_fail >>
+          steps:
+            - install-curl-if-missing
+
       # Install & start virtual display
       - run:
           name: Install & start Xvfb
@@ -172,12 +188,7 @@ jobs:
       - when:
           condition: << parameters.upload_coverage >>
           steps:
-            - run:
-                name: Install curl (if missing)
-                command: |
-                  if ! command -v curl >/dev/null; then
-                    apt-get update -y && apt-get install --no-install-recommends -y curl
-                  fi
+            - install-curl-if-missing
 
             - run: npm run coverage:report:ci || true
 


### PR DESCRIPTION
Closes FE-174

## What
- Move the `notify_on_fail` curl install in `.circleci/config.yml` to run immediately after checkout for nightly Cypress jobs.
- Keep the existing coverage curl install for non-nightly coverage uploads.

## Why
- The Slack orb requires `curl`; when an earlier setup, dependency, build, or Cypress step failed before curl was installed, the nightly failure notification could fail instead of posting to Slack.

## Scope
- Impacts the shared `run-cypress` CircleCI job only when `notify_on_fail: true`.
- Nightly Chrome, Firefox, Edge, and component Cypress jobs are affected.
- Regular PR/develop coverage upload behavior is intentionally unchanged.

## Deployment Impact
- No app redeploy is needed.
- This changes CircleCI workflow behavior for future scheduled nightly runs after merge.

## Testing
- `git diff --check`
- `circleci config validate -c .circleci/config.yml`
- `circleci config process .circleci/config.yml | rg -n "Install curl for Slack notify|Install & start Xvfb|Configure npm registry auth|Cypress tests|Nightly Cypress failed" -C 1`

No full CircleCI workflow was run locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `curl` early in the CircleCI `run-cypress` job when `notify_on_fail: true` so nightly Slack failure notifications still post if earlier steps fail. Adds a reusable `install-curl-if-missing` command and reuses it for coverage; addresses FE-174 on `cypress/browsers` executors.

- **Bug Fixes**
  - Add a post-checkout `install-curl-if-missing` step gated by `notify_on_fail` so Slack notify can run even after a Cypress failure.

- **Refactors**
  - Replace the duplicated coverage `curl` install with the new `install-curl-if-missing` command; non-nightly behavior unchanged.

<sup>Written for commit 9c6e93c3b5cb5fbbe7a4e31156b3ccc5857dc18c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability so failure notifications can still be sent even if earlier setup or test steps break.
  * Ensured required tools are available sooner in the process, reducing missed alerts during failed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->