### PR TITLE
fix(deploy): set Cache-Control on every S3 upload

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -18,7 +18,15 @@ const DEPLOYABLE_STATUSES = new Set([
   'UPDATE_COMPLETE',
   'UPDATE_ROLLBACK_COMPLETE',
 ]);
-const SHARED_RUNTIME_CACHE_CONTROL = 'no-cache';
+// Content-hashed bundles never change for a given URL, so they can be cached
+// forever. The rollout shell (index.html, sw.js, appconfig.json) and every
+// stable-named asset must revalidate so a deploy is never masked by a stale
+// browser/CDN copy.
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+const REVALIDATE_CACHE_CONTROL = 'no-cache';
+// Vite emits `<name>-<hash>.<ext>` (hashes may contain - or _), date-prefixed
+// for entry/chunk JS and under assets/ for CSS. Match that trailing hash only.
+const HASHED_ASSET_PATTERN = /-[a-zA-Z0-9_-]{8,}\.(?:js|css)$/;
 const PROD_WILDCARD_EXCLUDED_ORGANIZATIONS = new Set(['demonstration']);
 const CLOUDFRONT_DISTRIBUTION_LOGICAL_ID = 'CloudFrontDistribution';
 
@@ -187,6 +195,23 @@ function isSharedRuntimeAsset(assetPath) {
 }
 
 /**
+ * Resolve the Cache-Control header for an upload key. Content-hashed bundles
+ * are immutable; everything else (shell, shared runtime, stable static assets)
+ * must revalidate.
+ * @param {string} key - The S3 key (path)
+ * @returns {string} Cache-Control header value
+ */
+export function cacheControlFor(key) {
+  const assetPath = key.replace(/^\//, '');
+
+  if (isSharedRuntimeAsset(assetPath)) return REVALIDATE_CACHE_CONTROL;
+
+  return HASHED_ASSET_PATTERN.test(assetPath) ?
+    IMMUTABLE_CACHE_CONTROL :
+    REVALIDATE_CACHE_CONTROL;
+}
+
+/**
  * Upload a single file to S3.
  * @param {S3Client} s3Client - S3 client instance
  * @param {string} bucketName - The S3 bucket name
@@ -196,14 +221,14 @@ function isSharedRuntimeAsset(assetPath) {
 async function uploadFile(s3Client, bucketName, filePath, key) {
   const fileContent = await fs.readFile(filePath);
   const contentType = getContentType(filePath);
-  const cacheControl = isSharedRuntimeAsset(key) ? SHARED_RUNTIME_CACHE_CONTROL : undefined;
+  const cacheControl = cacheControlFor(key);
 
   const command = new PutObjectCommand({
     Bucket: bucketName,
     Key: key,
     Body: fileContent,
     ContentType: contentType,
-    ...(cacheControl && { CacheControl: cacheControl }),
+    CacheControl: cacheControl,
   });
 
   await s3Client.send(command);

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   addOrganizationsFromPage,
   buildDeployMarkerEnvironments,
+  cacheControlFor,
   deployOrganizations,
   formatFailedDeploymentsError,
   readDeployMarkerStatus,
@@ -418,4 +419,42 @@ test('deployOrganizations records failed environments and continues deploying re
   assert.deepEqual(JSON.parse(fs.readFileSync(statusFile, 'utf8')), markerStatus);
 
   fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+const IMMUTABLE = 'public, max-age=31536000, immutable';
+const REVALIDATE = 'no-cache';
+
+test('cacheControlFor marks content-hashed bundles immutable', () => {
+  // Date-prefixed entry/chunk JS, including hashes that contain - or _.
+  assert.equal(cacheControlFor('20260630-app-2ThoSfMB.js'), IMMUTABLE);
+  assert.equal(cacheControlFor('20260630-sorting-Bb-sFHyu.js'), IMMUTABLE);
+  assert.equal(cacheControlFor('20260630-app-frame_app-Bgxn_W94.js'), IMMUTABLE);
+  // Hashed CSS lives under assets/ with no date prefix.
+  assert.equal(cacheControlFor('assets/app-CL4oI3p2.css'), IMMUTABLE);
+  assert.equal(cacheControlFor('/assets/sidebar-D3caASSO.css'), IMMUTABLE);
+});
+
+test('cacheControlFor keeps the rollout shell revalidating', () => {
+  assert.equal(cacheControlFor('index.html'), REVALIDATE);
+  assert.equal(cacheControlFor('sw.js'), REVALIDATE);
+  assert.equal(cacheControlFor('appconfig.json'), REVALIDATE);
+  assert.equal(cacheControlFor('/index.html'), REVALIDATE);
+});
+
+test('cacheControlFor revalidates stable-named static assets', () => {
+  assert.equal(cacheControlFor('favicon.ico'), REVALIDATE);
+  assert.equal(cacheControlFor('android-chrome-512x512.png'), REVALIDATE);
+  assert.equal(cacheControlFor('site.webmanifest'), REVALIDATE);
+  assert.equal(cacheControlFor('rwell-logo.svg'), REVALIDATE);
+  assert.equal(cacheControlFor('images/roundingwell-logo.svg'), REVALIDATE);
+});
+
+test('cacheControlFor leaves shared runtime modules revalidating', () => {
+  // Shared-runtime assets are intentionally never marked immutable.
+  assert.equal(cacheControlFor('shared/config.js'), REVALIDATE);
+  assert.equal(cacheControlFor('/shared/datadog.js'), REVALIDATE);
+});
+
+test('cacheControlFor does not mark sourcemaps immutable', () => {
+  assert.equal(cacheControlFor('20260630-app-2ThoSfMB.js.map'), REVALIDATE);
 });


### PR DESCRIPTION
Closes FE-175 — https://linear.app/roundingwell/issue/FE-175

## Problem

Prod clients crash with `TypeError: Cannot read properties of undefined (reading 'is_enabled')` on the action page. A stale app shell runs against a fresh `appconfig.json`:

- `appconfig.json` is always live (`fetch(..., { cache: 'no-cache' })` + SW `NetworkFirst`).
- `index.html` / `sw.js` / hashed JS were uploaded to S3 with **no `Cache-Control`** (`scripts/deploy.js` set it only for `shared/`). Browsers apply heuristic freshness and keep serving an old `index.html`, which names old hashed JS.

Old code + new config → response without `is_enabled` → crash. CloudFront is already invalidated `/*` per deploy, so the gap is the missing header at the S3 origin.

## Change

`cacheControlFor(key)` sets an explicit header on every upload:

- Content-hashed bundles (`YYYYMMDD-<name>-<hash>.js`, `assets/<name>-<hash>.css`) → `public, max-age=31536000, immutable`
- Shell + stable-named static assets + `shared/**` + sourcemaps → `no-cache`

## Test

`scripts/deploy.test.js` — 29/29 pass (`node --test scripts/deploy.test.js`). Added cases for immutable bundles, the shell, stable assets, shared runtime, and sourcemaps.

## Notes

- Prevents **future** staleness; clients already holding a heuristically-fresh `index.html` self-heal when their window lapses. A startup version guard is a follow-up, not in this PR.
- Pre-existing lint errors in `scripts/deploy.js` (complexity / `preserve-caught-error`) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit Cache-Control on all S3 uploads to stop stale app shells causing action page crashes (FE-175). Hashed bundles are cached immutably; the shell, stable assets, `shared/**`, and sourcemaps revalidate.

- **Bug Fixes**
  - Added `cacheControlFor(key)` and applied it in `scripts/deploy.js` to set Cache-Control on every upload.
  - Rules: hashed `.js`/`.css` → `public, max-age=31536000, immutable`; `index.html`, `sw.js`, `appconfig.json`, stable assets, `shared/**`, `.map` → `no-cache`.
  - Added tests in `scripts/deploy.test.js` covering immutable bundles and revalidating assets.

<sup>Written for commit 77ab9bf9fed558f7b1f3e346bfa8a1f9d8e601f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved asset caching during deploys so static files now get more appropriate cache-control headers based on file type.

* **Bug Fixes**
  * Content-hashed JS/CSS bundles are now served with long-lived caching.
  * Shared runtime files and other frequently updated assets are now revalidated instead of cached too aggressively.
  * Sourcemaps and rollout-related files are kept out of immutable caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->