### PR TITLE
feat(patients): route workspace through patient pages

### DIFF
--- a/packages/care-ops-five9/five9_views.js
+++ b/packages/care-ops-five9/five9_views.js
@@ -61,7 +61,7 @@ const PatientButtonItemView = View.extend({
     'click': 'click',
   },
   onClick() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.id);
+    Radio.trigger('event-router', 'patient:workflow', this.model.id);
   },
 });
 

--- a/packages/care-ops-ringcentral/ringcentral_views.js
+++ b/packages/care-ops-ringcentral/ringcentral_views.js
@@ -44,7 +44,7 @@ const PatientButtonItemView = View.extend({
     'click': 'click',
   },
   onClick() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.id);
+    Radio.trigger('event-router', 'patient:workflow', this.model.id);
   },
 });
 

--- a/src/js/apps/globals/error/error.e2e.cy.js
+++ b/src/js/apps/globals/error/error.e2e.cy.js
@@ -24,8 +24,7 @@ context('Global Error Page', function() {
       .should('not.exist');
   });
 
-  // NOTE: 'legacy' means the workspace name isn't included in the URL
-  specify('404 not found - legacy routes', function() {
+  specify('404 not found - root routes', function() {
     cy
       .visit('/route-does-not-exist', { isRoot: true });
 
@@ -38,20 +37,6 @@ context('Global Error Page', function() {
       .get('.error-page')
       .contains('Back to Your Workspace')
       .click();
-
-    cy
-      .get('.error-page')
-      .should('not.exist');
-  });
-
-  // NOTE: 'legacy' means the workspace name isn't included in the URL
-  specify('handle legacy routes', function() {
-    cy
-      .visit('/worklist/owned-by', { isRoot: true });
-
-    cy
-      .url()
-      .should('contain', 'one/worklist/owned-by');
 
     cy
       .get('.error-page')

--- a/src/js/apps/globals/nav/app-nav.e2e.cy.js
+++ b/src/js/apps/globals/nav/app-nav.e2e.cy.js
@@ -682,7 +682,7 @@ context('App Nav', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ testNewPatientId }`);
+      .should('contain', `patient/${ testNewPatientId }/workflow`);
   });
 
   specify('add patient failure', function() {

--- a/src/js/apps/globals/search/patient-quick-search.e2e.cy.js
+++ b/src/js/apps/globals/search/patient-quick-search.e2e.cy.js
@@ -160,7 +160,7 @@ context('Patient Quick Search', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ patients[2].id }`);
+      .should('contain', `patient/${ patients[2].id }/workflow`);
 
     cy
       .get('@search')

--- a/src/js/apps/patients/patient/action/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/action/action.e2e.cy.js
@@ -3176,4 +3176,71 @@ context('patient action page', function() {
       .should('contain', `/patient/${ testPatient.id }/flow/${ testFlow.id }`)
       .should('not.contain', '/action/');
   });
+
+  specify('redirects to the workflow when an action route flow is gone', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship([workspaceOne]),
+      },
+    });
+
+    const testFlow = getFlow({
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateTodo),
+      },
+    });
+
+    const testAction = getAction({
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateTodo),
+      },
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      })
+      .intercept('GET', `/api/flows/${ testFlow.id }*`, {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find flow',
+            source: { parameter: 'flowId' },
+          }),
+        },
+      })
+      .as('routeGoneFlow')
+      .visit(`/patient/${ testPatient.id }/flow/${ testFlow.id }/action/${ testAction.id }`)
+      .wait('@routeGoneFlow');
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Flow you requested does not exist.');
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/workflow`)
+      .should('not.contain', '/flow/');
+  });
 });

--- a/src/js/apps/patients/patient/action/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/action/action.e2e.cy.js
@@ -2120,6 +2120,45 @@ context('patient action page', function() {
       .should('contain', 'Error code: 500.');
   });
 
+  specify('action unexpected client error', function() {
+    const testPatient = getPatient({ id: '1' });
+    const errorStub = cy.stub();
+
+    cy.on('uncaught:exception', error => {
+      errorStub(error);
+
+      return false;
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 404,
+        body: {
+          errors: getErrors({
+            status: '404',
+            title: 'Unexpected Client Error',
+            detail: 'Cannot load action',
+          }),
+        },
+      })
+      .as('routeAction')
+      .visit('/patient/1/action/1')
+      .wait('@routeAction');
+
+    cy
+      .wrap(null)
+      .should(() => {
+        expect(errorStub).to.be.calledOnce;
+        expect(errorStub.firstCall.args[0].message).to.contain('Error Status: 404');
+      });
+  });
+
   specify('outreach', function() {
     const testPatient = getPatient({
       attributes: {
@@ -2683,7 +2722,7 @@ context('patient action page', function() {
     cy
       .get('.patient-action')
       .find('[data-action-region] .patient-action__info')
-      .should('exist');
+      .should('contain', 'You are not able to change settings on this action.');
   });
 
   specify('flow action with work:team:manage permission', function() {
@@ -2870,7 +2909,7 @@ context('patient action page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 
@@ -2894,6 +2933,8 @@ context('patient action page', function() {
       },
     });
 
+    let replyToStaleAction;
+
     cy
       .routesForPatientDashboard()
       .routePatient(fx => {
@@ -2909,18 +2950,22 @@ context('patient action page', function() {
       .routeActionActivity()
       .routeActionComments()
       .routeActionFiles()
-      .intercept('GET', `/api/actions/${ staleAction.id }*`, {
-        statusCode: 410,
-        delay: 500,
-        body: {
-          errors: getErrors({
-            status: '410',
-            title: 'Not Found',
-            detail: 'Cannot find action',
-            source: { parameter: 'actionId' },
-          }),
-        },
-      })
+      .intercept('GET', `/api/actions/${ staleAction.id }*`, req => new Cypress.Promise(resolve => {
+        replyToStaleAction = () => {
+          req.reply({
+            statusCode: 410,
+            body: {
+              errors: getErrors({
+                status: '410',
+                title: 'Not Found',
+                detail: 'Cannot find action',
+                source: { parameter: 'actionId' },
+              }),
+            },
+          });
+          resolve();
+        };
+      }))
       .as('routeStaleAction')
       .intercept('GET', `/api/actions/${ currentAction.id }*`, {
         body: { data: currentAction, included: [] },
@@ -2933,17 +2978,29 @@ context('patient action page', function() {
 
     cy.window().then(win => {
       win.Radio.trigger('event-router', 'patient:action', testPatient.id, staleAction.id);
+    });
+
+    cy
+      .wrap(null)
+      .should(() => {
+        expect(replyToStaleAction).to.be.a('function');
+      });
+
+    cy.window().then(win => {
       win.Radio.trigger('event-router', 'patient:action', testPatient.id, currentAction.id);
     });
 
     cy
       .wait('@routeCurrentAction')
-      .wait('@routeActionActivity')
-      .wait('@routeStaleAction');
+      .wait('@routeActionActivity');
 
     cy
       .get('.patient-action__name')
       .should('contain', 'Current Action');
+
+    cy.then(() => replyToStaleAction());
+
+    cy.wait('@routeStaleAction');
 
     cy
       .get('.alert-box__body')
@@ -2961,7 +3018,7 @@ context('patient action page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 
@@ -2988,6 +3045,8 @@ context('patient action page', function() {
       },
     });
 
+    let replyToStaleAction;
+
     cy
       .routesForPatientDashboard()
       .routePatient(fx => {
@@ -3004,10 +3063,12 @@ context('patient action page', function() {
       .routeActionComments()
       .routeActionFiles()
       // the stale fetch succeeds, but resolves after the newer route
-      .intercept('GET', `/api/actions/${ staleAction.id }*`, {
-        body: { data: staleAction, included: [] },
-        delay: 500,
-      })
+      .intercept('GET', `/api/actions/${ staleAction.id }*`, req => new Cypress.Promise(resolve => {
+        replyToStaleAction = () => {
+          req.reply({ body: { data: staleAction, included: [] } });
+          resolve();
+        };
+      }))
       .as('routeStaleAction')
       .intercept('GET', `/api/actions/${ currentAction.id }*`, {
         body: { data: currentAction, included: [] },
@@ -3020,12 +3081,27 @@ context('patient action page', function() {
 
     cy.window().then(win => {
       win.Radio.trigger('event-router', 'patient:action', testPatient.id, staleAction.id);
-      win.Radio.trigger('event-router', 'patient:action', testPatient.id, currentAction.id);
     });
 
     cy
-      .wait('@routeCurrentAction')
-      .wait('@routeStaleAction');
+      .wrap(null)
+      .should(() => {
+        expect(replyToStaleAction).to.be.a('function');
+      });
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:action', testPatient.id, currentAction.id);
+    });
+
+    cy.wait('@routeCurrentAction');
+
+    cy
+      .get('.patient-action__name')
+      .should('contain', 'Current Action');
+
+    cy.then(() => replyToStaleAction());
+
+    cy.wait('@routeStaleAction');
 
     // the stale fetch resolved last, but its sidebar is suppressed
     cy

--- a/src/js/apps/patients/patient/action/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/action/action.e2e.cy.js
@@ -2078,8 +2078,20 @@ context('patient action page', function() {
   });
 
   specify('deleted action', function() {
+    const testPatient = getPatient({ id: '1' });
+
     cy
       .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
       .intercept('GET', '/api/actions/1*', {
         statusCode: 410,
         body: {
@@ -2100,7 +2112,9 @@ context('patient action page', function() {
       .should('contain', 'The Action you requested does not exist.');
 
     cy
-      .get('.list-page__list');
+      .url()
+      .should('contain', '/patient/1/workflow')
+      .should('not.contain', '/action/');
   });
 
   specify('outreach', function() {
@@ -3079,7 +3093,87 @@ context('patient action page', function() {
 
     cy
       .url()
-      .should('contain', `/patient/dashboard/${ testPatient.id }`)
+      .should('contain', `/patient/${ testPatient.id }/workflow`)
+      .should('not.contain', '/action/');
+  });
+
+  specify('redirects to the flow when an on-demand flow action is gone', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
+    const testFlow = getFlow({
+      attributes: {
+        name: 'Test Flow',
+      },
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateTodo),
+      },
+    });
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .routeFlow(fx => {
+        fx.data = testFlow;
+        fx.included = [];
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = [];
+        fx.included = [];
+
+        return fx;
+      })
+      .routeFlowActivity()
+      .intercept('GET', '/api/actions/deleted-action*', {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find action',
+            source: { parameter: 'actionId' },
+          }),
+        },
+      })
+      .as('routeGoneAction');
+
+    cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient');
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:flow:action', testPatient.id, testFlow.id, 'deleted-action');
+    });
+
+    cy
+      .wait('@routeGoneAction');
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Action you requested does not exist.');
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/flow/${ testFlow.id }`)
       .should('not.contain', '/action/');
   });
 });

--- a/src/js/apps/patients/patient/action/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/action/action.e2e.cy.js
@@ -927,19 +927,15 @@ context('patient action page', function() {
       .should('not.be.disabled');
 
     cy
-      .get('[data-header-region]')
+      .get('.patient-action')
       .find('[data-state-region]')
       .click();
 
     cy
       .get('.picklist')
       .contains('Complete')
-      .click();
-
-    cy
-      .get('.modal--small')
-      .find('.js-submit')
-      .click();
+      .click()
+      .wait('@routePatchAction');
 
     cy
       .get('@actionDialerButton')
@@ -1288,11 +1284,6 @@ context('patient action page', function() {
       .wait('@routeActionFiles');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-paperclip')
-      .should('not.exist');
-
-    cy
       .intercept('PUT', '/api/actions/**/relationships/files?urls=upload', req => {
         req.reply({
           statusCode: 201,
@@ -1354,11 +1345,6 @@ context('patient action page', function() {
       }, { force: true });
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-paperclip')
-      .should('exist');
-
-    cy
       .get('.patient-action')
       .find('[data-attachments-files-region]')
       .first()
@@ -1370,11 +1356,6 @@ context('patient action page', function() {
       .find('.js-submit')
       .click()
       .wait('@routeDeleteFile');
-
-    cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-paperclip')
-      .should('not.exist');
   });
 
   specify('action attachments - uploads not allowed on program action', function() {
@@ -1595,7 +1576,7 @@ context('patient action page', function() {
 
     cy
       .get('[data-activity-region]')
-      .find('.js-post')
+      .find('[data-comment-activity-region] .js-post')
       .should('contain', 'Save')
       .should('be.disabled');
 
@@ -1605,12 +1586,14 @@ context('patient action page', function() {
       .click();
 
     cy
-      .get('@activityComment')
+      .get('[data-activity-region]')
+      .contains('.comment__item', 'Least Recent Message from Clinician McTester')
       .should('contain', 'Least Recent Message from Clinician McTester')
       .should('not.contain', '(Edited)');
 
     cy
-      .get('@activityComment')
+      .get('[data-activity-region]')
+      .contains('.comment__item', 'Least Recent Message from Clinician McTester')
       .find('.js-edit')
       .click();
 
@@ -1623,13 +1606,13 @@ context('patient action page', function() {
 
     cy
       .get('[data-activity-region]')
-      .find('.js-input')
+      .find('[data-comment-activity-region] .js-input')
       .clear()
       .type('An edited comment');
 
     cy
       .get('[data-activity-region]')
-      .find('.js-post')
+      .find('[data-comment-activity-region] .js-post')
       .click();
 
     cy
@@ -1640,7 +1623,8 @@ context('patient action page', function() {
       });
 
     cy
-      .get('@activityComment')
+      .get('[data-activity-region]')
+      .contains('.comment__item', 'An edited comment')
       .should('contain', 'An edited comment')
       .find('.comment__edited');
 
@@ -1658,7 +1642,8 @@ context('patient action page', function() {
       .as('routeDeleteCommentFailure');
 
     cy
-      .get('@activityComment')
+      .get('[data-activity-region]')
+      .contains('.comment__item', 'An edited comment')
       .find('.js-edit')
       .click();
 
@@ -1705,6 +1690,7 @@ context('patient action page', function() {
     cy
       .get('.patient-action')
       .find('[data-comment-form-region]')
+      .last()
       .as('commentRegion')
       .find('[data-post-region] .js-post')
       .should('be.disabled');
@@ -1850,6 +1836,7 @@ context('patient action page', function() {
     cy
       .get('.patient-action')
       .find('[data-comment-form-region]')
+      .last()
       .as('postCommentRegion')
       .find('.js-input')
       .type('Test comment');
@@ -1877,13 +1864,6 @@ context('patient action page', function() {
       .find('.js-post')
       .click()
       .wait('@routePostComment');
-
-    cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-comment')
-      .should('exist')
-      .next()
-      .should('contain', '1');
 
     cy
       .get('@postCommentRegion')
@@ -1915,13 +1895,6 @@ context('patient action page', function() {
       .wait('@routePostComment');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-comment')
-      .should('exist')
-      .next()
-      .should('contain', '2');
-
-    cy
       .intercept('DELETE', '/api/comments/*', {
         statusCode: 204,
         body: {},
@@ -1947,13 +1920,6 @@ context('patient action page', function() {
       .wait('@routeDeleteComment');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-comment')
-      .should('exist')
-      .next()
-      .should('contain', '1');
-
-    cy
       .get('[data-activity-region]')
       .find('.comment__item')
       .first()
@@ -1970,14 +1936,11 @@ context('patient action page', function() {
       .find('.js-submit')
       .click()
       .wait('@routeDeleteComment');
-
-    cy
-      .get('.list-page__list')
-      .find('.table-list__item .fa-comment')
-      .should('not.exist');
   });
 
   specify('display action from program action', function() {
+    const testPatient = getPatient();
+
     const testProgram = getProgram({
       attributes: {
         name: 'Test Program',
@@ -1996,6 +1959,7 @@ context('patient action page', function() {
       },
       relationships: {
         'form': getRelationship(testForm),
+        'patient': getRelationship(testPatient),
         'program-action': getRelationship(testProgramAction),
       },
     });
@@ -2034,6 +1998,7 @@ context('patient action page', function() {
       })
       .routeFormByAction()
       .routeFormDefinition()
+      .routeFormActionFields()
       .routeLatestFormResponse()
       .visit(`/patient/1/action/${ testAction.id }`)
       .wait('@routeAction');
@@ -2054,15 +2019,22 @@ context('patient action page', function() {
       .should('exist');
 
     cy
-      .get('[data-activity-region]')
+      .get('.patient-action:visible')
+      .should('have.length', 1)
+      .find('[data-activity-region]')
       .find('[data-activities-region]')
+      .last()
       .should('contain', 'Clinician McTester (Nurse) added this action from the Test Program program')
       .children()
       .its('length')
       .should('equal', 5);
 
     cy
-      .routePatientByAction();
+      .routePatientByAction(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      });
 
     cy
       .get('[data-form-region] button')
@@ -2071,7 +2043,7 @@ context('patient action page', function() {
 
     cy
       .url()
-      .should('contain', `patient/${ testAction.relationships.patient.data.id }/form/${ testForm.id }/action/${ testAction.id }`);
+      .should('contain', `/form/${ testForm.id }/action/${ testAction.id }`);
 
     cy
       .go('back');
@@ -2115,6 +2087,37 @@ context('patient action page', function() {
       .url()
       .should('contain', '/patient/1/workflow')
       .should('not.contain', '/action/');
+  });
+
+  specify('action server error', function() {
+    const testPatient = getPatient({ id: '1' });
+
+    cy.on('uncaught:exception', () => false);
+
+    cy
+      .routesForPatientDashboard()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .intercept('GET', '/api/actions/1*', {
+        statusCode: 500,
+        body: {
+          errors: getErrors({
+            status: '500',
+            title: 'Server Error',
+            detail: 'Cannot load action',
+          }),
+        },
+      })
+      .as('routeAction')
+      .visit('/patient/1/action/1')
+      .wait('@routeAction');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Error code: 500.');
   });
 
   specify('outreach', function() {
@@ -2231,10 +2234,13 @@ context('patient action page', function() {
       .should('exist');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .contains('Canceled Outreach Action')
-      .click();
+      .routeAction(fx => {
+        fx.data = testCanceledOutreachAction;
+
+        return fx;
+      })
+      .visit(`/patient/${ testPatient.id }/action/${ testCanceledOutreachAction.id }`)
+      .wait('@routeAction');
 
     cy
       .get('.patient-action')
@@ -2244,10 +2250,13 @@ context('patient action page', function() {
       .should('exist');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .contains('Error Outreach Action')
-      .click();
+      .routeAction(fx => {
+        fx.data = testErrorOutreachAction;
+
+        return fx;
+      })
+      .visit(`/patient/${ testPatient.id }/action/${ testErrorOutreachAction.id }`)
+      .wait('@routeAction');
 
     cy
       .get('.patient-action')
@@ -2258,6 +2267,8 @@ context('patient action page', function() {
   });
 
   specify('outreach form', function() {
+    const testPatient = getPatient();
+
     const testAction = getAction({
       attributes: {
         outreach: 'patient',
@@ -2265,6 +2276,7 @@ context('patient action page', function() {
       },
       relationships: {
         form: getRelationship(testForm),
+        patient: getRelationship(testPatient),
         state: getRelationship(stateDone),
       },
     });
@@ -2278,12 +2290,17 @@ context('patient action page', function() {
       })
       .routeFormByAction()
       .routeFormDefinition()
+      .routeFormActionFields()
       .routeLatestFormResponse()
       .visit(`/patient/1/action/${ testAction.id }`)
       .wait('@routeAction');
 
     cy
-      .routePatientByAction();
+      .routePatientByAction(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      });
 
     cy
       .get('.patient-action')
@@ -2292,7 +2309,7 @@ context('patient action page', function() {
 
     cy
       .url()
-      .should('contain', `patient/${ testAction.relationships.patient.data.id }/form/${ testForm.id }/action/${ testAction.id }`);
+      .should('contain', `/form/${ testForm.id }/action/${ testAction.id }`);
 
     cy
       .go('back');
@@ -2492,7 +2509,7 @@ context('patient action page', function() {
         return fx;
       })
       .routeActionFiles()
-      .visit(`/patient/1/action/${ otherTeamAction }`)
+      .visit(`/patient/1/action/${ otherTeamAction.id }`)
       .wait('@routeAction')
       .wait('@routePatient');
 
@@ -2509,10 +2526,7 @@ context('patient action page', function() {
       });
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .last()
-      .click('top')
+      .visit(`/patient/1/action/${ nonTeamMemberAction.id }`)
       .wait('@routeAction');
 
     cy
@@ -2592,10 +2606,7 @@ context('patient action page', function() {
       });
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .contains('Not authored by Current User')
-      .click()
+      .visit(`/patient/1/action/${ notAuthoredByCurrentUserAction.id }`)
       .wait('@routeAction');
 
     cy
@@ -2663,35 +2674,6 @@ context('patient action page', function() {
       .wait('@routeFlow');
 
     cy
-      .intercept('PATCH', `/api/flows/${ testFlow.id }`, {
-        statusCode: 204,
-        body: {},
-      })
-      .as('routePatchFlow');
-
-    cy
-      .intercept('PATCH', `/api/actions/${ testAction.id }`, {
-        statusCode: 204,
-        body: {},
-      })
-      .as('routePatchAction');
-
-    cy
-      .get('[data-header-region]')
-      .find('[data-state-region]')
-      .click();
-
-    cy
-      .get('.picklist')
-      .contains('Complete')
-      .click();
-
-    cy
-      .get('.modal--small')
-      .find('.js-submit')
-      .click();
-
-    cy
       .get('[data-action-region]')
       .should('contain', 'Test Details')
       .and('contain', formatDate(testDateSubtract(2), 'SHORT'))
@@ -2700,8 +2682,8 @@ context('patient action page', function() {
 
     cy
       .get('.patient-action')
-      .find('[data-action-region] .sidebar__label')
-      .should('contain', 'Permissions');
+      .find('[data-action-region] .patient-action__info')
+      .should('exist');
   });
 
   specify('flow action with work:team:manage permission', function() {
@@ -2773,9 +2755,15 @@ context('patient action page', function() {
 
         return fx;
       })
+      .routeAction(fx => {
+        fx.data = ownedByAnotherTeamAction;
+
+        return fx;
+      })
       .routePatientByFlow()
       .visit(`/flow/${ testFlow.id }/action/${ ownedByAnotherTeamAction.id }`)
-      .wait('@routeFlow');
+      .wait('@routeFlow')
+      .wait('@routeAction');
 
     cy
       .get('[data-action-region]')
@@ -2783,10 +2771,22 @@ context('patient action page', function() {
       .and('contain', 'You are not able to change settings on this action.');
 
     cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .last()
-      .click('top');
+      .routeAction(fx => {
+        fx.data = ownedByNonTeamMemberAction;
+
+        return fx;
+      })
+      .window()
+      .then(win => {
+        win.Radio.trigger(
+          'event-router',
+          'patient:flow:action',
+          testFlow.relationships.patient.data.id,
+          testFlow.id,
+          ownedByNonTeamMemberAction.id,
+        );
+      })
+      .wait('@routeAction');
 
     cy
       .get('[data-action-region]')
@@ -3047,7 +3047,7 @@ context('patient action page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 
@@ -3104,7 +3104,7 @@ context('patient action page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 

--- a/src/js/apps/patients/patient/action/action_app.js
+++ b/src/js/apps/patients/patient/action/action_app.js
@@ -66,13 +66,17 @@ export default App.extend({
   fetchRouteResource(resource, request) {
     return request.catch(error => Promise.reject({ resource, error }));
   },
-  /* istanbul ignore next: page-level action error handling */
   onFail(options, failure) {
     const error = get(failure, 'error', failure);
+    const resource = get(failure, 'resource');
 
     if (get(error, ['response', 'status']) === 410) {
-      Radio.request('alert', 'show:error', intl.patients.patient.action.actionApp.notFound);
-      this.navigateAfterGone(options, get(failure, 'resource'));
+      const message = resource === 'flow' ?
+        intl.patients.patient.flow.flowViews.notFound :
+        intl.patients.patient.action.actionApp.notFound;
+
+      Radio.request('alert', 'show:error', message);
+      this.navigateAfterGone(options, resource);
       return;
     }
 

--- a/src/js/apps/patients/patient/action/action_app.js
+++ b/src/js/apps/patients/patient/action/action_app.js
@@ -51,20 +51,40 @@ export default App.extend({
     this.getRegion().startPreloader();
   },
   beforeStart({ actionId, flowId }) {
-    return [
+    const actionRequest = this.fetchRouteResource('action',
       Radio.request('entities', 'fetch:actions:model', actionId),
-      flowId && Radio.request('entities', 'fetch:flows:model', flowId),
-    ];
+    );
+
+    if (!flowId) return actionRequest;
+
+    const flowRequest = this.fetchRouteResource('flow',
+      Radio.request('entities', 'fetch:flows:model', flowId),
+    );
+
+    return [actionRequest, flowRequest];
+  },
+  fetchRouteResource(resource, request) {
+    return request.catch(error => Promise.reject({ resource, error }));
   },
   /* istanbul ignore next: page-level action error handling */
-  onFail(options, error) {
+  onFail(options, failure) {
+    const error = get(failure, 'error', failure);
+
     if (get(error, ['response', 'status']) === 410) {
       Radio.request('alert', 'show:error', intl.patients.patient.action.actionApp.notFound);
-      this.stop();
+      this.navigateAfterGone(options, get(failure, 'resource'));
       return;
     }
 
     handleErrors(error);
+  },
+  navigateAfterGone({ patient, flowId }, resource) {
+    if (flowId && resource === 'action') {
+      Radio.trigger('event-router', 'patient:flow', patient.id, flowId);
+      return;
+    }
+
+    Radio.trigger('event-router', 'patient:workflow', patient.id);
   },
   onStart(options, action, flow) {
     this.patient = options.patient;

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -42,7 +42,6 @@ export default App.extend({
       Radio.request('entities', 'fetch:actions:collection:byFlow', flowId),
     ];
   },
-  /* istanbul ignore next: error handling */
   onFail(options, error) {
     if (get(error, ['response', 'status']) === 410) {
       Radio.request('alert', 'show:error', i18n.notFound);

--- a/src/js/apps/patients/patient/flow/flow_app.js
+++ b/src/js/apps/patients/patient/flow/flow_app.js
@@ -45,8 +45,8 @@ export default App.extend({
   /* istanbul ignore next: error handling */
   onFail(options, error) {
     if (get(error, ['response', 'status']) === 410) {
-      Radio.trigger('event-router', 'notFound');
-      this.stop();
+      Radio.request('alert', 'show:error', i18n.notFound);
+      Radio.trigger('event-router', 'patient:workflow', options.patient.id);
       return;
     }
 

--- a/src/js/apps/patients/patient/flow/flow_views.js
+++ b/src/js/apps/patients/patient/flow/flow_views.js
@@ -27,12 +27,8 @@ export const i18n = intl.patients.patient.flow.flowViews;
 const HeaderView = View.extend({
   className: 'patient-flow__header',
   modelEvents: {
-    'editing': 'onEditing',
     'change': 'render',
     'change:_progress': 'onChangeFlowProgress',
-  },
-  onEditing(isEditing) {
-    this.$el.toggleClass('is-selected', isEditing);
   },
   template: HeaderTemplate,
   regions: {
@@ -134,7 +130,6 @@ const ActionItemView = View.extend({
   className: 'table-list__item',
   modelEvents: {
     'change': 'render',
-    'editing': 'onEditing',
   },
   initialize({ state }) {
     this.state = state;
@@ -175,15 +170,6 @@ const ActionItemView = View.extend({
   onClick() {
     Radio.trigger('event-router', 'patient:flow:action', this.model.getPatient().id, this.model.getFlow().id, this.model.id);
   },
-  onEditing(isEditing) {
-    this.isEditing = isEditing;
-
-    const isSelected = this.state.isSelected(this.model);
-
-    if (isSelected) return;
-
-    this.$el.toggleClass('is-selected', isEditing);
-  },
   onRender() {
     const canEdit = this.canEdit;
     this.canEdit = !this.flow.isDone() && this.model.canEdit();
@@ -202,8 +188,6 @@ const ActionItemView = View.extend({
     }
   },
   toggleSelected(isSelected) {
-    if (this.isEditing) return;
-
     this.$el.toggleClass('is-selected', isSelected);
   },
   showCheck() {

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -70,7 +70,11 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
       .routeFlowActions()
       .visit('/worklist/owned-by')
       .wait('@routeActions');
@@ -87,19 +91,19 @@ context('patient flow page', function() {
       .first()
       .click('top')
       .wait('@routeFlow')
-      .wait('@routePatientByFlow');
+      .wait('@routePatient');
 
     cy.url().as('flowUrl');
 
     cy
-      .get('.patient-flow__context-trail')
+      .get('.patient__context-trail')
       .should('contain', 'Test Flow')
       .contains('Test Patient')
       .click();
 
     cy
       .url()
-      .should('contain', `/patient/dashboard/${ testPatient.id }`);
+      .should('contain', `/patient/${ testPatient.id }/workflow`);
 
     cy
       .go('back');
@@ -109,7 +113,7 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.patient-flow__context-trail')
+      .get('.patient__context-trail')
       .contains('Back to List')
       .click();
 
@@ -196,7 +200,7 @@ context('patient flow page', function() {
       .should('contain', `/patient/${ testPatient.id }/workflow`);
   });
 
-  specify('patient flow action sidebar', function() {
+  specify('patient flow action page', function() {
     const testFileId = uuid();
     const testComment = getComment();
 
@@ -244,14 +248,13 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routeFlowActions(fx => {
-        fx.data = [testFlowAction];
-
+      .routeAction(fx => {
+        fx.data = testFlowAction;
         fx.included.push(testProgramAction, testFlow);
 
         return fx;
       })
-      .routePatientByFlow(fx => {
+      .routePatient(fx => {
         fx.data = testPatient;
 
         return fx;
@@ -262,16 +265,21 @@ context('patient flow page', function() {
         return fx;
       })
       .routeActionActivity()
-      .visitOnClock(`/flow/${ testFlow.id }/action/${ testFlowAction.id }`, { now: testTs() })
+      .routeFlowActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .visitOnClock(`/patient/${ testPatient.id }/flow/${ testFlow.id }/action/${ testFlowAction.id }`, { now: testTs() })
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions')
+      .wait('@routePatient')
+      .wait('@routeAction')
       .wait('@routeActionActivity')
       .wait('@routeActionComments')
       .wait('@routeActionFiles');
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-action-region] [data-testid="patient-action-name"]')
       .should('contain', 'Test Action');
 
@@ -289,19 +297,12 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-action-region] [data-testid="patient-action-name"]', { timeout: 10000 })
       .should('contain', 'New Websocket Name');
 
     cy
-      .get('.sidebar')
-      .find('.sidebar__footer')
-      .contains('Updated')
-      .next()
-      .should('contain', formatDate(testTs(), 'AT_TIME'));
-
-    cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-details-region] .js-input')
       .clear()
       .type('User manually added details.');
@@ -320,12 +321,12 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-details-region] .js-input')
       .should('have.value', 'User manually added details.');
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-save-region]')
       .contains('Cancel')
       .click();
@@ -344,7 +345,7 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-details-region] .js-input')
       .should('have.value', 'New websocket details.');
 
@@ -362,12 +363,12 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-duration-region]')
       .should('contain', '20 mins');
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('[data-form-sharing-region]')
       .should('be.empty');
 
@@ -598,11 +599,11 @@ context('patient flow page', function() {
     });
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .should('not.exist');
   });
 
-  specify('done patient flow action sidebar', function() {
+  specify('done patient flow action page', function() {
     cy
       .routesForPatientAction()
       .routeFlow(fx => {
@@ -615,21 +616,15 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routeFlowActions(fx => {
-        fx.data = [testAction];
-
-        return fx;
-      })
-      .routePatientByFlow()
+      .routePatient()
       .routeActionActivity()
-      .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
+      .visit(`/patient/1/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
+      .wait('@routePatient')
+      .wait('@routeAction');
 
     cy
-      .get('.sidebar')
-      .find('[data-action-region] .sidebar__label')
+      .get('.patient-action')
       .should('not.contain', 'Permissions');
   });
 
@@ -664,7 +659,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = [
           getAction({
@@ -718,7 +713,7 @@ context('patient flow page', function() {
       .routeActionActivity()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -816,13 +811,12 @@ context('patient flow page', function() {
         expect($action.find('[data-due-date-region] button')).not.to.be.disabled;
         expect($action.find('[data-due-time-region] button')).not.to.be.disabled;
       })
-      // Trigger the click on the table-list__item clicks the owner button
       .find('.patient__action-icon')
-      .click();
+      .click()
+      .wait('@routeAction');
 
     cy
-      .get('@lastAction')
-      .should('have.class', 'is-selected')
+      .get('.patient-action')
       .find('[data-owner-region]')
       .click();
 
@@ -834,12 +828,12 @@ context('patient flow page', function() {
       .wait('@routePatchAction');
 
     cy
-      .get('@lastAction')
+      .get('.patient-action')
       .find('[data-owner-region]')
-      .contains('NUR');
+      .contains('Nurse');
 
     cy
-      .get('@lastAction')
+      .get('.patient-action')
       .find('[data-due-date-region]')
       .click();
 
@@ -858,13 +852,13 @@ context('patient flow page', function() {
           .click();
 
         cy
-          .get('.sidebar')
+          .get('.patient-action')
           .find('[data-due-date-region]')
           .should('contain', `${ dueMonth } ${ dueDay }`);
       });
 
     cy
-      .get('@lastAction')
+      .get('.patient-action')
       .find('[data-due-time-region]')
       .click();
 
@@ -874,7 +868,7 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .get('@lastAction')
+      .get('.patient-action')
       .find('[data-due-time-region]')
       .should('contain', '11:15 AM');
 
@@ -895,7 +889,7 @@ context('patient flow page', function() {
       .as('routeDeleteFlowActionFailure');
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('.js-menu')
       .click();
 
@@ -920,7 +914,7 @@ context('patient flow page', function() {
       .as('routeDeleteFlowAction');
 
     cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('.js-menu')
       .click();
 
@@ -929,22 +923,12 @@ context('patient flow page', function() {
       .find('.js-picklist-item')
       .contains('Delete Action')
       .click()
-      .wait('@routeDeleteFlowAction');
-
-    cy
-      .get('@actionsList')
-      .find('.table-list__item')
-      .should('have.length', 2);
+      .wait('@routeDeleteFlowAction')
+      .wait('@routeFlowActions');
 
     cy
       .url()
       .should('not.contain', '/action/');
-
-    cy.go('back');
-
-    cy
-      .get('.alert-box')
-      .should('contain', 'The Action you requested does not exist');
   });
 
   specify('add action', function() {
@@ -1074,7 +1058,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = [
           getAction({
@@ -1108,7 +1092,7 @@ context('patient flow page', function() {
       .routeActionActivity()
       .visitOnClock(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions')
       .tick(60); // tick past debounce
 
@@ -1132,6 +1116,12 @@ context('patient flow page', function() {
         },
       })
       .as('routePostAction');
+
+    cy.routeAction(fx => {
+      fx.data = conditionalAction;
+
+      return fx;
+    });
 
     cy
       .get('.patient-flow__actions')
@@ -1185,8 +1175,7 @@ context('patient flow page', function() {
       .should('contain', `flow/${ testFlow.id }/action/${ conditionalAction.id }`);
 
     cy
-      .get('[data-content-region]')
-      .find('.is-selected')
+      .get('.patient-action')
       .contains('Conditional');
   });
 
@@ -1219,7 +1208,8 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .intercept('GET', `/api/flows/${ testFlow.id }**`, {
+      .routeFlowActions()
+      .intercept('GET', new RegExp(`/api/flows/${ testFlow.id }\\?`), {
         statusCode: 410,
         body: { errors },
       })
@@ -1237,6 +1227,85 @@ context('patient flow page', function() {
       .should('not.contain', '/flow/');
   });
 
+  specify('legacy flow not found', function() {
+    const flowId = uuid();
+
+    cy
+      .intercept('GET', new RegExp(`/api/flows/${ flowId }\\?`), {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find flow',
+          }),
+        },
+      })
+      .as('routeGoneFlow')
+      .visit(`/flow/${ flowId }`)
+      .wait('@routeGoneFlow');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'This page doesn\'t exist.');
+  });
+
+  specify('legacy flow server error', function() {
+    const flowId = uuid();
+
+    cy.on('uncaught:exception', () => false);
+
+    cy
+      .intercept('GET', new RegExp(`/api/flows/${ flowId }\\?`), {
+        statusCode: 500,
+        body: {
+          errors: getErrors({
+            status: '500',
+            title: 'Server Error',
+            detail: 'Cannot load flow',
+          }),
+        },
+      })
+      .as('routeFailedFlow')
+      .visit(`/flow/${ flowId }`)
+      .wait('@routeFailedFlow');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Error code: 500.');
+  });
+
+  specify('flow server error', function() {
+    const testPatient = getPatient();
+    const flowId = uuid();
+
+    cy.on('uncaught:exception', () => false);
+
+    cy
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .intercept('GET', new RegExp(`/api/flows/${ flowId }\\?`), {
+        statusCode: 500,
+        body: {
+          errors: getErrors({
+            status: '500',
+            title: 'Server Error',
+            detail: 'Cannot load flow',
+          }),
+        },
+      })
+      .as('routeFailedFlow')
+      .visit(`/patient/${ testPatient.id }/flow/${ flowId }`)
+      .wait('@routeFailedFlow');
+
+    cy
+      .get('.error-page')
+      .should('contain', 'Error code: 500.');
+  });
+
   specify('empty view', function() {
     cy
       .routeFlow(fx => {
@@ -1248,7 +1317,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = [];
 
@@ -1256,7 +1325,7 @@ context('patient flow page', function() {
       })
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1288,7 +1357,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = [
           getAction({
@@ -1343,7 +1412,7 @@ context('patient flow page', function() {
       .as('routePatchFlow')
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1492,11 +1561,11 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1567,7 +1636,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions()
       .routeFlowActivity()
       .visit('/patient/dashboard/1')
@@ -1597,7 +1666,7 @@ context('patient flow page', function() {
       .first()
       .click('top')
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1630,7 +1699,7 @@ context('patient flow page', function() {
       .last()
       .click('top')
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1658,7 +1727,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = getActions({
           relationships: {
@@ -1690,7 +1759,7 @@ context('patient flow page', function() {
       })
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1787,26 +1856,6 @@ context('patient flow page', function() {
     cy
       .get('.patient-flow__progress')
       .should('have.value', 2);
-
-    cy
-      .get('.table-list__item')
-      .first()
-      .click('top');
-
-    cy
-      .get('.sidebar')
-      .find('.js-menu')
-      .click();
-
-    cy
-      .get('.picklist')
-      .contains('Delete Action')
-      .click();
-
-    cy
-      .get('.patient-flow__progress')
-      .should('have.value', 1)
-      .and('have.attr', 'max', '2');
   });
 
   specify('bulk edit actions', function() {
@@ -1874,7 +1923,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow(fx => {
+      .routePatient(fx => {
         fx.data = testPatient;
 
         return fx;
@@ -1897,7 +1946,7 @@ context('patient flow page', function() {
       .routeActionComments()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -1927,44 +1976,7 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .routeAction(fx => {
-        fx.data = testFlowActions[0];
-
-        return fx;
-      });
-
-    cy
-      .get('@firstRow')
-      .find('.patient__action-icon')
-      .click();
-
-    cy
-      .get('@firstRow')
-      .find('.js-select')
-      .click();
-
-    cy
-      .get('@firstRow')
-      .should('have.class', 'is-selected');
-
-    cy
-      .get('@firstRow')
-      .find('.js-select')
-      .click();
-
-    cy
-      .get('[data-app-sidebar-region]')
-      .find('.js-close')
-      .click();
-
-    cy
-      .get('@firstRow')
-      .should('have.class', 'is-selected');
-
-    cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox')
+      .get('.patient-flow__actions > .button--checkbox')
       .as('selectAll')
       .click();
 
@@ -1985,8 +1997,7 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
+      .get('.patient-flow__actions')
       .find('.js-bulk-edit')
       .should('not.exist');
 
@@ -2010,8 +2021,7 @@ context('patient flow page', function() {
       .should('have.class', 'is-selected');
 
     cy
-      .get('[data-header-region]')
-      .next()
+      .get('.patient-flow__actions')
       .find('.js-bulk-edit')
       .click();
 
@@ -2023,38 +2033,28 @@ context('patient flow page', function() {
       .wait(['@routePatchAction', '@routePatchAction', '@routePatchAction']);
 
     cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox')
+      .get('.patient-flow__actions > .button--checkbox')
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox')
+      .get('.patient-flow__actions > .button--checkbox')
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox')
+      .get('.patient-flow__actions > .button--checkbox')
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
+      .get('.patient-flow__actions')
       .find('.js-cancel')
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox')
+      .get('.patient-flow__actions > .button--checkbox')
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
+      .get('.patient-flow__actions')
       .find('.js-bulk-edit')
       .click();
 
@@ -2266,8 +2266,7 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
+      .get('.patient-flow__actions')
       .find('.js-bulk-edit')
       .click();
 
@@ -2310,7 +2309,6 @@ context('patient flow page', function() {
 
     cy
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
       .wait('@routeFlowActions');
 
     cy
@@ -2332,25 +2330,32 @@ context('patient flow page', function() {
         return fx;
       })
       .routeFlowActions(fx => {
-        fx.data = getActions({
+        fx.data = _.map(getActions({
           relationships: {
             flow: getRelationship(testFlow),
             state: getRelationship(stateTodo),
           },
-        }, { sample: 3 });
+        }, { sample: 3 }), (action, sequence) => mergeJsonApi(action, {
+          attributes: { sequence },
+        }));
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeActionActivity()
       .visitOnClock(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions')
       .wait('@routeWorkspacePatient');
 
     cy
       .tick(60) // tick past debounce
+      .get('.app-frame__content')
+      .find('.table-list__item')
+      .should('have.length', 3);
+
+    cy
       .get('.app-frame__content')
       .find('.table-list__item')
       .first()
@@ -2482,10 +2487,10 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -2566,11 +2571,6 @@ context('patient flow page', function() {
       .click();
 
     cy
-      .get('[data-header-region]')
-      .next()
-      .find('.button--checkbox:disabled');
-
-    cy
       .get('.alert-box')
       .should('contain', '2 Actions have been updated');
   });
@@ -2642,10 +2642,10 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .visit(`/flow/${ testFlow.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -2720,7 +2720,7 @@ context('patient flow page', function() {
 
         return fx;
       })
-      .routePatientByFlow()
+      .routePatient()
       .routeFlowActions(fx => {
         fx.data = [
           testSocketAction,
@@ -2732,7 +2732,7 @@ context('patient flow page', function() {
       .routeFlowActivity()
       .visitOnClock(`/flow/${ testSocketFlow.id }`, { now: testTs() })
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -171,10 +171,16 @@ context('patient flow page', function() {
 
     cy
       .intercept('DELETE', `/api/flows/${ testPageFlow.id }`, {
-        statusCode: 204,
-        body: {},
+        statusCode: 403,
+        body: {
+          errors: getErrors({
+            status: '403',
+            title: 'Forbidden',
+            detail: 'Insufficient permissions to delete flow',
+          }),
+        },
       })
-      .as('routeDeleteFlow');
+      .as('routeDeleteFlowFailure');
 
     cy
       .get('.patient-flow__header-container .js-menu')
@@ -193,6 +199,34 @@ context('patient flow page', function() {
       .click();
 
     cy
+      .wait('@routeDeleteFlowFailure');
+
+    cy
+      .get('.alert-box')
+      .should('contain', 'Insufficient permissions to delete flow')
+      .find('.js-dismiss')
+      .click();
+
+    cy
+      .intercept('DELETE', `/api/flows/${ testPageFlow.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routeDeleteFlow');
+
+    cy
+      .get('.patient-flow__header-container .js-menu')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Delete Flow')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .find('.js-submit')
+      .click()
       .wait('@routeDeleteFlow');
 
     cy
@@ -282,6 +316,18 @@ context('patient flow page', function() {
       .get('.patient-action')
       .find('[data-action-region] [data-testid="patient-action-name"]')
       .should('contain', 'Test Action');
+
+    cy
+      .get('@wsHandleMessage')
+      .should(stub => {
+        const subscribedResources = _.flatten(stub.getCalls()
+          .map(call => call.args[0].data.resources));
+
+        expect(subscribedResources).to.deep.include({
+          id: testFlowAction.id,
+          type: testFlowAction.type,
+        });
+      });
 
     cy.sendWs({
       category: 'NameChanged',
@@ -810,7 +856,49 @@ context('patient flow page', function() {
         expect($action.find('[data-owner-region] button')).not.to.be.disabled;
         expect($action.find('[data-due-date-region] button')).not.to.be.disabled;
         expect($action.find('[data-due-time-region] button')).not.to.be.disabled;
-      })
+      });
+
+    cy
+      .get('@lastAction')
+      .find('[data-owner-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('Nurse')
+      .click()
+      .wait('@routePatchAction');
+
+    cy
+      .get('@lastAction')
+      .find('[data-due-date-region]')
+      .click();
+
+    cy
+      .get('.datepicker')
+      .find('.js-next')
+      .click();
+
+    cy
+      .get('.datepicker')
+      .find('.datepicker__days li')
+      .contains('1')
+      .click()
+      .wait('@routePatchAction');
+
+    cy
+      .get('@lastAction')
+      .find('[data-due-time-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .contains('11:15 AM')
+      .click()
+      .wait('@routePatchAction');
+
+    cy
+      .get('@lastAction')
       .find('.patient__action-icon')
       .click()
       .wait('@routeAction');
@@ -1275,6 +1363,83 @@ context('patient flow page', function() {
       .should('contain', 'Error code: 500.');
   });
 
+  specify('legacy flow unexpected client error', function() {
+    const flowId = uuid();
+    const errorStub = cy.stub();
+
+    cy.on('uncaught:exception', error => {
+      errorStub(error);
+
+      return false;
+    });
+
+    cy
+      .intercept('GET', new RegExp(`/api/flows/${ flowId }\\?`), {
+        statusCode: 404,
+        body: {
+          errors: getErrors({
+            status: '404',
+            title: 'Unexpected Client Error',
+            detail: 'Cannot load flow',
+          }),
+        },
+      })
+      .as('routeFailedFlow')
+      .visit(`/flow/${ flowId }`)
+      .wait('@routeFailedFlow');
+
+    cy
+      .wrap(null)
+      .should(() => {
+        expect(errorStub).to.be.calledOnce;
+        expect(errorStub.firstCall.args[0].message).to.contain('Error Status: 404');
+      });
+  });
+
+  specify('ignores a legacy flow resolver after leaving patient routes', function() {
+    const testPatient = getPatient();
+    const delayedFlow = getFlow({
+      relationships: {
+        patient: getRelationship(testPatient),
+      },
+    });
+    let replyToFlow;
+
+    cy
+      .intercept('GET', new RegExp(`/api/flows/${ delayedFlow.id }\\?`), req => new Cypress.Promise(resolve => {
+        replyToFlow = () => {
+          req.reply({ body: { data: delayedFlow, included: [testPatient] } });
+          resolve();
+        };
+      }))
+      .as('routeDelayedFlow')
+      .visit(`/flow/${ delayedFlow.id }`);
+
+    cy
+      .wrap(null)
+      .should(() => {
+        expect(replyToFlow).to.be.a('function');
+      });
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'notFound');
+    });
+
+    cy
+      .get('.error-page')
+      .should('contain', 'This page doesn\'t exist.');
+
+    cy.then(() => replyToFlow());
+
+    cy
+      .wait('@routeDelayedFlow');
+
+    cy
+      .url()
+      .should('contain', '/404')
+      .should('not.contain', `/patient/${ testPatient.id }/flow/${ delayedFlow.id }`);
+  });
+
   specify('flow server error', function() {
     const testPatient = getPatient();
     const flowId = uuid();
@@ -1284,6 +1449,11 @@ context('patient flow page', function() {
     cy
       .routePatient(fx => {
         fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = [];
 
         return fx;
       })
@@ -1304,6 +1474,50 @@ context('patient flow page', function() {
     cy
       .get('.error-page')
       .should('contain', 'Error code: 500.');
+  });
+
+  specify('flow unexpected client error', function() {
+    const testPatient = getPatient();
+    const flowId = uuid();
+    const errorStub = cy.stub();
+
+    cy.on('uncaught:exception', error => {
+      errorStub(error);
+
+      return false;
+    });
+
+    cy
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .intercept('GET', new RegExp(`/api/flows/${ flowId }\\?`), {
+        statusCode: 404,
+        body: {
+          errors: getErrors({
+            status: '404',
+            title: 'Unexpected Client Error',
+            detail: 'Cannot load flow',
+          }),
+        },
+      })
+      .as('routeFailedFlow')
+      .visit(`/patient/${ testPatient.id }/flow/${ flowId }`)
+      .wait('@routeFailedFlow');
+
+    cy
+      .wrap(null)
+      .should(() => {
+        expect(errorStub).to.be.calledOnce;
+        expect(errorStub.firstCall.args[0].message).to.contain('Error Status: 404');
+      });
   });
 
   specify('empty view', function() {
@@ -1709,6 +1923,95 @@ context('patient flow page', function() {
       .should('not.exist');
   });
 
+  specify('flow with work:authored:delete permission', function() {
+    const testPatient = getPatient();
+    const currentClinician = getCurrentClinician({
+      relationships: {
+        role: getRelationship(roleTeamEmployee),
+        team: getRelationship(teamCoordinator),
+      },
+    });
+    const authoredFlow = getFlow({
+      relationships: {
+        author: getRelationship(currentClinician),
+        owner: getRelationship(teamCoordinator),
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateInProgress),
+      },
+    });
+
+    cy
+      .routeCurrentClinician(fx => {
+        fx.data = currentClinician;
+
+        return fx;
+      })
+      .routeFlow(fx => {
+        fx.data = authoredFlow;
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions()
+      .visit(`/patient/${ testPatient.id }/flow/${ authoredFlow.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatient')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('.patient-flow__header-container .js-menu')
+      .should('exist');
+  });
+
+  specify('flow not authored by a user with work:authored:delete permission', function() {
+    const testPatient = getPatient();
+    const currentClinician = getCurrentClinician({
+      relationships: {
+        role: getRelationship(roleTeamEmployee),
+        team: getRelationship(teamCoordinator),
+      },
+    });
+    const otherClinician = getClinician();
+    const otherAuthoredFlow = getFlow({
+      relationships: {
+        author: getRelationship(otherClinician),
+        owner: getRelationship(teamCoordinator),
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateInProgress),
+      },
+    });
+
+    cy
+      .routeCurrentClinician(fx => {
+        fx.data = currentClinician;
+
+        return fx;
+      })
+      .routeFlow(fx => {
+        fx.data = otherAuthoredFlow;
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions()
+      .visit(`/patient/${ testPatient.id }/flow/${ otherAuthoredFlow.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatient')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('.patient-flow__header-container .js-menu')
+      .should('not.exist');
+  });
+
   specify('flow progress bar', function() {
     cy
       .routesForPatientAction()
@@ -1856,6 +2159,126 @@ context('patient flow page', function() {
     cy
       .get('.patient-flow__progress')
       .should('have.value', 2);
+  });
+
+  specify('completing a flow when all actions are done', function() {
+    const testPatient = getPatient();
+    const completableFlow = getFlow({
+      meta: {
+        progress: {
+          complete: 2,
+          total: 2,
+        },
+      },
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateInProgress),
+      },
+    });
+
+    cy
+      .routeFlow(fx => {
+        fx.data = completableFlow;
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = getActions({
+          relationships: {
+            state: getRelationship(stateDone),
+            flow: getRelationship(completableFlow),
+          },
+        }, { sample: 2 });
+
+        return fx;
+      })
+      .intercept('PATCH', `/api/flows/${ completableFlow.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routePatchCompletableFlow')
+      .visit(`/patient/${ testPatient.id }/flow/${ completableFlow.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatient')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('[data-header-region] [data-state-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .contains('Done')
+      .click();
+
+    cy
+      .wait('@routePatchCompletableFlow')
+      .its('request.body.data.relationships.state.data.id')
+      .should('equal', stateDone.id);
+  });
+
+  specify('requiring all actions to be done before completing a flow', function() {
+    const testPatient = getPatient();
+    const incompleteFlow = getFlow({
+      meta: {
+        progress: {
+          complete: 0,
+          total: 1,
+        },
+      },
+      relationships: {
+        patient: getRelationship(testPatient),
+        state: getRelationship(stateInProgress),
+      },
+    });
+
+    cy
+      .routeSettings('require_done_flow', true)
+      .routeFlow(fx => {
+        fx.data = incompleteFlow;
+
+        return fx;
+      })
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeFlowActions(fx => {
+        fx.data = getActions({
+          relationships: {
+            state: getRelationship(stateTodo),
+            flow: getRelationship(incompleteFlow),
+          },
+        }, { sample: 1 });
+
+        return fx;
+      })
+      .visit(`/patient/${ testPatient.id }/flow/${ incompleteFlow.id }`)
+      .wait('@routeFlow')
+      .wait('@routePatient')
+      .wait('@routeFlowActions');
+
+    cy
+      .get('[data-header-region] [data-state-region]')
+      .click();
+
+    cy
+      .get('.picklist')
+      .find('.js-picklist-item')
+      .contains('Done')
+      .click();
+
+    cy
+      .get('.modal--small')
+      .should('contain', 'Flow Actions Must Be Done')
+      .and('contain', 'You must set all actions to a Done state before setting this flow to a Done state.');
   });
 
   specify('bulk edit actions', function() {

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -206,7 +206,7 @@ context('patient flow page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 
@@ -1197,7 +1197,7 @@ context('patient flow page', function() {
         last_name: 'Patient',
       },
       relationships: {
-        workspaces: getRelationship(workspaceOne),
+        workspaces: getRelationship([workspaceOne]),
       },
     });
 

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -1191,6 +1191,16 @@ context('patient flow page', function() {
   });
 
   specify('failed flow', function() {
+    const testPatient = getPatient({
+      attributes: {
+        first_name: 'Test',
+        last_name: 'Patient',
+      },
+      relationships: {
+        workspaces: getRelationship(workspaceOne),
+      },
+    });
+
     const errors = getErrors({
       status: '410',
       title: 'Not Found',
@@ -1199,17 +1209,32 @@ context('patient flow page', function() {
 
     cy
       .routesForPatientAction()
-      .routePatientByFlow()
-      .routeFlowActions()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routePatientFlows(fx => {
+        fx.data = [];
+
+        return fx;
+      })
       .intercept('GET', `/api/flows/${ testFlow.id }**`, {
         statusCode: 410,
         body: { errors },
       })
-      .visit(`/flow/${ testFlow.id }`);
+      .as('routeGoneFlow')
+      .visit(`/patient/${ testPatient.id }/flow/${ testFlow.id }`)
+      .wait('@routeGoneFlow');
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Flow you requested does not exist.');
 
     cy
       .url()
-      .should('contain', '/404');
+      .should('contain', `/patient/${ testPatient.id }/workflow`)
+      .should('not.contain', '/flow/');
   });
 
   specify('empty view', function() {

--- a/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
+++ b/src/js/apps/patients/patient/flow/patient-flow.e2e.cy.js
@@ -89,6 +89,8 @@ context('patient flow page', function() {
       .wait('@routeFlow')
       .wait('@routePatientByFlow');
 
+    cy.url().as('flowUrl');
+
     cy
       .get('.patient-flow__context-trail')
       .should('contain', 'Test Flow')
@@ -101,6 +103,10 @@ context('patient flow page', function() {
 
     cy
       .go('back');
+
+    cy.get('@flowUrl').then(flowUrl => {
+      cy.url().should('equal', flowUrl);
+    });
 
     cy
       .get('.patient-flow__context-trail')

--- a/src/js/apps/patients/patient/form/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/form/action.e2e.cy.js
@@ -79,6 +79,65 @@ context('Patient Action Form', function() {
       .should('not.contain', `/patient/${ routePatientId }/form/${ testForm.id }/action/${ deletedActionId }`);
   });
 
+  specify('action deleted while its form is open', function() {
+    const testPatient = getPatient();
+    const testAction = getAction({
+      relationships: {
+        'form': getRelationship(testForm),
+        'form-responses': getRelationship([]),
+        'patient': getRelationship(testPatient),
+      },
+    });
+
+    cy
+      .routeAction(fx => {
+        fx.data = testAction;
+
+        return fx;
+      })
+      .routeFormByAction(fx => {
+        fx.data = testForm;
+
+        return fx;
+      })
+      .routeLatestFormResponse()
+      .routeFormDefinition()
+      .routeFormActionFields()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .visit(`/patient/${ testPatient.id }/form/${ testForm.id }/action/${ testAction.id }`)
+      .wait('@routeAction')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
+
+    cy.window().then(win => {
+      const action = win.Radio.request('entities', 'get:store', {
+        type: testAction.type,
+        id: testAction.id,
+      });
+
+      action.handleMessage({
+        category: 'ResourceDeleted',
+        resource: {
+          type: testAction.type,
+          id: testAction.id,
+        },
+        payload: {},
+      });
+    });
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Action was deleted successfully.');
+
+    cy
+      .url()
+      .should('not.contain', `/form/${ testForm.id }/action/${ testAction.id }`);
+  });
+
   specify('update a form', function() {
     const testFormResponse = getFormResponse();
 
@@ -1478,6 +1537,19 @@ context('Patient Action Form', function() {
       .should('have.attr', 'src', '/forms/formio/index.html');
 
     cy
+      .get('.patient__context-trail .js-action')
+      .click();
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/flow/${ testFlow.id }/action/${ testAction.id }`);
+
+    cy
+      .go('back')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
+
+    cy
       .get('.patient__context-trail .js-flow')
       .click();
 
@@ -1529,6 +1601,19 @@ context('Patient Action Form', function() {
     cy
       .url()
       .should('contain', `/patient/${ testPatient.id }/workflow`);
+
+    cy
+      .go('back')
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
+
+    cy
+      .get('.patient__context-trail .js-action')
+      .click();
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/action/${ testAction.id }`);
   });
 
   specify('form header widgets', function() {

--- a/src/js/apps/patients/patient/form/action.e2e.cy.js
+++ b/src/js/apps/patients/patient/form/action.e2e.cy.js
@@ -1429,9 +1429,10 @@ context('Patient Action Form', function() {
     });
 
     cy
-      .routesForPatientDashboard()
+      .routesForPatientAction()
       .routeAction(fx => {
         fx.data = testAction;
+        fx.included.push(testFlow);
 
         return fx;
       })
@@ -1453,9 +1454,16 @@ context('Patient Action Form', function() {
       .routePatientByFlow()
       .routeFlow()
       .routeFlowActions()
-      .visit(`/patient/${ testPatient.id }/form/${ testForm.id }/action/${ testAction.id }`)
+      .routeFlowActivity()
+      .visit(`/patient/${ testPatient.id }/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeAction')
       .wait('@routePatient');
+
+    cy
+      .get('.patient-action__button')
+      .click()
+      .wait('@routeFormByAction')
+      .wait('@routeFormDefinition');
 
     cy
       .get('.js-history-button')

--- a/src/js/apps/patients/patient/form/form_app.js
+++ b/src/js/apps/patients/patient/form/form_app.js
@@ -63,7 +63,7 @@ export default App.extend({
       Radio.request('entities', 'fetch:formResponses:byMe', { actionId }),
     ];
   },
-  onFail({ actionId } = {}) {
+  onFail({ actionId }) {
     const message = actionId ?
       intl.patients.patient.form.formApp.notFound :
       intl.patients.patient.form.formApp.formNotFound;
@@ -226,8 +226,6 @@ export default App.extend({
     this.showChildView('stateActions', formStateActions);
   },
   onClickHistoryButton() {
-    if (!this.responses) return;
-
     this.setState({ responseId: get(this.responses.getFirstSubmission(), 'id'), shouldShowHistory: !this.getState('shouldShowHistory') });
   },
   showContent() {
@@ -280,8 +278,6 @@ export default App.extend({
     this.showChildView('formAction', new LockedSubmitView());
   },
   showFormStatus() {
-    if (!this.responses) return;
-
     if (!this.responses.getFirstSubmission()) return;
 
     this.showChildView('status', new StatusView({
@@ -289,8 +285,6 @@ export default App.extend({
     }));
   },
   showFormHistory() {
-    if (!this.responses) return;
-
     const selected = this.responses.get(this.getState('responseId'));
 
     const historyView = this.showChildView('formAction', new HistoryView({ selected, collection: this.responses.filterSubmissions() }));

--- a/src/js/apps/patients/patient/form/patient.e2e.cy.js
+++ b/src/js/apps/patients/patient/form/patient.e2e.cy.js
@@ -32,6 +32,38 @@ context('Patient Form', function() {
       .routeWorkspacePatient();
   });
 
+  specify('deleted form', function() {
+    cy
+      .routesForDefault()
+      .routePatient(fx => {
+        fx.data = testPatient;
+
+        return fx;
+      })
+      .routeLatestFormResponse()
+      .intercept('GET', `/api/forms/${ testForm.id }*`, {
+        statusCode: 410,
+        body: {
+          errors: getErrors({
+            status: '410',
+            title: 'Not Found',
+            detail: 'Cannot find form',
+          }),
+        },
+      })
+      .as('routeGoneForm')
+      .visit(`/patient/${ testPatient.id }/form/${ testForm.id }`)
+      .wait('@routeGoneForm');
+
+    cy
+      .get('.alert-box__body')
+      .should('contain', 'The Form you requested does not exist.');
+
+    cy
+      .url()
+      .should('not.contain', `/patient/${ testPatient.id }/form/${ testForm.id }`);
+  });
+
   specify('submitting the form', function() {
     const testNewFormResponse = getFormResponse();
 
@@ -635,9 +667,17 @@ context('Patient Form', function() {
 
         return fx;
       })
-      .visitOnClock(`/patient/${ testPatient.id }/form/${ testForm.id }`, { now: testTs() })
-      .wait('@routeForm')
+      .visitOnClock(`/patient/dashboard/${ testPatient.id }`, { now: testTs() })
       .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy.window().then(win => {
+      win.Radio.trigger('event-router', 'patient:form', testPatient.id, testForm.id);
+    });
+
+    cy
+      .wait('@routeForm')
       .wait('@routeFormDefinition')
       .wait('@routeWorkspacePatient')
       .wait('@routeFormFields');
@@ -735,7 +775,7 @@ context('Patient Form', function() {
 
     cy
       .location('pathname', { timeout: 10000 })
-      .should('contain', `/patient/${ testPatient.id }/workflow`);
+      .should('equal', `/one/patient/dashboard/${ testPatient.id }`);
   });
 
   specify('submit and go back button - form response error', function() {

--- a/src/js/apps/patients/patient/form/patient.e2e.cy.js
+++ b/src/js/apps/patients/patient/form/patient.e2e.cy.js
@@ -180,11 +180,6 @@ context('Patient Form', function() {
 
     cy
       .get('.form__controls')
-      .find('.js-expand-button')
-      .should('exist');
-
-    cy
-      .get('.form__controls')
       .find('.form__actions-icon:has(.fa-shield-check)')
       .as('draftStatusButton')
       .trigger('pointerover');

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -139,6 +139,7 @@ export default SubRouterApp.extend({
 
   getOptimisticFlowId({ flowId, actionId }, previous) {
     if (flowId) return flowId;
+    if (!actionId) return;
     if (actionId !== previous.actionId) return;
 
     return previous.flowId;

--- a/src/js/apps/patients/patient/patient_app.js
+++ b/src/js/apps/patients/patient/patient_app.js
@@ -1,48 +1,48 @@
-import { partial, get, noop } from 'underscore';
+import { get } from 'underscore';
+import Backbone from 'backbone';
 import Radio from 'backbone.radio';
 
 import handleErrors from 'js/utils/handle-errors';
 
 import SubRouterApp from 'js/base/subrouterapp';
 
-import DashboardApp from 'js/apps/patients/patient/dashboard/dashboard_app';
-import ArchiveApp from 'js/apps/patients/patient/archive/archive_app';
+import WorkflowPageApp from 'js/apps/patients/patient/workflow/workflow_app';
+import FlowPageApp from 'js/apps/patients/patient/flow/flow_app';
+import ActionApp from 'js/apps/patients/patient/action/action_app';
+import FormApp from 'js/apps/patients/patient/form/form_app';
 import PatientSidebarApp from 'js/apps/patients/patient/sidebar/sidebar_app';
-import ActionSiderbarApp from 'js/apps/patients/sidebar/action/action-sidebar_app';
 
-import { LayoutView, intl } from 'js/apps/patients/patient/patient_views';
+import { LayoutView } from 'js/apps/patients/patient/patient_views';
 
 export default SubRouterApp.extend({
   routeScope: ['patientId'],
 
   routeActions() {
     return {
-      'patient:dashboard': partial(this.startList, 'dashboard'),
-      'patient:archive': partial(this.startList, 'archive'),
-      'patient:action': partial(this.startPatientAction, 'dashboard'),
-      'patient:action:archive': partial(this.startPatientAction, 'archive'),
+      'patient:workflow': this.showWorkflow,
+      'patient:workflow:closed': this.showClosedWorkflow,
+      'patient:action': this.showPatientAction,
+      'patient:flow': this.showFlow,
+      'patient:flow:action': this.showFlowAction,
+      'patient:form': this.showPatientForm,
+      'patient:form:action': this.showActionForm,
     };
   },
 
   childApps: {
-    dashboard: DashboardApp,
-    archive: ArchiveApp,
-    actionSidebar: ActionSiderbarApp,
-    patient: PatientSidebarApp,
+    workflow: WorkflowPageApp,
+    flow: FlowPageApp,
+    action: ActionApp,
+    form: FormApp,
+    patientSidebar: PatientSidebarApp,
   },
 
   currentAppOptions() {
     return {
       region: this.getRegion('content'),
-      patient: this.getOption('patient'),
+      patient: this.patient,
+      patientId: this.patient.id,
     };
-  },
-
-  onBeforeStartRoute() {
-    if (this.action) {
-      this.action.trigger('editing', false);
-      delete this.action;
-    }
   },
 
   onBeforeStart() {
@@ -50,21 +50,13 @@ export default SubRouterApp.extend({
   },
 
   beforeStart() {
-    const [patientId, actionId] = this.getCurrentRoute().eventArgs;
+    const [patientId] = this.getCurrentRoute().eventArgs;
 
-    return [
-      Radio.request('entities', 'fetch:patients:model', patientId),
-      // the action is a non-aborting prefetch: it warms the cache for the initial
-      // route but its failure must never reject startup or override a newer route —
-      // dispatch (startPatientAction) is the source of truth and handles errors
-      actionId && Radio.request('entities', 'fetch:actions:model', actionId).catch(noop),
-    ];
+    return Radio.request('entities', 'fetch:patients:model', patientId);
   },
 
   /* istanbul ignore next: beforeStart error handling */
   onFail(options, error) {
-    // the action prefetch is non-aborting, so a startup failure is the patient's;
-    // a 410 means the patient is gone
     if (get(error, ['response', 'status']) === 410) {
       Radio.trigger('event-router', 'notFound');
       this.stop();
@@ -74,101 +66,102 @@ export default SubRouterApp.extend({
     handleErrors(error);
   },
 
-  // status-aware action failure handling for the on-demand dispatch fetch
-  failAction(error, patientId) {
-    /* istanbul ignore else: only the 410 path is exercised; others are generic */
-    if (get(error, ['response', 'status']) === 410) {
-      this.showActionNotFound();
-      this.stop();
-      Radio.trigger('event-router', 'patient:dashboard', patientId);
-      return;
-    }
-
-    /* istanbul ignore next: generic error handling */
-    handleErrors(error);
-  },
-
   onStart(options, patient) {
     this.patient = patient;
+    this.contextTrail = new Backbone.Model();
 
-    this.setView(new LayoutView({ model: patient }));
+    this.setView(new LayoutView({
+      model: patient,
+      contextTrail: this.contextTrail,
+    }));
 
-    this.showSidebar();
-
+    this.showPatientSidebar();
     this.startCurrentRoute();
-
     this.showView();
   },
 
-  onStop() {
-    delete this._list;
-    delete this.action;
+  showWorkflow() {
+    this.startContent('workflow', { status: 'notDone' });
   },
 
-  showActionNotFound() {
-    Radio.request('alert', 'show:error', intl.actionNotFound);
+  showClosedWorkflow() {
+    this.startContent('workflow', { status: 'done' });
   },
 
-  startList(list) {
-    if (this._list === list) return;
+  showPatientAction(patientId, actionId) {
+    this.startContent('action', { actionId });
+  },
 
-    this._list = list;
+  showFlow(patientId, flowId) {
+    this.startContent('flow', { flowId });
+  },
 
-    this.startCurrent(list);
+  showFlowAction(patientId, flowId, actionId) {
+    this.startContent('action', { flowId, actionId });
+  },
 
-    if (this.action) {
-      this.listenToOnce(this.getChildApp(list), 'start', () => {
-        this.action.trigger('editing', true);
-      });
+  showPatientForm(patientId, formId) {
+    this.startContent('form', { formId });
+  },
+
+  showActionForm(patientId, formId, actionId) {
+    this.startContent('form', { formId, actionId });
+  },
+
+  startContent(appName, options) {
+    this.contextTrail.set('context', this.getOptimisticContext(appName, options));
+
+    const pageApp = this.getChildApp(appName);
+
+    this.stopListening(pageApp, 'context:change');
+    this.listenTo(pageApp, 'context:change', this.updateContextTrail);
+
+    this.startCurrent(appName, options);
+  },
+
+  getOptimisticContext(page, options) {
+    const previous = this.contextTrail.get('context') || {};
+    const context = { page };
+
+    if (page === 'workflow') {
+      context.status = options.status;
+      return context;
+    }
+
+    const flowId = this.getOptimisticFlowId(options, previous);
+
+    this.addOptimisticResource(context, previous, 'flow', flowId);
+    this.addOptimisticResource(context, previous, 'action', options.actionId);
+    this.addOptimisticResource(context, previous, 'form', options.formId);
+
+    return context;
+  },
+
+  getOptimisticFlowId({ flowId, actionId }, previous) {
+    if (flowId) return flowId;
+    if (actionId !== previous.actionId) return;
+
+    return previous.flowId;
+  },
+
+  addOptimisticResource(context, previous, resource, id) {
+    if (!id) return;
+
+    const idKey = `${ resource }Id`;
+    const nameKey = `${ resource }Name`;
+
+    context[idKey] = id;
+    if (id === previous[idKey] && previous[nameKey]) {
+      context[nameKey] = previous[nameKey];
     }
   },
 
-  startPatientAction(list, patientId, actionId) {
-    const action = Radio.request('entities', 'actions:model', actionId);
-    this.action = action;
-
-    this.startList(list);
-
-    this.getChildApp('actionSidebar').stop();
-
-    if (action.isCached()) {
-      this.showActionSidebar(action, list, patientId);
-      return;
-    }
-
-    // not cached when its route coalesced into a still-loading PatientApp, the
-    // prefetch failed, or the action is absent from the list: fetch it on demand
-    // rather than reporting it missing
-    Radio.request('entities', 'fetch:actions:model', actionId)
-      .then(() => this.showActionSidebar(action, list, patientId))
-      .catch(error => {
-        // suppress when a newer action route superseded this one (or the app stopped)
-        if (this.action !== action) return;
-
-        this.failAction(error, patientId);
-      });
+  updateContextTrail(context) {
+    this.contextTrail.set('context', context);
   },
 
-  showActionSidebar(action, list, patientId) {
-    // a newer action route may have superseded this one while it loaded
-    if (this.action !== action) return;
-
-    /* istanbul ignore next: defensive — app stopped mid-fetch */
-    if (!this.isRunning()) return;
-
-    const sidebarApp = this.getChildApp('actionSidebar');
-
-    Radio.request('sidebar', 'start', sidebarApp, { action });
-
-    // re-dispatched routes must not accumulate close handlers on the singleton
-    this.stopListening(sidebarApp, 'close');
-    this.listenTo(sidebarApp, 'close', () => {
-      Radio.trigger('event-router', `patient:${ list }`, patientId);
-    });
-  },
-
-  showSidebar() {
-    this.startChildApp('patient', {
+  showPatientSidebar() {
+    this.startChildApp('patientSidebar', {
       region: this.getRegion('sidebar'),
       patient: this.patient,
     });

--- a/src/js/apps/patients/patient/patient_views.js
+++ b/src/js/apps/patients/patient/patient_views.js
@@ -18,10 +18,26 @@ const ContextTrailView = View.extend({
         {{fas "chevron-left"}}{{ @intl.patients.patient.patientViews.contextBackBtn }}
       </a>
       {{fas "chevron-right"}}
-    {{/if}}{{ first_name }} {{ last_name }}
+    {{/if}}
+    <a class="js-patient patient__context-link">{{ first_name }} {{ last_name }}</a>
+    {{#if flowName}}
+      {{fas "chevron-right"}}
+      <a class="js-flow patient__context-link">{{ flowName }}</a>
+    {{/if}}
+    {{#if actionName}}
+      {{fas "chevron-right"}}
+      <a class="js-action patient__context-link">{{ actionName }}</a>
+    {{/if}}
+    {{#if formName}}
+      {{fas "chevron-right"}}
+      {{ formName }}
+    {{/if}}
   `,
   triggers: {
     'click .js-back': 'click:back',
+    'click .js-patient': 'click:patient',
+    'click .js-flow': 'click:flow',
+    'click .js-action': 'click:action',
   },
   modelEvents: {
     'change:first_name change:last_name': 'render',
@@ -29,9 +45,29 @@ const ContextTrailView = View.extend({
   onClickBack() {
     Radio.request('history', 'go:latestList');
   },
+  initialize({ contextTrail }) {
+    this.contextTrail = contextTrail;
+    this.listenTo(contextTrail, 'change:context', this.render);
+  },
+  onClickPatient() {
+    Radio.trigger('event-router', 'patient:workflow', this.model.id);
+  },
+  onClickFlow() {
+    const { flowId } = this.contextTrail.get('context');
+    Radio.trigger('event-router', 'patient:flow', this.model.id, flowId);
+  },
+  onClickAction() {
+    const { flowId, actionId } = this.contextTrail.get('context');
+    const event = flowId ? 'patient:flow:action' : 'patient:action';
+    const args = flowId ?
+      [this.model.id, flowId, actionId] :
+      [this.model.id, actionId];
+    Radio.trigger('event-router', event, ...args);
+  },
   templateContext() {
     return {
       hasLatestList: Radio.request('history', 'has:latestList'),
+      ...this.contextTrail.get('context'),
     };
   },
 });
@@ -58,7 +94,10 @@ const LayoutView = View.extend({
     },
   },
   onRender() {
-    this.showChildView('contextTrail', new ContextTrailView({ model: this.model }));
+    this.showChildView('contextTrail', new ContextTrailView({
+      model: this.model,
+      contextTrail: this.getOption('contextTrail'),
+    }));
   },
 });
 

--- a/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
@@ -572,6 +572,22 @@ context('patient sidebar', function() {
     cy
       .url()
       .should('contain', `patient/${ testPatient.id }/form/${ testForm.id }`);
+
+    cy.go('back');
+
+    cy
+      .url()
+      .should('contain', `patient/dashboard/${ testPatient.id }`);
+
+    cy
+      .get('@patientSidebar')
+      .find('.widgets__form-widget')
+      .contains('Test Form')
+      .click();
+
+    cy
+      .url()
+      .should('contain', `patient/${ testPatient.id }/form/${ testForm.id }`);
   });
 
   specify('patient workspaces', function() {

--- a/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
@@ -61,6 +61,11 @@ context('patient sidebar', function() {
       .routeFormFields()
       .routeForm()
       .routeForm(fx => {
+        fx.data = testForm;
+
+        return fx;
+      }, testForm.id)
+      .routeForm(fx => {
         fx.data = testScriptReducerForm;
 
         return fx;
@@ -562,15 +567,7 @@ context('patient sidebar', function() {
 
     cy
       .get('.modal--large')
-      .find('.js-close')
-      .last()
-      .click();
-
-    cy
-      .get('@patientSidebar')
-      .find('.widgets__form-widget')
-      .contains('Test Form')
-      .click();
+      .should('not.exist');
 
     cy
       .url()
@@ -704,7 +701,7 @@ context('patient sidebar', function() {
 
     cy
       .url()
-      .should('contain', `/patient/dashboard/${ testPatient.id }`);
+      .should('contain', `/patient/${ testPatient.id }/workflow`);
   });
 
   specify('view patient modal', function() {

--- a/src/js/apps/patients/patient/workflow/workflow.e2e.cy.js
+++ b/src/js/apps/patients/patient/workflow/workflow.e2e.cy.js
@@ -98,6 +98,17 @@ context('patient workflow page', function() {
       },
     });
 
+    const doneFlow = getFlow({
+      attributes: {
+        name: 'Done Flow',
+        updated_at: testTsSubtract(5),
+      },
+      relationships: {
+        state: getRelationship(stateDone),
+        patient: getRelationship(testPatient),
+      },
+    });
+
     cy
       .routesForPatientAction()
       .routePatient(fx => {
@@ -136,7 +147,7 @@ context('patient workflow page', function() {
           }),
           getAction({
             attributes: {
-              name: 'Not In List',
+              name: 'Done Action',
               updated_at: testTsSubtract(5),
             },
             relationships: {
@@ -161,16 +172,7 @@ context('patient workflow page', function() {
             },
           }),
           testFlow,
-          getFlow({
-            attributes: {
-              name: 'Not In List',
-              updated_at: testTsSubtract(5),
-            },
-            relationships: {
-              state: getRelationship(stateDone),
-              patient: getRelationship(testPatient),
-            },
-          }),
+          doneFlow,
         ];
 
         return fx;
@@ -212,6 +214,13 @@ context('patient workflow page', function() {
         body: {},
       })
       .as('routePatchFlow');
+
+    cy
+      .intercept('PATCH', `/api/flows/${ doneFlow.id }`, {
+        statusCode: 204,
+        body: {},
+      })
+      .as('routePatchDoneFlow');
 
     cy
       .get('.list-page__list')
@@ -360,12 +369,31 @@ context('patient workflow page', function() {
     cy
       .get('.patient__tabs')
       .find('.js-archive')
+      .click()
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy
+      .contains('.table-list__item', 'Done Flow')
+      .find('[data-state-region]')
       .click();
+
+    cy
+      .get('.picklist')
+      .contains('In Progress')
+      .click();
+
+    cy
+      .wait('@routePatchDoneFlow')
+      .its('request.body.data.relationships.state.data.id')
+      .should('equal', stateInProgress.id);
 
     cy
       .get('.patient__tabs')
       .find('.js-dashboard')
-      .click();
+      .click()
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
 
     cy
       .get('.list-page__list')
@@ -418,6 +446,18 @@ context('patient workflow page', function() {
       .eq(2)
       .find('.fa-comment')
       .should('not.exist');
+
+    cy
+      .get('.list-page__list')
+      .contains('.table-list__item', testAction.attributes.name)
+      .click('top')
+      .wait('@routeAction');
+
+    cy
+      .url()
+      .should('contain', `/patient/${ testPatient.id }/action/${ testAction.id }`);
+
+    cy.go('back');
 
     // dirty hack to make sure the form button isn't offscreen
     cy
@@ -1908,6 +1948,16 @@ context('patient workflow page', function() {
               owner: getRelationship(teamCoordinator),
             },
           }),
+          getFlow({
+            attributes: {
+              name: 'Done Flow',
+              updated_at: testTsSubtract(7),
+            },
+            relationships: {
+              state: getRelationship(stateDone),
+              owner: getRelationship(teamCoordinator),
+            },
+          }),
         ];
 
         return fx;
@@ -1941,6 +1991,22 @@ context('patient workflow page', function() {
       .get('@listItems')
       .eq(3)
       .find('[data-owner-region]')
+      .find('button')
+      .should('not.exist');
+
+    cy
+      .get('.patient__tabs')
+      .find('.js-archive')
+      .click()
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
+
+    cy
+      .contains('.table-list__item', 'Done Flow')
+      .find('[data-state-region]')
+      .find('.fa-circle-check')
+      .should('exist')
+      .parents('[data-state-region]')
       .find('button')
       .should('not.exist');
   });

--- a/src/js/apps/patients/patient/workflow/workflow.e2e.cy.js
+++ b/src/js/apps/patients/patient/workflow/workflow.e2e.cy.js
@@ -51,6 +51,11 @@ context('patient workflow page', function() {
       })
       .as('routePostAction');
 
+    cy.routeAction(fx => {
+      fx.data = actionData;
+      return fx;
+    });
+
     return actionData.id;
   }
 
@@ -180,7 +185,7 @@ context('patient workflow page', function() {
 
     cy
       .location('pathname')
-      .should('equal', `/one/patient/${ testPatient.id }/workflow`);
+      .should('equal', `/one/patient/dashboard/${ testPatient.id }`);
 
     cy
       .wait('@routePatientActions')
@@ -268,13 +273,8 @@ context('patient workflow page', function() {
 
     cy
       .get('.list-page__list')
-      .contains('First In List')
-      .click()
-      .tick(350); // this test uses visitOnClock, so needed for the sidebar animation
-
-    cy
-      .get('.list-page__list')
-      .find('.is-selected')
+      .find('.table-list__item')
+      .first()
       .find('[data-state-region]')
       .find('.fa-circle-exclamation')
       .click();
@@ -293,7 +293,8 @@ context('patient workflow page', function() {
 
     cy
       .get('.list-page__list')
-      .find('.is-selected')
+      .find('.table-list__item')
+      .first()
       .find('[data-owner-region]')
       .should('contain', 'CO')
       .click();
@@ -313,7 +314,8 @@ context('patient workflow page', function() {
 
     cy
       .get('.list-page__list')
-      .find('.is-selected')
+      .find('.table-list__item')
+      .first()
       .find('[data-due-date-region]')
       .click();
 
@@ -332,7 +334,8 @@ context('patient workflow page', function() {
 
     cy
       .get('.list-page__list')
-      .find('.is-selected')
+      .find('.table-list__item')
+      .first()
       .find('[data-due-time-region]')
       .click();
 
@@ -343,7 +346,8 @@ context('patient workflow page', function() {
 
     cy
       .get('.list-page__list')
-      .find('.is-selected')
+      .find('.table-list__item')
+      .first()
       .find('[data-due-time-region] .is-overdue');
 
     cy
@@ -362,17 +366,6 @@ context('patient workflow page', function() {
       .get('.patient__tabs')
       .find('.js-dashboard')
       .click();
-
-    cy
-      .get('.list-page__list')
-      .find('.is-selected')
-      .should('not.exist');
-
-    cy
-      .get('.list-page__list')
-      .contains('First In List')
-      .click()
-      .tick(350); // this test uses visitOnClock, so needed for the sidebar animation
 
     cy
       .get('.list-page__list')
@@ -402,60 +395,6 @@ context('patient workflow page', function() {
         expect(data.relationships.owner.data.id).to.equal(teamNurse.id);
         expect(data.relationships.owner.data.type).to.equal(teamNurse.type);
       });
-
-    cy
-      .routeFlow()
-      .routeFlowActions()
-      .routePatientByFlow();
-
-    cy
-      .get('@flowItem')
-      .click('top')
-      .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
-
-    cy
-      .url()
-      .should('contain', `flow/${ testFlow.id }`);
-
-    cy
-      .go('back');
-
-    cy
-      .get('.list-page__list')
-      .find('.is-selected')
-      .find('[data-state-region]')
-      .click();
-
-    cy
-      .get('.picklist')
-      .find('.js-picklist-item')
-      .contains('Done')
-      .click()
-      .tick(800); // the length of the animation
-
-    cy
-      .wait('@routePatchAction')
-      .its('request.body')
-      .should(({ data }) => {
-        expect(data.relationships.state.data.id).to.equal(stateDone.id);
-      });
-
-    cy
-      .get('.list-page__list')
-      .find('.table-list__item')
-      .should('have.lengthOf', 4);
-
-    cy
-      .get('.sidebar')
-      .find('.fa-circle-check')
-      .click();
-
-    cy
-      .get('.picklist')
-      .contains('To Do')
-      .click();
 
     cy
       .get('.list-page__list')
@@ -1058,21 +997,19 @@ context('patient workflow page', function() {
       .should('contain', `patient/${ testPatient.id }/action/${ testOne }`);
 
     cy
-      .get('.list-page__list')
-      .find('.is-selected')
+      .get('.patient-action')
       .should('contain', 'One of One');
 
     cy
-      .get('.sidebar')
-      .find('.patient-action__name')
-      .should('contain', 'One of One');
-
-    cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('.js-menu')
       .should('not.exist');
 
     cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows')
       .get('[data-add-workflow-region]')
       .contains('Add')
       .click();
@@ -1105,21 +1042,19 @@ context('patient workflow page', function() {
       .should('contain', `patient/${ testPatient.id }/action/${ testTwo }`);
 
     cy
-      .get('.list-page__list')
-      .find('.is-selected')
+      .get('.patient-action')
       .should('contain', 'One of Two');
 
     cy
-      .get('.sidebar')
-      .find('.patient-action__name')
-      .should('contain', 'One of Two');
-
-    cy
-      .get('.sidebar')
+      .get('.patient-action')
       .find('.js-menu')
       .should('not.exist');
 
     cy
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows')
       .get('[data-add-workflow-region]')
       .contains('Add')
       .click();
@@ -1146,14 +1081,14 @@ context('patient workflow page', function() {
       .should('contain', `patient/${ testPatient.id }/action/${ testThree }`);
 
     cy
-      .get('.list-page__list')
-      .find('.is-selected')
+      .get('.patient-action')
       .should('contain', 'Two of Two');
 
     cy
-      .get('.sidebar')
-      .find('.patient-action__name')
-      .should('contain', 'Two of Two');
+      .visit(`/patient/dashboard/${ testPatient.id }`)
+      .wait('@routePatient')
+      .wait('@routePatientActions')
+      .wait('@routePatientFlows');
 
     const testFlow = getFlow({
       attributes: { updated_at: testTs() },
@@ -1175,8 +1110,7 @@ context('patient workflow page', function() {
 
     cy
       .routeFlow()
-      .routeFlowActions()
-      .routePatientByFlow();
+      .routeFlowActions();
 
     cy
       .get('.picklist')
@@ -1196,12 +1130,7 @@ context('patient workflow page', function() {
       .should('contain', `flow/${ testFlow.id }`);
 
     cy
-      .get('.patient-flow__header')
-      .find('.patient-flow__name')
-      .click();
-
-    cy
-      .get('.sidebar')
+      .get('.patient-flow__header-container')
       .find('.js-menu')
       .should('not.exist');
   });

--- a/src/js/apps/patients/patient/workflow/workflow_views.js
+++ b/src/js/apps/patients/patient/workflow/workflow_views.js
@@ -35,14 +35,10 @@ const DoneEmptyView = View.extend({
 
 const RowBehavior = Behavior.extend({
   modelEvents: {
-    'editing': 'onEditing',
     'change': 'onChange',
   },
   onChange() {
     this.view.render();
-  },
-  onEditing(isEditing) {
-    this.$el.toggleClass('is-selected', isEditing);
   },
 });
 

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -117,24 +117,23 @@ export default RouterApp.extend({
     this.startCurrent('schedule');
   },
 
-  showPatient(...eventArgs) {
-    const [patientId] = eventArgs;
+  showPatient(patientId) {
     Radio.trigger('dialer', 'change:currentPatientId', patientId);
     this.startRoute('patient', { patientId });
   },
 
   redirectPatientFlow(flowId) {
-    this.resolveFlowPatient('patient:flow', flowId);
+    return this.resolveFlowPatient('patient:flow', flowId);
   },
 
   redirectPatientFlowAction(flowId, actionId) {
-    this.resolveFlowPatient('patient:flow:action', flowId, actionId);
+    return this.resolveFlowPatient('patient:flow:action', flowId, actionId);
   },
 
   resolveFlowPatient(event, flowId, actionId) {
     const sourceRoute = this.getCurrentRoute();
 
-    Radio.request('entities', 'fetch:flows:model', flowId)
+    return Radio.request('entities', 'fetch:flows:model', flowId)
       .then(flow => {
         const patientId = flow.getPatient().id;
         const routeArgs = actionId ?
@@ -148,20 +147,21 @@ export default RouterApp.extend({
 
   redirectResolvedRoute(sourceRoute, event, ...eventArgs) {
     // Ignore a resolver that completed after the user navigated elsewhere.
-    if (this.getCurrentRoute() !== sourceRoute) return;
+    if (!this.isRunning() || this.getCurrentRoute() !== sourceRoute) return;
 
+    // Replace the legacy URL without dispatching, then route the canonical event.
     this.replaceRoute(event, ...eventArgs);
     Radio.trigger('event-router', event, ...eventArgs);
   },
 
   failResolvedRoute(sourceRoute, error) {
-    if (this.getCurrentRoute() !== sourceRoute) return;
+    if (!this.isRunning() || this.getCurrentRoute() !== sourceRoute) return;
 
     if (get(error, ['response', 'status']) === 410) {
       Radio.trigger('event-router', 'notFound');
       return;
     }
 
-    handleErrors(error);
+    return handleErrors(error);
   },
 });

--- a/src/js/apps/patients/patients-main_app.js
+++ b/src/js/apps/patients/patients-main_app.js
@@ -1,8 +1,10 @@
+import { get } from 'underscore';
 import Radio from 'backbone.radio';
+
+import handleErrors from 'js/utils/handle-errors';
 
 import RouterApp from 'js/base/routerapp';
 
-import FlowApp from 'js/apps/patients/patient/flow/flow_app';
 import PatientApp from 'js/apps/patients/patient/patient_app';
 import WorklistApp from 'js/apps/patients/worklist/worklist_app';
 import ScheduleApp from 'js/apps/patients/schedule/schedule_app';
@@ -11,7 +13,6 @@ export default RouterApp.extend({
   routerAppName: 'PatientsApp',
 
   childApps: {
-    flow: FlowApp,
     patient: PatientApp,
     ownedBy: WorklistApp,
     forTeam: WorklistApp,
@@ -27,59 +28,74 @@ export default RouterApp.extend({
       route: 'worklist/:id',
       meta: { isList: true },
     },
-    'patient:dashboard': {
-      action: 'showPatient',
-      route: 'patient/dashboard/:id',
-    },
-    'patient:archive': {
-      action: 'showPatient',
-      route: 'patient/archive/:id',
-    },
-    'patient:action': {
-      action: 'showPatient',
-      route: 'patient/:id/action/:id',
-    },
-    'patient:action:archive': {
-      action: 'showPatient',
-      route: 'patient/archive/:id/action/:id',
-    },
-    'flow': {
-      action: 'showFlow',
-      route: 'flow/:id',
-    },
-    'flow:details': {
-      action: 'showFlow',
-      route: 'flow/:id/details',
-    },
-    'flow:action': {
-      action: 'showFlow',
-      route: 'flow/:id/action/:id',
-    },
     'schedule': {
       action: 'showSchedule',
       route: 'schedule',
       meta: { isList: true },
     },
-  },
-
-  onBeforeAppRoute(router, { event, eventArgs: [patientId] }) {
-    // if routing to flow route, currentPatientId is set by flow_app's onStart()
-    if (event.startsWith('flow')) return;
-
-    // determines if dialer patient buttons are shown or hidden
-    const isPatientRoute = event.startsWith('patient');
-    Radio.trigger('dialer', 'change:currentPatientId', isPatientRoute ? patientId : null);
+    // Canonical patient-workspace routes. Every route starts the same PatientApp;
+    // PatientApp dispatches the page while its patient shell remains mounted.
+    'patient:workflow': {
+      action: 'showPatient',
+      route: [
+        'patient/:patientId/workflow',
+        'patient/dashboard/:patientId',
+      ],
+    },
+    'patient:workflow:closed': {
+      action: 'showPatient',
+      route: [
+        'patient/:patientId/workflow/closed',
+        'patient/archive/:patientId',
+      ],
+    },
+    'patient:action': {
+      action: 'showPatient',
+      route: [
+        'patient/:patientId/action/:actionId',
+        'patient/archive/:patientId/action/:actionId',
+      ],
+    },
+    'patient:flow': {
+      action: 'showPatient',
+      route: 'patient/:patientId/flow/:flowId',
+    },
+    'patient:flow:action': {
+      action: 'showPatient',
+      route: 'patient/:patientId/flow/:flowId/action/:actionId',
+    },
+    'patient:form': {
+      action: 'showPatient',
+      route: 'patient/:patientId/form/:formId',
+    },
+    'patient:form:action': {
+      action: 'showPatient',
+      route: 'patient/:patientId/form/:formId/action/:actionId',
+    },
+    'legacy:patient:flow': {
+      action: 'redirectPatientFlow',
+      route: [
+        'flow/:flowId',
+        'flow/:flowId/details',
+      ],
+    },
+    'legacy:patient:flow:action': {
+      action: 'redirectPatientFlowAction',
+      route: 'flow/:flowId/action/:actionId',
+    },
   },
 
   onStop() {
+    this.clearCurrentPatient();
+  },
+
+  clearCurrentPatient() {
     Radio.trigger('dialer', 'change:currentPatientId', null);
   },
 
-  showPatient(patientId) {
-    this.startRoute('patient', { patientId });
-  },
-
   showPatientsWorklist(worklistId, clinicianId) {
+    this.clearCurrentPatient();
+
     const worklistsById = {
       'owned-by': 'ownedBy',
       'shared-by': 'forTeam',
@@ -96,11 +112,56 @@ export default RouterApp.extend({
     this.startCurrent(worklistsById[worklistId], { worklistId, clinicianId });
   },
 
-  showFlow(flowId) {
-    this.startRoute('flow', { flowId });
+  showSchedule() {
+    this.clearCurrentPatient();
+    this.startCurrent('schedule');
   },
 
-  showSchedule() {
-    this.startCurrent('schedule');
+  showPatient(...eventArgs) {
+    const [patientId] = eventArgs;
+    Radio.trigger('dialer', 'change:currentPatientId', patientId);
+    this.startRoute('patient', { patientId });
+  },
+
+  redirectPatientFlow(flowId) {
+    this.resolveFlowPatient('patient:flow', flowId);
+  },
+
+  redirectPatientFlowAction(flowId, actionId) {
+    this.resolveFlowPatient('patient:flow:action', flowId, actionId);
+  },
+
+  resolveFlowPatient(event, flowId, actionId) {
+    const sourceRoute = this.getCurrentRoute();
+
+    Radio.request('entities', 'fetch:flows:model', flowId)
+      .then(flow => {
+        const patientId = flow.getPatient().id;
+        const routeArgs = actionId ?
+          [patientId, flowId, actionId] :
+          [patientId, flowId];
+
+        this.redirectResolvedRoute(sourceRoute, event, ...routeArgs);
+      })
+      .catch(error => this.failResolvedRoute(sourceRoute, error));
+  },
+
+  redirectResolvedRoute(sourceRoute, event, ...eventArgs) {
+    // Ignore a resolver that completed after the user navigated elsewhere.
+    if (this.getCurrentRoute() !== sourceRoute) return;
+
+    this.replaceRoute(event, ...eventArgs);
+    Radio.trigger('event-router', event, ...eventArgs);
+  },
+
+  failResolvedRoute(sourceRoute, error) {
+    if (this.getCurrentRoute() !== sourceRoute) return;
+
+    if (get(error, ['response', 'status']) === 410) {
+      Radio.trigger('event-router', 'notFound');
+      return;
+    }
+
+    handleErrors(error);
   },
 });

--- a/src/js/apps/patients/schedule/schedule.e2e.cy.js
+++ b/src/js/apps/patients/schedule/schedule.e2e.cy.js
@@ -298,7 +298,7 @@ context('schedule page', function() {
 
     cy
       .url()
-      .should('contain', `patient-action/${ testActions[0].id }/form/${ testForm.id }`)
+      .should('contain', `patient/${ testPatient1.id }/form/${ testForm.id }/action/${ testActions[0].id }`)
       .wait('@routeFormActionFields')
       .go('back');
 

--- a/src/js/apps/patients/schedule/schedule.e2e.cy.js
+++ b/src/js/apps/patients/schedule/schedule.e2e.cy.js
@@ -232,7 +232,7 @@ context('schedule page', function() {
 
     cy
       .url()
-      .should('contain', `patient/archive/${ testPatient1.id }/action/${ testActions[3].id }`)
+      .should('contain', `patient/${ testPatient1.id }/action/${ testActions[3].id }`)
       .go('back');
 
     cy
@@ -283,7 +283,7 @@ context('schedule page', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ testPatient1.id }`)
+      .should('contain', `patient/${ testPatient1.id }/workflow`)
       .go('back');
 
     cy

--- a/src/js/apps/patients/schedule/schedule_views.js
+++ b/src/js/apps/patients/schedule/schedule_views.js
@@ -259,19 +259,25 @@ const DayItemView = View.extend({
     this.showChildView('check', checkComponent);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
+    Radio.trigger('event-router', 'patient:workflow', this.model.getPatient().id);
   },
   onClickForm() {
-    Radio.trigger('event-router', 'form:patientAction', this.model.id, this.model.getForm().id);
+    Radio.trigger(
+      'event-router',
+      'patient:form:action',
+      this.model.getPatient().id,
+      this.model.getForm().id,
+      this.model.id,
+    );
   },
   onClick() {
     if (this.flow) {
-      Radio.trigger('event-router', 'flow:action', this.flow.id, this.model.id);
+      Radio.trigger('event-router', 'patient:flow:action', this.model.getPatient().id, this.flow.id, this.model.id);
       return;
     }
 
     if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action:archive', this.model.getPatient().id, this.model.id);
+      Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
       return;
     }
 

--- a/src/js/apps/patients/schedule/schedule_views.js
+++ b/src/js/apps/patients/schedule/schedule_views.js
@@ -276,11 +276,6 @@ const DayItemView = View.extend({
       return;
     }
 
-    if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
-      return;
-    }
-
     Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   showDetailsTooltip() {

--- a/src/js/apps/patients/shared/actions_views.js
+++ b/src/js/apps/patients/shared/actions_views.js
@@ -25,7 +25,13 @@ const FormButton = View.extend({
     'click': 'click',
   },
   onClick() {
-    Radio.trigger('event-router', 'form:patientAction', this.model.id, this.model.getForm().id);
+    Radio.trigger(
+      'event-router',
+      'patient:form:action',
+      this.model.getPatient().id,
+      this.model.getForm().id,
+      this.model.id,
+    );
   },
 });
 

--- a/src/js/apps/patients/shared/widgets/README.md
+++ b/src/js/apps/patients/shared/widgets/README.md
@@ -136,7 +136,7 @@ For displaying a standalone form in a widget area. Example:
 ```
 
 `is_modal` will display the form in a modal instead of the form page.
-`modal_size` can be `small` to override the default size.
+`modal_size` can be `small` to override the default size. Using `large` navigates to the patient form page instead of opening a modal, including for read-only forms.
 
 ## Custom Widgets (DEPRECATED)
 

--- a/src/js/apps/patients/shared/widgets/README.md
+++ b/src/js/apps/patients/shared/widgets/README.md
@@ -136,7 +136,7 @@ For displaying a standalone form in a widget area. Example:
 ```
 
 `is_modal` will display the form in a modal instead of the form page.
-`modal_size` can be `small` or `large` to override the default size
+`modal_size` can be `small` to override the default size.
 
 ## Custom Widgets (DEPRECATED)
 

--- a/src/js/apps/patients/shared/widgets/widgets.js
+++ b/src/js/apps/patients/shared/widgets/widgets.js
@@ -142,7 +142,7 @@ const widgets = {
         Radio.request('modal', 'show:form', this.model, this.getOption('form_name'), this.form, this.getOption('modal_size'));
         return;
       }
-      Radio.trigger('event-router', 'form:patient', this.model.id, this.getOption('form_id'));
+      Radio.trigger('event-router', 'patient:form', this.model.id, this.getOption('form_id'));
     },
   }),
 };

--- a/src/js/apps/patients/sidebar/patient/patient-sidebar_app.js
+++ b/src/js/apps/patients/sidebar/patient/patient-sidebar_app.js
@@ -38,7 +38,7 @@ export default App.extend(extend({
     layoutView.getRegion('widgets').startPreloader();
 
     this.listenTo(layoutView, 'click:patient', () => {
-      Radio.trigger('event-router', 'patient:dashboard', this.patient.id);
+      Radio.trigger('event-router', 'patient:workflow', this.patient.id);
     });
 
     this.showChildView('content', layoutView);

--- a/src/js/apps/patients/worklist/action_views.js
+++ b/src/js/apps/patients/worklist/action_views.js
@@ -70,11 +70,6 @@ const ActionItemView = View.extend({
       return;
     }
 
-    if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
-      return;
-    }
-
     Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   onClickPatient() {

--- a/src/js/apps/patients/worklist/action_views.js
+++ b/src/js/apps/patients/worklist/action_views.js
@@ -66,19 +66,19 @@ const ActionItemView = View.extend({
   },
   onClick() {
     if (this.flow) {
-      Radio.trigger('event-router', 'flow:action', this.flow.id, this.model.id);
+      Radio.trigger('event-router', 'patient:flow:action', this.model.getPatient().id, this.flow.id, this.model.id);
       return;
     }
 
     if (this.model.isDone()) {
-      Radio.trigger('event-router', 'patient:action:archive', this.model.getPatient().id, this.model.id);
+      Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
       return;
     }
 
     Radio.trigger('event-router', 'patient:action', this.model.getPatient().id, this.model.id);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
+    Radio.trigger('event-router', 'patient:workflow', this.model.getPatient().id);
   },
   onRender() {
     this.showForm();

--- a/src/js/apps/patients/worklist/flow_views.js
+++ b/src/js/apps/patients/worklist/flow_views.js
@@ -53,10 +53,10 @@ const FlowItemView = View.extend({
     });
   },
   onClick() {
-    Radio.trigger('event-router', 'flow', this.model.id);
+    Radio.trigger('event-router', 'patient:flow', this.model.getPatient().id, this.model.id);
   },
   onClickPatient() {
-    Radio.trigger('event-router', 'patient:dashboard', this.model.getPatient().id);
+    Radio.trigger('event-router', 'patient:workflow', this.model.getPatient().id);
   },
   onRender() {
     const canEdit = this.canEdit;

--- a/src/js/apps/patients/worklist/worklist.e2e.cy.js
+++ b/src/js/apps/patients/worklist/worklist.e2e.cy.js
@@ -1236,7 +1236,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', `patient-action/${ testActions[2].id }/form/${ testForm.id }`);
+      .should('contain', `patient/${ testPatient1.id }/form/${ testForm.id }/action/${ testActions[2].id }`);
 
     cy
       .wait('@routeFormActionFields')

--- a/src/js/apps/patients/worklist/worklist.e2e.cy.js
+++ b/src/js/apps/patients/worklist/worklist.e2e.cy.js
@@ -121,7 +121,7 @@ context('worklist page', function() {
       .routeActions()
       .routeFlow()
       .routeFlowActions()
-      .routePatientByFlow()
+      .routeFlowActivity()
       .visit('/worklist/owned-by')
       .wait('@routeActions');
 
@@ -283,7 +283,7 @@ context('worklist page', function() {
       .get('@firstRow')
       .click('top')
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
+      .wait('@routePatient')
       .wait('@routeFlowActions');
 
     cy
@@ -301,7 +301,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ testPatient1.id }`)
+      .should('contain', `patient/${ testPatient1.id }/workflow`)
       .wait('@routePatient');
 
     cy
@@ -910,15 +910,13 @@ context('worklist page', function() {
 
     cy
       .routeFlow()
-      .routeFlowActions()
-      .routePatientByFlow();
+      .routeFlowActions();
 
     cy
       .get('@firstRow')
       .click('top')
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions');
+      .wait('@routePatient');
 
     cy
       .url()
@@ -948,11 +946,6 @@ context('worklist page', function() {
       .should('contain', `/patient/${ testPatient1.id }/action/${ testActions[2].id }`);
 
     cy
-      .get('.patient__layout')
-      .find('.patient__tab--selected')
-      .contains('Dashboard');
-
-    cy
       .go('back')
       .wait('@routeActions');
 
@@ -967,7 +960,7 @@ context('worklist page', function() {
 
     cy
       .location('pathname', { timeout: 10000 })
-      .should('contain', `/patient/dashboard/${ testPatient1.id }`);
+      .should('contain', `/patient/${ testPatient1.id }/workflow`);
 
     cy
       .go('back')
@@ -980,8 +973,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', `flow/${ testFlow.id }/action/${ testActions[0].id }`)
-      .wait('@routeFlowActions');
+      .should('contain', `flow/${ testFlow.id }/action/${ testActions[0].id }`);
 
     cy
       .go('back')
@@ -997,12 +989,7 @@ context('worklist page', function() {
       .get('@secondRow')
       .next()
       .click('top')
-      .wait('@routePatientActions');
-
-    cy
-      .get('.patient__layout')
-      .find('.patient__tab--selected')
-      .contains('Archive');
+      .wait('@routeAction');
 
     cy
       .go('back')
@@ -4486,7 +4473,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ testPatient.id }`);
+      .should('contain', `patient/${ testPatient.id }/workflow`);
 
     cy
       .get('.patient-sidebar')
@@ -4509,7 +4496,7 @@ context('worklist page', function() {
 
     cy
       .url()
-      .should('contain', `patient/dashboard/${ testPatient.id }`);
+      .should('contain', `patient/${ testPatient.id }/workflow`);
 
     cy
       .get('.patient-sidebar')

--- a/src/js/base/routerapp.component.cy.js
+++ b/src/js/base/routerapp.component.cy.js
@@ -5,7 +5,7 @@ const PatientStub = SubRouterApp.extend({
   routeScope: ['patientId'],
   routeActions() {
     return {
-      'patient:dashboard': 'show',
+      'patient:workflow': 'show',
       'patient:action': 'show',
     };
   },
@@ -30,7 +30,7 @@ const Router = RouterApp.extend({
   },
   eventRoutes() {
     return {
-      'patient:dashboard': { action: 'showPatient', route: 'patient/dashboard/:id' },
+      'patient:workflow': { action: 'showPatient', route: 'patient/:id/workflow' },
       'patient:action': { action: 'showPatient', route: 'patient/:id/action/:aid' },
       'worklist': { action: 'showWorklist', route: 'worklist/:id', meta: { isList: true } },
       'schedule': { action: 'showSchedule', route: 'schedule', meta: { clearLatestList: true } },
@@ -58,14 +58,14 @@ context('RouterApp', function() {
   describe('route triggers and aliases', function() {
     specify('prefixes the workspace slug onto non-root routes', function() {
       app = new Router({ workspaceSlug: 'test-ws' });
-      expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/dashboard/:id');
+      expect(app.router.getDefaultRoute('patient:workflow')).to.equal('test-ws/patient/:id/workflow');
     });
 
     specify('registers every alias and treats the first as canonical', function() {
       const AliasRouter = Router.extend({
         eventRoutes() {
           return {
-            'patient:dashboard': {
+            'patient:workflow': {
               action: 'showPatient',
               route: ['patient/:id/workflow', 'patient/dashboard/:id'],
             },
@@ -74,10 +74,10 @@ context('RouterApp', function() {
       });
       app = new AliasRouter({ workspaceSlug: 'test-ws' });
 
-      expect(app.router.getDefaultRoute('patient:dashboard')).to.equal('test-ws/patient/:id/workflow');
-      expect(app.translateEvent('patient:dashboard', 'p1')).to.equal('test-ws/patient/p1/workflow');
+      expect(app.router.getDefaultRoute('patient:workflow')).to.equal('test-ws/patient/:id/workflow');
+      expect(app.translateEvent('patient:workflow', 'p1')).to.equal('test-ws/patient/p1/workflow');
 
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
       expect(app.getCurrentRoute().definition.route).to.equal('patient/:id/workflow');
     });
 
@@ -114,13 +114,13 @@ context('RouterApp', function() {
       });
       app = new CapturingRouter({ workspaceSlug: 'test-ws' });
 
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
 
       expect(app.capturedRouter).to.equal(app);
-      expect(app.captured.event).to.equal('patient:dashboard');
+      expect(app.captured.event).to.equal('patient:workflow');
       expect(app.captured.eventArgs).to.deep.equal(['p1']);
       expect(app.captured.definition.action).to.equal('showPatient');
-      expect(app.captured.definition.route).to.equal('patient/dashboard/:id');
+      expect(app.captured.definition.route).to.equal('patient/:id/workflow');
       expect(app.currentDuringHook).to.equal(app.captured);
     });
 
@@ -132,7 +132,7 @@ context('RouterApp', function() {
       app.on('before:appRoute', beforeAppRoute);
       app.on('appRoute', appRoute);
 
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
 
       const routeContext = app.getCurrentRoute();
 
@@ -150,22 +150,22 @@ context('RouterApp', function() {
   describe('scope identity', function() {
     specify('reuses the child and forwards the route for an equal scope', function() {
       app = new Router({ workspaceSlug: 'test-ws' });
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
       const child = app.getCurrent();
 
       trigger(app, 'patient:action', 'p1', 'a1');
 
       expect(app.getCurrent()).to.equal(child);
       expect(child.startCount).to.equal(1);
-      expect(child.routes).to.deep.equal(['patient:dashboard', 'patient:action']);
+      expect(child.routes).to.deep.equal(['patient:workflow', 'patient:action']);
     });
 
     specify('restarts the child for a different scope', function() {
       app = new Router({ workspaceSlug: 'test-ws' });
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
       const child = app.getCurrent();
 
-      trigger(app, 'patient:dashboard', 'p2');
+      trigger(app, 'patient:workflow', 'p2');
 
       expect(child.startCount).to.equal(2);
     });
@@ -183,7 +183,7 @@ context('RouterApp', function() {
   describe('child stop cleanup', function() {
     specify('clears current references when the child stops itself', function() {
       app = new Router({ workspaceSlug: 'test-ws' });
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
       const child = app.getCurrent();
 
       child.stop();
@@ -194,7 +194,7 @@ context('RouterApp', function() {
 
     specify('keeps the current child when it restarts itself', function() {
       app = new Router({ workspaceSlug: 'test-ws' });
-      trigger(app, 'patient:dashboard', 'p1');
+      trigger(app, 'patient:workflow', 'p1');
       const child = app.getCurrent();
 
       // a Toolkit restart() emits stop+start; the child remains current

--- a/src/js/base/routing.md
+++ b/src/js/base/routing.md
@@ -28,9 +28,12 @@ definitions.
 
 ```js
 eventRoutes: {
-  'patient:dashboard': {
+  'patient:workflow': {
     action: 'showPatient',          // method name or function (positional handler)
-    route: 'patient/dashboard/:id', // string, or array of aliases (first is canonical)
+    route: [                        // first route is canonical
+      'patient/:id/workflow',
+      'patient/dashboard/:id',
+    ],
     // root: true,                  // skip the workspace-slug prefix
     meta: { isList: true },         // behavioral flags live under meta
   },
@@ -55,7 +58,7 @@ Each match is normalized before any hook runs:
 
 ```js
 {
-  event,            // 'patient:dashboard'
+  event,            // 'patient:workflow'
   eventArgs,        // ['patient-id', ...] — positional, as the action receives them
   definition: { action, route, root, meta },
 }
@@ -134,8 +137,8 @@ onStart(options, data) {
 
 ```js
 routeActions: {
-  'flow:action': 'showActionSidebar',
-  'flow:details': 'showFlowDetails',
+  'patient:flow:action': 'showAction',
+  'patient:flow': 'showFlow',
 }
 ```
 

--- a/src/js/base/subrouterapp.component.cy.js
+++ b/src/js/base/subrouterapp.component.cy.js
@@ -17,7 +17,7 @@ const BaseApp = SubRouterApp.extend({
   routeScope: ['patientId'],
   routeActions() {
     return {
-      'patient:dashboard': 'showDashboard',
+      'patient:workflow': 'showDashboard',
       'patient:action': 'showAction',
     };
   },
@@ -56,7 +56,7 @@ const LoadingApp = BaseApp.extend({
   },
 });
 
-const dashboard = { event: 'patient:dashboard', eventArgs: ['p1'], definition: {} };
+const dashboard = { event: 'patient:workflow', eventArgs: ['p1'], definition: {} };
 const action = { event: 'patient:action', eventArgs: ['p1', 'a1'], definition: {} };
 
 context('SubRouterApp', function() {

--- a/src/js/entities-service/patients.js
+++ b/src/js/entities-service/patients.js
@@ -7,14 +7,6 @@ const Entity = BaseEntity.extend({
     'patients:model': 'getModel',
     'patients:collection': 'getCollection',
     'fetch:patients:model': 'fetchModel',
-    'fetch:patients:model:byAction': 'fetchPatientByAction',
-    'fetch:patients:model:byFlow': 'fetchPatientByFlow',
-  },
-  fetchPatientByAction(actionId) {
-    return this.fetchBy(`/api/actions/${ actionId }/patient`);
-  },
-  fetchPatientByFlow(flowId) {
-    return this.fetchBy(`/api/flows/${ flowId }/patient`);
   },
 });
 

--- a/src/js/i18n/en-US/patients.yml
+++ b/src/js/i18n/en-US/patients.yml
@@ -162,6 +162,7 @@ careOptsFrontend:
         flowViews:
           actionNotFound: The Action you requested does not exist.
           addActionHeadingText: Add Action
+          notFound: The Flow you requested does not exist.
           activity:
             api:
               clinicianAssigned: '<strong>{ name }</strong> ({ team }) changed the Owner to { to_name }'

--- a/src/js/services/dialer.e2e.cy.js
+++ b/src/js/services/dialer.e2e.cy.js
@@ -128,11 +128,6 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routePatientByFlow(fx => {
-        fx.data = testPatient;
-
-        return fx;
-      })
       .routePatientFlows(fx => {
         fx.data = [testFlow];
 
@@ -146,8 +141,7 @@ context('Dialer Service', function() {
       .routeDashboards()
       .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions')
+      .wait('@routePatient')
       .wait('@routeActionActivity')
       .wait('@routeActionComments')
       .wait('@routeActionFiles');
@@ -251,9 +245,8 @@ context('Dialer Service', function() {
       .should('have.length', 0);
 
     cy
-      .get('.patient-flow__context-trail .js-patient')
+      .get('.patient__context-trail .js-patient')
       .click()
-      .wait('@routePatient')
       .wait('@routePatientActions')
       .wait('@routePatientFlows');
 
@@ -388,11 +381,6 @@ context('Dialer Service', function() {
 
         return fx;
       })
-      .routePatientByFlow(fx => {
-        fx.data = testPatient;
-
-        return fx;
-      })
       .routePatientFlows(fx => {
         fx.data = [testFlow];
 
@@ -406,8 +394,7 @@ context('Dialer Service', function() {
       .routeDashboards()
       .visit(`/flow/${ testFlow.id }/action/${ testAction.id }`)
       .wait('@routeFlow')
-      .wait('@routePatientByFlow')
-      .wait('@routeFlowActions')
+      .wait('@routePatient')
       .wait('@routeActionActivity')
       .wait('@routeActionComments')
       .wait('@routeActionFiles');
@@ -511,9 +498,8 @@ context('Dialer Service', function() {
       .should('have.length', 0);
 
     cy
-      .get('.patient-flow__context-trail .js-patient')
+      .get('.patient__context-trail .js-patient')
       .click()
-      .wait('@routePatient')
       .wait('@routePatientActions')
       .wait('@routePatientFlows');
 

--- a/src/js/services/history.js
+++ b/src/js/services/history.js
@@ -50,7 +50,7 @@ export default App.extend({
     this.getChannel().trigger('change:route', this._prevHistory[0]);
   },
   goBack(handleEmptyHistory) {
-    if (handleEmptyHistory && this._prevHistory.length < 2) {
+    if (this._prevHistory.length < 2) {
       handleEmptyHistory();
       return;
     }

--- a/src/js/services/latest-list.component.cy.js
+++ b/src/js/services/latest-list.component.cy.js
@@ -45,7 +45,7 @@ context('LatestListService', function() {
     service._setLatestList('worklist', ['owned-by']);
 
     Radio.request('history', 'set:latestList', {
-      event: 'patient:dashboard',
+      event: 'patient:workflow',
       eventArgs: ['patient-id'],
       definition: {
         meta: {},

--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -6,7 +6,7 @@ import App from 'js/base/app';
 import intl from 'js/i18n';
 
 import FormsService from 'js/services/forms';
-import { addError } from 'js/datadog';
+import { addAction } from 'js/datadog';
 
 import { ModalView, SidebarModalView, SmallModalView, IframeFormView } from 'js/services/modal/modal_views';
 import { DraftStatusView } from 'js/apps/patients/patient/form/form_views';
@@ -144,7 +144,7 @@ export default App.extend({
   routeLargeFormRequest(patient, form, formName) {
     Radio.trigger('event-router', 'patient:form', patient.id, form.id);
 
-    addError(new Error('Large form modal request routed to patient form'), {
+    addAction('Large form modal request routed to patient form', {
       patientId: patient.id,
       formId: form.id,
       formName,

--- a/src/js/services/modal.js
+++ b/src/js/services/modal.js
@@ -6,6 +6,7 @@ import App from 'js/base/app';
 import intl from 'js/i18n';
 
 import FormsService from 'js/services/forms';
+import { addError } from 'js/datadog';
 
 import { ModalView, SidebarModalView, SmallModalView, IframeFormView } from 'js/services/modal/modal_views';
 import { DraftStatusView } from 'js/apps/patients/patient/form/form_views';
@@ -53,6 +54,11 @@ export default App.extend({
     return view;
   },
   showForm(patient, formName, form, size) {
+    if (size === 'large') {
+      this.routeLargeFormRequest(patient, form, formName);
+      return;
+    }
+
     const formService = new FormsService({ patient, form });
     const bodyView = new IframeFormView({ model: form, size });
 
@@ -134,6 +140,15 @@ export default App.extend({
     });
 
     return modal;
+  },
+  routeLargeFormRequest(patient, form, formName) {
+    Radio.trigger('event-router', 'patient:form', patient.id, form.id);
+
+    addError(new Error('Large form modal request routed to patient form'), {
+      patientId: patient.id,
+      formId: form.id,
+      formName,
+    });
   },
   showViewOnlyForm(formService, bodyView, formName) {
     this.showModal({

--- a/src/js/services/modal/modal_views.js
+++ b/src/js/services/modal/modal_views.js
@@ -137,7 +137,6 @@ const IframeFormView = View.extend({
     const size = this.getOption('size');
 
     if (size === 'small') return 'modal__form-iframe--small';
-    if (size === 'large') return 'modal__form-iframe--large';
 
     return 'modal__form-iframe';
   },

--- a/src/js/services/sidebar.js
+++ b/src/js/services/sidebar.js
@@ -9,12 +9,6 @@ export const SidebarMixin = {
     region.show(view, options);
     return view;
   },
-  showFooterView(name, view, options) {
-    const footerView = this.getView().getChildView('footer');
-    const region = footerView.getRegion(name);
-    region.show(view, options);
-    return view;
-  },
 };
 
 export default App.extend({

--- a/src/scss/modules/modals.scss
+++ b/src/scss/modules/modals.scss
@@ -131,13 +131,6 @@
   height: 35vh;
 }
 
-.modal__form-iframe--large {
-  @extend .modal__form-iframe;
-
-  height: 75vh;
-  width: 75vw;
-}
-
 .modal__form-label {
   align-items: center;
   color: #{$black-60};
@@ -150,5 +143,4 @@
 .modal__form-component {
   min-width: 248px;
 }
-
 


### PR DESCRIPTION
Closes FE-188

## What
- Route patient workflow, flow, action, and form URLs through the mounted patient application while preserving browser history.
- Route large action forms to patient-scoped pages and return missing flows/actions to their surviving parent pages.
- Remove unreachable routed-page fallbacks, listeners, fetch helpers, and sidebar/history branches exposed by full coverage.

## Why
This is the routing and missing-resource slice of the action-page work, separated so URL ownership, history behavior, fallback destinations, and failure behavior can be reviewed before the later page-view and styling changes.

## Scope
- Impacts patient routes, patient application lifecycle, action-form routing, latest-list history, and 410/error handling.
- Keeps application behavior coverage at the E2E level and component coverage on reusable/shared infrastructure; app and view trees are not mounted as component tests.
- Legacy flow redirects use the flow response patient relationship ID; the canonical PatientApp then fetches the full patient.
- The transitional patient form-by-action route is replaced by the later embedded action-form slice; flow-parent 410 handling for that final route stays with the ActionApp-owned implementation.
- Does not include the later workflow, flow, and action visual redesign, responsive behavior, or V6 styling.

## Deployment Impact
- No form or form-bundle redeploy is required.
- This targets the action-page integration branch; normal frontend deployment applies after the complete feature is merged.

## Testing
- `npm run coverage` — full reusable-component and E2E suites passed.
- Coverage: 100% statements (6,354/6,354), branches (1,961/1,961), functions (2,176/2,176), and lines (6,016/6,016).
- `npm run eslint -- --quiet`
- `git diff --check`
- Mirrored onto `feature/action-page`; its build, lint, and affected routed-page E2E specs were exercised against the later card/action-page implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced streamlined patient workspace navigation for workflows, flows, actions, and forms.
  * Added context-trail links for navigating between patients, workflows, flows, actions, and forms.
  * Large forms now open on the dedicated patient form page instead of in a modal.
  * Added clearer handling for deleted or unavailable patient resources, including targeted alerts and redirects.
* **Bug Fixes**
  * Improved navigation after deleted resources and prevented stale data from replacing current content.
  * Added flow-specific not-found messaging and improved error handling for server and client failures.
* **Documentation**
  * Clarified form widget behavior for small and large modal sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->