### PR TITLE
feat(uuid): migrate generated IDs to UUIDv7

### DIFF
--- a/src/js/apps/dashboards/dashboard/dashboard.e2e.cy.js
+++ b/src/js/apps/dashboards/dashboard/dashboard.e2e.cy.js
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { getErrors } from 'helpers/json-api';
 

--- a/src/js/apps/forms/form/action.e2e.cy.js
+++ b/src/js/apps/forms/form/action.e2e.cy.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import formatDate from 'helpers/format-date';
 import { testDate, testDateSubtract } from 'helpers/test-date';

--- a/src/js/apps/globals/nav/app-nav.e2e.cy.js
+++ b/src/js/apps/globals/nav/app-nav.e2e.cy.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { getRelationship, getErrors } from 'helpers/json-api';
 

--- a/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
+import { v7 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { testTs, testTsSubtract } from 'helpers/test-timestamp';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';

--- a/src/js/apps/patients/schedule/schedule.e2e.cy.js
+++ b/src/js/apps/patients/schedule/schedule.e2e.cy.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import { v7 as uuidv7, v5 as uuidv5 } from 'uuid';
 
 import formatDate from 'helpers/format-date';
 import { testDate, testDateAdd, testDateSubtract } from 'helpers/test-date';
@@ -783,7 +783,7 @@ context('schedule page', function() {
       },
       actionsSelected: {
         [testActions[0].id]: true,
-        [uuidv4()]: true,
+        [uuidv7()]: true,
       },
     }));
 

--- a/src/js/apps/patients/sidebar/action/action-sidebar.e2e.cy.js
+++ b/src/js/apps/patients/sidebar/action/action-sidebar.e2e.cy.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import formatDate from 'helpers/format-date';
 import { testTs, testTsSubtract, testTsAdd } from 'helpers/test-timestamp';

--- a/src/js/apps/patients/worklist/worklist.e2e.cy.js
+++ b/src/js/apps/patients/worklist/worklist.e2e.cy.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid, NIL as NIL_UUID } from 'uuid';
+import { v7 as uuid, NIL as NIL_UUID } from 'uuid';
 
 import { ACTION_OUTREACH } from 'js/static';
 

--- a/src/js/apps/programs/program/flow/program-flow.e2e.cy.js
+++ b/src/js/apps/programs/program/flow/program-flow.e2e.cy.js
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { testTs } from 'helpers/test-timestamp';
 

--- a/src/js/apps/programs/sidebar/action/action-sidebar.e2e.cy.js
+++ b/src/js/apps/programs/sidebar/action/action-sidebar.e2e.cy.js
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import formatDate from 'helpers/format-date';
 import { testTs } from 'helpers/test-timestamp';

--- a/src/js/base/uuid.component.cy.js
+++ b/src/js/base/uuid.component.cy.js
@@ -1,0 +1,43 @@
+import Backbone from 'backbone';
+import { version } from 'uuid';
+
+import './uuid';
+
+context('base UUID generation', function() {
+  specify('generates UUIDv7 IDs for created resources', function() {
+    const sync = cy.stub(Backbone, 'sync');
+
+    const model = new Backbone.Model();
+    const options = {
+      data: JSON.stringify({ data: { type: 'tests' } }),
+    };
+
+    model.sync('create', model, options);
+
+    const [, , syncOptions] = sync.firstCall.args;
+    const { id } = JSON.parse(syncOptions.data).data;
+
+    expect(version(id)).to.equal(7);
+    expect(Backbone.sync).to.have.been.calledOnce;
+  });
+
+  specify('preserves model-specific deterministic IDs', function() {
+    const sync = cy.stub(Backbone, 'sync');
+
+    const Model = Backbone.Model.extend({
+      createId() {
+        return 'deterministic-id';
+      },
+    });
+    const model = new Model();
+    const options = {
+      data: JSON.stringify({ data: { type: 'tests' } }),
+    };
+
+    model.sync('create', model, options);
+
+    const [, , syncOptions] = sync.firstCall.args;
+
+    expect(JSON.parse(syncOptions.data).data.id).to.equal('deterministic-id');
+  });
+});

--- a/src/js/base/uuid.js
+++ b/src/js/base/uuid.js
@@ -1,6 +1,6 @@
 import { clone, isString } from 'underscore';
 import Backbone from 'backbone';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 // NOTE: Assumes idAttribute is _always_ id
 Backbone.Model.prototype.sync = function(method, model, options) {

--- a/src/js/entities-service/clinicians.js
+++ b/src/js/entities-service/clinicians.js
@@ -1,5 +1,5 @@
 import { setUser, startRum } from 'js/datadog';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import Radio from 'backbone.radio';
 import BaseEntity from 'js/base/entity-service';
 import { _Model, Model, Collection } from './entities/clinicians';

--- a/src/js/services/ws.component.cy.js
+++ b/src/js/services/ws.component.cy.js
@@ -1,5 +1,6 @@
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
+import { version } from 'uuid';
 
 import 'js/entities-service/entities/flows';
 
@@ -279,6 +280,7 @@ context('WS Service', function() {
       .should('be.calledWith', testData([notifications[0]]))
 
       .then(() => {
+        expect(version(service.subscriptionVersion)).to.equal(7);
         channel.request('add', notifications[1], { shouldPersist: true });
       })
       .get('@wsHandleMessage')

--- a/src/js/services/ws.js
+++ b/src/js/services/ws.js
@@ -1,7 +1,7 @@
 import { each, map, values, isArray, isEmpty } from 'underscore';
 import Backbone from 'backbone';
 import Radio from 'backbone.radio';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import App from 'js/base/app';
 import fetcher, { handleJSON } from 'js/base/fetch';

--- a/test/fixtures/config/actions.js
+++ b/test/fixtures/config/actions.js
@@ -27,7 +27,7 @@ export default () => {
   }));
 
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
     details: faker.lorem.sentences(),
     due_date: due.format('YYYY-MM-DD'),

--- a/test/fixtures/config/comments.js
+++ b/test/fixtures/config/comments.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     message: faker.lorem.sentences(),
     edited_at: faker.helpers.arrayElement([faker.date.between({
       from: dayjs().subtract(1, 'week').format(),

--- a/test/fixtures/config/dashboards.js
+++ b/test/fixtures/config/dashboards.js
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 export default () => {
-  const id = faker.string.uuid();
+  const id = faker.string.uuid({ version: 7 });
 
   return {
     id,

--- a/test/fixtures/config/filters.js
+++ b/test/fixtures/config/filters.js
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: faker.lorem.word(),
     description: faker.lorem.sentence(),
     slug: faker.lorem.slug(),

--- a/test/fixtures/config/flows.js
+++ b/test/fixtures/config/flows.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
     details: faker.lorem.sentences(),
     created_at: faker.date.between({

--- a/test/fixtures/config/forms.js
+++ b/test/fixtures/config/forms.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
     url: null,
     created_at: faker.date.between({

--- a/test/fixtures/config/patient-fields.js
+++ b/test/fixtures/config/patient-fields.js
@@ -1,9 +1,15 @@
 import { faker } from '@faker-js/faker';
+import { v5 as uuid } from 'uuid';
+
+import { RWELL_NS } from '../../../src/js/static.js';
 
 export default () => {
+  const name = faker.lorem.word();
+  const patientId = faker.string.uuid({ version: 7 });
+
   return {
-    id: faker.string.uuid(),
-    name: faker.lorem.word(),
+    id: uuid(`patient:${ patientId }:field:${ name }`, RWELL_NS),
+    name,
     value: faker.number.int({
       min: 0,
       max: 100000,

--- a/test/fixtures/config/patient-search.js
+++ b/test/fixtures/config/patient-search.js
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     first_name: faker.person.firstName(),
     last_name: faker.person.lastName(),
     birth_date: faker.date.past(40, '2010-01-01'),

--- a/test/fixtures/config/patients.js
+++ b/test/fixtures/config/patients.js
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     first_name: faker.person.firstName(),
     last_name: faker.person.lastName(),
     birth_date: faker.date.past(40, '2010-01-01'),

--- a/test/fixtures/config/program-actions.js
+++ b/test/fixtures/config/program-actions.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
     details: faker.lorem.sentences(),
     days_until_due: faker.number.int({

--- a/test/fixtures/config/program-flows.js
+++ b/test/fixtures/config/program-flows.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: `${ faker.company.buzzVerb() } ${ faker.company.catchPhraseNoun() }`,
     details: faker.lorem.sentences(),
     published_at: faker.helpers.arrayElement([faker.date.between({

--- a/test/fixtures/config/programs.js
+++ b/test/fixtures/config/programs.js
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: faker.company.buzzPhrase(),
     details: faker.lorem.sentences(),
     published_at: faker.helpers.arrayElement([faker.date.between({

--- a/test/fixtures/config/workspaces.js
+++ b/test/fixtures/config/workspaces.js
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 
 export default () => {
   return {
-    id: faker.string.uuid(),
+    id: faker.string.uuid({ version: 7 }),
     name: faker.company.buzzPhrase(),
     slug: faker.lorem.word(),
     settings: {},

--- a/test/helpers/json-api.js
+++ b/test/helpers/json-api.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 // NOTE: Set this to true to check for invalid types and relationships
 const DEBUG = false;

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxActions from 'fixtures/collections/actions';

--- a/test/support/api/clinicians.js
+++ b/test/support/api/clinicians.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid, v5 as uuidv5 } from 'uuid';
+import { v7 as uuid, v5 as uuidv5 } from 'uuid';
 import { RWELL_NS } from 'js/static';
 import { testTs } from 'helpers/test-timestamp';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';

--- a/test/support/api/comments.js
+++ b/test/support/api/comments.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import { getClinician } from './clinicians';

--- a/test/support/api/dashboards.js
+++ b/test/support/api/dashboards.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { getResource, mergeJsonApi } from 'helpers/json-api';
 

--- a/test/support/api/events.js
+++ b/test/support/api/events.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship } from 'helpers/json-api';
 
 import fxTestActionEvents from 'fixtures/test/events-actions';

--- a/test/support/api/files.js
+++ b/test/support/api/files.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { testTs } from 'helpers/test-timestamp';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';

--- a/test/support/api/filters.js
+++ b/test/support/api/filters.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, mergeJsonApi } from 'helpers/json-api';
 
 import fxFilters from 'fixtures/collections/filters';

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxFlows from 'fixtures/collections/flows';

--- a/test/support/api/form-responses.js
+++ b/test/support/api/form-responses.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import dayjs from 'dayjs';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxTestFormResponse from 'fixtures/test/form-response';

--- a/test/support/api/forms.js
+++ b/test/support/api/forms.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, mergeJsonApi } from 'helpers/json-api';
 
 import fxTestForms from 'fixtures/collections/forms';

--- a/test/support/api/patients.js
+++ b/test/support/api/patients.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import { getWorkspaces } from './workspaces';

--- a/test/support/api/program-actions.js
+++ b/test/support/api/program-actions.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 

--- a/test/support/api/program-flows.js
+++ b/test/support/api/program-flows.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxProgramFlows from 'fixtures/collections/program-flows';

--- a/test/support/api/programs.js
+++ b/test/support/api/programs.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { v4 as uuid } from 'uuid';
+import { v7 as uuid } from 'uuid';
 import { getResource, getRelationship, mergeJsonApi } from 'helpers/json-api';
 
 import fxPrograms from 'fixtures/collections/programs';


### PR DESCRIPTION
Closes FE-154

## What

- Generate UUIDv7 values for Backbone-created resources, websocket subscription versions, and clinician client keys.
- Migrate E2E helpers, API test support, and generated fixtures from UUIDv4 to UUIDv7 while preserving deterministic UUIDv5 and existing UUID parsing behavior.
- Add component assertions for representative Backbone and websocket UUIDv7 generation paths.

## Why

Frontend-created IDs need time-ordered UUIDv7 values for stable ordering, cursor behavior, and alignment with current backend expectations.

## Scope

- Affects frontend-generated IDs across the app and generated test data.
- Keeps existing persisted UUIDs, UUID validation, NIL sentinels, and deterministic UUIDv5 IDs unchanged.
- Uses the existing root `uuid@14.0.0`; no dependency or lockfile change is required.

## Deployment Impact

No form or bundle redeploy is required. This ships with the normal app deployment and affects all frontend resource creation paths that use the shared Backbone sync behavior.

## Testing

- `npm run lint`
- `npm ls uuid --all`
- Cypress component and E2E coverage deferred to CI, including the new UUIDv7 assertions in `src/js/base/uuid.component.cy.js` and `src/js/services/ws.component.cy.js`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move frontend ID generation to UUIDv7 for time-ordered IDs and stable ordering. Updates Backbone create paths, websocket subscription versions, and clinician client keys to meet FE-154.

- **Refactors**
  - Replace `uuid.v4` with `uuid.v7` for client-generated IDs, websocket subscription versions, and clinician client keys.
  - Update Cypress E2E, API helpers, and fixtures to v7 (use `faker.string.uuid({ version: 7 })` and v7 imports).
  - Add component tests: Backbone create emits v7; preserves model `createId`; WS `subscriptionVersion` is v7.
  - Keep UUID parsing/validation, NIL sentinels, and deterministic `uuid.v5` unchanged; make patient-field fixture IDs deterministic with `uuid.v5` using `RWELL_NS`.
  - No dependency changes; uses `uuid@14.0.0`.

<sup>Written for commit 1620bcca2bbdc5980a598664e9f78baba7ff4db4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Standardized generated identifiers to use UUID version 7 across core creation flows, clinician fetching, WebSocket subscription payloads, and related test/server fixtures.
  * Preserved explicit identifier overrides and existing routing/404 behavior.

* **Tests**
  * Added coverage to verify UUIDv7 generation during model create and that deterministic IDs are preserved.
  * Updated end-to-end and API/test helpers to generate and assert UUIDv7-based IDs and subscription version values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->