### PR TITLE
feat(patients): load backend-defined patient sidebars

### DIFF
--- a/src/js/apps/patients/patient/sidebar/patient-sidebar.scss
+++ b/src/js/apps/patients/patient/sidebar/patient-sidebar.scss
@@ -29,8 +29,55 @@
   top: 16px;
 }
 
-.patient-sidebar__widgets {
+.patient-sidebar__sidebars {
   .loader {
     margin-top: 60px;
+  }
+}
+
+.patient-sidebar__card {
+  background: #{$white};
+  border: 1px solid #{$black-90};
+  border-radius: 8px;
+  margin-top: 16px;
+  padding: 16px;
+}
+
+.patient-sidebar__card-heading {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+}
+
+.patient-sidebar__card-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  justify-content: space-between;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+
+  &:focus-visible {
+    outline: 2px solid color(blue);
+    outline-offset: 4px;
+  }
+}
+
+.patient-sidebar__card-toggle-icon {
+  transition: transform 0.15s linear;
+}
+
+.patient-sidebar__card.is-collapsed {
+  .patient-sidebar__card-heading {
+    margin-bottom: 0;
+  }
+
+  .patient-sidebar__card-toggle-icon {
+    transform: rotate(-90deg);
   }
 }

--- a/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js
@@ -6,7 +6,7 @@ import { testDate, testDateSubtract } from 'helpers/test-date';
 import { getResource, getRelationship, getErrors } from 'helpers/json-api';
 import { testTs } from 'helpers/test-timestamp';
 
-import { workspaceOne, getWorkspace } from 'support/api/workspaces';
+import { workspaceOne } from 'support/api/workspaces';
 import { getWorkspacePatient } from 'support/api/workspace-patients';
 import { getPatient } from 'support/api/patients';
 import { getCurrentClinician } from 'support/api/clinicians';
@@ -15,6 +15,101 @@ import { getForm, testForm } from 'support/api/forms';
 import { getFormResponse } from 'support/api/form-responses';
 
 context('patient sidebar', function() {
+  specify('renders and toggles backend sidebar sections', function() {
+    cy
+      .routesForPatientDashboard()
+      .routeSidebars(fx => {
+        const addSidebar = _.partial(getResource, _, 'sidebars');
+
+        fx.data = [
+          addSidebar({
+            id: 'demographics',
+            slug: 'demographics',
+            name: 'Demographics',
+            sequence: 1,
+            widgets: ['sex'],
+          }),
+          addSidebar({
+            id: 'care-team',
+            slug: 'care-team',
+            name: 'Care & Support',
+            sequence: 0,
+            widgets: ['sex'],
+          }),
+        ];
+
+        return fx;
+      })
+      .visit('/patient/dashboard/1')
+      .wait('@routePatient');
+
+    cy
+      .get('.patient-sidebar__card-toggle')
+      .should('have.length', 2)
+      .first()
+      .should('contain', 'Care & Support');
+
+    cy
+      .contains('.patient-sidebar__card-toggle', 'Care & Support')
+      .as('careToggle')
+      .should('have.attr', 'aria-expanded', 'true')
+      .and('have.attr', 'aria-label', 'Collapse Care & Support section')
+      .invoke('attr', 'aria-controls')
+      .then(regionId => {
+        cy.get(`#${ regionId }`).should('be.visible');
+      });
+
+    cy
+      .get('@careToggle')
+      .focus()
+      .typeEnter()
+      .should('have.attr', 'aria-expanded', 'false')
+      .and('have.attr', 'aria-label', 'Expand Care & Support section')
+      .invoke('attr', 'aria-controls')
+      .then(regionId => {
+        cy.get(`#${ regionId }`).should('not.be.visible');
+      });
+
+    cy
+      .get('@careToggle')
+      .typeEnter()
+      .should('have.attr', 'aria-expanded', 'true')
+      .and('have.attr', 'aria-label', 'Collapse Care & Support section')
+      .invoke('attr', 'aria-controls')
+      .then(regionId => {
+        cy.get(`#${ regionId }`).should('be.visible');
+      });
+
+    cy
+      .contains('.patient-sidebar__card-toggle', 'Demographics')
+      .should('have.attr', 'aria-expanded', 'true')
+      .click()
+      .should('have.attr', 'aria-expanded', 'false')
+      .and('have.attr', 'aria-label', 'Expand Demographics section')
+      .invoke('attr', 'aria-controls')
+      .then(regionId => {
+        cy.get(`#${ regionId }`).should('not.be.visible');
+      });
+  });
+
+  specify('renders an empty patient sidebar definition', function() {
+    cy
+      .routesForPatientDashboard()
+      .routeSidebars(fx => {
+        fx.data = [];
+
+        return fx;
+      })
+      .visit('/patient/dashboard/1')
+      .wait('@routePatient');
+
+    cy
+      .get('.patient-sidebar')
+      .should('be.visible')
+      .find('.patient-sidebar__card')
+      .should('not.exist');
+  });
+
   specify('display patient data', function() {
     const dob = testDateSubtract(10, 'years');
 
@@ -83,8 +178,8 @@ context('patient sidebar', function() {
 
         return fx;
       })
-      .routeSettings('widgets_patient_sidebar', {
-        widgets: [
+      .routeSidebars(fx => {
+        fx.data[0].attributes.widgets = [
           'dob',
           'sex',
           'status',
@@ -102,7 +197,9 @@ context('patient sidebar', function() {
           'hbsEmptyWidget',
           'hbsNoRegionWidget',
           'hbsEmptyTemplateWidget',
-        ],
+        ];
+
+        return fx;
       })
       .routeWidgets(fx => {
         const addWidget = _.partial(getResource, _, 'widgets');
@@ -621,19 +718,11 @@ context('patient sidebar', function() {
       .should('not.contain', 'Workspace Two');
   });
 
-  specify('workspace specific widgets setting', function() {
+  specify('renders widgets from the sidebar definition', function() {
     cy
       .routesForPatientDashboard()
-      .routeWorkspaces(fx => {
-        fx.data[0] = getWorkspace({
-          attributes: {
-            settings: {
-              widgets_patient_sidebar: {
-                widgets: ['divider'],
-              },
-            },
-          },
-        }, { id: workspaceOne.id });
+      .routeSidebars(fx => {
+        fx.data[0].attributes.widgets = ['divider'];
 
         return fx;
       });

--- a/src/js/apps/patients/patient/sidebar/sidebar_app.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_app.js
@@ -14,13 +14,13 @@ export default App.extend({
   onBeforeStart({ patient }) {
     this.showView(new SidebarView({ model: patient }));
 
-    this.widgets = Radio.request('widgets', 'sidebarWidgets');
+    this.sidebars = Radio.request('sidebars', 'patient');
 
-    this.getRegion('widgets').startPreloader();
+    this.getRegion('sidebars').startPreloader();
   },
   beforeStart({ patient }) {
     const workspacePatient = Radio.request('entities', 'fetch:workspacePatients:byPatient', patient.id);
-    const values = this.widgets.invoke('fetchValues', patient.id);
+    const values = this.getWidgetValueRequests(patient.id);
 
     return [workspacePatient, ...values];
   },
@@ -29,8 +29,14 @@ export default App.extend({
 
     this.showView(new SidebarView({
       model: this.patient,
-      collection: this.widgets,
+      collection: this.sidebars,
     }));
+  },
+  getWidgetValueRequests(patientId) {
+    return this.sidebars.reduce((requests, sidebar) => {
+      requests.push(...sidebar.getWidgets().invoke('fetchValues', patientId));
+      return requests;
+    }, []);
   },
   showPatientModal() {
     Radio.request('patient-modal', 'show', this.patient);

--- a/src/js/apps/patients/patient/sidebar/sidebar_views.js
+++ b/src/js/apps/patients/patient/sidebar/sidebar_views.js
@@ -1,10 +1,10 @@
 import Radio from 'backbone.radio';
 import Backbone from 'backbone';
-import { View } from 'marionette';
+import { View, CollectionView } from 'marionette';
 import hbs from 'handlebars-inline-precompile';
 
 import { PATIENT_STATUS } from 'js/static';
-import intl from 'js/i18n';
+import intl, { renderTemplate } from 'js/i18n';
 
 import PreloadRegion from 'js/regions/preload_region';
 
@@ -19,6 +19,11 @@ import './patient-sidebar.scss';
 
 const i18n = intl.patients.patient.sidebar.sidebarViews;
 
+const sectionLabelTemplates = {
+  collapse: hbs`{{{formatMessage (intlGet "patients.patient.sidebar.sidebarViews.sidebarSectionView.collapseSectionLabel") section=name}}}`,
+  expand: hbs`{{{formatMessage (intlGet "patients.patient.sidebar.sidebarViews.sidebarSectionView.expandSectionLabel") section=name}}}`,
+};
+
 const NameView = View.extend({
   tagName: 'h1',
   className: 'patient-sidebar__name',
@@ -28,18 +33,87 @@ const NameView = View.extend({
   },
 });
 
+const SidebarSectionView = View.extend({
+  className: 'patient-sidebar__card',
+  template: hbs`
+    <h2 class="patient-sidebar__card-heading">
+      <button class="patient-sidebar__card-toggle js-toggle-section" type="button" aria-label="{{ toggleLabel }}" aria-expanded="{{ isExpanded }}" aria-controls="{{ widgetsRegionId }}">
+        <span>{{ name }}</span>
+        <span class="patient-sidebar__card-toggle-icon">{{far "chevron-down"}}</span>
+      </button>
+    </h2>
+    <div id="{{ widgetsRegionId }}" data-widgets-region></div>
+  `,
+  ui: {
+    toggleSection: '.js-toggle-section',
+    widgets: '[data-widgets-region]',
+  },
+  regions: {
+    widgets: '[data-widgets-region]',
+  },
+  triggers: {
+    'click @ui.toggleSection': 'click:toggle',
+  },
+  initialize() {
+    this.isExpanded = true;
+    this.widgetsRegionId = `patient-sidebar-section-${ this.cid }`;
+  },
+  onRender() {
+    this.showChildView('widgets', new WidgetCollectionView({
+      model: this.getOption('patient'),
+      collection: this.model.getWidgets(),
+      itemClassName: 'patient-sidebar__section',
+    }));
+
+    this.updateDisclosure();
+  },
+  onClickToggle() {
+    this.isExpanded = !this.isExpanded;
+    this.updateDisclosure();
+  },
+  getToggleLabel() {
+    const labelTemplate = this.isExpanded ? sectionLabelTemplates.collapse : sectionLabelTemplates.expand;
+
+    return renderTemplate(labelTemplate, { name: this.model.get('name') });
+  },
+  updateDisclosure() {
+    this.ui.toggleSection
+      .attr('aria-expanded', String(this.isExpanded))
+      .attr('aria-label', this.getToggleLabel());
+    this.ui.widgets.prop('hidden', !this.isExpanded);
+    this.$el.toggleClass('is-collapsed', !this.isExpanded);
+  },
+  templateContext() {
+    return {
+      isExpanded: this.isExpanded,
+      toggleLabel: this.getToggleLabel(),
+      widgetsRegionId: this.widgetsRegionId,
+    };
+  },
+});
+
+const SidebarsView = CollectionView.extend({
+  childView: SidebarSectionView,
+  childViewOptions() {
+    return {
+      patient: this.model,
+    };
+  },
+  viewComparator: false,
+});
+
 const SidebarView = View.extend({
   className: 'patient-sidebar flex-region',
   template: hbs`
     <div data-name-region></div>
     <span class="patient-sidebar__icon">{{far "address-card"}}</span>
     <button class="button--icon patient-sidebar__menu js-menu">{{far "ellipsis"}}</button>
-    <div class="patient-sidebar__widgets" data-widgets-region></div>
+    <div class="patient-sidebar__sidebars" data-sidebars-region></div>
   `,
   regions: {
     name: '[data-name-region]',
-    widgets: {
-      el: '[data-widgets-region]',
+    sidebars: {
+      el: '[data-sidebars-region]',
       regionClass: PreloadRegion,
     },
   },
@@ -48,10 +122,9 @@ const SidebarView = View.extend({
       model: this.model,
     }));
 
-    this.showChildView('widgets', new WidgetCollectionView({
+    this.showChildView('sidebars', new SidebarsView({
       model: this.model,
       collection: this.collection,
-      itemClassName: 'patient-sidebar__section',
     }));
   },
   triggers: {

--- a/src/js/entities-service/entities/sidebars.js
+++ b/src/js/entities-service/entities/sidebars.js
@@ -1,0 +1,27 @@
+import Radio from 'backbone.radio';
+import Store from 'backbone.store';
+
+import BaseCollection from 'js/base/collection';
+import BaseModel from 'js/base/model';
+
+const TYPE = 'sidebars';
+
+const _Model = BaseModel.extend({
+  type: TYPE,
+  getWidgets() {
+    return Radio.request('widgets', 'build', this.get('widgets'));
+  },
+});
+
+const Model = Store(_Model, TYPE);
+const Collection = BaseCollection.extend({
+  url: '/api/sidebars',
+  model: Model,
+  comparator: 'sequence',
+});
+
+export {
+  _Model,
+  Model,
+  Collection,
+};

--- a/src/js/entities-service/index.js
+++ b/src/js/entities-service/index.js
@@ -38,6 +38,8 @@ import './roles';
 
 import './settings';
 
+import './sidebars';
+
 import './states';
 
 import './tags';

--- a/src/js/entities-service/sidebars.js
+++ b/src/js/entities-service/sidebars.js
@@ -1,0 +1,15 @@
+import BaseEntity from 'js/base/entity-service';
+
+import { _Model, Model, Collection } from './entities/sidebars';
+
+const Entity = BaseEntity.extend({
+  Entity: { _Model, Model, Collection },
+  isWorkspaceScoped: false,
+  radioRequests: {
+    'sidebars:model': 'getModel',
+    'sidebars:collection': 'getCollection',
+    'fetch:sidebars:collection': 'fetchCollectionCache',
+  },
+});
+
+export default new Entity();

--- a/src/js/i18n/en-US/patients.yml
+++ b/src/js/i18n/en-US/patients.yml
@@ -199,6 +199,9 @@ careOptsFrontend:
             bodyText: Are you sure you want to archive this patient? The patient will no longer be accessible in this workspace.
             headingText: Confirm Archive Patient
             submitText: Archive Patient
+          sidebarSectionView:
+            collapseSectionLabel: Collapse { section } section
+            expandSectionLabel: Expand { section } section
           menuOptions:
             activate: Activate Patient
             archive: Archive Patient

--- a/src/js/services/bootstrap.js
+++ b/src/js/services/bootstrap.js
@@ -7,6 +7,7 @@ import getWorkspaceRoute from 'js/utils/root-route';
 
 import App from 'js/base/app';
 
+import SidebarsService from './sidebars';
 import SettingsService from './settings';
 import WidgetsService from './widgets';
 import WorkspaceService from './workspace';
@@ -70,16 +71,19 @@ export default App.extend({
       Radio.request('entities', 'fetch:teams:collection'),
       Radio.request('entities', 'fetch:workspaces:collection'),
       Radio.request('entities', 'fetch:settings:collection'),
+      Radio.request('entities', 'fetch:sidebars:collection'),
       Radio.request('entities', 'fetch:widgets:collection'),
     ];
   },
-  onStart(options, currentUser, roles, teams, workspaces, settings, widgets) {
+  onStart(options, currentUser, roles, teams, workspaces, settings, sidebars, widgets) {
     this.currentUser = currentUser;
     this.roles = roles;
     this.teams = teams;
     this.workspaces = workspaces;
 
     new SettingsService({ settings });
+
+    new SidebarsService({ sidebars });
 
     new WidgetsService({ widgets });
 

--- a/src/js/services/sidebars.js
+++ b/src/js/services/sidebars.js
@@ -1,0 +1,14 @@
+import App from 'js/base/app';
+
+export default App.extend({
+  channelName: 'sidebars',
+  radioRequests: {
+    'patient': 'getPatientSidebars',
+  },
+  initialize({ sidebars }) {
+    this.sidebars = sidebars;
+  },
+  getPatientSidebars() {
+    return this.sidebars;
+  },
+});

--- a/test/fixtures/test/sidebars.json
+++ b/test/fixtures/test/sidebars.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "demographics",
+    "slug": "demographics",
+    "name": "Demographics",
+    "sequence": 0,
+    "widgets": [
+      "dob",
+      "sex",
+      "status",
+      "divider",
+      "workspaces"
+    ]
+  }
+]

--- a/test/support/api/sidebars.js
+++ b/test/support/api/sidebars.js
@@ -1,0 +1,20 @@
+import _ from 'underscore';
+import { getResource } from 'helpers/json-api';
+
+import fxTestSidebars from 'fixtures/test/sidebars';
+
+const TYPE = 'sidebars';
+
+Cypress.Commands.add('routeSidebars', (mutator = _.identity) => {
+  const data = getResource(fxTestSidebars, TYPE);
+
+  cy
+    .intercept('GET', '/api/sidebars*', {
+      body: mutator({ data, included: [] }),
+    })
+    .as('routeSidebars');
+});
+
+export {
+  fxTestSidebars,
+};

--- a/test/support/defaults.js
+++ b/test/support/defaults.js
@@ -56,6 +56,7 @@ beforeEach(function() {
     .routeTeams()
     .routeSettings()
     .routeWorkspaces()
+    .routeSidebars()
     .routeWidgets()
     .routeWorkspaceClinicians()
     .routeWorkspacePrograms()

--- a/test/support/e2e.js
+++ b/test/support/e2e.js
@@ -39,6 +39,7 @@ import './api/program-flows';
 import './api/programs';
 import './api/roles';
 import './api/settings';
+import './api/sidebars';
 import './api/states';
 import './api/tags';
 import './api/teams';


### PR DESCRIPTION
Closes FE-189

## What

- Load patient sidebar definitions during bootstrap through the entities service.
- Render ordered backend-defined patient sidebar sections with accessible expand/collapse controls and no legacy fallback.
- Cover populated, reordered, collapsed, keyboard-toggle, pointer-toggle, and empty sidebar definitions through E2E.

## Why

This isolates the backend-defined patient sidebar behavior as the final nonvisual action-page review slice before the later view and styling work.

## Scope

- Impacts the main patient sidebar, sidebar bootstrap data, fixtures, and E2E support.
- Preserves the shared patient-sidebar section styles still used by the reduced-patient view on this review base.
- Does not include embedded forms, persistent filters, responsive navigation, or the V6 visual redesign.

## Deployment Impact

Normal app deployment only. No forms or form bundles require redeployment.

## Testing

- `npm run lint`
- `npm run build -- --mode test`
- `npx cypress run --spec "src/js/apps/patients/patient/sidebar/sidebar.e2e.cy.js" --reporter dot` — 8 passing
- `npm run coverage` — 100% statements, branches, functions, and lines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load backend-defined patient sidebar sections on the action page. Fetch definitions at bootstrap from /api/sidebars and replace workspace-based sidebar settings; render ordered, accessible section cards with keyboard and click toggles to meet FE-189.

- New Features
  - Fetch sidebars at bootstrap via the entities service and expose them through the `sidebars` service.
  - Render API-defined sections ordered by sequence as cards; all start expanded with proper aria attributes and a controlled region; toggle via keyboard and click; empty responses render no cards.
  - Build widgets per section and fetch their values before start; aggregate widget value requests across sections.
  - Add card/toggle styles and preload the sidebars container.
  - Add fixtures and a Cypress helper (`routeSidebars`) with E2E coverage for populated, reordered, collapsed/expanded (keyboard and pointer), and empty definitions.
  - Add i18n strings for dynamic expand/collapse labels.

<sup>Written for commit 613aa2a4dca521dd7f0d8cea17a2fa6d21c0a9bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable patient sidebar sections with independently rendered widgets.
  * Sidebar sections now follow their configured order and display patient-specific content.
  * Added accessible expand/collapse controls with localized labels and visual state indicators.
  * Added support for empty sidebar configurations.

* **Bug Fixes**
  * Improved sidebar layout, focus styling, icon transitions, and collapsed-state presentation.

* **Documentation**
  * Added accessibility text for expanding and collapsing sidebar sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->