### PR TITLE
ci(cypress): prepare dedicated nightly pipeline

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,23 @@
+# CircleCI Pipelines
+
+The project uses three pipeline definitions with separate responsibilities:
+
+- `CI` uses the GitHub OAuth integration and
+  [`.circleci/config.yml`](config.yml). It runs for pull requests, default-branch
+  pushes, and tags. The setup config detects `ci:defer-cypress`, then continues
+  into [`.circleci/workflows.yml`](workflows.yml).
+- `nightly-cypress` uses the GitHub App integration and loads
+  [`.circleci/workflows.yml`](workflows.yml) directly. Its `nightly-cypress`
+  schedule runs the cross-browser Cypress matrix on `develop` at `0 11 * * *`.
+- `deploy` uses the GitHub App integration and
+  [`.circleci/deploy.yml`](deploy.yml). It has no GitHub event trigger; releases
+  invoke it manually or through the CircleCI API.
+
+`workflows.yml` is shared so pull request, branch, tag, and nightly jobs reuse
+the same commands and executors. `pipeline.trigger_source` selects either the
+normal `test-build` workflow or the scheduled `test-nightly` workflow.
+
+When a config path or pipeline definition changes, merge the checked-in config
+first, then update CircleCI Project Setup. Keep the existing schedule active
+until its replacement is configured, and remove the old schedule only after the
+new pipeline has produced a successful nightly run.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Detect Cypress deferral label
           command: bash .circleci/detect-cypress-defer.sh /tmp/pipeline-parameters.json
       - continuation/continue:
-          configuration_path: .circleci/continue.yml
+          configuration_path: .circleci/workflows.yml
           parameters: /tmp/pipeline-parameters.json
 
 workflows:

--- a/.circleci/detect-cypress-defer.sh
+++ b/.circleci/detect-cypress-defer.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 readonly defer_label='ci:defer-cypress'
 readonly output_path="${1:-/tmp/pipeline-parameters.json}"
+readonly label_attempts=8
+readonly label_poll_seconds=2
 
 defer_cypress=false
 
@@ -15,23 +17,63 @@ if [[ -n "${CIRCLE_BRANCH:-}" && "${CIRCLE_BRANCH}" != 'develop' && -z "${CIRCLE
   api_root="${GITHUB_API_URL:-https://api.github.com}"
   api_url="${api_root%/}/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commits/${CIRCLE_SHA1}/pulls"
 
-  if curl \
-    --fail \
-    --silent \
-    --show-error \
-    --retry 3 \
-    --header 'Accept: application/vnd.github+json' \
-    --header 'X-GitHub-Api-Version: 2022-11-28' \
-    --header 'User-Agent: app-frontend-circleci' \
-    --output "${response_file}" \
-    "${api_url}"; then
-    defer_cypress="$(
+  api_read_succeeded=false
+
+  for ((attempt = 1; attempt <= label_attempts; attempt += 1)); do
+    if ! curl \
+      --fail \
+      --silent \
+      --show-error \
+      --connect-timeout 5 \
+      --max-time 15 \
+      --retry 3 \
+      --retry-max-time 15 \
+      --header 'Accept: application/vnd.github+json' \
+      --header 'X-GitHub-Api-Version: 2022-11-28' \
+      --header 'User-Agent: app-frontend-circleci' \
+      --output "${response_file}" \
+      "${api_url}"; then
+      break
+    fi
+
+    api_read_succeeded=true
+    if ! defer_cypress="$(
       jq \
         --arg label_name "${defer_label}" \
         'any(.[]; .state == "open" and any(.labels[]?; .name == $label_name))' \
         "${response_file}"
-    )"
-  else
+    )"; then
+      api_read_succeeded=false
+      defer_cypress=false
+      break
+    fi
+
+    if [[ "${defer_cypress}" == 'true' ]]; then
+      break
+    fi
+
+    # A PR-created pipeline can start before automation attaches its labels.
+    # Only poll for new PRs so ordinary pushes to older human PRs are not delayed.
+    if ! should_poll="$(
+      jq \
+        '([.[] | select(.state == "open")] as $open_prs |
+          ($open_prs | length) > 0 and
+          any($open_prs[]; (.created_at | fromdateiso8601) > (now - 120)))' \
+        "${response_file}"
+    )"; then
+      api_read_succeeded=false
+      break
+    fi
+
+    if [[ "${should_poll}" != 'true' || "${attempt}" == "${label_attempts}" ]]; then
+      break
+    fi
+
+    echo "Waiting briefly for ${defer_label} to be attached to the new PR."
+    sleep "${label_poll_seconds}"
+  done
+
+  if [[ "${api_read_succeeded}" != 'true' ]]; then
     echo 'Unable to read PR labels; running Cypress by default.' >&2
   fi
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -464,8 +464,8 @@ workflows:
             and pipeline.parameters.defer_cypress
 
   test-nightly:
-    # Dynamic configuration requires this cron to be configured as a CircleCI
-    # schedule trigger named nightly-cypress for develop at 0 11 * * *.
+    # The dedicated nightly-cypress pipeline schedules this workflow for
+    # develop at 0 11 * * *.
     when:
       equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,8 @@ generated code, and do not flag them as issues, tech debt, or risks in review.
   E2E, component, and coverage jobs for the current commit.
 - Never merge while Cypress is held or without a passing Cypress result for the
   current commit. A new commit requires a new approval and Cypress result.
+- Read [`.circleci/README.md`](.circleci/README.md) before changing CircleCI
+  pipeline definitions, config paths, or schedule triggers.
 
 ## Validation
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -108,7 +108,8 @@ This pages CloudFormation results, filters by the `stage=<stage>` tag, and deplo
 Release artifact publishing runs only for version tags matching:
 - `vYYMMDD.N`
 
-The tag pipeline in [`.circleci/config.yml`](../.circleci/config.yml):
+The `release-artifact` workflow in
+[`.circleci/workflows.yml`](../.circleci/workflows.yml):
 1. Builds `dist/`
 2. Uploads sourcemaps to Datadog
 3. Packages `dist/` as `/tmp/dist.tar.gz`
@@ -178,7 +179,7 @@ Additional CircleCI secrets for the QA2 E2E dispatch step:
 
 CircleCI context for the Linear release steps:
 - `linear-secrets` context, providing `LINEAR_ACCESS_KEY` (Linear release pipeline access key)
-- attached to the `release-artifact` workflow in [`.circleci/config.yml`](../.circleci/config.yml) (sync + `Started` stage on tag build), and to the `deploy-qa` and `deploy-prod` workflows in [`.circleci/deploy.yml`](../.circleci/deploy.yml). The `deploy-dev` workflow does not have access to the Linear secret.
+- attached to the `release-artifact` workflow in [`.circleci/workflows.yml`](../.circleci/workflows.yml) (sync + `Started` stage on tag build), and to the `deploy-qa` and `deploy-prod` workflows in [`.circleci/deploy.yml`](../.circleci/deploy.yml). The `deploy-dev` workflow does not have access to the Linear secret.
 - the Linear release pipeline is configured as **scheduled**; stages used: built-in `Started`, custom `QA` (frozen) and `Sandbox`, and built-in terminal `Released`. CI also calls `complete` after a successful prod deploy.
 
 For QA deploys that include `qa2`, [`.circleci/deploy.yml`](../.circleci/deploy.yml) resolves the release SHA, passes the release tag, SHA, and a CircleCI run URL to [`scripts/dispatch-qa2-e2e.js`](../scripts/dispatch-qa2-e2e.js), and that script uses the GitHub App credentials above plus the `app-tests` installation id to mint a short-lived installation token before posting `repository_dispatch` with this payload:


### PR DESCRIPTION
Closes FE-181

## What

- Rename the shared CircleCI continuation config to `.circleci/workflows.yml`.
- Keep regular CI and nightly Cypress on the same job and executor definitions.
- Document the intended `CI`, `nightly-cypress`, and `deploy` pipeline responsibilities and safe migration order.
- Briefly poll labels on newly opened PRs so `ci:defer-cypress` wins the PR-created event race.

## Why

Nightly Cypress is operationally separate from PR, branch, tag, and release CI. A dedicated pipeline makes that ownership visible without duplicating the Cypress configuration.

The first live run also showed that CircleCI setup could finish before PR automation attached `ci:defer-cypress`, starting Cypress despite the intended review hold.

## Scope

CircleCI configuration and repository CI documentation only. Cypress commands, recording, parallelism, coverage, notifications, and deploy behavior are unchanged.

Only newly opened PRs receive the short label grace period. Existing human PR revisions without the label continue immediately.

The live CircleCI pipeline definitions and schedule remain unchanged until this PR merges.

## Deployment Impact

No application or form redeploy is required.

After merge, CircleCI Project Setup must be updated to:

1. Rename `app-frontend` to `CI`.
2. Repurpose `Test-release` as `nightly-cypress` and point it to `.circleci/workflows.yml`.
3. Rename `deploy-pipeline` to `deploy`.
4. Add the existing `develop` schedule to `nightly-cypress`.
5. Remove the old schedule only after the new pipeline produces a successful nightly run.

## Testing

- `circleci config validate .circleci/config.yml`
- `circleci config validate .circleci/workflows.yml`
- Processed `.circleci/workflows.yml` with `defer_cypress` set to both `false` and `true`.
- `bash -n .circleci/detect-cypress-defer.sh`
- Live script check against this labeled PR produced `defer_cypress: true`.
- Live script check for `develop` produced `defer_cypress: false`.
- `npm run lint`
- `git diff --check`

Current-commit CircleCI passed lint, E2E, component, and Coveralls after the approval gate; Cypress Cloud reports 240 E2E tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cypress deferral detection by checking repeatedly for the defer label, reducing race conditions for newly created pull requests.
  * Cypress now runs by default if label detection cannot be completed successfully.

* **Documentation**
  * Added guidance for CircleCI pipelines, workflow triggers, schedules, and configuration updates.
  * Updated deployment documentation to reference the current release workflow and secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->