### PR TITLE
fix(deploy): exclude source maps from website uploads

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -163,8 +163,11 @@ function getContentType(filePath) {
   return contentTypes[ext] || 'application/octet-stream';
 }
 
-function shouldSkipUploadEntry(entryName) {
-  return entryName.startsWith('.');
+function shouldSkipUploadEntry(entry) {
+  // Keep sourcemaps in release artifacts for Datadog, but never publish them
+  // to a customer-facing website bucket.
+  return entry.name.startsWith('.') ||
+    (!entry.isDirectory() && path.extname(entry.name).toLowerCase() === '.map');
 }
 
 const FINAL_UPLOAD_ORDER = new Map([
@@ -186,7 +189,7 @@ function compareUploadEntries(a, b, prefix = '') {
 
 export function sortUploadEntries(entries, prefix = '') {
   return [...entries]
-    .filter(entry => !shouldSkipUploadEntry(entry.name))
+    .filter(entry => !shouldSkipUploadEntry(entry))
     .sort((a, b) => compareUploadEntries(a, b, prefix));
 }
 
@@ -235,13 +238,13 @@ async function uploadFile(s3Client, bucketName, filePath, key) {
 }
 
 /**
- * Upload entire directory to S3 recursively.
+ * Upload public deployment files to S3 recursively, excluding dot entries and sourcemaps.
  * @param {S3Client} s3Client - S3 client instance
  * @param {string} bucketName - The S3 bucket name
  * @param {string} dirPath - The local directory path
  * @param {string} prefix - The S3 key prefix
  */
-async function uploadDirectory(s3Client, bucketName, dirPath, prefix = '') {
+export async function uploadDirectory(s3Client, bucketName, dirPath, prefix = '') {
   const entries = sortUploadEntries(
     await fs.readdir(dirPath, { withFileTypes: true }),
     prefix,

--- a/scripts/deploy.test.js
+++ b/scripts/deploy.test.js
@@ -13,6 +13,7 @@ import {
   readResolvedDeployTargets,
   resolveInvalidationDistribution,
   shouldIncludeDeployTarget,
+  uploadDirectory,
   writeDeployMarkerStatus,
   writeResolvedDeployTargets,
 } from './deploy.js';
@@ -417,6 +418,36 @@ test('deployOrganizations records failed environments and continues deploying re
     successfulEnvironments: ['sandbox:beta'],
   });
   assert.deepEqual(JSON.parse(fs.readFileSync(statusFile, 'utf8')), markerStatus);
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('uploadDirectory excludes source maps at every directory depth', async() => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-upload-'));
+  const uploadedKeys = [];
+  const s3Client = {
+    async send(command) {
+      uploadedKeys.push(command.input.Key);
+    },
+  };
+
+  fs.mkdirSync(path.join(tempDir, 'assets', 'chunks'), { recursive: true });
+  fs.writeFileSync(path.join(tempDir, 'index.html'), 'app');
+  fs.writeFileSync(path.join(tempDir, 'app.js'), 'app');
+  fs.writeFileSync(path.join(tempDir, 'app.js.map'), 'map');
+  fs.writeFileSync(path.join(tempDir, 'assets', 'app.css'), 'styles');
+  fs.writeFileSync(path.join(tempDir, 'assets', 'app.css.map'), 'map');
+  fs.writeFileSync(path.join(tempDir, 'assets', 'chunks', 'feature.js'), 'feature');
+  fs.writeFileSync(path.join(tempDir, 'assets', 'chunks', 'feature.js.map'), 'map');
+
+  await uploadDirectory(s3Client, 'website-bucket', tempDir);
+
+  assert.deepEqual(uploadedKeys, [
+    'assets/chunks/feature.js',
+    'assets/app.css',
+    'app.js',
+    'index.html',
+  ]);
 
   fs.rmSync(tempDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
Closes FE-179

## What
- Exclude .map files from recursive website-bucket uploads.
- Add a deployment test covering root and nested source maps while preserving normal uploads.

## Why
Source maps are needed by Datadog and remain in the private release artifact, but they should not be publicly retrievable from application website buckets.

## Scope
Deployment uploader and its Node tests only. Datadog upload, artifact packaging, checksums, release semantics, and Cypress behavior are unchanged.

## Deployment Impact
Applies to future app deployments: source maps in release artifacts will no longer be copied to website buckets. No forms or bundles require a separate redeploy beyond the normal app deployment.

## Testing
- node --test scripts/deploy.test.js (30 passed)
- npm run lint
- Cypress not run; this changes deployment-only Node code with focused Node coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude source maps from public website uploads while keeping them in release artifacts for Datadog. Prevents public access to `.map` files and applies to future deployments.

- **Bug Fixes**
  - Skip `.map` files during recursive uploads via `shouldSkipUploadEntry` (handles nested paths; only skips files, not directories).
  - Exported `uploadDirectory` and added a unit test proving maps are excluded at every depth and normal files still upload.
  - Aligns with FE-179: Datadog uploads unchanged; no `.map` files reach website buckets; other deployment behavior unchanged.

<sup>Written for commit 2416a790ba5c15ac14f83b333f06549ef3abbc62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

