### PR TITLE
fix(entities): use canonical collection endpoints

### DIFF
--- a/src/js/entities-service/actions.js
+++ b/src/js/entities-service/actions.js
@@ -32,13 +32,13 @@ const Entity = BaseEntity.extend({
   },
   fetchActionsByPatient({ patientId, filter }) {
     const data = { filter };
-    const url = `/api/patients/${ patientId }/relationships/actions`;
+    const url = `/api/patients/${ patientId }/actions`;
 
     return this.fetchCollection({ url, data });
   },
   fetchActionsByFlow(flowId) {
     const data = { include: ACTION_INCLUDE };
-    const url = `/api/flows/${ flowId }/relationships/actions`;
+    const url = `/api/flows/${ flowId }/actions`;
 
     return this.fetchCollection({ url, data });
   },

--- a/src/js/entities-service/files.js
+++ b/src/js/entities-service/files.js
@@ -9,7 +9,7 @@ const Entity = BaseEntity.extend({
     'fetch:files:collection:byAction': 'fetchFilesByAction',
   },
   fetchFilesByAction(actionId) {
-    const url = `/api/actions/${ actionId }/relationships/files`;
+    const url = `/api/actions/${ actionId }/files`;
     const data = { urls: ['download', 'view'] };
 
     return this.fetchCollection({ url, data });

--- a/src/js/entities-service/flows.js
+++ b/src/js/entities-service/flows.js
@@ -21,7 +21,7 @@ const Entity = BaseEntity.extend({
   },
   fetchFlowsByPatient({ patientId, filter }) {
     const data = { filter };
-    const url = `/api/patients/${ patientId }/relationships/flows`;
+    const url = `/api/patients/${ patientId }/flows`;
 
     return this.fetchCollection({ url, data });
   },

--- a/src/js/entities-service/program-actions.js
+++ b/src/js/entities-service/program-actions.js
@@ -14,7 +14,7 @@ const Entity = BaseEntity.extend({
     'fetch:programActions:collection:byProgramFlow': 'fetchProgramActionsByFlow',
   },
   fetchProgramActionsByProgram({ programId }) {
-    const url = `/api/programs/${ programId }/relationships/actions`;
+    const url = `/api/programs/${ programId }/actions`;
 
     return this.fetchCollection({ url });
   },

--- a/src/js/entities-service/program-flows.js
+++ b/src/js/entities-service/program-flows.js
@@ -13,7 +13,7 @@ const Entity = BaseEntity.extend({
     'fetch:programFlows:collection': 'fetchProgramFlows',
   },
   fetchProgramFlowsByProgram({ programId }) {
-    const url = `/api/programs/${ programId }/relationships/flows`;
+    const url = `/api/programs/${ programId }/flows`;
 
     return this.fetchCollection({ url });
   },

--- a/src/js/entities-service/programs.js
+++ b/src/js/entities-service/programs.js
@@ -15,7 +15,7 @@ const Entity = BaseEntity.extend({
     return this.fetchBy(`/api/program-flows/${ flowId }/program`);
   },
   fetchProgramsByWorkspace(workspaceId) {
-    const url = `/api/workspaces/${ workspaceId }/relationships/programs`;
+    const url = `/api/workspaces/${ workspaceId }/programs`;
     return this.fetchCollectionCache({ url });
   },
 });

--- a/test/support/api/actions.js
+++ b/test/support/api/actions.js
@@ -111,7 +111,7 @@ Cypress.Commands.add('routePatientActions', (mutator = routePatientActions) => {
   const included = [];
 
   cy
-    .intercept('GET', '/api/patients/**/relationships/actions*', {
+    .intercept('GET', '/api/patients/**/actions*', {
       body: mutator({ data, included }),
     })
     .as('routePatientActions');
@@ -138,7 +138,7 @@ Cypress.Commands.add('routeFlowActions', (mutator = routeFlowActions) => {
   const included = [];
 
   cy
-    .intercept('GET', '/api/flows/**/relationships/actions*', {
+    .intercept('GET', '/api/flows/**/actions*', {
       body: mutator({ data, included }),
     })
     .as('routeFlowActions');

--- a/test/support/api/files.js
+++ b/test/support/api/files.js
@@ -32,7 +32,7 @@ export function getFile(data) {
 
 Cypress.Commands.add('routeActionFiles', (mutator = _.identity) => {
   cy
-    .intercept('GET', '/api/actions/**/relationships/files?urls=download,view', {
+    .intercept('GET', '/api/actions/**/files?urls=download,view', {
       body: mutator({ data: [], included: [] }),
     })
     .as('routeActionFiles');

--- a/test/support/api/flows.js
+++ b/test/support/api/flows.js
@@ -125,7 +125,7 @@ Cypress.Commands.add('routePatientFlows', (mutator = routePatientFlows) => {
   const included = [];
 
   cy
-    .intercept('GET', '/api/patients/**/relationships/flows*', {
+    .intercept('GET', '/api/patients/**/flows*', {
       body: mutator({ data, included }),
     })
     .as('routePatientFlows');

--- a/test/support/api/program-actions.js
+++ b/test/support/api/program-actions.js
@@ -50,7 +50,7 @@ Cypress.Commands.add('routeProgramActions', (mutator = _.identity) => {
   });
 
   cy
-    .intercept('GET', '/api/programs/**/relationships/actions*', {
+    .intercept('GET', '/api/programs/**/actions*', {
       body: mutator({ data, included: [] }),
     })
     .as('routeProgramActions');

--- a/test/support/api/program-flows.js
+++ b/test/support/api/program-flows.js
@@ -49,7 +49,7 @@ Cypress.Commands.add('routeProgramFlows', (mutator = _.identity) => {
   });
 
   cy
-    .intercept('GET', '/api/programs/**/relationships/flows*', {
+    .intercept('GET', '/api/programs/**/flows*', {
       body: mutator({ data, included: [] }),
     })
     .as('routeProgramFlows');

--- a/test/support/api/programs.js
+++ b/test/support/api/programs.js
@@ -93,7 +93,7 @@ Cypress.Commands.add('routeWorkspacePrograms', (mutator = _.identity) => {
   const data = getPrograms();
 
   cy
-    .intercept('GET', '/api/workspaces/**/relationships/programs*', {
+    .intercept('GET', '/api/workspaces/**/programs*', {
       body: mutator({ data, included: [] }),
     })
     .as('routeWorkspacePrograms');


### PR DESCRIPTION
Related BE-243

## What

- Migrate seven collection GETs from deprecated `/relationships/...` paths to their canonical API endpoints.
- Update the shared Cypress intercepts to match the canonical request URLs.

## Why

Backend release 26.26.0 began warning on the legacy GET routes introduced by BE-243. The app still uses those routes across patient work, program configuration, action files, and workspace bootstrap.

## Scope

- Changes shared entity services for patient actions and flows, flow actions, program actions and flows, action files, and workspace programs.
- Affects all app surfaces that consume those shared services.
- Leaves relationship write endpoints unchanged.
- Intentionally leaves patient flow creation on `POST /patients/{patientId}/relationships/flows` pending BE-287, because the backend does not yet provide `POST /flows`.

## Deployment Impact

No forms or form bundles need redeploy. This ships through the normal app deployment and changes shared request URLs globally for the listed entity services.

## Testing

- `npm run lint`
- Cypress was not run locally; relevant E2E and component coverage is deferred to CI via `ci:defer-cypress`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch seven collection GETs from deprecated `/relationships/*` routes to canonical endpoints to clear BE-243 deprecation warnings on backend 26.26.0. Updates shared entity services and Cypress intercepts with no behavior change.

- **Bug Fixes**
  - Migrate collection reads for patient actions/flows, flow actions, program actions/flows, action files, and workspace programs to their canonical endpoints.
  - Update Cypress intercepts to match the new URLs.
  - Leave write routes unchanged; patient flow creation stays on `POST /patients/{id}/relationships/flows` until BE-287.

<sup>Written for commit 5e0dd502d95295b24739c150d873f16b8d5e918e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data retrieval across actions, files, flows, and programs to use the correct API routes.
  * Improved reliability when loading related records for patients, programs, workspaces, and actions.

* **Tests**
  * Updated automated API request stubs to match the corrected routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->