### PR TITLE
feat(flows): use canonical flow creation endpoint

### DIFF
--- a/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
+++ b/src/js/apps/patients/patient/dashboard/dashboard.e2e.cy.js
@@ -1156,7 +1156,7 @@ context('patient dashboard page', function() {
     });
 
     cy
-      .intercept('POST', `/api/patients/${ testPatient.id }/relationships/flows*`, {
+      .intercept('POST', '/api/flows*', {
         statusCode: 201,
         body: {
           data: testFlow,
@@ -1183,6 +1183,7 @@ context('patient dashboard page', function() {
       .wait('@routePostFlow')
       .its('request.body')
       .should(({ data }) => {
+        expect(data.relationships.patient.data.id).to.equal(testPatient.id);
         expect(data.relationships.state.data.id).to.equal(stateTodo.id);
         expect(data.relationships['program-flow'].data.id).to.be.equal(testProgramFlows[0].id);
       });

--- a/src/js/entities-service/entities/flows.js
+++ b/src/js/entities-service/entities/flows.js
@@ -27,14 +27,7 @@ const _Model = BaseModel.extend({
       this.destroy({ isDeleted: true });
     },
   },
-  urlRoot() {
-    if (this.isNew()) {
-      const patient = this.getPatient();
-      return `/api/patients/${ patient.id }/relationships/flows`;
-    }
-
-    return '/api/flows';
-  },
+  urlRoot: '/api/flows',
   type: TYPE,
   getPatient() {
     return this.getRelationship('_patient');
@@ -117,6 +110,7 @@ const _Model = BaseModel.extend({
     if (this.isNew()) attrs = extend({}, this.attributes, attrs);
 
     const relationships = {
+      'patient': this.toRelation(attrs._patient),
       'state': this.toRelation(attrs._state),
       'owner': this.toRelation(attrs._owner),
       'program-flow': this.toRelation(attrs._program_flow),


### PR DESCRIPTION
Closes FE-184

## What
- Route new patient flow creation through the canonical `POST /api/flows` endpoint.
- Include the patient relationship in the JSON:API create payload.
- Update patient dashboard E2E coverage for the endpoint and relationship contract.

## Why
Backend 26.30.0 deployed BE-287 to production, so the frontend can stop using the deprecated patient-scoped relationship endpoint.

## Scope
- Shared flow entity creation behavior.
- Patient dashboard E2E coverage for manually adding a flow.
- Existing flow update URLs, program-flow creation, forms, and backend behavior are unchanged.

## Deployment Impact
- The normal app deployment is required to deliver this change.
- No form or form-bundle redeploy is required.
- The shared flow entity change applies globally once the frontend is deployed.

## Testing
- `npm run lint`
- Cypress was deferred to CI per the AI-authored PR workflow. The patient dashboard E2E contract and full required Cypress coverage will run after the review hold is approved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated patient flow creation to the canonical `POST /api/flows` and added the `patient` relationship to the create payload. Updated patient dashboard E2E to cover the new endpoint and relationship, meeting FE-184.

- **Refactors**
  - Set `urlRoot` to `'/api/flows'` and removed the patient-scoped create route.
  - Added `relationships.patient` to the JSON:API payload (alongside `state`, `owner`, and `program-flow`).
  - Updated dashboard E2E to intercept `POST /api/flows` and assert the patient relationship.

<sup>Written for commit a844a124754950650b868b8b964ccfd3f79ff2f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed flow creation so new flows are submitted through the standard flows endpoint.
  - Ensured patient relationships are included when saving flows.
  - Updated end-to-end coverage to verify the flow request contains the associated patient relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->