### PR TITLE
fix(json-api): exclude resource type from attributes

### DIFF
--- a/src/js/apps/forms/form/action.e2e.cy.js
+++ b/src/js/apps/forms/form/action.e2e.cy.js
@@ -428,6 +428,8 @@ context('Patient Action Form', function() {
       .its('request.body')
       .should(({ data }) => {
         expect(data.id).to.equal(formResponse.id);
+        expect(data.type).to.equal('form-responses');
+        expect(data.attributes).not.to.have.any.keys('id', 'type');
         expect(data.attributes.status).to.equal(FORM_RESPONSE_STATUS.DRAFT);
         expect(data.attributes.response.data.fields.foo).to.equal('baz');
       });

--- a/src/js/base/model.component.cy.js
+++ b/src/js/base/model.component.cy.js
@@ -1,0 +1,44 @@
+import Store from 'backbone.store';
+
+import { Model as Clinician } from 'js/entities-service/entities/clinicians';
+import { Model as FormResponse } from 'js/entities-service/entities/form-responses';
+import { Model as PatientField } from 'js/entities-service/entities/patient-fields';
+
+context('Base model JSON:API serialization', function() {
+  afterEach(function() {
+    Store.resetAll();
+  });
+
+  specify('excludes Store resource identity from attributes', function() {
+    const resources = [
+      {
+        Model: FormResponse,
+        id: 'form-response-id',
+        type: 'form-responses',
+        attributes: { status: 'draft', response: {} },
+      },
+      {
+        Model: PatientField,
+        id: 'patient-field-id',
+        type: 'patient-fields',
+        attributes: { name: 'priority', value: 'high' },
+      },
+      {
+        Model: Clinician,
+        id: 'clinician-id',
+        type: 'clinicians',
+        attributes: { name: 'Test Clinician', email: 'test.clinician@roundingwell.com' },
+      },
+    ];
+
+    resources.forEach(({ Model, id, type, attributes }) => {
+      const model = new Model({ id, ...attributes });
+
+      // Relationship resources update the shared Store model with both id and type.
+      const relationshipModel = new Model({ id, type });
+
+      expect(relationshipModel).to.equal(model);
+      expect(model.toJSONApi()).to.deep.equal({ id, type, attributes });
+    });
+  });
+});

--- a/src/js/base/model.js
+++ b/src/js/base/model.js
@@ -89,9 +89,9 @@ export default Backbone.Model.extend(extend({
     }, {});
   },
   removeFEOnly(attrs) {
-    // Removes id and frontend _fields for POST/PATCHes
+    // Removes JSON:API identity and frontend _fields for POST/PATCHes
     return pick(attrs, function(value, key) {
-      return key !== 'id' && /^[^_]/.test(key);
+      return key !== 'id' && key !== 'type' && /^[^_]/.test(key);
     });
   },
   toJSONApi(attributes = this.attributes) {


### PR DESCRIPTION
Closes FE-190

## What
- Exclude JSON:API `id` and `type` identity fields from serialized request attributes.
- Add shared serializer regression coverage for form responses, patient fields, and clinicians.
- Assert the existing action-form draft PATCH keeps `data.type` while omitting identity fields from `data.attributes`.

## Why
Store-backed relationship resources can add `type` to a shared model attribute set. Existing form-response PATCH requests could then send `attributes.type`, causing the API to reject form saves and submissions.

## Scope
- Changes shared `BaseModel` JSON:API serialization used across app-frontend.
- Covers the patient action-form existing-draft path and representative Store-backed writable resources.
- Does not change backend behavior or customer-form bundles.

## Deployment Impact
- Normal app-frontend deployment only.
- The serializer change affects all JSON:API writes using the shared base model.
- No customer-form bundle redeploy is required.

## Testing
- `npm run lint`
- Cypress was deferred to CI per repository policy. CI should run `src/js/base/model.component.cy.js` and `src/js/apps/forms/form/action.e2e.cy.js` through the full component and E2E suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent leaking JSON:API `type` into `data.attributes` so PATCH saves don’t get rejected. Addresses Linear FE-190 for form responses and other `backbone.store`-cached models.

- **Bug Fixes**
  - Updated shared serializer to omit `id` and `type` from attributes, preserving `data.id` and `data.type`.
  - Added base serializer tests and form action e2e to verify no leakage for form responses, patient fields, and clinicians.

<sup>Written for commit 5e7e72642899f6d883dd1df208f2c542ad389615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/RoundingWell/app-frontend/pull/1749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON:API request payloads to exclude resource identity fields from submitted attributes.
  * Ensured form response updates use the correct JSON:API resource type.

* **Tests**
  * Added coverage for JSON:API serialization across forms, patient fields, and clinicians.
  * Added validation that related resources reuse shared models correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->